### PR TITLE
For #8188 - Expose BrowserIcons.clear() as a public API

### DIFF
--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/BrowserIcons.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/BrowserIcons.kt
@@ -238,7 +238,7 @@ class BrowserIcons(
      * If custom [IconLoader] and [IconProcessor] instances with a custom storage are provided to
      * [BrowserIcons] then the calling app is responsible for clearing that data.
      */
-    private fun clear() {
+    fun clear() {
         sharedDiskCache.clear(context)
         sharedMemoryCache.clear()
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -42,6 +42,9 @@ permalink: /changelog/
 * **ui-widgets**
   * Added widget for showing a website in a list, such as in bookmarks or history. The `mozac_primary_text_color` and `mozac_caption_text_color` attributes should be set.
 
+* **browser-icons**
+  * Expose `BrowserIcons.clear()` as a public API to remove all saved data from disk and memory caches.
+
 # 55.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v54.0.0...v55.0.0)


### PR DESCRIPTION
This allows removing all saved icons data from disk and memory caches.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR does not include any user facing features.

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
