### PR TITLE
Find upstream and downstream dependencies when determining which components to build (fixes #8265)

### DIFF
--- a/taskcluster/ac_taskgraph/loader/build_config.py
+++ b/taskcluster/ac_taskgraph/loader/build_config.py
@@ -12,7 +12,6 @@ import subprocess
 from collections import defaultdict
 from copy import deepcopy
 from taskgraph.loader.transform import loader as base_loader
-from taskgraph.util.memoize import memoize
 from taskgraph.util.taskcluster import get_session
 from taskgraph.util.templates import merge
 
@@ -48,6 +47,8 @@ def get_upstream_deps_for_components(components):
     """Return the full list of local upstream dependencies of a component."""
     deps = set()
     cmd = ["./gradlew"]
+    # This is eventually going to fail if there's ever enough components to make the command line
+    # too long. If that happens, we'll need to split this list up and run gradle more than once.
     for c in sorted(components):
         cmd.extend(["%s:dependencies" % c, "--configuration", "implementation"])
     # Parsing output like this is not ideal but bhearsum couldn't find a way


### PR DESCRIPTION
I tested this locally by rerunning the decision task for #8250, which ended up with a much lengthier list of affected components:
```
2020-08-27 15:30:29,758 - INFO - Affected components: browser-icons browser-menu browser-session browser-state browser-thumbnails concept-engine feature-accounts feature-addons feature-app-links feature-awesomebar feature-containers feature-contextmenu feature-customtabs feature-downloads feature-findinpage feature-intent feature-media feature-p2p feature-privatemode feature-prompts feature-pwa feature-readerview feature-search feature-session feature-sitepermissions feature-syncedtabs feature-tab-collections feature-tabs feature-toolbar samples-browser support-ktx support-migration support-utils support-webextensions
```

The implementation is not great -- we end up running ` ./gradlew X:dependencies --configuration implementation` for every single component. On my laptop this took about 7min - it may take longer in CI. This could be improved if someone can figure out a way to more quickly dump dependencies for a single component, or even better - dump the entire dependency tree.