### PR TITLE
Release 54.0.5 with GV 80.0.20200827204751

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -1,4 +1,4 @@
-componentsVersion: 54.0.4
+componentsVersion: 54.0.5
 projects:
   concept-awesomebar:
     path: components/concept/awesomebar

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -16,7 +16,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Release Version.
      */
-    const val release_version = "80.0.20200818235255"
+    const val release_version = "80.0.20200827204751"
 }
 
 @Suppress("Unused", "MaxLineLength")


### PR DESCRIPTION
This patch updates GeckoView to `80.0.20200827204751` and sets the Android Components release version to `54.0.5`.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
