### PR TITLE
No issue: add command line build hints to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,26 @@ $ cd android-components
 $ ./gradlew assemble
 ```
 
+### Configuring the Android SDK ###
+
+You will need the Android SDK installed (i.e. pointed to by the `ANDROID_SDK_ROOT` environment variable), and configured to indicate acceptance of the Android SDK licenses. This can be accomplished on Linux as follows:
+
+```
+$ wget http://dl.google.com/android/android-sdk_r24.2-linux.tgz
+$ tar -xvf android-sdk_r24.2-linux.tgz
+$ cd android-sdk-linux
+$ mkdir -p licenses
+$ echo "8933bad161af4178b1185d1a37fbf41ea5269c55" >> licenses/android-sdk-license
+$ echo "d56f5187479451eabf01fb78af6dfcb131a6481e" >> licenses/android-sdk-license
+$ echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" >> licenses/android-sdk-license
+```
+
+Then run `pwd` and use the resulting value as `ANDROID_SDK_ROOT`
+
+### Configuring Java ###
+
+You will need `JAVA_HOME` set to a path to a JDK (which should not end in `/jre`).
+
 ## Android Studio ##
 
 If the environment variable `JAVA_HOME` is not defined, you will need to set it. If you would like to use the JDK installed by Android Studio, here's how to find it:


### PR DESCRIPTION
I'm not really an Android developer, so my system didn't have the Android SDK and JAVA_HOME setting required to build the project, and it wasn't quite clear how to obtain them (or that the Android SDK was actually a build dependency).

This adds material to the README that I had to work out by trial and error, and which may be helpful to the next inexperienced Android developer.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
