### PR TITLE
Closes #8273: Set timestamp of crash reports to when crash occurred

### DIFF
--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/handler/ExceptionHandler.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/handler/ExceptionHandler.kt
@@ -36,6 +36,7 @@ class ExceptionHandler(
             crashReporter.onCrash(
                 context,
                 Crash.UncaughtExceptionCrash(
+                    timestamp = System.currentTimeMillis(),
                     throwable = throwable,
                     breadcrumbs = crashReporter.crashBreadcrumbsCopy()
                 )

--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/SentryService.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/SentryService.kt
@@ -18,6 +18,7 @@ import io.sentry.event.EventBuilder
 import io.sentry.event.interfaces.ExceptionInterface
 import mozilla.components.Build
 import mozilla.components.lib.crash.Crash
+import java.util.Date
 import mozilla.components.support.base.crash.Breadcrumb as CrashBreadcrumb
 
 /**
@@ -83,6 +84,7 @@ class SentryService(
         }
 
         val eventBuilder = EventBuilder().withMessage(createMessage(crash))
+                .withTimestamp(Date(crash.timestamp))
                 .withLevel(Event.Level.FATAL)
                 .withSentryInterface(ExceptionInterface(crash.throwable))
 
@@ -104,6 +106,7 @@ class SentryService(
             }
 
             val eventBuilder = EventBuilder()
+                .withTimestamp(Date(crash.timestamp))
                 .withMessage(createMessage(crash))
                 .withLevel(level)
 

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/CrashReporterTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/CrashReporterTest.kt
@@ -155,6 +155,7 @@ class CrashReporterTest {
         ).install(testContext))
 
         val crash = Crash.NativeCodeCrash(
+            0,
             "dump.path",
             true,
             "extras.path",
@@ -346,7 +347,7 @@ class CrashReporterTest {
         ).install(testContext))
 
         reporter.submitReport(
-            Crash.UncaughtExceptionCrash(RuntimeException(), arrayListOf())
+            Crash.UncaughtExceptionCrash(0, RuntimeException(), arrayListOf())
         ).joinBlocking()
         assertTrue(exceptionCrash)
     }
@@ -379,7 +380,7 @@ class CrashReporterTest {
         ).install(testContext))
 
         reporter.submitReport(
-            Crash.NativeCodeCrash("", true, "", false, arrayListOf())
+            Crash.NativeCodeCrash(0, "", true, "", false, arrayListOf())
         ).joinBlocking()
         assertTrue(nativeCrash)
     }
@@ -499,7 +500,7 @@ class CrashReporterTest {
         ).install(testContext))
 
         reporter.submitCrashTelemetry(
-            Crash.NativeCodeCrash("", true, "", false, arrayListOf())
+            Crash.NativeCodeCrash(0, "", true, "", false, arrayListOf())
         ).joinBlocking()
         assertTrue(nativeCrash)
     }
@@ -539,6 +540,7 @@ class CrashReporterTest {
         ).install(context)
 
         val nativeCrash = Crash.NativeCodeCrash(
+            0,
             "dump.path",
             true,
             "extras.path",
@@ -575,6 +577,7 @@ class CrashReporterTest {
         ).install(testContext))
 
         val nativeCrash = Crash.NativeCodeCrash(
+            0,
             "dump.path",
             true,
             "extras.path",
@@ -601,6 +604,7 @@ class CrashReporterTest {
         ).install(testContext))
 
         val nativeCrash = Crash.NativeCodeCrash(
+            0,
             "dump.path",
             true,
             "extras.path",
@@ -742,6 +746,6 @@ class CrashReporterTest {
 
 private fun createUncaughtExceptionCrash(): Crash.UncaughtExceptionCrash {
     return Crash.UncaughtExceptionCrash(
-        RuntimeException(), ArrayList()
+        0, RuntimeException(), ArrayList()
     )
 }

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/CrashTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/CrashTest.kt
@@ -19,6 +19,7 @@ class CrashTest {
     @Test
     fun `fromIntent() can deserialize a GeckoView crash Intent`() {
         val originalCrash = Crash.NativeCodeCrash(
+            123,
             "/data/data/org.mozilla.samples.browser/files/mozilla/Crash Reports/pending/3ba5f665-8422-dc8e-a88e-fc65c081d304.dmp",
             true,
             "/data/data/org.mozilla.samples.browser/files/mozilla/Crash Reports/pending/3ba5f665-8422-dc8e-a88e-fc65c081d304.extra",
@@ -32,6 +33,7 @@ class CrashTest {
         val recoveredCrash = Crash.fromIntent(intent) as? Crash.NativeCodeCrash
             ?: throw AssertionError("Expected NativeCodeCrash instance")
 
+        assertEquals(recoveredCrash.timestamp, 123)
         assertEquals(recoveredCrash.minidumpSuccess, true)
         assertEquals(recoveredCrash.isFatal, false)
         assertEquals(
@@ -48,7 +50,7 @@ class CrashTest {
     fun `Serialize and deserialize UncaughtExceptionCrash`() {
         val exception = RuntimeException("Hello World!")
 
-        val originalCrash = Crash.UncaughtExceptionCrash(exception, arrayListOf())
+        val originalCrash = Crash.UncaughtExceptionCrash(0, exception, arrayListOf())
 
         val intent = Intent()
         originalCrash.fillIn(intent)
@@ -70,13 +72,13 @@ class CrashTest {
 
         assertTrue(Crash.isCrashIntent(
             Intent().apply {
-                Crash.UncaughtExceptionCrash(RuntimeException(), arrayListOf()).fillIn(this)
+                Crash.UncaughtExceptionCrash(0, RuntimeException(), arrayListOf()).fillIn(this)
             }
         ))
 
         assertTrue(Crash.isCrashIntent(
             Intent().apply {
-                val crash = Crash.NativeCodeCrash("", true, "", false, arrayListOf())
+                val crash = Crash.NativeCodeCrash(0, "", true, "", false, arrayListOf())
                 crash.fillIn(this)
             }
         ))

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/NativeCodeCrashTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/NativeCodeCrashTest.kt
@@ -49,6 +49,7 @@ class NativeCodeCrashTest {
     @Test
     fun `to and from bundle`() {
         val crash = Crash.NativeCodeCrash(
+            0,
             "minidumpPath",
             true,
             "extrasPath",

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/UncaughtExceptionCrashTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/UncaughtExceptionCrashTest.kt
@@ -16,7 +16,7 @@ class UncaughtExceptionCrashTest {
     fun `UncaughtExceptionCrash wraps exception`() {
         val exception = RuntimeException("Kaput")
 
-        val crash = Crash.UncaughtExceptionCrash(exception, arrayListOf())
+        val crash = Crash.UncaughtExceptionCrash(0, exception, arrayListOf())
 
         assertEquals(exception, crash.throwable)
     }
@@ -24,7 +24,7 @@ class UncaughtExceptionCrashTest {
     @Test
     fun `to and from bundle`() {
         val exception = RuntimeException("Kaput")
-        val crash = Crash.UncaughtExceptionCrash(exception, arrayListOf())
+        val crash = Crash.UncaughtExceptionCrash(0, exception, arrayListOf())
 
         val bundle = crash.toBundle()
         val otherCrash = Crash.UncaughtExceptionCrash.fromBundle(bundle)

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/notification/CrashNotificationTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/notification/CrashNotificationTest.kt
@@ -23,6 +23,7 @@ class CrashNotificationTest {
     @Test
     fun shouldShowNotificationInsteadOfPrompt() {
         val nonFatalNativeCrash = Crash.NativeCodeCrash(
+            timestamp = 0,
             minidumpPath = "",
             minidumpSuccess = true,
             extrasPath = "",
@@ -43,6 +44,7 @@ class CrashNotificationTest {
         assertFalse(CrashNotification.shouldShowNotificationInsteadOfPrompt(nonFatalNativeCrash, sdkLevel = 31))
 
         val fatalNativeCrash = Crash.NativeCodeCrash(
+            timestamp = 0,
             minidumpPath = "",
             minidumpSuccess = true,
             extrasPath = "",
@@ -62,7 +64,7 @@ class CrashNotificationTest {
         assertTrue(CrashNotification.shouldShowNotificationInsteadOfPrompt(fatalNativeCrash, sdkLevel = 30))
         assertTrue(CrashNotification.shouldShowNotificationInsteadOfPrompt(fatalNativeCrash, sdkLevel = 31))
 
-        val exceptionCrash = Crash.UncaughtExceptionCrash(RuntimeException("Boom"), arrayListOf())
+        val exceptionCrash = Crash.UncaughtExceptionCrash(0, RuntimeException("Boom"), arrayListOf())
 
         assertFalse(CrashNotification.shouldShowNotificationInsteadOfPrompt(exceptionCrash, sdkLevel = 21))
         assertFalse(CrashNotification.shouldShowNotificationInsteadOfPrompt(exceptionCrash, sdkLevel = 22))
@@ -85,7 +87,7 @@ class CrashNotificationTest {
         assertEquals(0, shadowNotificationManager.notificationChannels.size)
         assertEquals(0, shadowNotificationManager.size())
 
-        val crash = Crash.UncaughtExceptionCrash(RuntimeException("Boom"), arrayListOf())
+        val crash = Crash.UncaughtExceptionCrash(0, RuntimeException("Boom"), arrayListOf())
 
         val crashNotification = CrashNotification(testContext, crash, CrashReporter.PromptConfiguration(
             appName = "TestApp"

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/prompt/CrashReporterActivityTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/prompt/CrashReporterActivityTest.kt
@@ -63,7 +63,7 @@ class CrashReporterActivityTest {
             scope = scope
         ).install(testContext)
 
-        val crash = Crash.UncaughtExceptionCrash(RuntimeException("Hello World"), arrayListOf())
+        val crash = Crash.UncaughtExceptionCrash(0, RuntimeException("Hello World"), arrayListOf())
         val scenario = launchActivityWith(crash)
 
         scenario.onActivity { activity ->
@@ -87,7 +87,7 @@ class CrashReporterActivityTest {
             scope = scope
         ).install(testContext)
 
-        val crash = Crash.UncaughtExceptionCrash(RuntimeException("Hello World"), arrayListOf())
+        val crash = Crash.UncaughtExceptionCrash(0, RuntimeException("Hello World"), arrayListOf())
         val scenario = launchActivityWith(crash)
 
         scenario.onActivity { activity ->
@@ -114,7 +114,7 @@ class CrashReporterActivityTest {
             services = listOf(mock())
         ).install(testContext)
 
-        val crash = Crash.UncaughtExceptionCrash(RuntimeException("Hello World"), arrayListOf())
+        val crash = Crash.UncaughtExceptionCrash(0, RuntimeException("Hello World"), arrayListOf())
         val scenario = launchActivityWith(crash)
 
         scenario.onActivity { activity ->
@@ -132,7 +132,7 @@ class CrashReporterActivityTest {
             scope = scope
         ).install(testContext)
 
-        val crash = Crash.UncaughtExceptionCrash(RuntimeException("Hello World"), arrayListOf())
+        val crash = Crash.UncaughtExceptionCrash(0, RuntimeException("Hello World"), arrayListOf())
         val scenario = launchActivityWith(crash)
 
         scenario.onActivity { activity ->

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/GleanCrashReporterServiceTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/GleanCrashReporterServiceTest.kt
@@ -45,7 +45,7 @@ class GleanCrashReporterServiceTest {
 
             assertFalse("No previous persisted crashes must exist", service.file.exists())
 
-            val crash = Crash.NativeCodeCrash("", true, "", true, arrayListOf())
+            val crash = Crash.NativeCodeCrash(0, "", true, "", true, arrayListOf())
             service.record(crash)
 
             verify(service).record(crash)
@@ -84,7 +84,7 @@ class GleanCrashReporterServiceTest {
 
             assertFalse("No previous persisted crashes must exist", service.file.exists())
 
-            val crash = Crash.NativeCodeCrash("", true, "", false, arrayListOf())
+            val crash = Crash.NativeCodeCrash(0, "", true, "", false, arrayListOf())
             service.record(crash)
 
             assertTrue("Persistence file must exist", service.file.exists())
@@ -121,7 +121,7 @@ class GleanCrashReporterServiceTest {
 
             assertFalse("No previous persisted crashes must exist", service.file.exists())
 
-            val crash = Crash.UncaughtExceptionCrash(RuntimeException("Test"), arrayListOf())
+            val crash = Crash.UncaughtExceptionCrash(0, RuntimeException("Test"), arrayListOf())
             service.record(crash)
 
             assertTrue("Persistence file must exist", service.file.exists())
@@ -203,9 +203,9 @@ class GleanCrashReporterServiceTest {
 
             assertFalse("No previous persisted crashes must exist", service.file.exists())
 
-            val uncaughtExceptionCrash = Crash.UncaughtExceptionCrash(RuntimeException("Test"), arrayListOf())
-            val fatalNativeCodeCrash = Crash.NativeCodeCrash("", true, "", true, arrayListOf())
-            val nonfatalNativeCodeCrash = Crash.NativeCodeCrash("", true, "", false, arrayListOf())
+            val uncaughtExceptionCrash = Crash.UncaughtExceptionCrash(0, RuntimeException("Test"), arrayListOf())
+            val fatalNativeCodeCrash = Crash.NativeCodeCrash(0, "", true, "", true, arrayListOf())
+            val nonfatalNativeCodeCrash = Crash.NativeCodeCrash(0, "", true, "", false, arrayListOf())
 
             // Record some crashes
             service.record(uncaughtExceptionCrash)
@@ -255,7 +255,7 @@ class GleanCrashReporterServiceTest {
 
         assertFalse("No previous persisted crashes must exist", service.file.exists())
 
-        val crash = Crash.UncaughtExceptionCrash(RuntimeException("Test"), arrayListOf())
+        val crash = Crash.UncaughtExceptionCrash(0, RuntimeException("Test"), arrayListOf())
         service.record(crash)
 
         assertTrue("Persistence file must exist", service.file.exists())
@@ -279,7 +279,7 @@ class GleanCrashReporterServiceTest {
 
             assertFalse("No previous persisted crashes must exist", service.file.exists())
 
-            val crash = Crash.NativeCodeCrash("", true, "", true, arrayListOf())
+            val crash = Crash.NativeCodeCrash(0, "", true, "", true, arrayListOf())
             service.record(crash)
 
             assertTrue("Persistence file must exist", service.file.exists())

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/MozillaSocorroServiceTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/MozillaSocorroServiceTest.kt
@@ -18,6 +18,7 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
@@ -37,13 +38,13 @@ class MozillaSocorroServiceTest {
             testContext,
             "Test App"
         ))
-        doReturn("").`when`(service).sendReport(any(), any(), any(), anyBoolean(), anyBoolean(), any())
+        doReturn("").`when`(service).sendReport(anyLong(), any(), any(), any(), anyBoolean(), anyBoolean(), any())
 
-        val crash = Crash.NativeCodeCrash("", true, "", false, arrayListOf())
+        val crash = Crash.NativeCodeCrash(123, "", true, "", false, arrayListOf())
         service.report(crash)
 
         verify(service).report(crash)
-        verify(service).sendReport(null, crash.minidumpPath, crash.extrasPath, true, false, crash.breadcrumbs)
+        verify(service).sendReport(123, null, crash.minidumpPath, crash.extrasPath, true, false, crash.breadcrumbs)
     }
 
     @Test
@@ -65,13 +66,13 @@ class MozillaSocorroServiceTest {
             testContext,
             "Test App"
         ))
-        doReturn("").`when`(service).sendReport(any(), any(), any(), anyBoolean(), anyBoolean(), any())
+        doReturn("").`when`(service).sendReport(anyLong(), any(), any(), any(), anyBoolean(), anyBoolean(), any())
 
-        val crash = Crash.UncaughtExceptionCrash(RuntimeException("Test"), arrayListOf())
+        val crash = Crash.UncaughtExceptionCrash(123, RuntimeException("Test"), arrayListOf())
         service.report(crash)
 
         verify(service).report(crash)
-        verify(service).sendReport(crash.throwable, null, null, false, true, crash.breadcrumbs)
+        verify(service).sendReport(123, crash.throwable, null, null, false, true, crash.breadcrumbs)
     }
 
     @Test
@@ -80,13 +81,13 @@ class MozillaSocorroServiceTest {
                 testContext,
                 "Test App"
         ))
-        doReturn("").`when`(service).sendReport(any(), any(), any(), anyBoolean(), anyBoolean(), any())
+        doReturn("").`when`(service).sendReport(anyLong(), any(), any(), any(), anyBoolean(), anyBoolean(), any())
         val throwable = RuntimeException("Test")
         val breadcrumbs: ArrayList<Breadcrumb> = arrayListOf()
         val id = service.report(throwable, breadcrumbs)
 
         verify(service).report(throwable, breadcrumbs)
-        verify(service, never()).sendReport(any(), any(), any(), anyBoolean(), anyBoolean(), any())
+        verify(service, never()).sendReport(anyLong(), any(), any(), any(), anyBoolean(), anyBoolean(), any())
         assertNull(id)
     }
 
@@ -111,6 +112,7 @@ class MozillaSocorroServiceTest {
             )
 
             val crash = Crash.NativeCodeCrash(
+                123456,
                 "dump.path",
                 true,
                 "extras.path",
@@ -133,9 +135,10 @@ class MozillaSocorroServiceTest {
             assert(request.contains("name=Android_PackageName\r\n\r\nmozilla.components.lib.crash.test"))
             assert(request.contains("name=Android_Device\r\n\r\nrobolectric"))
             assert(request.contains("name=CrashType\r\n\r\n$FATAL_NATIVE_CRASH_TYPE"))
+            assert(request.contains("name=CrashTime\r\n\r\n123"))
 
             verify(service).report(crash)
-            verify(service).sendReport(null, "dump.path", "extras.path", true, true, crash.breadcrumbs)
+            verify(service).sendReport(123456, null, "dump.path", "extras.path", true, true, crash.breadcrumbs)
         } finally {
             mockWebServer.shutdown()
         }
@@ -162,6 +165,7 @@ class MozillaSocorroServiceTest {
             )
 
             val crash = Crash.NativeCodeCrash(
+                123456,
                 "dump.path",
                 true,
                 "extras.path",
@@ -184,9 +188,10 @@ class MozillaSocorroServiceTest {
             assert(request.contains("name=Android_PackageName\r\n\r\nmozilla.components.lib.crash.test"))
             assert(request.contains("name=Android_Device\r\n\r\nrobolectric"))
             assert(request.contains("name=CrashType\r\n\r\n$NON_FATAL_NATIVE_CRASH_TYPE"))
+            assert(request.contains("name=CrashTime\r\n\r\n123"))
 
             verify(service).report(crash)
-            verify(service).sendReport(null, "dump.path", "extras.path", true, false, crash.breadcrumbs)
+            verify(service).sendReport(123456, null, "dump.path", "extras.path", true, false, crash.breadcrumbs)
         } finally {
             mockWebServer.shutdown()
         }
@@ -212,7 +217,7 @@ class MozillaSocorroServiceTest {
                 )
             )
 
-            val crash = Crash.UncaughtExceptionCrash(RuntimeException("Test"), arrayListOf())
+            val crash = Crash.UncaughtExceptionCrash(123456, RuntimeException("Test"), arrayListOf())
             service.report(crash)
 
             val fileInputStream =
@@ -230,9 +235,10 @@ class MozillaSocorroServiceTest {
             assert(request.contains("name=Android_PackageName\r\n\r\nmozilla.components.lib.crash.test"))
             assert(request.contains("name=Android_Device\r\n\r\nrobolectric"))
             assert(request.contains("name=CrashType\r\n\r\n$UNCAUGHT_EXCEPTION_TYPE"))
+            assert(request.contains("name=CrashTime\r\n\r\n123"))
 
             verify(service).report(crash)
-            verify(service).sendReport(crash.throwable, null, null, false, true, crash.breadcrumbs)
+            verify(service).sendReport(123456, crash.throwable, null, null, false, true, crash.breadcrumbs)
         } finally {
             mockWebServer.shutdown()
         }
@@ -257,12 +263,12 @@ class MozillaSocorroServiceTest {
                 )
             )
 
-            val crash = Crash.UncaughtExceptionCrash(RuntimeException("Test"), arrayListOf())
+            val crash = Crash.UncaughtExceptionCrash(123, RuntimeException("Test"), arrayListOf())
             service.report(crash)
 
             mockWebServer.shutdown()
             verify(service).report(crash)
-            verify(service).sendReport(crash.throwable, null, null, false, true, crash.breadcrumbs)
+            verify(service).sendReport(123, crash.throwable, null, null, false, true, crash.breadcrumbs)
         } finally {
             mockWebServer.shutdown()
         }
@@ -284,12 +290,12 @@ class MozillaSocorroServiceTest {
                 )
             )
 
-            val crash = Crash.NativeCodeCrash(null, true, null, false, arrayListOf())
+            val crash = Crash.NativeCodeCrash(123, null, true, null, false, arrayListOf())
             service.report(crash)
             mockWebServer.shutdown()
 
             verify(service).report(crash)
-            verify(service).sendReport(null, crash.minidumpPath, crash.extrasPath, true, false, crash.breadcrumbs)
+            verify(service).sendReport(123, null, crash.minidumpPath, crash.extrasPath, true, false, crash.breadcrumbs)
         } finally {
             mockWebServer.shutdown()
         }
@@ -432,6 +438,7 @@ class MozillaSocorroServiceTest {
             )
 
             val crash = Crash.NativeCodeCrash(
+                0,
                 "dump.path",
                 true,
                 "extras.path",

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SendCrashReportServiceTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SendCrashReportServiceTest.kt
@@ -83,6 +83,7 @@ class SendCrashReportServiceTest {
             scope = scope
         )).install(testContext)
         val originalCrash = Crash.NativeCodeCrash(
+                123,
                 "/data/data/org.mozilla.samples.browser/files/mozilla/Crash Reports/pending/3ba5f665-8422-dc8e-a88e-fc65c081d304.dmp",
                 true,
                 "/data/data/org.mozilla.samples.browser/files/mozilla/Crash Reports/pending/3ba5f665-8422-dc8e-a88e-fc65c081d304.extra",
@@ -115,6 +116,7 @@ class SendCrashReportServiceTest {
         val nativeCrash = caughtCrash
             ?: throw AssertionError("Expected NativeCodeCrash instance")
 
+        assertEquals(123, nativeCrash.timestamp)
         assertEquals(true, nativeCrash.minidumpSuccess)
         assertEquals(false, nativeCrash.isFatal)
         assertEquals(

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SendCrashTelemetryServiceTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SendCrashTelemetryServiceTest.kt
@@ -71,6 +71,7 @@ class SendCrashTelemetryServiceTest {
             scope = scope
         )).install(testContext)
         val originalCrash = Crash.NativeCodeCrash(
+            123,
             "/data/data/org.mozilla.samples.browser/files/mozilla/Crash Reports/pending/3ba5f665-8422-dc8e-a88e-fc65c081d304.dmp",
             true,
             "/data/data/org.mozilla.samples.browser/files/mozilla/Crash Reports/pending/3ba5f665-8422-dc8e-a88e-fc65c081d304.extra",
@@ -104,6 +105,7 @@ class SendCrashTelemetryServiceTest {
         val nativeCrash = caughtCrash
             ?: throw AssertionError("Expected NativeCodeCrash instance")
 
+        assertEquals(123, nativeCrash.timestamp)
         assertEquals(true, nativeCrash.minidumpSuccess)
         assertEquals(false, nativeCrash.isFatal)
         assertEquals(

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SentryServiceTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SentryServiceTest.kt
@@ -44,7 +44,7 @@ class SentryServiceTest {
         var usedDsn: Dsn? = null
 
         val client: SentryClient = mock()
-        val uncaughtExceptionCrash = Crash.UncaughtExceptionCrash(RuntimeException("test"), arrayListOf())
+        val uncaughtExceptionCrash = Crash.UncaughtExceptionCrash(0, RuntimeException("test"), arrayListOf())
         val factory = object : SentryClientFactory() {
             override fun createSentryClient(dsn: Dsn?): SentryClient {
                 usedDsn = dsn
@@ -93,7 +93,7 @@ class SentryServiceTest {
             clientFactory = factory)
 
         val exception = RuntimeException("Hello World")
-        service.report(Crash.UncaughtExceptionCrash(exception, arrayListOf()))
+        service.report(Crash.UncaughtExceptionCrash(0, exception, arrayListOf()))
 
         verify(client).sendEvent(ArgumentMatchers.any(EventBuilder::class.java))
         verify(clientContext).clearBreadcrumbs()
@@ -139,7 +139,7 @@ class SentryServiceTest {
             sendEventForNativeCrashes = true
         )
 
-        service.report(Crash.NativeCodeCrash("", true, "", false, arrayListOf()))
+        service.report(Crash.NativeCodeCrash(0, "", true, "", false, arrayListOf()))
 
         verify(client).sendEvent(any<EventBuilder>())
         verify(clientContext).clearBreadcrumbs()
@@ -161,7 +161,7 @@ class SentryServiceTest {
             sendEventForNativeCrashes = true
         )
 
-        service.report(Crash.NativeCodeCrash("", true, "", true, arrayListOf()))
+        service.report(Crash.NativeCodeCrash(0, "", true, "", true, arrayListOf()))
 
         val eventBuilderCaptor: ArgumentCaptor<EventBuilder> = ArgumentCaptor.forClass(EventBuilder::class.java)
         verify(client, times(1)).sendEvent(eventBuilderCaptor.capture())
@@ -187,7 +187,7 @@ class SentryServiceTest {
             sendEventForNativeCrashes = true
         )
 
-        service.report(Crash.NativeCodeCrash("", true, "", false, arrayListOf()))
+        service.report(Crash.NativeCodeCrash(0, "", true, "", false, arrayListOf()))
 
         val eventBuilderCaptor: ArgumentCaptor<EventBuilder> = ArgumentCaptor.forClass(EventBuilder::class.java)
         verify(client, times(1)).sendEvent(eventBuilderCaptor.capture())
@@ -212,7 +212,7 @@ class SentryServiceTest {
             }
         )
 
-        service.report(Crash.UncaughtExceptionCrash(RuntimeException("test"), arrayListOf()))
+        service.report(Crash.UncaughtExceptionCrash(0, RuntimeException("test"), arrayListOf()))
 
         val eventBuilderCaptor: ArgumentCaptor<EventBuilder> = ArgumentCaptor.forClass(EventBuilder::class.java)
         verify(client, times(1)).sendEvent(eventBuilderCaptor.capture())
@@ -260,7 +260,7 @@ class SentryServiceTest {
                 override fun createSentryClient(dsn: Dsn?): SentryClient = client
             })
 
-        service.report(Crash.NativeCodeCrash("", true, "", false, arrayListOf()))
+        service.report(Crash.NativeCodeCrash(0, "", true, "", false, arrayListOf()))
 
         verify(client, never()).sendEvent(any<EventBuilder>())
     }
@@ -268,7 +268,7 @@ class SentryServiceTest {
     @Test
     fun `SentryService adds default tags`() {
         val client: SentryClient = mock()
-        val uncaughtExceptionCrash = Crash.UncaughtExceptionCrash(RuntimeException("test"), arrayListOf())
+        val uncaughtExceptionCrash = Crash.UncaughtExceptionCrash(0, RuntimeException("test"), arrayListOf())
         val clientContext: Context = mock()
         doReturn(clientContext).`when`(client).context
         doNothing().`when`(clientContext).clearBreadcrumbs()
@@ -292,7 +292,7 @@ class SentryServiceTest {
         val client: SentryClient = mock()
         val clientContext: Context = mock()
         val environmentString = "production"
-        val uncaughtExceptionCrash = Crash.UncaughtExceptionCrash(RuntimeException("test"), arrayListOf())
+        val uncaughtExceptionCrash = Crash.UncaughtExceptionCrash(0, RuntimeException("test"), arrayListOf())
         doReturn(clientContext).`when`(client).context
         doNothing().`when`(clientContext).clearBreadcrumbs()
 
@@ -352,6 +352,7 @@ class SentryServiceTest {
         val crashBreadCrumbs = arrayListOf<Breadcrumb>()
         crashBreadCrumbs.addAll(reporter.crashBreadcrumbs)
         val nativeCrash = Crash.NativeCodeCrash(
+                0,
                 "dump.path",
                 true,
                 "extras.path",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,10 @@ permalink: /changelog/
 
 * **lib-push-firebase**
   * Removed non-essential dependency on `com.google.firebase:firebase-core`.
+  
+* **lib-crash**
+  * Crash report timestamp is now set to when the crash occurred.
+  * When breadcrumbs limit is reached, oldest breadcrumbs are dropped.
 
 * **feature-toolbar**
   * Added `ContainerToolbarFeature` to update the toolbar with the container page action whenever the selected tab changes.


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
