### PR TITLE
For mozilla-mobile/fenix#9056: Search with custom tab

### DIFF
--- a/components/feature/search/src/test/java/mozilla/components/feature/search/BrowserStoreSeachAdapterTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/BrowserStoreSeachAdapterTest.kt
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.search
+
+import mozilla.components.browser.state.action.ContentAction
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.createCustomTab
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.engine.search.SearchRequest
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+
+private const val SELECTED_TAB_ID = "1"
+private const val CUSTOM_TAB_ID = "2"
+
+class BrowserStoreSearchAdapterTest {
+
+    private lateinit var browserStore: BrowserStore
+    private val state = BrowserState(
+        tabs = listOf(createTab(id = SELECTED_TAB_ID, url = "https://mozilla.org", private = true)),
+        customTabs = listOf(createCustomTab(id = CUSTOM_TAB_ID, url = "https://firefox.com")),
+        selectedTabId = SELECTED_TAB_ID
+    )
+
+    @Before
+    fun setup() {
+        browserStore = mock()
+        whenever(browserStore.state).thenReturn(state)
+    }
+
+    @Test
+    fun `adapter does nothing with null tab`() {
+        whenever(browserStore.state).thenReturn(BrowserState())
+        val searchAdapter = BrowserStoreSearchAdapter(browserStore)
+
+        searchAdapter.sendSearch(isPrivate = false, text = "normal search")
+        searchAdapter.sendSearch(isPrivate = true, text = "private search")
+
+        verify(browserStore, never()).dispatch(any())
+        assertFalse(searchAdapter.isPrivateSession())
+    }
+
+    @Test
+    fun `sendSearch with selected tab`() {
+        val searchAdapter = BrowserStoreSearchAdapter(browserStore)
+        searchAdapter.sendSearch(isPrivate = false, text = "normal search")
+        verify(browserStore).dispatch(
+            ContentAction.UpdateSearchRequestAction(
+                SELECTED_TAB_ID,
+                SearchRequest(isPrivate = false, query = "normal search")
+            )
+        )
+
+        searchAdapter.sendSearch(isPrivate = true, text = "private search")
+        verify(browserStore).dispatch(
+            ContentAction.UpdateSearchRequestAction(
+                SELECTED_TAB_ID,
+                SearchRequest(isPrivate = true, query = "private search")
+            )
+        )
+
+        assertTrue(searchAdapter.isPrivateSession())
+    }
+
+    @Test
+    fun `sendSearch with custom tab`() {
+        val searchAdapter = BrowserStoreSearchAdapter(browserStore, CUSTOM_TAB_ID)
+        searchAdapter.sendSearch(isPrivate = false, text = "normal search")
+        verify(browserStore).dispatch(
+            ContentAction.UpdateSearchRequestAction(
+                CUSTOM_TAB_ID,
+                SearchRequest(isPrivate = false, query = "normal search")
+            )
+        )
+
+        searchAdapter.sendSearch(isPrivate = true, text = "private search")
+        verify(browserStore).dispatch(
+            ContentAction.UpdateSearchRequestAction(
+                CUSTOM_TAB_ID,
+                SearchRequest(isPrivate = true, query = "private search")
+            )
+        )
+
+        assertFalse(searchAdapter.isPrivateSession())
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **feature-search**
+  * ⚠️ **This is a breaking change**: `SearchFeature.performSearch` now takes a second parameter.
+  * `BrowserStoreSearchAdapter` and `SearchFeature` can now take a `tabId` parameter.
+
 # 56.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v55.0.0...v56.0.0)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -142,10 +142,11 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         )
 
         searchFeature.set(
-            feature = SearchFeature(components.store) {
-                when (it.isPrivate) {
-                    true -> components.searchUseCases.newPrivateTabSearch.invoke(it.query)
-                    false -> components.searchUseCases.newTabSearch.invoke(it.query)
+            feature = SearchFeature(components.store) { request, _ ->
+                if (request.isPrivate) {
+                    components.searchUseCases.newPrivateTabSearch.invoke(request.query)
+                } else {
+                    components.searchUseCases.newTabSearch.invoke(request.query)
                 }
             },
             owner = this,


### PR DESCRIPTION
We need to know if a search was started from a custom tab using the tabId, along with setting the tab ID for the search request.

Related Fenix PR: https://github.com/mozilla-mobile/fenix/pull/13903

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
