### PR TITLE
Close #8232: Remove firebase-core dependency from lib-push-firebase

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -156,6 +156,5 @@ object Dependencies {
     const val thirdparty_jna = "net.java.dev.jna:jna:${Versions.jna}@jar"
     const val thirdparty_disklrucache = "com.jakewharton:disklrucache:${Versions.disklrucache}"
 
-    const val firebase_core = "com.google.firebase:firebase-core:${Versions.Firebase.core}"
     const val firebase_messaging = "com.google.firebase:firebase-messaging:${Versions.Firebase.messaging}"
 }

--- a/components/lib/push-firebase/build.gradle
+++ b/components/lib/push-firebase/build.gradle
@@ -28,7 +28,6 @@ dependencies {
     implementation project(':concept-push')
     implementation project(':support-base')
 
-    implementation Dependencies.firebase_core
     api Dependencies.firebase_messaging
 
     testImplementation project(':support-test')

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,9 @@ permalink: /changelog/
   * Implements TopSitesFeature based on the RFC [0006-top-sites-feature.md](https://github.com/mozilla-mobile/android-components/blob/master/docs/rfcs/0006-top-sites-feature.md).
   * Downloads, redirect targets, reloads, embedded resources, and frames are no longer considered for inclusion in top sites. Please see [this Application Services PR](https://github.com/mozilla/application-services/pull/3505) for more details.
 
+* **lib-push-firebase**
+  * Removed non-essential dependency on `com.google.firebase:firebase-core`.
+
 # 56.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v55.0.0...v56.0.0)


### PR DESCRIPTION
For Cloud Messaging, we no longer need `firebase-core` as a dependency. This removes unneeded services that can run on the device.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Closes #8232 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
