### PR TITLE
Closes issue #8042: Intermittent failing test in AbstractFetchDownloadService

### DIFF
--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadNotification.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadNotification.kt
@@ -49,7 +49,7 @@ internal object DownloadNotification {
         context: Context,
         notifications: List<DownloadJobState>
     ): Notification {
-        val allDownloadsHaveFinished = notifications.all { it.state.status != DOWNLOADING }
+        val allDownloadsHaveFinished = notifications.all { it.status != DOWNLOADING }
         val icon = if (allDownloadsHaveFinished) {
             R.drawable.mozac_feature_download_ic_download_complete
         } else {
@@ -79,7 +79,7 @@ internal object DownloadNotification {
         downloadJobState: DownloadJobState
     ): Notification {
         val downloadState = downloadJobState.state
-        val bytesCopied = downloadJobState.state.currentBytesCopied
+        val bytesCopied = downloadJobState.currentBytesCopied
         val channelId = ensureChannelExists(context)
         val isIndeterminate = downloadState.contentLength == null
 
@@ -280,7 +280,7 @@ internal fun NotificationCompat.Builder.setCompatGroup(groupKey: String): Notifi
 
 @VisibleForTesting
 internal fun DownloadJobState.getProgress(): String {
-    val bytesCopied = state.currentBytesCopied
+    val bytesCopied = currentBytesCopied
     val isIndeterminate = state.contentLength == null || bytesCopied == 0L
     return if (isIndeterminate) {
         ""
@@ -291,7 +291,7 @@ internal fun DownloadJobState.getProgress(): String {
 
 @VisibleForTesting
 internal fun DownloadJobState.getStatusDescription(context: Context): String {
-    return when (this.state.status) {
+    return when (this.status) {
         DOWNLOADING -> {
             getProgress()
         }

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadNotificationTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadNotificationTest.kt
@@ -27,7 +27,9 @@ class DownloadNotificationTest {
                         currentBytesCopied = 10,
                         status = DownloadState.Status.DOWNLOADING),
                 foregroundServiceId = 1,
-                downloadDeleted = false
+                downloadDeleted = false,
+                currentBytesCopied = 10,
+                status = DownloadState.Status.DOWNLOADING
         )
 
         assertEquals("10%", downloadJobState.getProgress())
@@ -65,7 +67,9 @@ class DownloadNotificationTest {
                         currentBytesCopied = 10,
                         status = DownloadState.Status.DOWNLOADING),
                 foregroundServiceId = 1,
-                downloadDeleted = false
+                downloadDeleted = false,
+                status = DownloadState.Status.DOWNLOADING,
+                currentBytesCopied = 10
         )
 
         assertEquals(downloadJobState.getProgress(), downloadJobState.getStatusDescription(testContext))
@@ -76,7 +80,8 @@ class DownloadNotificationTest {
                         currentBytesCopied = 10,
                         status = DownloadState.Status.PAUSED),
                 foregroundServiceId = 1,
-                downloadDeleted = false
+                downloadDeleted = false,
+                status = DownloadState.Status.PAUSED
         )
 
         assertEquals(pausedText, downloadJobState.getStatusDescription(testContext))
@@ -87,7 +92,8 @@ class DownloadNotificationTest {
                         currentBytesCopied = 10,
                         status = DownloadState.Status.COMPLETED),
                 foregroundServiceId = 1,
-                downloadDeleted = false
+                downloadDeleted = false,
+                status = DownloadState.Status.COMPLETED
         )
 
         assertEquals(completedText, downloadJobState.getStatusDescription(testContext))
@@ -98,7 +104,8 @@ class DownloadNotificationTest {
                         currentBytesCopied = 10,
                         status = DownloadState.Status.FAILED),
                 foregroundServiceId = 1,
-                downloadDeleted = false
+                downloadDeleted = false,
+                status = DownloadState.Status.FAILED
         )
 
         assertEquals(failedText, downloadJobState.getStatusDescription(testContext))
@@ -109,7 +116,8 @@ class DownloadNotificationTest {
                         currentBytesCopied = 10,
                         status = DownloadState.Status.CANCELLED),
                 foregroundServiceId = 1,
-                downloadDeleted = false
+                downloadDeleted = false,
+                status = DownloadState.Status.CANCELLED
         )
 
         assertEquals("", downloadJobState.getStatusDescription(testContext))
@@ -123,7 +131,9 @@ class DownloadNotificationTest {
                         currentBytesCopied = 10,
                         status = DownloadState.Status.DOWNLOADING),
                 foregroundServiceId = 1,
-                downloadDeleted = false
+                downloadDeleted = false,
+                currentBytesCopied = 10,
+                status = DownloadState.Status.DOWNLOADING
         )
         val download2 = DownloadJobState(
                 job = null,
@@ -131,7 +141,9 @@ class DownloadNotificationTest {
                         currentBytesCopied = 20,
                         status = DownloadState.Status.DOWNLOADING),
                 foregroundServiceId = 1,
-                downloadDeleted = false
+                downloadDeleted = false,
+                currentBytesCopied = 20,
+                status = DownloadState.Status.DOWNLOADING
         )
 
         val summary = DownloadNotification.getSummaryList(testContext, listOf(download1, download2))


### PR DESCRIPTION
We are adding back `currentBytesCopied`, and `status` to `AbstractFetchDownloadService` as in [this commit](https://github.com/mozilla-mobile/android-components/commit/1003535f8127b68b2b45688d8d098842b680da46) we removed them and started reading directly from the store, due to the async nature of the store reading directly from it doesn't warranty that values will be up today (if we want to do that we should observe the store), this caused the tests and the behaviour to be Intermittent. Refactoring the code will be a bigger effort, for the moment having these values duplicated is not a big lost, until we can invest into refactoring this piece, that will happen on https://github.com/mozilla-mobile/android-components/issues/8151.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
