### PR TITLE
For #8305 - Initialize browserToolbar in onLayoutChild

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBottomBehavior.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBottomBehavior.kt
@@ -134,15 +134,22 @@ class BrowserToolbarBottomBehavior(
     }
 
     override fun layoutDependsOn(parent: CoordinatorLayout, child: BrowserToolbar, dependency: View): Boolean {
-        browserToolbar = child
-
-        engineView = parent.findViewInHierarchy { it is EngineView } as? EngineView
-
         if (dependency is Snackbar.SnackbarLayout) {
             positionSnackbar(child, dependency)
         }
 
         return super.layoutDependsOn(parent, child, dependency)
+    }
+
+    override fun onLayoutChild(
+        parent: CoordinatorLayout,
+        child: BrowserToolbar,
+        layoutDirection: Int
+    ): Boolean {
+        browserToolbar = child
+        engineView = parent.findViewInHierarchy { it is EngineView } as? EngineView
+
+        return super.onLayoutChild(parent, child, layoutDirection)
     }
 
     /**

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBottomBehaviorTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBottomBehaviorTest.kt
@@ -5,15 +5,20 @@
 package mozilla.components.browser.toolbar.behavior
 
 import android.animation.ValueAnimator
+import android.content.Context
+import android.graphics.Bitmap
 import android.view.Gravity
 import android.view.MotionEvent.ACTION_DOWN
 import android.view.MotionEvent.ACTION_MOVE
+import android.widget.FrameLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.ViewCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.android.material.snackbar.Snackbar
 import mozilla.components.browser.toolbar.BrowserToolbar
+import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
+import mozilla.components.concept.engine.selection.SelectionActionDelegate
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
@@ -358,5 +363,32 @@ class BrowserToolbarBottomBehaviorTest {
 
         verify(behavior).tryToScrollVertically(-30f)
         verify(behavior).forceExpand(toolbar)
+    }
+
+    @Test
+    fun `onLayoutChild initializes browserToolbar and engineView`() {
+        val toolbarView = BrowserToolbar(testContext)
+        val engineView = createDummyEngineView(testContext).asView()
+        val container = CoordinatorLayout(testContext).apply {
+            addView(BrowserToolbar(testContext))
+            addView(engineView)
+        }
+        val behavior = spy(BrowserToolbarBottomBehavior(testContext, attrs = null))
+
+        behavior.onLayoutChild(container, toolbarView, ViewCompat.LAYOUT_DIRECTION_LTR)
+
+        assertEquals(toolbarView, behavior.browserToolbar)
+        assertEquals(engineView, behavior.engineView)
+    }
+
+    private fun createDummyEngineView(context: Context): EngineView = DummyEngineView(context)
+
+    open class DummyEngineView(context: Context) : FrameLayout(context), EngineView {
+        override fun setVerticalClipping(clippingHeight: Int) {}
+        override fun setDynamicToolbarMaxHeight(height: Int) {}
+        override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) = Unit
+        override fun render(session: EngineSession) {}
+        override fun release() {}
+        override var selectionActionDelegate: SelectionActionDelegate? = null
     }
 }


### PR DESCRIPTION
Speculative fix that moves the initialization to another method that should
also be called before the user can interact with the toolbar.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests
- [x] **Changelog**: This PR does not need one
- [x] **Accessibility**: The code in this PR does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
