### PR TITLE
For #8245: Use settingAutoComplete to disable autocomplete

### DIFF
--- a/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
+++ b/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
@@ -273,12 +273,12 @@ open class InlineAutocompleteEditText @JvmOverloads constructor(
     }
 
     fun setText(text: CharSequence?, shouldAutoComplete: Boolean = true) {
-        val previousEnabledState = isEnabled
+        val wasSettingAutoComplete = settingAutoComplete
 
-        // Disable the edit text if necessary in order to stop auto completion
-        isEnabled = shouldAutoComplete
+        // Disable listeners in order to stop auto completion
+        settingAutoComplete = !shouldAutoComplete
         setText(text, BufferType.EDITABLE)
-        isEnabled = previousEnabledState
+        settingAutoComplete = wasSettingAutoComplete
     }
 
     override fun getText(): Editable {

--- a/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
+++ b/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
@@ -22,6 +22,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.Robolectric.buildAttributeSet
@@ -414,5 +415,13 @@ class InlineAutocompleteEditTextTest {
 
         et.setText("g")
         assertEquals("google.com", "${et.text}")
+    }
+
+    @Test
+    fun `WHEN setting text THEN isEnabled is never modified`() {
+        val et = spy(InlineAutocompleteEditText(testContext, attributes))
+        et.setText("", shouldAutoComplete = false)
+        // assigning here so it verifies the setter, not the getter
+        verify(et, never()).isEnabled = true
     }
 }


### PR DESCRIPTION
Instead of using `isEnabled` we can temporarily set `settingAutoComplete`, which is checked before invoking listeners (which would cause autocompletion) as well, but has no side effects.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
