### PR TITLE
Update GeckoView (release) to 79.0.20200813192915.

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -16,7 +16,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Release Version.
      */
-    const val release_version = "79.0.20200720193547"
+    const val release_version = "79.0.20200813192915"
 }
 
 @Suppress("Unused", "MaxLineLength")


### PR DESCRIPTION
A new GeckoView 79.0 was released to fix some crashes.