### PR TITLE
Issue #7808 Expose cookie purging setting

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -546,6 +546,10 @@ class GeckoEngine(
                         if (cookieBehavior != value.cookiePolicy.id) {
                             cookieBehavior = value.cookiePolicy.id
                         }
+
+                        if (cookiePurging != value.cookiePurging) {
+                            setCookiePurging(value.cookiePurging)
+                        }
                     }
 
                     defaultSettings?.trackingProtectionPolicy = value

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicy.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicy.kt
@@ -19,6 +19,7 @@ fun TrackingProtectionPolicy.toContentBlockingSetting(
     enhancedTrackingProtectionLevel(getEtpLevel())
     antiTracking(getAntiTrackingPolicy())
     cookieBehavior(cookiePolicy.id)
+    cookiePurging(cookiePurging)
     safeBrowsing(safeBrowsingPolicy.sumBy { it.id })
     strictSocialTrackingProtection(getStrictSocialTrackingProtection())
 }.build()

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -363,6 +363,27 @@ class GeckoEngineTest {
     }
 
     @Test
+    fun `cookiePurging is only invoked when the value is changed`() {
+        val mockRuntime = mock<GeckoRuntime>()
+        val settings = spy(ContentBlocking.Settings.Builder().build())
+        whenever(mockRuntime.settings).thenReturn(mock())
+        whenever(mockRuntime.settings.contentBlocking).thenReturn(settings)
+
+        val engine = GeckoEngine(testContext, runtime = mockRuntime)
+        val policy = TrackingProtectionPolicy.recommended()
+
+        engine.settings.trackingProtectionPolicy = policy
+
+        verify(mockRuntime.settings.contentBlocking).setCookiePurging(policy.cookiePurging)
+
+        reset(settings)
+
+        engine.settings.trackingProtectionPolicy = policy
+
+        verify(mockRuntime.settings.contentBlocking, never()).setCookiePurging(policy.cookiePurging)
+    }
+
+    @Test
     fun `setCookieBehavior is only invoked when the value is changed`() {
         val mockRuntime = mock<GeckoRuntime>()
         val settings = spy(ContentBlocking.Settings.Builder().build())

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicyKtTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicyKtTest.kt
@@ -27,7 +27,8 @@ class TrackingProtectionPolicyKtTest {
         assertEquals(policy.getAntiTrackingPolicy(), setting.antiTrackingCategories)
         assertEquals(policy.cookiePolicy.id, setting.cookieBehavior)
         assertEquals(defaultSafeBrowsing.sumBy { it.id }, setting.safeBrowsingCategories)
-        assertEquals(setting.strictSocialTrackingProtection, setting.strictSocialTrackingProtection)
+        assertEquals(setting.strictSocialTrackingProtection, policy.strictSocialTrackingProtection)
+        assertEquals(setting.cookiePurging, policy.cookiePurging)
 
         val policyWithSafeBrowsing = TrackingProtectionPolicy.recommended().toContentBlockingSetting(emptyArray())
         assertEquals(0, policyWithSafeBrowsing.safeBrowsingCategories)

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -178,12 +178,14 @@ abstract class EngineSession(
      * a [TrackingProtectionPolicy] is applicable to all session types (see
      * [TrackingProtectionPolicyForSessionTypes]).
      */
+    @Suppress("LongParameterList")
     open class TrackingProtectionPolicy internal constructor(
         val trackingCategories: Array<TrackingCategory> = arrayOf(TrackingCategory.RECOMMENDED),
         val useForPrivateSessions: Boolean = true,
         val useForRegularSessions: Boolean = true,
         val cookiePolicy: CookiePolicy = ACCEPT_NON_TRACKERS,
-        val strictSocialTrackingProtection: Boolean? = null
+        val strictSocialTrackingProtection: Boolean? = null,
+        val cookiePurging: Boolean = false
     ) {
 
         /**
@@ -297,7 +299,8 @@ abstract class EngineSession(
             fun strict() = TrackingProtectionPolicyForSessionTypes(
                 trackingCategory = arrayOf(TrackingCategory.STRICT),
                 cookiePolicy = ACCEPT_NON_TRACKERS,
-                strictSocialTrackingProtection = true
+                strictSocialTrackingProtection = true,
+                cookiePurging = true
             )
 
             /**
@@ -308,17 +311,32 @@ abstract class EngineSession(
             fun recommended() = TrackingProtectionPolicyForSessionTypes(
                 trackingCategory = arrayOf(TrackingCategory.RECOMMENDED),
                 cookiePolicy = ACCEPT_NON_TRACKERS,
-                strictSocialTrackingProtection = false
+                strictSocialTrackingProtection = false,
+                cookiePurging = true
             )
 
+            /**
+            *  Creates a custom [TrackingProtectionPolicyForSessionTypes] using the provide values .
+            *  @param trackingCategories a list of tracking categories to apply.
+            *  @param cookiePolicy indicate how cookies should behave for this policy.
+            *  @param strictSocialTrackingProtection indicate  if content should be blocked from the
+            *  social-tracking-protection-digest256 list, when given a null value,
+            *  it is only applied when the [EngineSession.TrackingProtectionPolicy.TrackingCategory.STRICT]
+            *  is set.
+            *  @param cookiePurging Whether or not to automatically purge tracking cookies. This will
+            *  purge cookies from tracking sites that do not have recent user interaction provided.
+            */
+            @Suppress("LongParameterList")
             fun select(
                 trackingCategories: Array<TrackingCategory> = arrayOf(TrackingCategory.RECOMMENDED),
                 cookiePolicy: CookiePolicy = ACCEPT_NON_TRACKERS,
-                strictSocialTrackingProtection: Boolean? = null
+                strictSocialTrackingProtection: Boolean? = null,
+                cookiePurging: Boolean = false
             ) = TrackingProtectionPolicyForSessionTypes(
                 trackingCategories,
                 cookiePolicy,
-                strictSocialTrackingProtection
+                strictSocialTrackingProtection,
+                cookiePurging = cookiePurging
             )
         }
 
@@ -346,15 +364,19 @@ abstract class EngineSession(
      *  social-tracking-protection-digest256 list, when given a null value,
      *  it is only applied when the [EngineSession.TrackingProtectionPolicy.TrackingCategory.STRICT]
      *  is set.
+     *  @param cookiePurging Whether or not to automatically purge tracking cookies. This will
+     *  purge cookies from tracking sites that do not have recent user interaction provided.
      */
     class TrackingProtectionPolicyForSessionTypes internal constructor(
         trackingCategory: Array<TrackingCategory> = arrayOf(TrackingCategory.RECOMMENDED),
         cookiePolicy: CookiePolicy = ACCEPT_NON_TRACKERS,
-        strictSocialTrackingProtection: Boolean? = null
+        strictSocialTrackingProtection: Boolean? = null,
+        cookiePurging: Boolean = false
     ) : TrackingProtectionPolicy(
         trackingCategories = trackingCategory,
         cookiePolicy = cookiePolicy,
-        strictSocialTrackingProtection = strictSocialTrackingProtection
+        strictSocialTrackingProtection = strictSocialTrackingProtection,
+        cookiePurging = cookiePurging
     ) {
         /**
          * Marks this policy to be used for private sessions only.
@@ -364,7 +386,8 @@ abstract class EngineSession(
             useForPrivateSessions = true,
             useForRegularSessions = false,
             cookiePolicy = cookiePolicy,
-            strictSocialTrackingProtection = strictSocialTrackingProtection
+            strictSocialTrackingProtection = strictSocialTrackingProtection,
+            cookiePurging = cookiePurging
         )
 
         /**
@@ -375,7 +398,8 @@ abstract class EngineSession(
             useForPrivateSessions = false,
             useForRegularSessions = true,
             cookiePolicy = cookiePolicy,
-            strictSocialTrackingProtection = strictSocialTrackingProtection
+            strictSocialTrackingProtection = strictSocialTrackingProtection,
+            cookiePurging = cookiePurging
         )
     }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,6 +33,12 @@ permalink: /changelog/
 * **browser-menu**
   * ⚠️ **This is a breaking change**: Removed `SimpleBrowserMenuHighlightableItem.itemType`. Use a WeakMap instead if you need to attach private data.
 
+* **concept-engine**
+  * Added the `cookiePurging` property to `TrackingProtectionPolicy` and `TrackingProtectionPolicyForSessionTypes` constructors to enable/disable cookie purging feature read more about it [here](https://blog.mozilla.org/blog/2020/08/04/latest-firefox-rolls-out-enhanced-tracking-protection-2-0-blocking-redirect-trackers-by-default/).
+
+* **browser-engine-nightly**
+  * Added `cookiePurging` to `TrackingProtectionPolicy.toContentBlockingSetting`.
+
 # 53.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v52.0.0...v53.0.0)


### PR DESCRIPTION
 Allow consumers of AC to enable/disable [the cookie purging feature](https://blog.mozilla.org/blog/2020/08/04/latest-firefox-rolls-out-enhanced-tracking-protection-2-0-blocking-redirect-trackers-by-default/)

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
