### PR TITLE
Closes #8292: DownloadMiddleware uses context.dispatch on wrong thread

### DIFF
--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadMiddleware.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadMiddleware.kt
@@ -101,7 +101,7 @@ class DownloadMiddleware(
         downloadStorage.getDownloads().collect { downloads ->
             downloads.forEach { download ->
                 if (!context.state.downloads.containsKey(download.id)) {
-                    context.dispatch(DownloadAction.RestoreDownloadStateAction(download))
+                    context.store.dispatch(DownloadAction.RestoreDownloadStateAction(download))
                     logger.debug("Download restarted from the storage ${download.fileName}")
                 }
             }


### PR DESCRIPTION
@Amejia481 when reviewing https://github.com/mozilla-mobile/android-components/issues/8271 I missed that we're switching to an IO thread in `restoreDownloads`. My mistake.

We're not allowing a synchronous dispatch on the store from another thread. Undoing that and adding a fix for the intermittent test failure.