### PR TITLE
For #8175: Allow SuggestionProviders to specify a edit suggestion

### DIFF
--- a/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/layout/DefaultSuggestionViewHolder.kt
+++ b/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/layout/DefaultSuggestionViewHolder.kt
@@ -75,8 +75,13 @@ internal sealed class DefaultSuggestionViewHolder {
                 selectionListener.invoke()
             }
 
-            editView.setOnClickListener {
-                awesomeBar.editSuggestionListener?.invoke(title.toString())
+            if (suggestion.editSuggestion.isNullOrEmpty()) {
+                editView.visibility = View.GONE
+            } else {
+                editView.visibility = View.VISIBLE
+                editView.setOnClickListener {
+                    awesomeBar.editSuggestionListener?.invoke(suggestion.editSuggestion!!)
+                }
             }
         }
 

--- a/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/layout/DefaultSuggestionViewHolderTest.kt
+++ b/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/layout/DefaultSuggestionViewHolderTest.kt
@@ -113,13 +113,17 @@ class DefaultSuggestionViewHolderTest {
 
         val viewHolder = DefaultSuggestionViewHolder.Default(
                 BrowserAwesomeBar(testContext).apply {
-                    setOnEditSuggestionListener { callbackExecuted = true }
+                    setOnEditSuggestionListener {
+                        assertEquals("Hello World", it)
+                        callbackExecuted = true
+                    }
                 },
                 view
         )
 
         val suggestion = AwesomeBar.Suggestion(
-            mock()
+            mock(),
+            editSuggestion = "Hello World"
         )
 
         viewHolder.bind(suggestion) {
@@ -128,6 +132,29 @@ class DefaultSuggestionViewHolderTest {
 
         view.findViewById<View>(R.id.mozac_browser_awesomebar_edit_suggestion).performClick()
         assertTrue(callbackExecuted)
+    }
+
+    @Test
+    fun `Edit suggestion button is hidden when editSuggestion is empty`() {
+        val view = LayoutInflater.from(testContext).inflate(
+            R.layout.mozac_browser_awesomebar_item_generic, null, false)
+
+        val viewHolder = DefaultSuggestionViewHolder.Default(
+            BrowserAwesomeBar(testContext),
+            view
+        )
+
+        val suggestion = AwesomeBar.Suggestion(
+            mock(),
+            editSuggestion = ""
+        )
+
+        viewHolder.bind(suggestion) {
+            // Do nothing
+        }
+
+        val editSuggestionView = view.findViewById<View>(R.id.mozac_browser_awesomebar_edit_suggestion)
+        assertEquals(View.GONE, editSuggestionView.visibility)
     }
 
     @Test

--- a/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
+++ b/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
@@ -81,6 +81,7 @@ interface AwesomeBar {
      * animates showing the new suggestion.
      * @property title A user-readable title for the [Suggestion].
      * @property description A user-readable description for the [Suggestion].
+     * @property editSuggestion The string that will be set to the url bar when using the edit suggestion arrow.
      * @property icon A lambda that can be invoked by the [AwesomeBar] implementation to receive an icon [Bitmap] for
      * this [Suggestion]. The [AwesomeBar] will pass in its desired width and height for the Bitmap.
      * @property indicatorIcon A drawable for indicating different types of [Suggestion].
@@ -96,6 +97,7 @@ interface AwesomeBar {
         val id: String = UUID.randomUUID().toString(),
         val title: String? = null,
         val description: String? = null,
+        val editSuggestion: String? = null,
         val icon: Bitmap? = null,
         val indicatorIcon: Drawable? = null,
         val chips: List<Chip> = emptyList(),

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProvider.kt
@@ -69,6 +69,7 @@ class BookmarksStorageSuggestionProvider(
                 flags = setOf(AwesomeBar.Suggestion.Flag.BOOKMARK),
                 title = result.title,
                 description = result.url,
+                editSuggestion = result.url,
                 onSuggestionClicked = { loadUrlUseCase.invoke(result.url!!) }
             )
         }

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProvider.kt
@@ -60,6 +60,7 @@ class ClipboardSuggestionProvider(
             provider = this,
             id = url,
             description = url,
+            editSuggestion = url,
             flags = setOf(AwesomeBar.Suggestion.Flag.CLIPBOARD),
             icon = icon ?: context.getDrawable(R.drawable.mozac_ic_search)?.toBitmap(),
             title = title,

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProvider.kt
@@ -66,6 +66,7 @@ class HistoryStorageSuggestionProvider(
                 icon = icon?.await()?.bitmap,
                 title = result.title,
                 description = result.url,
+                editSuggestion = result.url,
                 score = result.score,
                 onSuggestionClicked = { loadUrlUseCase.invoke(result.url) }
             )

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProvider.kt
@@ -156,6 +156,7 @@ class SearchSuggestionProvider private constructor(
         }
     }
 
+    @Suppress("ComplexMethod")
     private fun createMultipleSuggestions(text: String, result: List<String>?): List<AwesomeBar.Suggestion> {
         val suggestions = mutableListOf<AwesomeBar.Suggestion>()
 
@@ -181,6 +182,8 @@ class SearchSuggestionProvider private constructor(
                 id = if (item == text) ID_OF_ENTERED_TEXT else item,
                 title = item,
                 description = description,
+                // Don't show an autocomplete arrow for the entered text
+                editSuggestion = if (item == text) null else item,
                 icon = icon ?: client.searchEngine?.icon,
                 score = Int.MAX_VALUE - (index + 1),
                 onSuggestionClicked = {


### PR DESCRIPTION
The edit suggestion arrow will only be shown if the suggestion is not null or empty. Tapping it autocompletes the suggestion, which can now be specified by the `SuggestionProvider`.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
