### PR TITLE
for #8200 - renamed "users" to "reviews" in add-on manager

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
@@ -185,7 +185,7 @@ class AddonsManagerAdapter(
     internal fun bindAddon(holder: AddonViewHolder, addon: Addon) {
         val context = holder.itemView.context
         addon.rating?.let {
-            val userCount = context.getString(R.string.mozac_feature_addons_user_rating_count)
+            val userCount = context.getString(R.string.mozac_feature_addons_user_rating_count_2)
             val ratingContentDescription =
                 String.format(
                     context.getString(R.string.mozac_feature_addons_rating_content_description),

--- a/components/feature/addons/src/main/res/layout/mozac_feature_addons_item.xml
+++ b/components/feature/addons/src/main/res/layout/mozac_feature_addons_item.xml
@@ -102,7 +102,7 @@
                 android:layout_marginStart="6dp"
                 android:textSize="12sp"
                 android:layout_gravity="center_vertical"
-                tools:text="Users: 591,642" />
+                tools:text="Reviews: 591,642" />
 
         </LinearLayout>
 

--- a/components/feature/addons/src/main/res/values/strings.xml
+++ b/components/feature/addons/src/main/res/values/strings.xml
@@ -105,8 +105,8 @@
     <string name="mozac_feature_addons_install_addon_content_description">Install Add-on</string>
     <!-- This is the label of a button to cancel an ongoing add-on installation. -->
     <string name="mozac_feature_addons_install_addon_dialog_cancel">Cancel</string>
-    <!-- Indicates how many users have rated an add-on. %1$s will be replaced with number of users -->
-    <string name="mozac_feature_addons_user_rating_count">Users: %1$s</string>
+    <!-- Indicates how many users have rated an add-on. %1$s will be replaced with number of reviews -->
+    <string name="mozac_feature_addons_user_rating_count_2">Reviews: %1$s</string>
     <!-- Accessibility content description for the amount of stars that add-on has, where %1$.02f will be the amount of stars and / separator and 5 the maximum number of stars e.g (2/5, 4.5/5 or 5/5)  . -->
     <string name="mozac_feature_addons_rating_content_description">%1$.02f/5</string>
     <!-- This is the title of page where all the add-ons are listed-->


### PR DESCRIPTION
string change because the old string was misleading.