### PR TITLE
Issue #8300: Ensure that the default top sites are added in order

### DIFF
--- a/components/feature/top-sites/src/androidTest/java/mozilla/components/feature/top/sites/PinnedSitesStorageTest.kt
+++ b/components/feature/top-sites/src/androidTest/java/mozilla/components/feature/top/sites/PinnedSitesStorageTest.kt
@@ -60,6 +60,35 @@ class PinnedSitesStorageTest {
     }
 
     @Test
+    fun testAddingAllDefaultSites() = runBlocking {
+        val defaultTopSites = listOf(
+            Pair("Mozilla", "https://www.mozilla.org"),
+            Pair("Firefox", "https://www.firefox.com"),
+            Pair("Wikipedia", "https://www.wikipedia.com"),
+            Pair("Pocket", "https://www.getpocket.com")
+        )
+
+        storage.addAllPinnedSites(defaultTopSites, isDefault = true)
+
+        val topSites = storage.getPinnedSites()
+
+        assertEquals(4, topSites.size)
+
+        assertEquals("Mozilla", topSites[0].title)
+        assertEquals("https://www.mozilla.org", topSites[0].url)
+        assertEquals(DEFAULT, topSites[0].type)
+        assertEquals("Firefox", topSites[1].title)
+        assertEquals("https://www.firefox.com", topSites[1].url)
+        assertEquals(DEFAULT, topSites[2].type)
+        assertEquals("Wikipedia", topSites[2].title)
+        assertEquals("https://www.wikipedia.com", topSites[2].url)
+        assertEquals(DEFAULT, topSites[2].type)
+        assertEquals("Pocket", topSites[3].title)
+        assertEquals("https://www.getpocket.com", topSites[3].url)
+        assertEquals(DEFAULT, topSites[3].type)
+    }
+
+    @Test
     fun testAddingPinnedSite() = runBlocking {
         storage.addPinnedSite("Mozilla", "https://www.mozilla.org")
         storage.addPinnedSite("Firefox", "https://www.firefox.com", isDefault = true)

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/DefaultTopSitesStorage.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/DefaultTopSitesStorage.kt
@@ -8,9 +8,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import mozilla.components.browser.storage.sync.PlacesHistoryStorage
-import mozilla.components.feature.top.sites.ext.toTopSite
 import mozilla.components.feature.top.sites.TopSite.Type.FRECENT
 import mozilla.components.feature.top.sites.ext.hasUrl
+import mozilla.components.feature.top.sites.ext.toTopSite
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
 import kotlin.coroutines.CoroutineContext
@@ -39,9 +39,7 @@ class DefaultTopSitesStorage(
     init {
         if (defaultTopSites.isNotEmpty()) {
             scope.launch {
-                defaultTopSites.forEach { (title, url) ->
-                    addTopSite(title, url, isDefault = true)
-                }
+                pinnedSitesStorage.addAllPinnedSites(defaultTopSites, isDefault = true)
             }
         }
     }

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/PinnedSiteStorage.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/PinnedSiteStorage.kt
@@ -5,10 +5,11 @@
 package mozilla.components.feature.top.sites
 
 import android.content.Context
+import androidx.room.withTransaction
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
-import mozilla.components.feature.top.sites.db.TopSiteDatabase
 import mozilla.components.feature.top.sites.db.PinnedSiteEntity
+import mozilla.components.feature.top.sites.db.TopSiteDatabase
 import mozilla.components.feature.top.sites.db.toPinnedSite
 
 /**
@@ -20,6 +21,30 @@ class PinnedSiteStorage(context: Context) {
     private val pinnedSiteDao by lazy { database.value.pinnedSiteDao() }
 
     /**
+     * Adds the given list pinned sites.
+     *
+     * @param topSites A list containing a title to url pair of top sites to be added.
+     * @param isDefault Whether or not the pinned site added should be a default pinned site. This
+     * is used to identify pinned sites that are added by the application.
+     */
+    suspend fun addAllPinnedSites(
+        topSites: List<Pair<String, String>>,
+        isDefault: Boolean = false
+    ) = withContext(IO) {
+        database.value.withTransaction {
+            topSites.forEach { (title, url) ->
+                val entity = PinnedSiteEntity(
+                    title = title,
+                    url = url,
+                    isDefault = isDefault,
+                    createdAt = System.currentTimeMillis()
+                )
+                entity.id = pinnedSiteDao.insertPinnedSite(entity)
+            }
+        }
+    }
+
+    /**
      * Adds a new pinned site.
      *
      * @param title The title string.
@@ -27,15 +52,16 @@ class PinnedSiteStorage(context: Context) {
      * @param isDefault Whether or not the pinned site added should be a default pinned site. This
      * is used to identify pinned sites that are added by the application.
      */
-    suspend fun addPinnedSite(title: String, url: String, isDefault: Boolean = false) = withContext(IO) {
-        val entity = PinnedSiteEntity(
-            title = title,
-            url = url,
-            isDefault = isDefault,
-            createdAt = System.currentTimeMillis()
-        )
-        entity.id = pinnedSiteDao.insertPinnedSite(entity)
-    }
+    suspend fun addPinnedSite(title: String, url: String, isDefault: Boolean = false) =
+        withContext(IO) {
+            val entity = PinnedSiteEntity(
+                title = title,
+                url = url,
+                isDefault = isDefault,
+                createdAt = System.currentTimeMillis()
+            )
+            entity.id = pinnedSiteDao.insertPinnedSite(entity)
+        }
 
     /**
      * Returns a list of all the pinned sites.

--- a/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/DefaultTopSitesStorageTest.kt
+++ b/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/DefaultTopSitesStorageTest.kt
@@ -40,17 +40,7 @@ class DefaultTopSitesStorageTest {
             coroutineContext
         )
 
-        verify(pinnedSitesStorage).addPinnedSite(
-            "Mozilla",
-            "https://mozilla.com",
-            isDefault = true
-        )
-
-        verify(pinnedSitesStorage).addPinnedSite(
-            "Firefox",
-            "https://firefox.com",
-            isDefault = true
-        )
+        verify(pinnedSitesStorage).addAllPinnedSites(defaultTopSites, isDefault = true)
     }
 
     @Test


### PR DESCRIPTION
Adds a new method `addAllPinnedSites` in `PinnedSitesStorage` to execute adding all the default top sites in order.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Fixes #8300 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
