### PR TITLE
Improve qr support

### DIFF
--- a/components/feature/qr/src/main/java/mozilla/components/feature/qr/QrFeature.kt
+++ b/components/feature/qr/src/main/java/mozilla/components/feature/qr/QrFeature.kt
@@ -47,19 +47,20 @@ class QrFeature(
     internal val scanCompleteListener: QrFragment.OnScanCompleteListener = object : QrFragment.OnScanCompleteListener {
         @MainThread
         override fun onScanComplete(result: String) {
+            setScanCompleteListener(null)
             removeQrFragment()
             onScanResult(result)
         }
     }
 
     override fun start() {
-        (fragmentManager.findFragmentByTag(QR_FRAGMENT_TAG) as? QrFragment)?.let {
-            it.scanCompleteListener = scanCompleteListener
-        }
+        setScanCompleteListener(scanCompleteListener)
     }
 
     override fun stop() {
-        // Nothing to do here for now.
+        // Prevent an already in progress qr decode operation informing us later of a result
+        // and so triggering an IllegalStateException when trying to remove the qr fragment.
+        setScanCompleteListener(null)
     }
 
     override fun onBackPressed(): Boolean {
@@ -112,6 +113,16 @@ class QrFeature(
             }
         }
         return false
+    }
+
+    /**
+     * Set a callback for when a qr code has been successfully scanned and decoded.
+     */
+    @VisibleForTesting
+    internal fun setScanCompleteListener(listener: QrFragment.OnScanCompleteListener?) {
+        (fragmentManager.findFragmentByTag(QR_FRAGMENT_TAG) as? QrFragment)?.let {
+            it.scanCompleteListener = listener
+        }
     }
 
     companion object {

--- a/components/feature/qr/src/test/java/mozilla/components/feature/qr/QrFeatureTest.kt
+++ b/components/feature/qr/src/test/java/mozilla/components/feature/qr/QrFeatureTest.kt
@@ -27,7 +27,6 @@ import org.mockito.Mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mockito.MockitoAnnotations.initMocks
 
 @RunWith(AndroidJUnit4::class)
@@ -151,33 +150,71 @@ class QrFeatureTest {
         whenever(fragmentManager.findFragmentByTag(QR_FRAGMENT_TAG))
             .thenReturn(fragment)
 
-        val feature = QrFeature(
+        val feature = spy(QrFeature(
             testContext,
             fragmentManager
-        )
+        ))
+        val listener = feature.scanCompleteListener
 
         // When
         feature.start()
 
         // Then
-        verify(fragment).scanCompleteListener = feature.scanCompleteListener
+        verify(feature).setScanCompleteListener(listener)
     }
 
     @Test
-    fun `do nothing when stop() is called`() {
+    fun `stop attaches a null listener`() {
         // Given
-        val scanResultCallback = mock<OnScanResult>()
-        val feature = QrFeature(
+        val fragment = mock<QrFragment>()
+        whenever(fragmentManager.findFragmentByTag(QR_FRAGMENT_TAG))
+            .thenReturn(fragment)
+        val feature = spy(QrFeature(
             testContext,
-            fragmentManager,
-            onScanResult = scanResultCallback
-        )
+            fragmentManager
+        ))
 
         // When
         feature.stop()
 
         // Then
-        verifyNoMoreInteractions(scanResultCallback, fragmentManager)
+        verify(feature).setScanCompleteListener(null)
+    }
+
+    @Test
+    fun `setScanCompleteListener allows setting a null callback in QrFragment`() {
+        // Given
+        val fragment = mock<QrFragment>()
+        whenever(fragmentManager.findFragmentByTag(QR_FRAGMENT_TAG))
+            .thenReturn(fragment)
+        val feature = QrFeature(
+            testContext,
+            fragmentManager
+        )
+        fragment.scanCompleteListener = feature.scanCompleteListener
+
+        // When
+        feature.setScanCompleteListener(null)
+        // Then
+        verify(fragment).scanCompleteListener = null
+    }
+
+    @Test
+    fun `setScanCompleteListener allows setting a valid callback in QrFragment`() {
+        // Given
+        val fragment = mock<QrFragment>()
+        whenever(fragmentManager.findFragmentByTag(QR_FRAGMENT_TAG))
+            .thenReturn(fragment)
+        val feature = QrFeature(
+            testContext,
+            fragmentManager
+        )
+        fragment.scanCompleteListener = null
+
+        // When
+        feature.setScanCompleteListener(feature.scanCompleteListener)
+        // Then
+        verify(fragment).scanCompleteListener = feature.scanCompleteListener
     }
 }
 


### PR DESCRIPTION
Our scanCompleteListener was being leaked by an AsyncTask.
Make sure we won't get called after onStop anymore.

Refactor the heavy AsyncTask to a cancellable coroutine and allow for an easy
resume of decoding the images.

<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR does not need one
- [x] **Accessibility**: The code in this PR does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
