### PR TITLE
Closes #8065: Support subdomain stripping for "mobile." URLs

### DIFF
--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksInterceptor.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksInterceptor.kt
@@ -16,7 +16,8 @@ import mozilla.components.feature.app.links.AppLinksUseCases.Companion.ENGINE_SU
 import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
 
 private const val WWW = "www."
-private const val MOBILE = "m."
+private const val M = "m."
+private const val MOBILE = "mobile."
 
 /**
  * This feature implements use cases for detecting and handling redirects to external apps. The user
@@ -146,6 +147,7 @@ class AppLinksInterceptor(
         return when {
             url == null -> return null
             url.startsWith(WWW) -> url.replaceFirst(WWW, "")
+            url.startsWith(M) -> url.replaceFirst(M, "")
             url.startsWith(MOBILE) -> url.replaceFirst(MOBILE, "")
             else -> url
         }

--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksInterceptorTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksInterceptorTest.kt
@@ -149,6 +149,9 @@ class AppLinksInterceptorTest {
 
         response = appLinksInterceptor.onLoadRequest(mockEngineSession, "http://m.example.com", "https://www.example.com", true, true, true, false, false)
         assertEquals(null, response)
+
+        response = appLinksInterceptor.onLoadRequest(mockEngineSession, "http://mobile.example.com", "http://m.example.com", true, true, true, false, false)
+        assertEquals(null, response)
     }
 
     @Test


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
