### PR TITLE
Avoid double layout in WidgetSiteItemView

### DIFF
--- a/components/ui/widgets/src/main/res/layout/mozac_widget_site_item.xml
+++ b/components/ui/widgets/src/main/res/layout/mozac_widget_site_item.xml
@@ -2,10 +2,11 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<androidx.constraintlayout.widget.ConstraintLayout
+<merge
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="@dimen/mozac_widget_site_item_height"
@@ -73,4 +74,4 @@
         app:layout_constraintStart_toEndOf="@id/label"
         app:layout_constraintEnd_toEndOf="parent" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</merge>


### PR DESCRIPTION
The parent class extends constraint layout, so the XML layout resource should use a `<merge>` tag.