### PR TITLE
Bug 1657393 - add resource-monitoring toolchain

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,7 +7,7 @@ tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: 0c74426138739b1cad3bb4ff169af67eef6003fc
+              revision: d40a892a7c80367d001abb1b536fed76ee699b49
           trustDomain: mobile
       in:
           $let:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,7 +7,7 @@ tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: cab4565345d0d0effa66f18fe91335dd6d744031
+              revision: 0c74426138739b1cad3bb4ff169af67eef6003fc
           trustDomain: mobile
       in:
           $let:
@@ -295,7 +295,14 @@ tasks:
                                         type: 'directory'
                                         path: '/builds/worker/artifacts'
                                         expires: {$fromNow: '1 year'}
-
+                                    'public/docker-contexts':
+                                      type: 'directory'
+                                      path: '/builds/worker/checkouts/src/docker-contexts'
+                                      # This needs to be at least the deadline of the
+                                      # decision task + the docker-image task deadlines.
+                                      # It is set to a week to allow for some time for
+                                      # debugging, but they are not useful long-term.
+                                      expires: {$fromNow: '7 day'}
                             extra:
                                 $merge:
                                     - treeherder:

--- a/taskcluster/ci/build-samples-browser/kind.yml
+++ b/taskcluster/ci/build-samples-browser/kind.yml
@@ -16,6 +16,7 @@ kind-dependencies:
 
 job-defaults:
     attributes:
+        resource-monitor: true
         build-type: regular
         code-review: true
         component: samples-browser

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -45,6 +45,7 @@ job-defaults:
         name: public/github/customCheckRunText.md
         path: '/builds/worker/github/customCheckRunText.md'
     attributes:
+        resource-monitor: true
         code-review:
             by-build-type:
                 release: false

--- a/taskcluster/ci/complete/kind.yml
+++ b/taskcluster/ci/complete/kind.yml
@@ -18,7 +18,6 @@ transforms:
 
 job-defaults:
     attributes:
-        resource-monitor: true
         code-review: true
     worker-type: b-android
     worker:

--- a/taskcluster/ci/complete/kind.yml
+++ b/taskcluster/ci/complete/kind.yml
@@ -18,6 +18,7 @@ transforms:
 
 job-defaults:
     attributes:
+        resource-monitor: true
         code-review: true
     worker-type: b-android
     worker:

--- a/taskcluster/ci/fetch/kind.yml
+++ b/taskcluster/ci/fetch/kind.yml
@@ -23,3 +23,16 @@ jobs:
             size: 136964098
         artifact-prefix: mobile/android-sdk
         fetch-alias: android-sdk
+    go-1.14.4:
+        description: Golang 1.14.4 build tools
+        fetch:
+            type: static-url
+            url: https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz
+            sha256: aed845e4185a0b2a3c3d5e1d0a35491702c55889192bb9c30e67a3de6849c067
+            size: 123711003
+    resource-monitor:
+        description: Resource monitoring tools
+        fetch:
+            type: git
+            repo: https://github.com/mozilla-releng/resource-monitor
+            revision: 17371502a3b04579375d707844e6bf08dee95d22

--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -14,6 +14,7 @@ kind-dependencies:
 
 job-defaults:
     attributes:
+        resource-monitor: true
         build-type: debug
         code-review: true
     fetches:

--- a/taskcluster/ci/toolchain/kind.yml
+++ b/taskcluster/ci/toolchain/kind.yml
@@ -15,3 +15,4 @@ transforms:
 
 jobs-from:
     - android.yml
+    - resourcemonitor.yml

--- a/taskcluster/ci/toolchain/resourcemonitor.yml
+++ b/taskcluster/ci/toolchain/resourcemonitor.yml
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+job-defaults:
+    fetches:
+        fetch:
+            - go-1.14.4
+            - resource-monitor
+    run:
+        script: build-resourcemonitor.sh
+        sparse-profile: null
+        toolchain-artifact: public/build/resource-monitor.tar.xz
+
+linux64-resource-monitor:
+    description: "linux64 resourcemonitor toolchain build"
+    run:
+        arguments: ['linux64']

--- a/taskcluster/ci/toolchain/resourcemonitor.yml
+++ b/taskcluster/ci/toolchain/resourcemonitor.yml
@@ -8,11 +8,22 @@ job-defaults:
             - go-1.14.4
             - resource-monitor
     run:
+        using: toolchain-script
         script: build-resourcemonitor.sh
         sparse-profile: null
         toolchain-artifact: public/build/resource-monitor.tar.xz
+    treeherder:
+        kind: build
+        platform: toolchains/opt
+        tier: 1
+    worker-type: b-android
+    worker:
+        docker-image: {in-tree: base}
+        max-run-time: 600
 
 linux64-resource-monitor:
     description: "linux64 resourcemonitor toolchain build"
     run:
         arguments: ['linux64']
+    treeherder:
+        symbol: TL(linux-resource-monitor)

--- a/taskcluster/docker/android-build/Dockerfile
+++ b/taskcluster/docker/android-build/Dockerfile
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# %ARG DOCKER_IMAGE_PARENT
 FROM $DOCKER_IMAGE_PARENT
 
 MAINTAINER Johan Lorenzo <jlorenzo+tc@mozilla.com>

--- a/taskcluster/docker/base/Dockerfile
+++ b/taskcluster/docker/base/Dockerfile
@@ -45,7 +45,10 @@ RUN apt-get update -qq \
     && apt-get clean
 
 RUN pip install --upgrade pip
-RUN pip install taskcluster
+RUN pip install \
+    taskcluster
+    # Required to manipulate archiving operations in fetch tasks for git repos
+    zstandard
 
 RUN locale-gen "$LANG"
 

--- a/taskcluster/docker/base/Dockerfile
+++ b/taskcluster/docker/base/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update -qq \
 
 RUN pip install --upgrade pip
 RUN pip install \
-    taskcluster
+    taskcluster \
     # Required to manipulate archiving operations in fetch tasks for git repos
     zstandard
 

--- a/taskcluster/docker/ui-tests/Dockerfile
+++ b/taskcluster/docker/ui-tests/Dockerfile
@@ -1,4 +1,3 @@
-# %ARG DOCKER_IMAGE_PARENT
 FROM $DOCKER_IMAGE_PARENT
 
 LABEL authors="Richard Pappalardo <rpappalax@gmail.com>, Aaron Train <atrain@mozilla.com>"

--- a/taskcluster/scripts/toolchain/build-resourcemonitor.sh
+++ b/taskcluster/scripts/toolchain/build-resourcemonitor.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -x -e -v
+
+COMPRESS_EXT=xz
+EXE_SUFFIX=""
+
+PATH="$MOZ_FETCHES_DIR/go/bin:$PATH"
+export PATH
+
+# Bug 1425787: in the Github world we're only building Linux toolchain for now,
+# but for consistency we're backporting all platforms
+case "$1" in
+    linux64)   GOOS=linux; GOARCH=amd64 ;;
+    macos64)   GOOS=darwin; GOARCH=amd64 ;;
+    windows64) GOOS=windows; GOARCH=amd64; EXE_SUFFIX=".exe" ;;
+    windows32) GOOS=windows; GOARCH=386;   EXE_SUFFIX=".exe" ;;
+    *)
+        echo "Unknown architecture $1 not recognized in build-resourcemonitor.sh" >&2
+        exit 1
+    ;;
+esac
+
+export GOOS
+export GOARCH
+export EXE_SUFFIX
+
+echo "GOOS=$GOOS"
+echo "GOARCH=$GOARCH"
+
+# XXX: make sure we're in the right repo to be able to build
+cd "$MOZ_FETCHES_DIR"/resource-monitor || exit 1
+go build .
+
+STAGING_DIR="resource-monitor"
+mv "resource-monitor${EXE_SUFFIX}" resource-monitor.tmp
+mkdir "${STAGING_DIR}"
+
+cp resource-monitor.tmp "${STAGING_DIR}/resource-monitor${EXE_SUFFIX}"
+
+tar -acf "resource-monitor.tar.$COMPRESS_EXT" "${STAGING_DIR}"/
+mkdir -p "$UPLOAD_DIR"
+cp "resource-monitor.tar.$COMPRESS_EXT" "$UPLOAD_DIR"


### PR DESCRIPTION
RelEng has developed a tool to collect CPU/memory/DiskIO/Network usage for any tasks running `runtask`. It's now live and we're turning it on in this repo. This means that from now on, in Github-pull requests, master pushes and releases, the jobs are creating a `resource-monitor.json` at the end. This is collected automatically in BigQuery for us to analyze in order to infer better-fitted (price, powerload, etC) instance types for our workers. 

Once this lands on master pushes and the level-3 toolchains are generated, we'll no longer schedule the individual fetch/toolchain tasks but cache instead.