### PR TITLE
Close #8115: Add onTabsUpdated to TabsTray.Observer

### DIFF
--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsAdapter.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsAdapter.kt
@@ -54,6 +54,8 @@ open class TabsAdapter(
 
     override fun updateTabs(tabs: Tabs) {
         this.tabs = tabs
+
+        notifyObservers { onTabsUpdated() }
     }
 
     override fun onTabsInserted(position: Int, count: Int) = notifyItemRangeInserted(position, count)

--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/ext/TabsAdapter.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/ext/TabsAdapter.kt
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.tabstray.ext
+
+import mozilla.components.browser.tabstray.TabsAdapter
+import mozilla.components.concept.tabstray.Tab
+import mozilla.components.concept.tabstray.TabsTray
+
+/**
+ * Performs the given action when the [TabsTray.Observer.onTabsUpdated] is invoked.
+ *
+ * The action will only be invoked once and then removed.
+ */
+inline fun TabsAdapter.doOnTabsUpdated(crossinline action: () -> Unit) {
+    register(object : TabsTray.Observer {
+        override fun onTabsUpdated() {
+            unregister(this)
+            action()
+        }
+
+        override fun onTabSelected(tab: Tab) = Unit
+        override fun onTabClosed(tab: Tab) = Unit
+    })
+}

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabsAdapterTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabsAdapterTest.kt
@@ -114,4 +114,25 @@ class TabsAdapterTest {
         adapter.onTabsChanged(42, 78)
         verify(adapter).notifyItemRangeChanged(42, 78)
     }
+
+    @Test
+    fun `tabs updated notifies observers`() {
+        val adapter = TabsAdapter()
+        val observer: TabsTray.Observer = mock()
+
+        adapter.register(observer)
+
+        adapter.updateTabs(
+            Tabs(
+                list = listOf(
+                    Tab("A", "https://www.mozilla.org"),
+                    Tab("B", "https://www.firefox.com"),
+                    Tab("C", "https://getpocket.com")
+                ),
+                selectedIndex = 0
+            )
+        )
+
+        verify(observer).onTabsUpdated()
+    }
 }

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/ext/TabsAdapterKtTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/ext/TabsAdapterKtTest.kt
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.tabstray.ext
+
+import mozilla.components.browser.tabstray.TabsAdapter
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class TabsAdapterKtTest {
+
+    @Test
+    fun `doOnTabsUpdated is invoked once`() {
+        val adapter = TabsAdapter()
+        var invokedCount = 0
+
+        adapter.doOnTabsUpdated {
+            invokedCount++
+        }
+
+        assertEquals(0, invokedCount)
+
+        adapter.notifyObservers { onTabsUpdated() }
+
+        assertEquals(1, invokedCount)
+
+        adapter.notifyObservers { onTabsUpdated() }
+
+        assertEquals(1, invokedCount)
+        assertFalse(adapter.isObserved())
+    }
+}

--- a/components/concept/tabstray/src/main/java/mozilla/components/concept/tabstray/TabsTray.kt
+++ b/components/concept/tabstray/src/main/java/mozilla/components/concept/tabstray/TabsTray.kt
@@ -16,6 +16,11 @@ interface TabsTray : Observable<TabsTray.Observer> {
      */
     interface Observer {
         /**
+         * One or many tabs have been added or removed.
+         */
+        fun onTabsUpdated() = Unit
+
+        /**
          * A new tab has been selected.
          */
         fun onTabSelected(tab: Tab)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,11 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **concept-tabstray**
+  * Added `onTabsUpdated` to `TabsTray.Observer` for notifying observers when one or more tabs have been added/removed.
+
+* **browser-tabstray**
+  * Added the convenience function `TabsAdapter.doOnTabsUpdated` for performing actions only once when the tabs are updated.
 
 # 55.0.0
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Closes #8115 

Added a convenience function as well, as I've noticed that there are times when we want to apply one-time functions after the tabs have loaded like in [this case](https://searchfox.org/mozilla-mobile/rev/caf6c9c63a24845399cfac0ddc6c3027974d0adc/fenix/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt#159-160) in Fenix.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
