### PR TITLE
Update flank-arm.yml with a device swap

### DIFF
--- a/automation/taskcluster/androidTest/flank-arm.yml
+++ b/automation/taskcluster/androidTest/flank-arm.yml
@@ -34,7 +34,7 @@ gcloud:
   performance-metrics: true
 
   device:
-   - model: walleye
+   - model: blueline
      version: 28
    - model: Nexus6
      version: 21


### PR DESCRIPTION
For https://github.com/mozilla-mobile/android-components/issues/8150

The Pixel 2 (walleye) is a very constrained device, so the queue can build up and take a long time on Firebase. The Pixel 3 (blueline) and Pixel 4 (flame) have a lot more capacity and will likely run much faster. I'll swap this to the Pixel 3 as its using the same API as the Pixel 2.