### PR TITLE
Close #8067: Add usage documentation on how to setup feature-thumbnails

### DIFF
--- a/components/browser/thumbnails/README.md
+++ b/components/browser/thumbnails/README.md
@@ -12,6 +12,68 @@ Use Gradle to download the library from [maven.mozilla.org](https://maven.mozill
 implementation "org.mozilla.components:browser-thumbnails:{latest-version}"
 ```
 
+## Requesting thumbnails
+
+To get thumbnail images from the browser, we need to request them from the `EngineView`. This can
+be done easily by using `BrowserThumbnails` which will then notify the `BrowserStore` when a
+thumbnail has been received:
+
+```kotlin
+browserThumbnails.set(
+    feature = BrowserThumbnails(context, layout.engineView, browserStore),
+    owner = this,
+    view = layout
+)
+```
+
+`BrowserThumbnails` tries to make requests as frequent as possible in order to get the most
+up-to-date state of the site in the images.
+
+The various situations when we try to request a thumbnail:
+ - During the Android lifecycle event `onStart`.
+ - When the selected tab's `loading` state changes.
+ - More to be added..
+
+## Storing to disk
+
+When we receive new thumbnails, we may want to persist them to disk as these images can be quite large.
+
+To do this, we need to add the `BrowserMiddleware` to receive the image from the store 
+and put it in our storage:
+
+```kotlin
+val thumbnailStorage by lazy { ThumbnailStorage(applicationContext) }
+
+val store by lazy {
+    BrowserStore(middleware = listOf(
+        ThumbnailsMiddleware(thumbnailStorage)
+    ))
+}
+```
+
+## Loading from disk
+
+Now that we have the thumbnails stored to disk, we can access them via the `ThumbnailStorage`
+directly:
+
+```kotlin
+runBlocking {
+    val bitmap = thumbnailStorage.loadThumbnail(
+      request = ImageLoadRequest("thumbnailId", maxPreferredImageDimen)
+    )
+}
+```
+
+A better way, is to use the `ThumbnailLoader`:
+
+```kotlin
+val thumbnailLoader = ThumbnailLoader(components.thumbnailStorage)
+thumbnailLoader.loadIntoView(
+    view = thumbnailView,
+    request = ImageLoadRequest(id = tab.id, size = thumbnailSize)
+)
+```
+
 ## License
 
     This Source Code Form is subject to the terms of the Mozilla Public


### PR DESCRIPTION
Setting up thumbnails for the first time is more complex than our other
features, so having more documentation on how to do this is always good!

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
Closes #8067

@pocmo you might be interested in also taking a peek at this as well. I noticed it wasn't a straight-forward API when integrating the first time. ❄️ 🐜 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
