### PR TITLE
Closes #7204: Allow to substitute GeckoView in all projects.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,14 @@ subprojects {
         apply from: "${rootProject.projectDir}/${appServicesSrcDir}/build-scripts/substitute-local-appservices.gradle"
     }
 
+    if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopsrcdir')) {
+        if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopobjdir')) {
+            ext.topobjdir = gradle."localProperties.dependencySubstitutions.geckoviewTopobjdir"
+        }
+        ext.topsrcdir = gradle."localProperties.dependencySubstitutions.geckoviewTopsrcdir"
+        apply from: "${topsrcdir}/substitute-local-geckoview.gradle"
+    }
+
     // Define a reusable task for updating the version in manifest.json for modules that package
     // a web extension. We automate this to make sure we never forget to update the version, either
     // in local development or for releases. In both cases, we want to make sure the latest version

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -154,13 +154,5 @@ dependencies {
     androidTestImplementation Dependencies.testing_mockwebserver
 }
 
-if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopsrcdir')) {
-    if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopobjdir')) {
-        ext.topobjdir = gradle."localProperties.dependencySubstitutions.geckoviewTopobjdir"
-    }
-    ext.topsrcdir = gradle."localProperties.dependencySubstitutions.geckoviewTopsrcdir"
-    apply from: "${topsrcdir}/substitute-local-geckoview.gradle"
-}
-
 preBuild.dependsOn updateBorderifyExtensionVersion
 preBuild.dependsOn updateTestExtensionVersion


### PR DESCRIPTION
In particular, this allows to substitute local GeckoView versions with
JVM-level API changes.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [n/a] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [n/a] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [n/a] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
