### PR TITLE
Issue #8216: Add photonViolet50, photonDarkGrey40 and photonLightGrey50 to photon_colors

### DIFF
--- a/components/ui/colors/src/main/res/values/photon_colors.xml
+++ b/components/ui/colors/src/main/res/values/photon_colors.xml
@@ -54,61 +54,66 @@
     <color name="photonYellow70">#a47f00</color>
     <color name="photonYellow80">#715100</color>
     <color name="photonYellow90">#3e2800</color>
-   
-   <!-- Teal -->
-   <color name="photonTeal50">#00feff</color>
-   <color name="photonTeal60">#00c8d7</color>
-   <color name="photonTeal70">#008ea4</color>
-   <color name="photonTeal80">#005a71</color>
-   <color name="photonTeal90">#002d3e</color>
-   
-   <!-- Purple -->
-   <color name="photonPurple50">#9400ff</color>
-   <color name="photonPurple60">#8000d7</color>
-   <color name="photonPurple70">#6200a4</color>
-   <color name="photonPurple80">#440071</color>
-   <color name="photonPurple90">#25003e</color>
-   
-   <!-- Orange -->
-   <color name="photonOrange50">#ff9400</color>
-   <color name="photonOrange60">#d76e00</color>
-   <color name="photonOrange70">#a44900</color>
-   <color name="photonOrange80">#712b00</color>
-   <color name="photonOrange90">#3e1300</color>
-   
-   <!-- Ink -->
-   <color name="photonInk20">#312A65</color>
-   <color name="photonInk50">#291D4F</color>
-   <color name="photonInk70">#363959</color>
-   <color name="photonInk80">#202340</color>
-   <color name="photonInk90">#0f1126</color>
-   
-   <!-- Grey -->
-   <color name="photonGrey10">#f9f9fa</color>
-   <color name="photonGrey20">#ededf0</color>
-   <color name="photonGrey30">#d7d7db</color>
-   <color name="photonGrey40">#b1b1b3</color>
-   <color name="photonGrey50">#737373</color>
-   <color name="photonGrey60">#4a4a4f</color>
-   <color name="photonGrey70">#38383d</color>
-   <color name="photonGrey80">#2a2a2e</color>
-   <color name="photonGrey90">#0c0c0d</color>
 
-   <!-- Light Grey -->
-   <color name="photonLightGrey05">#FBFBFE</color>
-   <color name="photonLightGrey10">#F9F9FB</color>
-   <color name="photonLightGrey30">#E0E0E6</color>
-   <color name="photonLightGrey60">#AFAFBB</color>
-   <color name="photonLightGrey70">#9F9FAD</color>
-   <color name="photonLightGrey80">#8F8F9D</color>
-   <color name="photonLightGrey90">#80808E</color>
+    <!-- Teal -->
+    <color name="photonTeal50">#00feff</color>
+    <color name="photonTeal60">#00c8d7</color>
+    <color name="photonTeal70">#008ea4</color>
+    <color name="photonTeal80">#005a71</color>
+    <color name="photonTeal90">#002d3e</color>
 
-   <!-- Dark Grey -->
-   <color name="photonDarkGrey05">#5B5B66</color>
-   <color name="photonDarkGrey10">#52525E</color>
-   <color name="photonDarkGrey50">#32313C</color>
-   <color name="photonDarkGrey80">#1C1B22</color>
-  
-   <!-- White -->
-   <color name="photonWhite">#ffffff</color>
+    <!-- Purple -->
+    <color name="photonPurple50">#9400ff</color>
+    <color name="photonPurple60">#8000d7</color>
+    <color name="photonPurple70">#6200a4</color>
+    <color name="photonPurple80">#440071</color>
+    <color name="photonPurple90">#25003e</color>
+
+    <!-- Orange -->
+    <color name="photonOrange50">#ff9400</color>
+    <color name="photonOrange60">#d76e00</color>
+    <color name="photonOrange70">#a44900</color>
+    <color name="photonOrange80">#712b00</color>
+    <color name="photonOrange90">#3e1300</color>
+
+    <!-- Ink -->
+    <color name="photonInk20">#312A65</color>
+    <color name="photonInk50">#291D4F</color>
+    <color name="photonInk70">#363959</color>
+    <color name="photonInk80">#202340</color>
+    <color name="photonInk90">#0f1126</color>
+
+    <!-- Grey -->
+    <color name="photonGrey10">#f9f9fa</color>
+    <color name="photonGrey20">#ededf0</color>
+    <color name="photonGrey30">#d7d7db</color>
+    <color name="photonGrey40">#b1b1b3</color>
+    <color name="photonGrey50">#737373</color>
+    <color name="photonGrey60">#4a4a4f</color>
+    <color name="photonGrey70">#38383d</color>
+    <color name="photonGrey80">#2a2a2e</color>
+    <color name="photonGrey90">#0c0c0d</color>
+
+    <!-- Light Grey -->
+    <color name="photonLightGrey05">#FBFBFE</color>
+    <color name="photonLightGrey10">#F9F9FB</color>
+    <color name="photonLightGrey30">#E0E0E6</color>
+    <color name="photonLightGrey50">#BFBFC9</color>
+    <color name="photonLightGrey60">#AFAFBB</color>
+    <color name="photonLightGrey70">#9F9FAD</color>
+    <color name="photonLightGrey80">#8F8F9D</color>
+    <color name="photonLightGrey90">#80808E</color>
+
+    <!-- Dark Grey -->
+    <color name="photonDarkGrey05">#5B5B66</color>
+    <color name="photonDarkGrey10">#52525E</color>
+    <color name="photonDarkGrey40">#3A3944</color>
+    <color name="photonDarkGrey50">#32313C</color>
+    <color name="photonDarkGrey80">#1C1B22</color>
+
+    <!-- Violet -->
+    <color name="photonViolet50">#9059FF</color>
+
+    <!-- White -->
+    <color name="photonWhite">#ffffff</color>
 </resources>


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Fixes #8216. 

This imports photonViolet50 and photonLightGrey50 from https://github.com/mozilla-mobile/fenix/blob/bb3fd4eb168132baf05be5f7ecce63f67022e848/app/src/main/res/values/colors.xml#L6.
photonDarkGrey40 came from slack and commented here https://github.com/mozilla-mobile/fenix/issues/8312#issuecomment-679292000.

This also formats the tabbing to be 4 spaces instead of 3 spaces.

I choose to not import photon colours with custom alphas. I reason that it is less likely to be reused generally and can be kept in app.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
