### PR TITLE
For #7725 - Expose the result of sending tabs

### DIFF
--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/Devices.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/Devices.kt
@@ -70,7 +70,10 @@ interface DeviceConstellation : Observable<AccountEventsObserver> {
      * @param outgoingCommand An event to send.
      * @return A [Deferred] that will be resolved with a success flag once operation is complete.
      */
-    fun sendCommandToDeviceAsync(targetDeviceId: String, outgoingCommand: DeviceCommandOutgoing): Deferred<Boolean>
+    fun sendCommandToDeviceAsync(
+        targetDeviceId: String,
+        outgoingCommand: DeviceCommandOutgoing
+    ): Deferred<FxaOperationResult>
 
     /**
      * Process a raw event, obtained via a push message or some other out-of-band mechanism.

--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/FxaOperationResult.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/FxaOperationResult.kt
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.sync
+
+/**
+ * Possible outcomes of a FXA operation.
+ */
+sealed class FxaOperationResult {
+    /**
+     * Operation completed successfully.
+     */
+    object Success : FxaOperationResult()
+
+    /**
+     * Operation was unsuccessful.
+     *
+     * @param reason [FxaException] specific subclass identifying what caused to operation to fail.
+     * May contain an optional [String] with more details.
+     */
+    class Failure(val reason: FxaException) : FxaOperationResult()
+}
+
+/**
+ * Reasons for why a certain FXA operation failed.
+ */
+@Suppress("UNUSED_PARAMETER")
+sealed class FxaException {
+    /**
+     * Operation failed because of a network problem.
+     * The network issue may be actionable by the user.
+     */
+    class FxaNetworkException(reason: String?) : FxaException()
+
+    /**
+     * Operation failed because of auth issues.
+     */
+    class FxaUnauthorizedException(reason: String?) : FxaException()
+
+    /**
+     * Operation failed for an unknown reason.
+     */
+    class FxaUnspecifiedException(reason: String?) : FxaException()
+}

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
@@ -12,16 +12,17 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import mozilla.appservices.fxaclient.FirefoxAccount
+import mozilla.components.concept.sync.AccountEvent
+import mozilla.components.concept.sync.AccountEventsObserver
 import mozilla.components.concept.sync.ConstellationState
 import mozilla.components.concept.sync.Device
 import mozilla.components.concept.sync.DeviceCapability
+import mozilla.components.concept.sync.DeviceCommandOutgoing
 import mozilla.components.concept.sync.DeviceConstellation
 import mozilla.components.concept.sync.DeviceConstellationObserver
-import mozilla.components.concept.sync.AccountEvent
-import mozilla.components.concept.sync.AccountEventsObserver
-import mozilla.components.concept.sync.DeviceCommandOutgoing
 import mozilla.components.concept.sync.DevicePushSubscription
 import mozilla.components.concept.sync.DeviceType
+import mozilla.components.concept.sync.FxaOperationResult
 import mozilla.components.support.base.crash.CrashReporting
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.base.observer.Observable
@@ -108,9 +109,9 @@ class FxaDeviceConstellation(
     override fun sendCommandToDeviceAsync(
         targetDeviceId: String,
         outgoingCommand: DeviceCommandOutgoing
-    ): Deferred<Boolean> {
+    ): Deferred<FxaOperationResult> {
         return scope.async {
-            handleFxaExceptions(logger, "sending device command") {
+            executeFxaOperationAndGetResult(logger, "sending device command") {
                 when (outgoingCommand) {
                     is DeviceCommandOutgoing.SendTab -> {
                         account.sendSingleTab(targetDeviceId, outgoingCommand.title, outgoingCommand.url)

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Types.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Types.kt
@@ -18,6 +18,7 @@ import mozilla.components.concept.sync.AuthType
 import mozilla.components.concept.sync.Avatar
 import mozilla.components.concept.sync.DeviceCapability
 import mozilla.components.concept.sync.DeviceType
+import mozilla.components.concept.sync.FxaOperationResult
 import mozilla.components.concept.sync.InFlightMigrationState
 import mozilla.components.concept.sync.OAuthScopedKey
 import mozilla.components.concept.sync.SyncAuthInfo
@@ -247,4 +248,20 @@ fun MigrationState.into(): InFlightMigrationState {
         MigrationState.COPY_SESSION_TOKEN -> InFlightMigrationState.COPY_SESSION_TOKEN
         MigrationState.REUSE_SESSION_TOKEN -> InFlightMigrationState.REUSE_SESSION_TOKEN
     }
+}
+
+/**
+ * Simple mapper allowing FxaExceptions to be exposed to client of this module.
+ */
+fun FxaException.toFxaOperationResult(): FxaOperationResult {
+    return FxaOperationResult.Failure(
+        when (this) {
+            is FxaNetworkException ->
+                mozilla.components.concept.sync.FxaException.FxaNetworkException(stackTrace.toString())
+            is FxaUnauthorizedException ->
+                mozilla.components.concept.sync.FxaException.FxaUnauthorizedException(stackTrace.toString())
+            else ->
+                mozilla.components.concept.sync.FxaException.FxaUnspecifiedException(stackTrace.toString())
+        }
+    )
 }

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Utils.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Utils.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.fxa
 
+import mozilla.components.concept.sync.FxaOperationResult
 import mozilla.components.service.fxa.manager.GlobalAccountManager
 import mozilla.components.support.base.log.logger.Logger
 
@@ -68,6 +69,18 @@ suspend fun handleFxaExceptions(logger: Logger, operation: String, block: () -> 
         block()
         true
     })
+}
+
+/**
+ * Helper method that executes a FXA operation and returns a [FxaOperationResult]
+ * for success / failure allowing clients more granularity in how to handle such cases.
+ */
+suspend fun executeFxaOperationAndGetResult(logger: Logger, operation: String, block: () -> Unit):
+    FxaOperationResult {
+    return handleFxaExceptions(logger, operation, { it.toFxaOperationResult() }) {
+        block()
+        FxaOperationResult.Success
+    }
 }
 
 private fun shouldThrow(e: FxaException): Boolean {

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaDeviceConstellationTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaDeviceConstellationTest.kt
@@ -25,6 +25,7 @@ import mozilla.components.concept.sync.AccountEventsObserver
 import mozilla.components.concept.sync.AccountEvent
 import mozilla.components.concept.sync.DevicePushSubscription
 import mozilla.components.concept.sync.DeviceType
+import mozilla.components.concept.sync.FxaOperationResult
 import mozilla.components.concept.sync.TabData
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
@@ -168,9 +169,13 @@ class FxaDeviceConstellationTest {
     @Test
     fun `send command to device`() = runBlocking(coroutinesTestRule.testDispatcher) {
         `when`(account.gatherTelemetry()).thenReturn("{}")
-        assertTrue(constellation.sendCommandToDeviceAsync(
-            "targetID", DeviceCommandOutgoing.SendTab("Mozilla", "https://www.mozilla.org")
-        ).await())
+
+        assertEquals(
+            FxaOperationResult.Success,
+            constellation.sendCommandToDeviceAsync(
+                "targetID", DeviceCommandOutgoing.SendTab("Mozilla", "https://www.mozilla.org")
+            ).await()
+        )
 
         verify(account).sendSingleTab("targetID", "Mozilla", "https://www.mozilla.org")
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -34,6 +34,9 @@ permalink: /changelog/
 * **feature-prompts**
   * Replaced generic icon in `LoginDialogFragment` with site icon (keep the generic one as fallback)
 
+* **feature-accounts-push**
+  **This is a breaking change**: Changed the return type of sending tabs from a Boolean to FxaOperationResult that exposes more data about the end status of the operation.
+
 # 56.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v55.0.0...v56.0.0)


### PR DESCRIPTION
Needed for Fenix to log errors that might occur when sending tabs.
For proper logging we need to expose not just the success/failure status but
also the reason for why the operation failed, since there may be different
causes that need to be logged differently / acted upon differently.

Previously we would just fold the success/failure - true/false results of the
"share tab" operations. To be able to log exactly why sharing failed we need
the exact reasons exposed to the client.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
