### PR TITLE
For #7832: Support concept-menu in custom tabs

### DIFF
--- a/components/feature/customtabs/build.gradle
+++ b/components/feature/customtabs/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation project(':browser-toolbar')
     implementation project(':concept-engine')
     implementation project(':concept-fetch')
+    implementation project(':concept-menu')
     implementation project(':feature-session')
     implementation project(':feature-intent')
     implementation project(':service-digitalassetlinks')

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
@@ -5,7 +5,6 @@
 package mozilla.components.feature.customtabs
 
 import android.app.PendingIntent
-import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.view.Window
@@ -13,7 +12,6 @@ import androidx.annotation.ColorInt
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.content.res.AppCompatResources.getDrawable
 import androidx.core.graphics.drawable.toDrawable
-import androidx.core.net.toUri
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.BrowserMenuItem
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
@@ -25,6 +23,7 @@ import mozilla.components.browser.state.state.CustomTabMenuItem
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.feature.customtabs.feature.CustomTabSessionTitleObserver
+import mozilla.components.feature.customtabs.menu.sendWithUrl
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.ktx.android.content.share
@@ -177,7 +176,7 @@ class CustomTabsToolbarFeature(
                 config.description
             ) {
                 emitActionButtonFact()
-                config.pendingIntent.sendWithSession(session)
+                config.pendingIntent.sendWithUrl(context, session.url)
             }
 
             toolbar.addBrowserAction(button)
@@ -216,7 +215,7 @@ class CustomTabsToolbarFeature(
     ) {
         menuItems.map { item ->
             SimpleBrowserMenuItem(item.name) {
-                item.pendingIntent.sendWithSession(session)
+                item.pendingIntent.sendWithUrl(context, session.url)
             }
         }.also { items ->
             val combinedItems = menuBuilder?.let { builder ->
@@ -253,10 +252,4 @@ class CustomTabsToolbarFeature(
             }
         }
     }
-
-    private fun PendingIntent.sendWithSession(session: Session) = send(
-        context,
-        0,
-        Intent(null, session.url.toUri())
-    )
 }

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/menu/CustomTabMenuCandidates.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/menu/CustomTabMenuCandidates.kt
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.customtabs.menu
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.net.toUri
+import mozilla.components.browser.state.state.CustomTabSessionState
+import mozilla.components.concept.menu.candidate.TextMenuCandidate
+
+/**
+ * Build menu items displayed when the 3-dot overflow menu is opened.
+ * These items are provided by the app that creates the custom tab,
+ * and should be inserted alongside menu items created by the browser.
+ */
+fun CustomTabSessionState.createCustomTabMenuCandidates(context: Context) =
+    config.menuItems.map { item ->
+        TextMenuCandidate(
+            text = item.name
+        ) {
+            item.pendingIntent.sendWithUrl(context, content.url)
+        }
+    }
+
+internal fun PendingIntent.sendWithUrl(context: Context, url: String) = send(
+    context,
+    0,
+    Intent(null, url.toUri())
+)

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/menu/CustomTabMenuCandidatesTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/menu/CustomTabMenuCandidatesTest.kt
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.customtabs.menu
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.state.state.CustomTabConfig
+import mozilla.components.browser.state.state.CustomTabMenuItem
+import mozilla.components.browser.state.state.createCustomTab
+import mozilla.components.concept.menu.candidate.MenuCandidate
+import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.eq
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class CustomTabMenuCandidatesTest {
+
+    @Test
+    fun `return an empty list if there are no menu items`() {
+        val customTabSessionState = createCustomTab(
+            url = "https://mozilla.org",
+            config = CustomTabConfig(menuItems = emptyList())
+        )
+
+        assertEquals(
+            emptyList<MenuCandidate>(),
+            customTabSessionState.createCustomTabMenuCandidates(mock())
+        )
+    }
+
+    @Test
+    fun `create a candidate for each menu item`() {
+        val pendingIntent1 = mock<PendingIntent>()
+        val pendingIntent2 = mock<PendingIntent>()
+        val customTabSessionState = createCustomTab(
+            url = "https://mozilla.org",
+            config = CustomTabConfig(
+                menuItems = listOf(
+                    CustomTabMenuItem(
+                        name = "item1",
+                        pendingIntent = pendingIntent1
+                    ),
+                    CustomTabMenuItem(
+                        name = "item2",
+                        pendingIntent = pendingIntent2
+                    )
+                )
+            )
+        )
+
+        val context = mock<Context>()
+        val intent = argumentCaptor<Intent>()
+        val menuCandidates = customTabSessionState.createCustomTabMenuCandidates(context)
+
+        assertEquals(2, menuCandidates.size)
+        assertEquals("item1", menuCandidates[0].text)
+        assertEquals("item2", menuCandidates[1].text)
+
+        menuCandidates[0].onClick()
+        verify(pendingIntent1).send(eq(context), anyInt(), intent.capture())
+        assertEquals("https://mozilla.org".toUri(), intent.value.data)
+
+        menuCandidates[1].onClick()
+        verify(pendingIntent2).send(eq(context), anyInt(), intent.capture())
+        assertEquals("https://mozilla.org".toUri(), intent.value.data)
+    }
+}


### PR DESCRIPTION
I'm thinking that we can adjust the menu down the line so that it just responds to browser state updates instead of having a couple of components change the menu themselves. This is part of that work for custom tabs. No changelog yet as this is just groundwork for later.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
