### PR TITLE
Fix error message when the version in the tag does not match what is …

### DIFF
--- a/taskcluster/ac_taskgraph/__init__.py
+++ b/taskcluster/ac_taskgraph/__init__.py
@@ -58,6 +58,6 @@ def get_decision_parameters(graph_config, parameters):
         if head_tag[1:] != version:
             raise ValueError(
                 "Cannot run github-release if tag {} is different than in-tree "
-                "{version} from buildconfig.yml".format(head_tag[1:], version)
+                "{} from buildconfig.yml".format(head_tag[1:], version)
             )
         parameters["target_tasks_method"] = "release"


### PR DESCRIPTION
…on .buildconfig.yml

Follows #7555 up.

Fixes[1]

```
[task 2020-08-10T09:20:55.042Z]   File "taskcluster/ac_taskgraph/__init__.py", line 61, in get_decision_parameters
[task 2020-08-10T09:20:55.043Z]     "{version} from buildconfig.yml".format(head_tag[1:], version)
[task 2020-08-10T09:20:55.043Z] KeyError: u'version'
```

[1] https://firefox-ci-tc.services.mozilla.com/tasks/QFVrI65XRCyYorEnDX75FQ/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FQFVrI65XRCyYorEnDX75FQ%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log#L2958

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
