### PR TITLE
Closes issue #7983: Generate a file name when the content provider doesn't provide one.

### DIFF
--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -13,6 +13,7 @@ import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.prompt.PromptRequest.MultipleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.SingleChoice
 import mozilla.components.support.ktx.kotlin.toDate
+import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.whenever
@@ -24,6 +25,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.doReturn
 import org.mozilla.gecko.util.GeckoBundle
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoSession
@@ -35,7 +38,6 @@ import org.mozilla.geckoview.GeckoSession.PromptDelegate.DateTimePrompt.Type.WEE
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.FilePrompt.Capture.ANY
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.FilePrompt.Capture.NONE
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.FilePrompt.Capture.USER
-import org.robolectric.Shadows.shadowOf
 import java.io.FileInputStream
 import java.security.InvalidParameterException
 import java.util.Calendar
@@ -549,20 +551,24 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `Calling onFilePrompt must provide a FilePicker PromptRequest`() {
-        val context = testContext
-
+        val context = spy(testContext)
+        val contentResolver = spy(context.contentResolver)
         val mockSession = GeckoEngineSession(runtime)
         var onSingleFileSelectedWasCalled = false
         var onMultipleFilesSelectedWasCalled = false
         var onDismissWasCalled = false
         val mockUri: Uri = mock()
-        val mockFileInput: FileInputStream = mock()
-        val shadowContentResolver = shadowOf(context.contentResolver)
 
-        shadowContentResolver.registerInputStream(mockUri, mockFileInput)
+        doReturn(contentResolver).`when`(context).contentResolver
+        doReturn(mock<FileInputStream>()).`when`(contentResolver).openInputStream(mozilla.components.support.test.any())
+
         var filePickerRequest: PromptRequest.File = mock()
 
-        val promptDelegate = GeckoPromptDelegate(mockSession)
+        val promptDelegate = spy(GeckoPromptDelegate(mockSession))
+
+        // Prevent the file from being copied
+        doReturn(0L).`when`(promptDelegate).copyFile(any(), any())
+
         mockSession.register(object : EngineSession.Observer {
             override fun onPromptRequest(promptRequest: PromptRequest) {
                 filePickerRequest = promptRequest as PromptRequest.File

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -13,6 +13,7 @@ import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.prompt.PromptRequest.MultipleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.SingleChoice
 import mozilla.components.support.ktx.kotlin.toDate
+import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.whenever
@@ -24,6 +25,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.doReturn
 import org.mozilla.gecko.util.GeckoBundle
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoSession
@@ -35,7 +38,6 @@ import org.mozilla.geckoview.GeckoSession.PromptDelegate.DateTimePrompt.Type.WEE
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.FilePrompt.Capture.ANY
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.FilePrompt.Capture.NONE
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.FilePrompt.Capture.USER
-import org.robolectric.Shadows.shadowOf
 import java.io.FileInputStream
 import java.security.InvalidParameterException
 import java.util.Calendar
@@ -549,20 +551,24 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `Calling onFilePrompt must provide a FilePicker PromptRequest`() {
-        val context = testContext
-
+        val context = spy(testContext)
+        val contentResolver = spy(context.contentResolver)
         val mockSession = GeckoEngineSession(runtime)
         var onSingleFileSelectedWasCalled = false
         var onMultipleFilesSelectedWasCalled = false
         var onDismissWasCalled = false
         val mockUri: Uri = mock()
-        val mockFileInput: FileInputStream = mock()
-        val shadowContentResolver = shadowOf(context.contentResolver)
 
-        shadowContentResolver.registerInputStream(mockUri, mockFileInput)
+        doReturn(contentResolver).`when`(context).contentResolver
+        doReturn(mock<FileInputStream>()).`when`(contentResolver).openInputStream(any())
+
         var filePickerRequest: PromptRequest.File = mock()
 
-        val promptDelegate = GeckoPromptDelegate(mockSession)
+        val promptDelegate = spy(GeckoPromptDelegate(mockSession))
+
+        // Prevent the file from being copied
+        doReturn(0L).`when`(promptDelegate).copyFile(any(), any())
+
         mockSession.register(object : EngineSession.Observer {
             override fun onPromptRequest(promptRequest: PromptRequest) {
                 filePickerRequest = promptRequest as PromptRequest.File

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,8 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **browser-engine-gecko**, **browser-engine-gecko-beta**, **browser-engine-gecko-nightly**
+  * Fixed issue [#7983](https://github.com/mozilla-mobile/android-components/issues/7983), crash when a file name wasn't provided when uploading a file.
 
 # 54.0.0
 


### PR DESCRIPTION
When we get an `uri` from a file provider, we were trusting the provider to always provide a valid file name (`DISPLAY_NAME`) that is not always true, as we can see crashes on https://github.com/mozilla-mobile/android-components/issues/7983, now when we can't find the file name, we are trying to generate a file name as it's required for the [file to be updated](https://github.com/mozilla-mobile/android-components/blob/0aff44eb2797c05d7bc28edc9cb0ebc5409371b4/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt#L541).

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
