### PR TITLE
Issue #8009: Handle all throwables in hasCamera check

### DIFF
--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt
@@ -80,7 +80,7 @@ fun Context.hasCamera(): Boolean {
     return try {
         val cameraManager: CameraManager? = getSystemService()
         cameraManager?.cameraIdList?.isNotEmpty() ?: false
-    } catch (e: Exception) {
+    } catch (_: Throwable) {
         false
     }
 }

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/content/ContextTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/content/ContextTest.kt
@@ -31,6 +31,7 @@ import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowApplication
 import org.robolectric.shadows.ShadowCameraCharacteristics
 import org.robolectric.shadows.ShadowProcess
+import java.lang.AssertionError
 import java.lang.IllegalStateException
 
 @RunWith(AndroidJUnit4::class)
@@ -157,7 +158,18 @@ class ContextTest {
         val context = spy(testContext)
         val cameraManager: CameraManager = mock()
         whenever(context.getSystemService(Context.CAMERA_SERVICE)).thenReturn(cameraManager)
+
         whenever(cameraManager.cameraIdList).thenThrow(IllegalStateException("Test"))
+        assertFalse(context.hasCamera())
+    }
+
+    @Test
+    fun `hasCamera returns false if assertion is thrown`() {
+        val context = spy(testContext)
+        val cameraManager: CameraManager = mock()
+        whenever(context.getSystemService(Context.CAMERA_SERVICE)).thenReturn(cameraManager)
+
+        whenever(cameraManager.cameraIdList).thenThrow(AssertionError("Test"))
         assertFalse(context.hasCamera())
     }
 }


### PR DESCRIPTION
We're seeing some devices that throw `AssertionErrors` here! 💯 🤦 

Let's not crash in those cases either and return false:
https://github.com/mozilla-mobile/fenix/issues/13956