### PR TITLE
Lazily restore engine sessions after content process kill or crash.

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -77,8 +77,6 @@ class GeckoEngineSession(
     internal var scrollY: Int = 0
 
     internal var job: Job = Job()
-    private var lastSessionState: GeckoSession.SessionState? = null
-    private var stateBeforeCrash: GeckoSession.SessionState? = null
     private var canGoBack: Boolean = false
 
     /**
@@ -187,13 +185,6 @@ class GeckoEngineSession(
      */
     override fun goToHistoryIndex(index: Int) {
         geckoSession.gotoHistoryIndex(index)
-    }
-
-    /**
-     * See [EngineSession.saveState]
-     */
-    override fun saveState(): EngineSessionState {
-        return GeckoEngineSessionState(lastSessionState)
     }
 
     /**
@@ -369,22 +360,6 @@ class GeckoEngineSession(
      */
     override fun exitFullScreenMode() {
         geckoSession.exitFullScreen()
-    }
-
-    /**
-     * See [EngineSession.recoverFromCrash]
-     */
-    @Synchronized
-    override fun recoverFromCrash(): Boolean {
-        val state = stateBeforeCrash
-
-        return if (state != null) {
-            geckoSession.restoreState(state)
-            stateBeforeCrash = null
-            true
-        } else {
-            false
-        }
     }
 
     /**
@@ -601,7 +576,9 @@ class GeckoEngineSession(
         }
 
         override fun onSessionStateChange(session: GeckoSession, sessionState: GeckoSession.SessionState) {
-            lastSessionState = sessionState
+            notifyObservers {
+                onStateUpdated(GeckoEngineSessionState(sessionState))
+            }
         }
     }
 
@@ -726,23 +703,10 @@ class GeckoEngineSession(
         }
 
         override fun onCrash(session: GeckoSession) {
-            stateBeforeCrash = lastSessionState
-
-            recoverGeckoSession()
-
             notifyObservers { onCrash() }
         }
 
         override fun onKill(session: GeckoSession) {
-            // The content process of this session got killed (resources reclaimed by Android).
-            // Let's recover and restore the last known state.
-
-            val state = lastSessionState
-
-            recoverGeckoSession()
-
-            state?.let { geckoSession.restoreState(it) }
-
             notifyObservers { onProcessKilled() }
         }
 

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -7,14 +7,12 @@ package mozilla.components.browser.engine.gecko
 import android.content.Context
 import android.graphics.Bitmap
 import android.util.AttributeSet
-import android.view.View
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
 import androidx.core.view.ViewCompat
 import mozilla.components.browser.engine.gecko.selection.GeckoSelectionActionDelegate
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
-import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.selection.SelectionActionDelegate
 import org.mozilla.geckoview.BasicSelectionActionDelegate
 import org.mozilla.geckoview.GeckoResult
@@ -30,7 +28,7 @@ class GeckoEngineView @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr), EngineView {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal var currentGeckoView = object : NestedGeckoView(context) {
+    internal var geckoView = object : NestedGeckoView(context) {
 
         override fun onAttachedToWindow() {
             try {
@@ -40,12 +38,12 @@ class GeckoEngineView @JvmOverloads constructor(
                 val otherActivityClassName =
                     this.session?.accessibility?.view?.context?.javaClass?.simpleName
                 val otherActivityClassHashcode =
-                        this.session?.accessibility?.view?.context?.hashCode()
+                    this.session?.accessibility?.view?.context?.hashCode()
                 val activityClassName = context.javaClass.simpleName
                 val activityClassHashCode = context.hashCode()
                 val msg = "ATTACH VIEW: Current activity: $activityClassName hashcode " +
-                        "$activityClassHashCode Other activity: $otherActivityClassName " +
-                        "hashcode $otherActivityClassHashcode"
+                    "$activityClassHashCode Other activity: $otherActivityClassName " +
+                    "hashcode $otherActivityClassHashcode"
                 throw IllegalStateException(msg, e)
             }
         }
@@ -64,24 +62,6 @@ class GeckoEngineView @JvmOverloads constructor(
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal val observer = object : EngineSession.Observer {
-        override fun onCrash() {
-            rebind()
-        }
-
-        override fun onProcessKilled() {
-            rebind()
-        }
-
-        override fun onFirstContentfulPaint() {
-            visibility = View.VISIBLE
-        }
-
-        override fun onAppPermissionRequest(permissionRequest: PermissionRequest) = Unit
-        override fun onContentPermissionRequest(permissionRequest: PermissionRequest) = Unit
-    }
-
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal var currentSession: GeckoEngineSession? = null
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -90,9 +70,7 @@ class GeckoEngineView @JvmOverloads constructor(
     override var selectionActionDelegate: SelectionActionDelegate? = null
 
     init {
-        // Currently this is just a FrameLayout with a single GeckoView instance. Eventually this
-        // implementation should handle at least two GeckoView so that we can switch between
-        addView(currentGeckoView)
+        addView(geckoView)
     }
 
     /**
@@ -101,23 +79,18 @@ class GeckoEngineView @JvmOverloads constructor(
     @Synchronized
     override fun render(session: EngineSession) {
         val internalSession = session as GeckoEngineSession
+        currentSession = session
 
-        currentSession?.apply { unregister(observer) }
-
-        currentSession = session.apply {
-            register(observer)
-        }
-
-        if (currentGeckoView.session != internalSession.geckoSession) {
-            currentGeckoView.session?.let {
+        if (geckoView.session != internalSession.geckoSession) {
+            geckoView.session?.let {
                 // Release a previously assigned session. Otherwise GeckoView will close it
                 // automatically.
                 detachSelectionActionDelegate(it)
-                currentGeckoView.releaseSession()
+                geckoView.releaseSession()
             }
 
             try {
-                currentGeckoView.setSession(internalSession.geckoSession)
+                geckoView.setSession(internalSession.geckoSession)
                 attachSelectionActionDelegate(internalSession.geckoSession)
             } catch (e: IllegalStateException) {
                 // This is to debug "display already acquired" crashes
@@ -128,8 +101,8 @@ class GeckoEngineView @JvmOverloads constructor(
                 val activityClassName = context.javaClass.simpleName
                 val activityClassHashCode = context.hashCode()
                 val msg = "SET SESSION: Current activity: $activityClassName hashcode " +
-                        "$activityClassHashCode Other activity: $otherActivityClassName " +
-                        "hashcode $otherActivityClassHashcode"
+                    "$activityClassHashCode Other activity: $otherActivityClassName " +
+                    "hashcode $otherActivityClassHashcode"
                 throw IllegalStateException(msg, e)
             }
         }
@@ -150,40 +123,13 @@ class GeckoEngineView @JvmOverloads constructor(
         }
     }
 
-    /**
-     * Rebinds the current session to this view. This may be required after the session crashed and
-     * the view needs to notified about a new underlying GeckoSession (created under the hood by
-     * GeckoEngineSession) - since the previous one is no longer usable.
-     */
-    private fun rebind() {
-        try {
-            currentSession?.let { currentGeckoView.setSession(it.geckoSession) }
-        } catch (e: IllegalArgumentException) {
-            // This is to debug "Display not attached" crashes
-            val otherActivityClassName =
-                currentSession?.geckoSession?.accessibility?.view?.context?.javaClass?.simpleName
-            val otherActivityClassHashcode =
-                    currentSession?.geckoSession?.accessibility?.view?.context?.hashCode()
-            val activityClassName = context.javaClass.simpleName
-            val activityClassHashCode = context.hashCode()
-            val msg = "REBIND: Current activity: $activityClassName hashcode " +
-                    "$activityClassHashCode Other activity: $otherActivityClassName " +
-                    "hashcode $otherActivityClassHashcode"
-            throw IllegalArgumentException(msg, e)
-        }
-    }
-
     @Synchronized
     override fun release() {
         detachSelectionActionDelegate(currentSession?.geckoSession)
 
-        currentSession?.apply {
-            unregister(observer)
-        }
-
         currentSession = null
 
-        currentGeckoView.releaseSession()
+        geckoView.releaseSession()
     }
 
     override fun onDetachedFromWindow() {
@@ -201,21 +147,21 @@ class GeckoEngineView @JvmOverloads constructor(
     override fun getInputResult(): EngineView.InputResult {
         // Direct mapping of GeckoView's returned values.
         // There should be a 1-1 relation. If not fail fast to allow for a quick fix.
-        return EngineView.InputResult.values().first { it.value == currentGeckoView.inputResult }
+        return EngineView.InputResult.values().first { it.value == geckoView.inputResult }
     }
 
     override fun setVerticalClipping(clippingHeight: Int) {
-        currentGeckoView.setVerticalClipping(clippingHeight)
+        geckoView.setVerticalClipping(clippingHeight)
     }
 
     override fun setDynamicToolbarMaxHeight(height: Int) {
-        currentGeckoView.setDynamicToolbarMaxHeight(height)
+        geckoView.setDynamicToolbarMaxHeight(height)
     }
 
     @Suppress("TooGenericExceptionCaught")
     override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) {
         try {
-            val geckoResult = currentGeckoView.capturePixels()
+            val geckoResult = geckoView.capturePixels()
             geckoResult.then({ bitmap ->
                 onFinish(bitmap)
                 GeckoResult<Void>()
@@ -243,7 +189,7 @@ class GeckoEngineView @JvmOverloads constructor(
         // https://bugzilla.mozilla.org/show_bug.cgi?id=1630775
         // We do this to prevent the content from resizing when the view is not visible:
         // https://github.com/mozilla-mobile/android-components/issues/6664
-        currentGeckoView.visibility = visibility
+        geckoView.visibility = visibility
         super.setVisibility(visibility)
     }
 }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -23,7 +23,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
-import org.mockito.Mockito.reset
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mozilla.gecko.util.GeckoBundle
@@ -47,7 +46,7 @@ class GeckoEngineViewTest {
         val geckoView = mock<NestedGeckoView>()
 
         whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
+        engineView.geckoView = geckoView
 
         engineView.render(engineSession)
         verify(geckoView, times(1)).setSession(geckoSession)
@@ -65,7 +64,7 @@ class GeckoEngineViewTest {
 
         var geckoResult = GeckoResult<Bitmap>()
         whenever(mockGeckoView.capturePixels()).thenReturn(geckoResult)
-        engineView.currentGeckoView = mockGeckoView
+        engineView.geckoView = mockGeckoView
 
         // Test GeckoResult resolves successfuly
         engineView.captureThumbnail {
@@ -98,7 +97,7 @@ class GeckoEngineViewTest {
     @Test
     fun `clearSelection is forwarded to BasicSelectionAction instance`() {
         val engineView = GeckoEngineView(context)
-        engineView.currentGeckoView = mock()
+        engineView.geckoView = mock()
         engineView.currentSelection = mock()
 
         engineView.clearSelection()
@@ -109,21 +108,21 @@ class GeckoEngineViewTest {
     @Test
     fun `setVerticalClipping is forwarded to GeckoView instance`() {
         val engineView = GeckoEngineView(context)
-        engineView.currentGeckoView = mock()
+        engineView.geckoView = mock()
 
         engineView.setVerticalClipping(-42)
 
-        verify(engineView.currentGeckoView).setVerticalClipping(-42)
+        verify(engineView.geckoView).setVerticalClipping(-42)
     }
 
     @Test
     fun `setDynamicToolbarMaxHeight is forwarded to GeckoView instance`() {
         val engineView = GeckoEngineView(context)
-        engineView.currentGeckoView = mock()
+        engineView.geckoView = mock()
 
         engineView.setDynamicToolbarMaxHeight(42)
 
-        verify(engineView.currentGeckoView).setDynamicToolbarMaxHeight(42)
+        verify(engineView.geckoView).setDynamicToolbarMaxHeight(42)
     }
 
     @Test
@@ -134,7 +133,7 @@ class GeckoEngineViewTest {
         val geckoView = mock<NestedGeckoView>()
 
         whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
+        engineView.geckoView = geckoView
 
         engineView.render(engineSession)
 
@@ -144,47 +143,6 @@ class GeckoEngineViewTest {
         engineView.release()
 
         verify(geckoView).releaseSession()
-        verify(engineSession).unregister(any())
-    }
-
-    @Test
-    fun `View will rebind session if process gets killed`() {
-        val engineView = GeckoEngineView(context)
-        val engineSession = mock<GeckoEngineSession>()
-        val geckoSession = mock<GeckoSession>()
-        val geckoView = mock<NestedGeckoView>()
-
-        whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
-
-        engineView.render(engineSession)
-
-        reset(geckoView)
-        verify(geckoView, never()).setSession(geckoSession)
-
-        engineView.observer.onProcessKilled()
-
-        verify(geckoView).setSession(geckoSession)
-    }
-
-    @Test
-    fun `View will rebind session if session crashed`() {
-        val engineView = GeckoEngineView(context)
-        val engineSession = mock<GeckoEngineSession>()
-        val geckoSession = mock<GeckoSession>()
-        val geckoView = mock<NestedGeckoView>()
-
-        whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
-
-        engineView.render(engineSession)
-
-        reset(geckoView)
-        verify(geckoView, never()).setSession(geckoSession)
-
-        engineView.observer.onCrash()
-
-        verify(geckoView).setSession(geckoSession)
     }
 
     @Test
@@ -197,7 +155,7 @@ class GeckoEngineViewTest {
         val geckoView = mock<NestedGeckoView>()
 
         whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
+        engineView.geckoView = geckoView
 
         engineView.render(engineSession)
 
@@ -216,7 +174,7 @@ class GeckoEngineViewTest {
         val geckoView = mock<NestedGeckoView>()
 
         whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
+        engineView.geckoView = geckoView
 
         engineView.render(engineSession)
 
@@ -247,7 +205,7 @@ class GeckoEngineViewTest {
         val geckoView = mock<NestedGeckoView>()
 
         whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
+        engineView.geckoView = geckoView
 
         engineView.render(engineSession)
 
@@ -273,16 +231,16 @@ class GeckoEngineViewTest {
     @Test
     fun `setVisibility is propagated to gecko view`() {
         val engineView = GeckoEngineView(context)
-        engineView.currentGeckoView = mock()
+        engineView.geckoView = mock()
 
         engineView.visibility = View.GONE
-        verify(engineView.currentGeckoView)?.visibility = View.GONE
+        verify(engineView.geckoView)?.visibility = View.GONE
     }
 
     @Test
     fun `canClearSelection should return false for null selection, null and empty selection text`() {
         val engineView = GeckoEngineView(context)
-        engineView.currentGeckoView = mock()
+        engineView.geckoView = mock()
         engineView.currentSelection = mock()
 
         // null selection returns false

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -77,8 +77,6 @@ class GeckoEngineSession(
     internal var scrollY: Int = 0
 
     internal var job: Job = Job()
-    private var lastSessionState: GeckoSession.SessionState? = null
-    private var stateBeforeCrash: GeckoSession.SessionState? = null
     private var canGoBack: Boolean = false
 
     /**
@@ -187,13 +185,6 @@ class GeckoEngineSession(
      */
     override fun goToHistoryIndex(index: Int) {
         geckoSession.gotoHistoryIndex(index)
-    }
-
-    /**
-     * See [EngineSession.saveState]
-     */
-    override fun saveState(): EngineSessionState {
-        return GeckoEngineSessionState(lastSessionState)
     }
 
     /**
@@ -369,22 +360,6 @@ class GeckoEngineSession(
      */
     override fun exitFullScreenMode() {
         geckoSession.exitFullScreen()
-    }
-
-    /**
-     * See [EngineSession.recoverFromCrash]
-     */
-    @Synchronized
-    override fun recoverFromCrash(): Boolean {
-        val state = stateBeforeCrash
-
-        return if (state != null) {
-            geckoSession.restoreState(state)
-            stateBeforeCrash = null
-            true
-        } else {
-            false
-        }
     }
 
     /**
@@ -601,7 +576,9 @@ class GeckoEngineSession(
         }
 
         override fun onSessionStateChange(session: GeckoSession, sessionState: GeckoSession.SessionState) {
-            lastSessionState = sessionState
+            notifyObservers {
+                onStateUpdated(GeckoEngineSessionState(sessionState))
+            }
         }
     }
 
@@ -726,24 +703,13 @@ class GeckoEngineSession(
         }
 
         override fun onCrash(session: GeckoSession) {
-            stateBeforeCrash = lastSessionState
-
-            recoverGeckoSession()
-
             notifyObservers { onCrash() }
         }
 
         override fun onKill(session: GeckoSession) {
-            // The content process of this session got killed (resources reclaimed by Android).
-            // Let's recover and restore the last known state.
-
-            val state = lastSessionState
-
-            recoverGeckoSession()
-
-            state?.let { geckoSession.restoreState(it) }
-
-            notifyObservers { onProcessKilled() }
+            notifyObservers {
+                onProcessKilled()
+            }
         }
 
         private fun recoverGeckoSession() {

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -7,14 +7,12 @@ package mozilla.components.browser.engine.gecko
 import android.content.Context
 import android.graphics.Bitmap
 import android.util.AttributeSet
-import android.view.View
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
 import androidx.core.view.ViewCompat
 import mozilla.components.browser.engine.gecko.selection.GeckoSelectionActionDelegate
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
-import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.selection.SelectionActionDelegate
 import org.mozilla.geckoview.BasicSelectionActionDelegate
 import org.mozilla.geckoview.GeckoResult
@@ -30,7 +28,7 @@ class GeckoEngineView @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr), EngineView {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal var currentGeckoView = object : NestedGeckoView(context) {
+    internal var geckoView = object : NestedGeckoView(context) {
 
         override fun onAttachedToWindow() {
             try {
@@ -64,24 +62,6 @@ class GeckoEngineView @JvmOverloads constructor(
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal val observer = object : EngineSession.Observer {
-        override fun onCrash() {
-            rebind()
-        }
-
-        override fun onProcessKilled() {
-            rebind()
-        }
-
-        override fun onFirstContentfulPaint() {
-            visibility = View.VISIBLE
-        }
-
-        override fun onAppPermissionRequest(permissionRequest: PermissionRequest) = Unit
-        override fun onContentPermissionRequest(permissionRequest: PermissionRequest) = Unit
-    }
-
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal var currentSession: GeckoEngineSession? = null
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -90,9 +70,7 @@ class GeckoEngineView @JvmOverloads constructor(
     override var selectionActionDelegate: SelectionActionDelegate? = null
 
     init {
-        // Currently this is just a FrameLayout with a single GeckoView instance. Eventually this
-        // implementation should handle at least two GeckoView so that we can switch between
-        addView(currentGeckoView)
+        addView(geckoView)
     }
 
     /**
@@ -101,23 +79,18 @@ class GeckoEngineView @JvmOverloads constructor(
     @Synchronized
     override fun render(session: EngineSession) {
         val internalSession = session as GeckoEngineSession
+        currentSession = session
 
-        currentSession?.apply { unregister(observer) }
-
-        currentSession = session.apply {
-            register(observer)
-        }
-
-        if (currentGeckoView.session != internalSession.geckoSession) {
-            currentGeckoView.session?.let {
+        if (geckoView.session != internalSession.geckoSession) {
+            geckoView.session?.let {
                 // Release a previously assigned session. Otherwise GeckoView will close it
                 // automatically.
                 detachSelectionActionDelegate(it)
-                currentGeckoView.releaseSession()
+                geckoView.releaseSession()
             }
 
             try {
-                currentGeckoView.setSession(internalSession.geckoSession)
+                geckoView.setSession(internalSession.geckoSession)
                 attachSelectionActionDelegate(internalSession.geckoSession)
             } catch (e: IllegalStateException) {
                 // This is to debug "display already acquired" crashes
@@ -150,40 +123,13 @@ class GeckoEngineView @JvmOverloads constructor(
         }
     }
 
-    /**
-     * Rebinds the current session to this view. This may be required after the session crashed and
-     * the view needs to notified about a new underlying GeckoSession (created under the hood by
-     * GeckoEngineSession) - since the previous one is no longer usable.
-     */
-    private fun rebind() {
-        try {
-            currentSession?.let { currentGeckoView.setSession(it.geckoSession) }
-        } catch (e: IllegalArgumentException) {
-            // This is to debug "Display not attached" crashes
-            val otherActivityClassName =
-                currentSession?.geckoSession?.accessibility?.view?.context?.javaClass?.simpleName
-            val otherActivityClassHashcode =
-                    currentSession?.geckoSession?.accessibility?.view?.context?.hashCode()
-            val activityClassName = context.javaClass.simpleName
-            val activityClassHashCode = context.hashCode()
-            val msg = "REBIND: Current activity: $activityClassName hashcode " +
-                    "$activityClassHashCode Other activity: $otherActivityClassName " +
-                    "hashcode $otherActivityClassHashcode"
-            throw IllegalArgumentException(msg, e)
-        }
-    }
-
     @Synchronized
     override fun release() {
         detachSelectionActionDelegate(currentSession?.geckoSession)
 
-        currentSession?.apply {
-            unregister(observer)
-        }
-
         currentSession = null
 
-        currentGeckoView.releaseSession()
+        geckoView.releaseSession()
     }
 
     override fun onDetachedFromWindow() {
@@ -201,21 +147,21 @@ class GeckoEngineView @JvmOverloads constructor(
     override fun getInputResult(): EngineView.InputResult {
         // Direct mapping of GeckoView's returned values.
         // There should be a 1-1 relation. If not fail fast to allow for a quick fix.
-        return EngineView.InputResult.values().first { it.value == currentGeckoView.inputResult }
+        return EngineView.InputResult.values().first { it.value == geckoView.inputResult }
     }
 
     override fun setVerticalClipping(clippingHeight: Int) {
-        currentGeckoView.setVerticalClipping(clippingHeight)
+        geckoView.setVerticalClipping(clippingHeight)
     }
 
     override fun setDynamicToolbarMaxHeight(height: Int) {
-        currentGeckoView.setDynamicToolbarMaxHeight(height)
+        geckoView.setDynamicToolbarMaxHeight(height)
     }
 
     @Suppress("TooGenericExceptionCaught")
     override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) {
         try {
-            val geckoResult = currentGeckoView.capturePixels()
+            val geckoResult = geckoView.capturePixels()
             geckoResult.then({ bitmap ->
                 onFinish(bitmap)
                 GeckoResult<Void>()
@@ -243,7 +189,7 @@ class GeckoEngineView @JvmOverloads constructor(
         // https://bugzilla.mozilla.org/show_bug.cgi?id=1630775
         // We do this to prevent the content from resizing when the view is not visible:
         // https://github.com/mozilla-mobile/android-components/issues/6664
-        currentGeckoView.visibility = visibility
+        geckoView.visibility = visibility
         super.setVisibility(visibility)
     }
 }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -11,7 +11,6 @@ import android.view.View
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.selection.GeckoSelectionActionDelegate
 import mozilla.components.concept.engine.selection.SelectionActionDelegate
-import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
@@ -23,7 +22,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
-import org.mockito.Mockito.reset
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mozilla.gecko.util.GeckoBundle
@@ -47,7 +45,7 @@ class GeckoEngineViewTest {
         val geckoView = mock<NestedGeckoView>()
 
         whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
+        engineView.geckoView = geckoView
 
         engineView.render(engineSession)
         verify(geckoView, times(1)).setSession(geckoSession)
@@ -65,7 +63,7 @@ class GeckoEngineViewTest {
 
         var geckoResult = GeckoResult<Bitmap>()
         whenever(mockGeckoView.capturePixels()).thenReturn(geckoResult)
-        engineView.currentGeckoView = mockGeckoView
+        engineView.geckoView = mockGeckoView
 
         // Test GeckoResult resolves successfuly
         engineView.captureThumbnail {
@@ -98,7 +96,7 @@ class GeckoEngineViewTest {
     @Test
     fun `clearSelection is forwarded to BasicSelectionAction instance`() {
         val engineView = GeckoEngineView(context)
-        engineView.currentGeckoView = mock()
+        engineView.geckoView = mock()
         engineView.currentSelection = mock()
 
         engineView.clearSelection()
@@ -109,21 +107,21 @@ class GeckoEngineViewTest {
     @Test
     fun `setVerticalClipping is forwarded to GeckoView instance`() {
         val engineView = GeckoEngineView(context)
-        engineView.currentGeckoView = mock()
+        engineView.geckoView = mock()
 
         engineView.setVerticalClipping(-42)
 
-        verify(engineView.currentGeckoView).setVerticalClipping(-42)
+        verify(engineView.geckoView).setVerticalClipping(-42)
     }
 
     @Test
     fun `setDynamicToolbarMaxHeight is forwarded to GeckoView instance`() {
         val engineView = GeckoEngineView(context)
-        engineView.currentGeckoView = mock()
+        engineView.geckoView = mock()
 
         engineView.setDynamicToolbarMaxHeight(42)
 
-        verify(engineView.currentGeckoView).setDynamicToolbarMaxHeight(42)
+        verify(engineView.geckoView).setDynamicToolbarMaxHeight(42)
     }
 
     @Test
@@ -134,57 +132,15 @@ class GeckoEngineViewTest {
         val geckoView = mock<NestedGeckoView>()
 
         whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
+        engineView.geckoView = geckoView
 
         engineView.render(engineSession)
 
         verify(geckoView, never()).releaseSession()
-        verify(engineSession, never()).unregister(any())
 
         engineView.release()
 
         verify(geckoView).releaseSession()
-        verify(engineSession).unregister(any())
-    }
-
-    @Test
-    fun `View will rebind session if process gets killed`() {
-        val engineView = GeckoEngineView(context)
-        val engineSession = mock<GeckoEngineSession>()
-        val geckoSession = mock<GeckoSession>()
-        val geckoView = mock<NestedGeckoView>()
-
-        whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
-
-        engineView.render(engineSession)
-
-        reset(geckoView)
-        verify(geckoView, never()).setSession(geckoSession)
-
-        engineView.observer.onProcessKilled()
-
-        verify(geckoView).setSession(geckoSession)
-    }
-
-    @Test
-    fun `View will rebind session if session crashed`() {
-        val engineView = GeckoEngineView(context)
-        val engineSession = mock<GeckoEngineSession>()
-        val geckoSession = mock<GeckoSession>()
-        val geckoView = mock<NestedGeckoView>()
-
-        whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
-
-        engineView.render(engineSession)
-
-        reset(geckoView)
-        verify(geckoView, never()).setSession(geckoSession)
-
-        engineView.observer.onCrash()
-
-        verify(geckoView).setSession(geckoSession)
     }
 
     @Test
@@ -197,7 +153,7 @@ class GeckoEngineViewTest {
         val geckoView = mock<NestedGeckoView>()
 
         whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
+        engineView.geckoView = geckoView
 
         engineView.render(engineSession)
 
@@ -216,7 +172,7 @@ class GeckoEngineViewTest {
         val geckoView = mock<NestedGeckoView>()
 
         whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
+        engineView.geckoView = geckoView
 
         engineView.render(engineSession)
 
@@ -247,7 +203,7 @@ class GeckoEngineViewTest {
         val geckoView = mock<NestedGeckoView>()
 
         whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
+        engineView.geckoView = geckoView
 
         engineView.render(engineSession)
 
@@ -273,16 +229,16 @@ class GeckoEngineViewTest {
     @Test
     fun `setVisibility is propagated to gecko view`() {
         val engineView = GeckoEngineView(context)
-        engineView.currentGeckoView = mock()
+        engineView.geckoView = mock()
 
         engineView.visibility = View.GONE
-        verify(engineView.currentGeckoView)?.visibility = View.GONE
+        verify(engineView.geckoView)?.visibility = View.GONE
     }
 
     @Test
     fun `canClearSelection should return false for null selection, null and empty selection text`() {
         val engineView = GeckoEngineView(context)
-        engineView.currentGeckoView = mock()
+        engineView.geckoView = mock()
         engineView.currentSelection = mock()
 
         // null selection returns false

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -23,7 +23,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
-import org.mockito.Mockito.reset
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mozilla.gecko.util.GeckoBundle
@@ -47,7 +46,7 @@ class GeckoEngineViewTest {
         val geckoView = mock<NestedGeckoView>()
 
         whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
+        engineView.geckoView = geckoView
 
         engineView.render(engineSession)
         verify(geckoView, times(1)).setSession(geckoSession)
@@ -65,7 +64,7 @@ class GeckoEngineViewTest {
 
         var geckoResult = GeckoResult<Bitmap>()
         whenever(mockGeckoView.capturePixels()).thenReturn(geckoResult)
-        engineView.currentGeckoView = mockGeckoView
+        engineView.geckoView = mockGeckoView
 
         // Test GeckoResult resolves successfuly
         engineView.captureThumbnail {
@@ -98,7 +97,7 @@ class GeckoEngineViewTest {
     @Test
     fun `clearSelection is forwarded to BasicSelectionAction instance`() {
         val engineView = GeckoEngineView(context)
-        engineView.currentGeckoView = mock()
+        engineView.geckoView = mock()
         engineView.currentSelection = mock()
 
         engineView.clearSelection()
@@ -109,21 +108,21 @@ class GeckoEngineViewTest {
     @Test
     fun `setVerticalClipping is forwarded to GeckoView instance`() {
         val engineView = GeckoEngineView(context)
-        engineView.currentGeckoView = mock()
+        engineView.geckoView = mock()
 
         engineView.setVerticalClipping(-42)
 
-        verify(engineView.currentGeckoView).setVerticalClipping(-42)
+        verify(engineView.geckoView).setVerticalClipping(-42)
     }
 
     @Test
     fun `setDynamicToolbarMaxHeight is forwarded to GeckoView instance`() {
         val engineView = GeckoEngineView(context)
-        engineView.currentGeckoView = mock()
+        engineView.geckoView = mock()
 
         engineView.setDynamicToolbarMaxHeight(42)
 
-        verify(engineView.currentGeckoView).setDynamicToolbarMaxHeight(42)
+        verify(engineView.geckoView).setDynamicToolbarMaxHeight(42)
     }
 
     @Test
@@ -134,7 +133,7 @@ class GeckoEngineViewTest {
         val geckoView = mock<NestedGeckoView>()
 
         whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
+        engineView.geckoView = geckoView
 
         engineView.render(engineSession)
 
@@ -144,47 +143,6 @@ class GeckoEngineViewTest {
         engineView.release()
 
         verify(geckoView).releaseSession()
-        verify(engineSession).unregister(any())
-    }
-
-    @Test
-    fun `View will rebind session if process gets killed`() {
-        val engineView = GeckoEngineView(context)
-        val engineSession = mock<GeckoEngineSession>()
-        val geckoSession = mock<GeckoSession>()
-        val geckoView = mock<NestedGeckoView>()
-
-        whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
-
-        engineView.render(engineSession)
-
-        reset(geckoView)
-        verify(geckoView, never()).setSession(geckoSession)
-
-        engineView.observer.onProcessKilled()
-
-        verify(geckoView).setSession(geckoSession)
-    }
-
-    @Test
-    fun `View will rebind session if session crashed`() {
-        val engineView = GeckoEngineView(context)
-        val engineSession = mock<GeckoEngineSession>()
-        val geckoSession = mock<GeckoSession>()
-        val geckoView = mock<NestedGeckoView>()
-
-        whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
-
-        engineView.render(engineSession)
-
-        reset(geckoView)
-        verify(geckoView, never()).setSession(geckoSession)
-
-        engineView.observer.onCrash()
-
-        verify(geckoView).setSession(geckoSession)
     }
 
     @Test
@@ -197,7 +155,7 @@ class GeckoEngineViewTest {
         val geckoView = mock<NestedGeckoView>()
 
         whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
+        engineView.geckoView = geckoView
 
         engineView.render(engineSession)
 
@@ -216,7 +174,7 @@ class GeckoEngineViewTest {
         val geckoView = mock<NestedGeckoView>()
 
         whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
+        engineView.geckoView = geckoView
 
         engineView.render(engineSession)
 
@@ -247,7 +205,7 @@ class GeckoEngineViewTest {
         val geckoView = mock<NestedGeckoView>()
 
         whenever(engineSession.geckoSession).thenReturn(geckoSession)
-        engineView.currentGeckoView = geckoView
+        engineView.geckoView = geckoView
 
         engineView.render(engineSession)
 
@@ -273,16 +231,16 @@ class GeckoEngineViewTest {
     @Test
     fun `setVisibility is propagated to gecko view`() {
         val engineView = GeckoEngineView(context)
-        engineView.currentGeckoView = mock()
+        engineView.geckoView = mock()
 
         engineView.visibility = View.GONE
-        verify(engineView.currentGeckoView)?.visibility = View.GONE
+        verify(engineView.geckoView)?.visibility = View.GONE
     }
 
     @Test
     fun `canClearSelection should return false for null selection, null and empty selection text`() {
         val engineView = GeckoEngineView(context)
-        engineView.currentGeckoView = mock()
+        engineView.geckoView = mock()
         engineView.currentSelection = mock()
 
         // null selection returns false

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -5,7 +5,6 @@
 package mozilla.components.browser.engine.system
 
 import android.content.Context
-import android.os.Bundle
 import android.webkit.CookieManager
 import android.webkit.WebChromeClient
 import android.webkit.WebSettings
@@ -16,11 +15,9 @@ import android.webkit.WebViewDatabase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.Engine.BrowsingData
 import mozilla.components.concept.engine.EngineSession
-import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
@@ -135,18 +132,6 @@ class SystemEngineSession(
     }
 
     /**
-     * See [EngineSession.saveState]
-     */
-    override fun saveState(): EngineSessionState {
-        return runBlocking(Dispatchers.Main) {
-            val state = Bundle()
-            webView.saveState(state)
-
-            SystemEngineSessionState(state)
-        }
-    }
-
-    /**
      * See [EngineSession.restoreState]
      */
     override fun restoreState(state: EngineSessionState): Boolean {
@@ -245,16 +230,6 @@ class SystemEngineSession(
      */
     override fun clearFindMatches() {
         webView.clearMatches()
-    }
-
-    /**
-     * This method is a no-op.
-     */
-    override fun recoverFromCrash(): Boolean {
-        // Do nothing.
-        // Technically we could remember saved states and restore the last one we saw. But for that to be useful we
-        // would need to implement and handle onRenderProcessGone() first.
-        return false
     }
 
     /**

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -44,7 +44,6 @@ class SessionManager(
 
         return Snapshot.Item(
             session,
-            tab?.engineState?.engineSession,
             tab?.engineState?.engineSessionState,
             tab?.readerState)
     }
@@ -212,12 +211,8 @@ class SessionManager(
         store?.syncDispatch(TabListAction.RestoreAction(tabs, selectedTabId))
 
         items.forEach { item ->
-            item.engineSession?.let { store?.syncDispatch(LinkEngineSessionAction(item.session.id, it)) }
-
-            if (item.engineSession == null) {
-                item.engineSessionState?.let {
-                    store?.syncDispatch(UpdateEngineSessionStateAction(item.session.id, it))
-                }
+            item.engineSessionState?.let {
+                store?.syncDispatch(UpdateEngineSessionStateAction(item.session.id, it))
             }
 
             item.readerState?.let {
@@ -305,7 +300,6 @@ class SessionManager(
 
         data class Item(
             val session: Session,
-            val engineSession: EngineSession? = null,
             val engineSessionState: EngineSessionState? = null,
             val readerState: ReaderState? = null,
             val lastAccess: Long = 0

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineMiddleware.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineMiddleware.kt
@@ -59,16 +59,13 @@ object EngineMiddleware {
             WebExtensionMiddleware(),
             TrimMemoryMiddleware(),
             LastAccessMiddleware(),
-            CrashMiddleware(
-                engine,
-                sessionLookup,
-                scope
-            )
+            CrashMiddleware()
         )
     }
 }
 
 @MainThread
+@Suppress("ReturnCount")
 internal fun getOrCreateEngineSession(
     engine: Engine,
     logger: Logger,
@@ -82,8 +79,13 @@ internal fun getOrCreateEngineSession(
         return null
     }
 
+    if (tab.engineState.crashed) {
+        logger.warn("Not creating engine session, since tab is crashed. Waiting for restore.")
+        return null
+    }
+
     tab.engineState.engineSession?.let {
-        logger.debug("Engine Session already exists for tab $tabId")
+        logger.debug("Engine session already exists for tab $tabId")
         return it
     }
 

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -17,6 +17,7 @@ import mozilla.components.browser.session.ext.toElement
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.CrashAction
+import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.MediaAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
 import mozilla.components.browser.state.state.BrowserState
@@ -24,6 +25,7 @@ import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.state.content.DownloadState.Status.INITIATED
 import mozilla.components.browser.state.state.content.FindResultState
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.content.blocking.Tracker
 import mozilla.components.concept.engine.history.HistoryItem
@@ -308,6 +310,18 @@ internal class EngineObserver(
     override fun onCrash() {
         store?.dispatch(CrashAction.SessionCrashedAction(
             session.id
+        ))
+    }
+
+    override fun onProcessKilled() {
+        store?.dispatch(EngineAction.SuspendEngineSessionAction(
+            session.id
+        ))
+    }
+
+    override fun onStateUpdated(state: EngineSessionState) {
+        store?.dispatch(EngineAction.UpdateEngineSessionStateAction(
+            session.id, state
         ))
     }
 

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/middleware/CrashMiddleware.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/middleware/CrashMiddleware.kt
@@ -4,55 +4,39 @@
 
 package mozilla.components.browser.session.engine.middleware
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
-import mozilla.components.browser.session.Session
-import mozilla.components.browser.session.engine.getOrCreateEngineSession
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.CrashAction
-import mozilla.components.browser.state.selector.findTabOrCustomTab
+import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.state.BrowserState
-import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.MiddlewareContext
-import mozilla.components.lib.state.Store
-import mozilla.components.support.base.log.logger.Logger
 
 /**
  * [Middleware] responsible for recovering crashed [EngineSession] instances.
  */
-internal class CrashMiddleware(
-    private val engine: Engine,
-    private val sessionLookup: (String) -> Session?,
-    private val scope: CoroutineScope
-) : Middleware<BrowserState, BrowserAction> {
-    private val logger = Logger("CrashMiddleware")
-
+internal class CrashMiddleware : Middleware<BrowserState, BrowserAction> {
     override fun invoke(
         context: MiddlewareContext<BrowserState, BrowserAction>,
         next: (BrowserAction) -> Unit,
         action: BrowserAction
     ) {
-        if (action is CrashAction.RestoreCrashedSessionAction) {
-            restore(context.store, action)
+        if (action is CrashAction.SessionCrashedAction) {
+            onCrash(context, action)
         }
 
         next(action)
     }
 
-    private fun restore(
-        store: Store<BrowserState, BrowserAction>,
-        action: CrashAction.RestoreCrashedSessionAction
-    ) = scope.launch {
-        val tab = store.state.findTabOrCustomTab(action.tabId) ?: return@launch
-
-        // Currently we are forcing the creation of an engine session here. This is mimicing
-        // the previous behavior. But it is questionable if this is the right approach:
-        // - How did this tab crash if it does not have an engine session?
-        // - Instead of creating the engine session, could we turn it into a suspended
-        //   session with the "crash state" as the last state?
-        val engineSession = getOrCreateEngineSession(engine, logger, sessionLookup, store, tab.id)
-        engineSession?.recoverFromCrash()
+    private fun onCrash(
+        context: MiddlewareContext<BrowserState, BrowserAction>,
+        action: CrashAction.SessionCrashedAction
+    ) {
+        // We suspend the crashed session here. After that the reducer will mark it as "crashed".
+        // That will prevent it from getting recreated until explicitly handling the crash by
+        // restoring.
+        context.dispatch(
+            EngineAction.SuspendEngineSessionAction(action.tabId)
+        )
     }
 }

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/middleware/SuspendMiddleware.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/middleware/SuspendMiddleware.kt
@@ -43,24 +43,11 @@ internal class SuspendMiddleware(
         context: MiddlewareContext<BrowserState, BrowserAction>,
         action: EngineAction.SuspendEngineSessionAction
     ) {
-        val tab = context.state.findTab(action.sessionId)
-        val state = tab?.engineState?.engineSession?.saveState()
-
-        if (tab == null || state == null) {
-            // If we can't find this tab or if there's no state for this tab then there's nothing
-            // to do here.
-            return
-        }
+        val tab = context.state.findTab(action.sessionId) ?: return
 
         // First we unlink (which clearsEngineSession and state)
         context.dispatch(EngineAction.UnlinkEngineSessionAction(
             tab.id
-        ))
-
-        // Then we attach the saved state to it.
-        context.dispatch(EngineAction.UpdateEngineSessionStateAction(
-            tab.id,
-            state
         ))
 
         // Now we can close the unlinked EngineSession (on the main thread).

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/storage/BrowserStateSerializer.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/storage/BrowserStateSerializer.kt
@@ -57,9 +57,7 @@ class BrowserStateSerializer {
         itemJson.put(Keys.SESSION_KEY, sessionJson)
 
         val engineSessionState = tab.engineState.engineSessionState
-        val engineSessionStateJson = engineSessionState?.toJSON()
-            ?: (tab.engineState.engineSession?.saveState()?.toJSON()
-                ?: JSONObject())
+        val engineSessionStateJson = engineSessionState?.toJSON() ?: JSONObject()
         itemJson.put(Keys.ENGINE_SESSION_KEY, engineSessionStateJson)
 
         return itemJson

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/storage/SnapshotSerializer.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/storage/SnapshotSerializer.kt
@@ -59,12 +59,9 @@ class SnapshotSerializer(
         sessionJson.put(Keys.SESSION_LAST_ACCESS, item.lastAccess)
         itemJson.put(Keys.SESSION_KEY, sessionJson)
 
-        val engineSessionState = if (item.engineSessionState != null) {
-            item.engineSessionState.toJSON()
-        } else {
-            item.engineSession?.saveState()?.toJSON() ?: JSONObject()
-        }
+        val engineSessionState = item.engineSessionState?.toJSON() ?: JSONObject()
         itemJson.put(Keys.ENGINE_SESSION_KEY, engineSessionState)
+
         return itemJson
     }
 
@@ -111,7 +108,6 @@ class SnapshotSerializer(
 
         return SessionManager.Snapshot.Item(
             session,
-            engineSession = null,
             engineSessionState = engineState,
             readerState = readerState,
             lastAccess = lastAccess

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
@@ -788,7 +788,6 @@ class SessionManagerMigrationTest {
         val store = BrowserStore()
         val sessionManager = SessionManager(engine, store)
 
-        val engineSession: EngineSession = mock()
         val engineSessionState: EngineSessionState = mock()
 
         val snapshot = SessionManager.Snapshot(
@@ -798,8 +797,7 @@ class SessionManagerMigrationTest {
                     engineSessionState = engineSessionState
                 ),
                 SessionManager.Snapshot.Item(
-                    session = Session(id = "session2", initialUrl = "http://www.mozilla.org"),
-                    engineSession = engineSession
+                    session = Session(id = "session2", initialUrl = "http://www.mozilla.org")
                 )
             ),
             selectedSessionIndex = 0
@@ -810,10 +808,6 @@ class SessionManagerMigrationTest {
 
         store.state.findTab("session1")!!.also { tab ->
             assertEquals(engineSessionState, tab.engineState.engineSessionState)
-        }
-
-        store.state.findTab("session2")!!.also { tab ->
-            assertEquals(engineSession, tab.engineState.engineSession)
         }
     }
 

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -9,7 +9,6 @@ import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.action.LastAccessAction
 import mozilla.components.browser.state.state.CustomTabConfig
 import mozilla.components.browser.state.store.BrowserStore
-import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
@@ -335,14 +334,12 @@ class SessionManagerTest {
         // Multiple sessions in the snapshot.
         val regularSession = Session("http://www.firefox.com")
         val engineSessionState: EngineSessionState = mock()
-        val engineSession = mock(EngineSession::class.java)
-        `when`(engineSession.saveState()).thenReturn(engineSessionState)
 
         val snapshot = SessionManager.Snapshot(
             listOf(
                 SessionManager.Snapshot.Item(
                     session = regularSession,
-                    engineSession = engineSession
+                    engineSessionState = engineSessionState
                 ),
                 SessionManager.Snapshot.Item(session = Session("http://www.wikipedia.org"))
             ),

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -70,8 +70,6 @@ class EngineObserverTest {
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
             override fun exitFullScreenMode() {}
-            override fun saveState(): EngineSessionState = mock()
-            override fun recoverFromCrash(): Boolean { return false }
 
             override fun loadData(data: String, mimeType: String, encoding: String) {
                 notifyObservers { onLocationChange(data) }
@@ -124,9 +122,7 @@ class EngineObserverTest {
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
             override fun exitFullScreenMode() {}
-            override fun saveState(): EngineSessionState = mock()
             override fun loadData(data: String, mimeType: String, encoding: String) {}
-            override fun recoverFromCrash(): Boolean { return false }
             override fun loadUrl(
                 url: String,
                 parent: EngineSession?,
@@ -170,7 +166,6 @@ class EngineObserverTest {
             }
 
             override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {}
-            override fun saveState(): EngineSessionState = mock()
             override fun loadUrl(
                 url: String,
                 parent: EngineSession?,
@@ -182,7 +177,6 @@ class EngineObserverTest {
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
             override fun exitFullScreenMode() {}
-            override fun recoverFromCrash(): Boolean { return false }
         }
         val observer = EngineObserver(session, mock())
         engineSession.register(observer)

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/middleware/CrashMiddlewareTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/middleware/CrashMiddlewareTest.kt
@@ -21,9 +21,6 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.doReturn
-import org.mockito.Mockito.never
-import org.mockito.Mockito.reset
-import org.mockito.Mockito.verify
 
 class CrashMiddlewareTest {
     @Test
@@ -65,13 +62,9 @@ class CrashMiddlewareTest {
             "tab3"
         )).joinBlocking()
 
-        assertTrue(store.state.tabs[0].crashed)
-        assertFalse(store.state.tabs[1].crashed)
-        assertTrue(store.state.tabs[2].crashed)
-
-        verify(engineSession1, never()).recoverFromCrash()
-        verify(engineSession2, never()).recoverFromCrash()
-        verify(engineSession3, never()).recoverFromCrash()
+        assertTrue(store.state.tabs[0].engineState.crashed)
+        assertFalse(store.state.tabs[1].engineState.crashed)
+        assertTrue(store.state.tabs[2].engineState.crashed)
 
         // Restoring crashed session
         store.dispatch(CrashAction.RestoreCrashedSessionAction(
@@ -80,14 +73,9 @@ class CrashMiddlewareTest {
 
         dispatcher.advanceUntilIdle()
 
-        verify(engineSession1).recoverFromCrash()
-        verify(engineSession2, never()).recoverFromCrash()
-        verify(engineSession3, never()).recoverFromCrash()
-        reset(engineSession1, engineSession2, engineSession3)
-
-        assertFalse(store.state.tabs[0].crashed)
-        assertFalse(store.state.tabs[1].crashed)
-        assertTrue(store.state.tabs[2].crashed)
+        assertFalse(store.state.tabs[0].engineState.crashed)
+        assertFalse(store.state.tabs[1].engineState.crashed)
+        assertTrue(store.state.tabs[2].engineState.crashed)
 
         // Restoring a non crashed session
         store.dispatch(CrashAction.RestoreCrashedSessionAction(
@@ -96,13 +84,6 @@ class CrashMiddlewareTest {
 
         dispatcher.advanceUntilIdle()
 
-        // EngineSession.recoverFromCrash() handles internally the situation where there's no
-        // crashed state.
-        verify(engineSession1, never()).recoverFromCrash()
-        verify(engineSession2).recoverFromCrash()
-        verify(engineSession3, never()).recoverFromCrash()
-        reset(engineSession1, engineSession2, engineSession3)
-
         // Restoring unknown session
         store.dispatch(CrashAction.RestoreCrashedSessionAction(
             "unknown"
@@ -110,13 +91,9 @@ class CrashMiddlewareTest {
 
         dispatcher.advanceUntilIdle()
 
-        verify(engineSession1, never()).recoverFromCrash()
-        verify(engineSession2, never()).recoverFromCrash()
-        verify(engineSession3, never()).recoverFromCrash()
-
-        assertFalse(store.state.tabs[0].crashed)
-        assertFalse(store.state.tabs[1].crashed)
-        assertTrue(store.state.tabs[2].crashed)
+        assertFalse(store.state.tabs[0].engineState.crashed)
+        assertFalse(store.state.tabs[1].engineState.crashed)
+        assertTrue(store.state.tabs[2].engineState.crashed)
     }
 
     @Test
@@ -147,7 +124,7 @@ class CrashMiddlewareTest {
 
         dispatcher.advanceUntilIdle()
 
-        assertTrue(store.state.tabs[0].crashed)
+        assertTrue(store.state.tabs[0].engineState.crashed)
 
         store.dispatch(CrashAction.RestoreCrashedSessionAction(
             "tab1"
@@ -155,9 +132,6 @@ class CrashMiddlewareTest {
 
         dispatcher.advanceUntilIdle()
 
-        verify(engine).createSession()
-        verify(engineSession).recoverFromCrash()
-
-        assertFalse(store.state.tabs[0].crashed)
+        assertFalse(store.state.tabs[0].engineState.crashed)
     }
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/middleware/SuspendMiddlewareTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/middleware/SuspendMiddlewareTest.kt
@@ -18,7 +18,6 @@ import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
-import mozilla.components.support.test.whenever
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -50,15 +49,16 @@ class SuspendMiddlewareTest {
         )
 
         val engineSession: EngineSession = mock()
-        val state: EngineSessionState = mock()
-        whenever(engineSession.saveState()).thenReturn(state)
         store.dispatch(EngineAction.LinkEngineSessionAction(tab.id, engineSession)).joinBlocking()
 
+        val state: EngineSessionState = mock()
+        store.dispatch(EngineAction.UpdateEngineSessionStateAction(tab.id, state)).joinBlocking()
+
         store.dispatch(EngineAction.SuspendEngineSessionAction(tab.id)).joinBlocking()
-        verify(engineSession).saveState()
 
         store.waitUntilIdle()
         dispatcher.advanceUntilIdle()
+
         assertNull(store.state.findTab(tab.id)?.engineState?.engineSession)
         assertEquals(state, store.state.findTab(tab.id)?.engineState?.engineSessionState)
         verify(engineSession).close()

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/storage/SessionStorageTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/storage/SessionStorageTest.kt
@@ -59,9 +59,6 @@ class SessionStorageTest {
             override fun toJSON() = JSONObject()
         }
 
-        val engineSession = mock(EngineSession::class.java)
-        `when`(engineSession.saveState()).thenReturn(engineSessionState)
-
         val engine = mock(Engine::class.java)
         `when`(engine.name()).thenReturn("gecko")
         `when`(engine.createSession()).thenReturn(mock(EngineSession::class.java))

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/storage/SnapshotSerializerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/storage/SnapshotSerializerTest.kt
@@ -10,7 +10,6 @@ import mozilla.components.browser.session.SessionManager.Snapshot
 import mozilla.components.browser.state.state.ReaderState
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.concept.engine.Engine
-import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
@@ -52,8 +51,6 @@ class SnapshotSerializerTest {
     fun `Serialize and deserialize with engine session state`() {
         val engineSessionState: EngineSessionState = mock()
         val engineSessionJson = JSONObject().apply { put("state", "test") }
-        val engineSession: EngineSession = mock()
-        whenever(engineSession.saveState()).thenReturn(engineSessionState)
         whenever(engineSessionState.toJSON()).thenReturn(engineSessionJson)
 
         val engine: Engine = mock()
@@ -73,7 +70,7 @@ class SnapshotSerializerTest {
         val json = serializer.itemToJSON(
             Snapshot.Item(
                 originalSession,
-                engineSession = engineSession,
+                engineSessionState = engineSessionState,
                 lastAccess = 1
             )
         )

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/CrashReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/CrashReducer.kt
@@ -13,12 +13,16 @@ internal object CrashReducer {
      */
     fun reduce(state: BrowserState, action: CrashAction): BrowserState = when (action) {
         is CrashAction.SessionCrashedAction -> state.updateTabState(action.tabId) { tab ->
-            tab.createCopy(crashed = true)
+            tab.createCopy(engineState = tab.engineState.copy(
+                crashed = true
+            ))
         }
         is CrashAction.RestoreCrashedSessionAction -> state.updateTabState(action.tabId) { tab ->
-            // We only update the flag in the reducer. A middleware is responsible for actually
-            // performing a restoring side effect.
-            tab.createCopy(crashed = false)
+            // We only update the flag in the reducer. With that the next action trying to get
+            // the engine session will automatically restore this tab lazily.
+            tab.createCopy(engineState = tab.engineState.copy(
+                crashed = false
+            ))
         }
     }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/EngineStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/EngineStateReducer.kt
@@ -17,22 +17,26 @@ internal object EngineStateReducer {
     fun reduce(state: BrowserState, action: EngineAction): BrowserState = when (action) {
         is EngineAction.LinkEngineSessionAction -> state.copyWithEngineState(action.sessionId) {
             it.copy(
-                engineSession = action.engineSession,
-                engineSessionState = null
+                engineSession = action.engineSession
             )
         }
         is EngineAction.UnlinkEngineSessionAction -> state.copyWithEngineState(action.sessionId) {
             it.copy(
                 engineSession = null,
-                engineSessionState = null,
                 engineObserver = null
             )
         }
         is EngineAction.UpdateEngineSessionObserverAction -> state.copyWithEngineState(action.sessionId) {
             it.copy(engineObserver = action.engineSessionObserver)
         }
-        is EngineAction.UpdateEngineSessionStateAction -> state.copyWithEngineState(action.sessionId) {
-            it.copy(engineSessionState = action.engineSessionState)
+        is EngineAction.UpdateEngineSessionStateAction -> state.copyWithEngineState(action.sessionId) { engineState ->
+            if (engineState.crashed) {
+                // We ignore state updates for a crashed engine session. We want to keep the last state until
+                // this tab gets restored (or closed).
+                engineState
+            } else {
+                engineState.copy(engineSessionState = action.engineSessionState)
+            }
         }
         is EngineAction.SuspendEngineSessionAction,
         is EngineAction.CreateEngineSessionAction,

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabSessionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabSessionState.kt
@@ -25,8 +25,7 @@ data class CustomTabSessionState(
     override val engineState: EngineState = EngineState(),
     override val extensionState: Map<String, WebExtensionState> = emptyMap(),
     override val contextId: String? = null,
-    override val source: SessionState.Source = SessionState.Source.CUSTOM_TAB,
-    override val crashed: Boolean = false
+    override val source: SessionState.Source = SessionState.Source.CUSTOM_TAB
 ) : SessionState {
 
     override fun createCopy(
@@ -35,16 +34,14 @@ data class CustomTabSessionState(
         trackingProtection: TrackingProtectionState,
         engineState: EngineState,
         extensionState: Map<String, WebExtensionState>,
-        contextId: String?,
-        crashed: Boolean
+        contextId: String?
     ) = copy(
         id = id,
         content = content,
         trackingProtection = trackingProtection,
         engineState = engineState,
         extensionState = extensionState,
-        contextId = contextId,
-        crashed = crashed
+        contextId = contextId
     )
 }
 

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/EngineState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/EngineState.kt
@@ -21,5 +21,6 @@ import mozilla.components.concept.engine.EngineSessionState
 data class EngineState(
     val engineSession: EngineSession? = null,
     val engineSessionState: EngineSessionState? = null,
-    val engineObserver: EngineSession.Observer? = null
+    val engineObserver: EngineSession.Observer? = null,
+    val crashed: Boolean = false
 )

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/SessionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/SessionState.kt
@@ -31,7 +31,6 @@ interface SessionState {
     val extensionState: Map<String, WebExtensionState>
     val contextId: String?
     val source: Source
-    val crashed: Boolean
 
     /**
      * Copy the class and override some parameters.
@@ -43,8 +42,7 @@ interface SessionState {
         trackingProtection: TrackingProtectionState = this.trackingProtection,
         engineState: EngineState = this.engineState,
         extensionState: Map<String, WebExtensionState> = this.extensionState,
-        contextId: String? = this.contextId,
-        crashed: Boolean = this.crashed
+        contextId: String? = this.contextId
     ): SessionState
 
     /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabSessionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabSessionState.kt
@@ -30,7 +30,6 @@ data class TabSessionState(
     override val extensionState: Map<String, WebExtensionState> = emptyMap(),
     override val contextId: String? = null,
     override val source: SessionState.Source = SessionState.Source.NONE,
-    override val crashed: Boolean = false,
     val parentId: String? = null,
     val lastAccess: Long = 0L,
     val readerState: ReaderState = ReaderState()
@@ -42,16 +41,14 @@ data class TabSessionState(
         trackingProtection: TrackingProtectionState,
         engineState: EngineState,
         extensionState: Map<String, WebExtensionState>,
-        contextId: String?,
-        crashed: Boolean
+        contextId: String?
     ): SessionState = copy(
         id = id,
         content = content,
         trackingProtection = trackingProtection,
         engineState = engineState,
         extensionState = extensionState,
-        contextId = contextId,
-        crashed = crashed
+        contextId = contextId
     )
 }
 

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/EngineActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/EngineActionTest.kt
@@ -58,7 +58,7 @@ class EngineActionTest {
 
         store.dispatch(EngineAction.UnlinkEngineSessionAction(tab.id)).joinBlocking()
         assertNull(engineState().engineSession)
-        assertNull(engineState().engineSessionState)
+        assertNotNull(engineState().engineSessionState)
         assertNull(engineState().engineObserver)
     }
 

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -89,6 +89,11 @@ abstract class EngineSession(
         fun onRecordingStateChanged(devices: List<RecordingDevice>) = Unit
 
         /**
+         * Event to indicate that a new saved [EngineSessionState] is available.
+         */
+        fun onStateUpdated(state: EngineSessionState) = Unit
+
+        /**
          * The engine received a request to load a request.
          *
          * @param url The string url that was requested.
@@ -508,19 +513,10 @@ abstract class EngineSession(
     abstract fun goToHistoryIndex(index: Int)
 
     /**
-     * Saves and returns the engine state. Engine implementations are not required
-     * to persist the state anywhere else than in the returned map. Engines that
-     * already provide a serialized state can use a single entry in this map to
-     * provide this state. The only requirement is that the same map can be used
-     * to restore the original state. See [restoreState] and the specific
-     * engine implementation for details.
-     */
-    abstract fun saveState(): EngineSessionState
-
-    /**
-     * Restores the engine state as provided by [saveState].
+     * Restore a saved state; only data that is saved (history, scroll position, zoom, and form data)
+     * will be restored.
      *
-     * @param state state retrieved from [saveState]
+     * @param state A saved session state.
      * @return true if the engine session has successfully been restored with the provided state,
      * false otherwise.
      */
@@ -567,13 +563,6 @@ abstract class EngineSession(
      * Exits fullscreen mode if currently in it that state.
      */
     abstract fun exitFullScreenMode()
-
-    /**
-     * Tries to recover from a crash by restoring the last know state.
-     *
-     * Returns true if a last known state was restored, otherwise false.
-     */
-    abstract fun recoverFromCrash(): Boolean
 
     /**
      * Marks this session active/inactive for web extensions to support

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -818,8 +818,6 @@ open class DummyEngineSession : EngineSession() {
 
     override fun restoreState(state: EngineSessionState): Boolean { return false }
 
-    override fun saveState(): EngineSessionState { return mock() }
-
     override fun loadUrl(
         url: String,
         parent: EngineSession?,
@@ -852,10 +850,6 @@ open class DummyEngineSession : EngineSession() {
     override fun clearFindMatches() {}
 
     override fun exitFullScreenMode() {}
-
-    override fun recoverFromCrash(): Boolean {
-        return false
-    }
 
     // Helper method to access the protected method from test cases.
     fun notifyInternalObservers(block: Observer.() -> Unit) {

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
@@ -330,7 +330,7 @@ class SessionUseCases(
             val tabIds = store.state.let {
                 it.tabs + it.customTabs
             }.filter {
-                it.crashed
+                it.engineState.crashed
             }.map {
                 it.id
             }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.session
 
+import android.view.View
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
@@ -55,7 +56,11 @@ class SessionFeatureTest {
     @Test
     fun `start renders selected session`() {
         val store = prepareStore()
+
+        val actualView: View = mock()
         val view: EngineView = mock()
+        doReturn(actualView).`when`(view).asView()
+
         val engineSession: EngineSession = mock()
         store.dispatch(EngineAction.LinkEngineSessionAction("B", engineSession)).joinBlocking()
 
@@ -64,6 +69,7 @@ class SessionFeatureTest {
 
         feature.start()
         testDispatcher.advanceUntilIdle()
+
         store.waitUntilIdle()
         verify(view).render(engineSession)
     }
@@ -71,7 +77,11 @@ class SessionFeatureTest {
     @Test
     fun `start renders fixed session`() {
         val store = prepareStore()
+
+        val actualView: View = mock()
         val view: EngineView = mock()
+        doReturn(actualView).`when`(view).asView()
+
         val engineSession: EngineSession = mock()
         store.dispatch(EngineAction.LinkEngineSessionAction("C", engineSession)).joinBlocking()
 
@@ -79,8 +89,10 @@ class SessionFeatureTest {
         verify(view, never()).render(any())
 
         feature.start()
+
         testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
+
         verify(view).render(engineSession)
     }
 
@@ -88,7 +100,10 @@ class SessionFeatureTest {
     fun `start renders custom tab session`() {
         val store = prepareStore()
 
+        val actualView: View = mock()
         val view: EngineView = mock()
+        doReturn(actualView).`when`(view).asView()
+
         val engineSession: EngineSession = mock()
         store.dispatch(EngineAction.LinkEngineSessionAction("D", engineSession)).joinBlocking()
 
@@ -98,13 +113,18 @@ class SessionFeatureTest {
 
         testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
+
         verify(view).render(engineSession)
     }
 
     @Test
     fun `renders selected tab after changes`() {
         val store = prepareStore()
+
+        val actualView: View = mock()
         val view: EngineView = mock()
+        doReturn(actualView).`when`(view).asView()
+
         val engineSessionA: EngineSession = mock()
         val engineSessionB: EngineSession = mock()
         store.dispatch(EngineAction.LinkEngineSessionAction("A", engineSessionA)).joinBlocking()
@@ -127,7 +147,9 @@ class SessionFeatureTest {
     @Test
     fun `creates engine session if needed`() {
         val store = spy(prepareStore())
+        val actualView: View = mock()
         val view: EngineView = mock()
+        doReturn(actualView).`when`(view).asView()
 
         val feature = SessionFeature(store, mock(), view)
         verify(view, never()).render(any())
@@ -141,7 +163,11 @@ class SessionFeatureTest {
     @Test
     fun `does not render new selected session after stop`() {
         val store = prepareStore()
+
+        val actualView: View = mock()
         val view: EngineView = mock()
+        doReturn(actualView).`when`(view).asView()
+
         val engineSessionA: EngineSession = mock()
         val engineSessionB: EngineSession = mock()
         store.dispatch(EngineAction.LinkEngineSessionAction("A", engineSessionA)).joinBlocking()
@@ -166,14 +192,20 @@ class SessionFeatureTest {
     @Test
     fun `releases when last selected session gets removed`() {
         val store = prepareStore()
+
+        val actualView: View = mock()
         val view: EngineView = mock()
+        doReturn(actualView).`when`(view).asView()
+
         val engineSession: EngineSession = mock()
         store.dispatch(EngineAction.LinkEngineSessionAction("B", engineSession)).joinBlocking()
         val feature = SessionFeature(store, mock(), view)
 
         feature.start()
+
         testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
+
         verify(view).render(engineSession)
         verify(view, never()).release()
 
@@ -184,7 +216,11 @@ class SessionFeatureTest {
     @Test
     fun `release stops observing and releases session from view`() {
         val store = prepareStore()
+        val actualView: View = mock()
+
         val view: EngineView = mock()
+        doReturn(actualView).`when`(view).asView()
+
         val engineSession: EngineSession = mock()
         store.dispatch(EngineAction.LinkEngineSessionAction("B", engineSession)).joinBlocking()
 
@@ -192,8 +228,10 @@ class SessionFeatureTest {
         verify(view, never()).render(any())
 
         feature.start()
+
         testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
+
         verify(view).render(engineSession)
 
         val newEngineSession: EngineSession = mock()
@@ -208,7 +246,10 @@ class SessionFeatureTest {
     fun `releases when custom tab gets removed`() {
         val store = prepareStore()
 
+        val actualView: View = mock()
         val view: EngineView = mock()
+        doReturn(actualView).`when`(view).asView()
+
         val engineSession: EngineSession = mock()
         store.dispatch(EngineAction.LinkEngineSessionAction("D", engineSession)).joinBlocking()
 
@@ -216,8 +257,10 @@ class SessionFeatureTest {
         verify(view, never()).render(any())
 
         feature.start()
+
         testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
+
         verify(view).render(engineSession)
         verify(view, never()).release()
 

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -88,6 +88,7 @@ dependencies {
 
     implementation project(':lib-fetch-httpurlconnection')
     implementation project(':lib-nearby')
+    implementation project(":lib-crash")
 
     implementation project(':feature-awesomebar')
     implementation project(':feature-app-links')

--- a/samples/browser/src/geckoBeta/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoBeta/java/org/mozilla/samples/browser/Components.kt
@@ -11,6 +11,7 @@ import mozilla.components.browser.engine.gecko.fetch.GeckoViewFetchClient
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.webcompat.WebCompatFeature
 import mozilla.components.feature.webcompat.reporter.WebCompatReporterFeature
+import mozilla.components.lib.crash.handler.CrashHandlerService
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoRuntimeSettings
 
@@ -21,6 +22,7 @@ class Components(applicationContext: Context) : DefaultComponents(applicationCon
     private val runtime by lazy {
         // Allow for exfiltrating Gecko metrics through the Glean SDK.
         val builder = GeckoRuntimeSettings.Builder()
+        builder.crashHandler(CrashHandlerService::class.java)
         builder.telemetryDelegate(GeckoAdapter())
         GeckoRuntime.create(applicationContext, builder.build())
     }

--- a/samples/browser/src/geckoNightly/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoNightly/java/org/mozilla/samples/browser/Components.kt
@@ -10,6 +10,7 @@ import mozilla.components.browser.engine.gecko.glean.GeckoAdapter
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.webcompat.WebCompatFeature
 import mozilla.components.feature.webcompat.reporter.WebCompatReporterFeature
+import mozilla.components.lib.crash.handler.CrashHandlerService
 import mozilla.components.support.base.log.Log
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoRuntimeSettings
@@ -22,6 +23,7 @@ class Components(private val applicationContext: Context) : DefaultComponents(ap
         // Allow for exfiltrating Gecko metrics through the Glean SDK.
         val builder = GeckoRuntimeSettings.Builder().aboutConfigEnabled(true)
         builder.telemetryDelegate(GeckoAdapter())
+        builder.crashHandler(CrashHandlerService::class.java)
         GeckoRuntime.create(applicationContext, builder.build())
     }
 

--- a/samples/browser/src/geckoRelease/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoRelease/java/org/mozilla/samples/browser/Components.kt
@@ -10,6 +10,7 @@ import mozilla.components.browser.engine.gecko.fetch.GeckoViewFetchClient
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.webcompat.WebCompatFeature
 import mozilla.components.feature.webcompat.reporter.WebCompatReporterFeature
+import mozilla.components.lib.crash.handler.CrashHandlerService
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoRuntimeSettings
 
@@ -20,6 +21,7 @@ class Components(private val applicationContext: Context) : DefaultComponents(ap
     private val runtime by lazy {
         // Allow for exfiltrating Gecko metrics through the Glean SDK.
         val builder = GeckoRuntimeSettings.Builder()
+        builder.crashHandler(CrashHandlerService::class.java)
         builder.telemetryDelegate(GeckoAdapter())
         GeckoRuntime.create(applicationContext, builder.build())
     }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -65,10 +65,14 @@ import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.sitepermissions.SitePermissionsStorage
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.feature.webnotifications.WebNotificationFeature
+import mozilla.components.lib.crash.Crash
+import mozilla.components.lib.crash.CrashReporter
+import mozilla.components.lib.crash.service.CrashReporterService
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.lib.nearby.NearbyConnection
 import mozilla.components.service.digitalassetlinks.local.StatementApi
 import mozilla.components.service.digitalassetlinks.local.StatementRelationChecker
+import mozilla.components.support.base.crash.Breadcrumb
 import org.mozilla.samples.browser.addons.AddonsActivity
 import org.mozilla.samples.browser.downloads.DownloadService
 import org.mozilla.samples.browser.ext.components
@@ -290,6 +294,9 @@ open class DefaultComponents(private val applicationContext: Context) {
             SimpleBrowserMenuItem("P2P") {
                 P2PIntegration.launch?.invoke()
             },
+            SimpleBrowserMenuItem("Restore after crash") {
+                sessionUseCases.crashRecovery.invoke()
+            },
             BrowserMenuDivider()
         )
 
@@ -382,4 +389,37 @@ open class DefaultComponents(private val applicationContext: Context) {
     val tabsUseCases: TabsUseCases by lazy { TabsUseCases(store, sessionManager) }
     val downloadsUseCases: DownloadsUseCases by lazy { DownloadsUseCases(store) }
     val contextMenuUseCases: ContextMenuUseCases by lazy { ContextMenuUseCases(store) }
+
+    val crashReporter: CrashReporter by lazy {
+        CrashReporter(
+            applicationContext,
+            services = listOf(
+                object : CrashReporterService {
+                    override val id: String
+                        get() = "xxx"
+                    override val name: String
+                        get() = "Test"
+
+                    override fun createCrashReportUrl(identifier: String): String? {
+                        return null
+                    }
+
+                    override fun report(crash: Crash.UncaughtExceptionCrash): String? {
+                        return null
+                    }
+
+                    override fun report(crash: Crash.NativeCodeCrash): String? {
+                        return null
+                    }
+
+                    override fun report(
+                        throwable: Throwable,
+                        breadcrumbs: ArrayList<Breadcrumb>
+                    ): String? {
+                        return null
+                    }
+                }
+            )
+        ).install(applicationContext)
+    }
 }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
@@ -40,6 +40,8 @@ class SampleApplication : Application() {
 
         Log.addSink(AndroidLogSink())
 
+        components.crashReporter.install(this)
+
         if (!isMainProcess()) {
             return
         }


### PR DESCRIPTION
* Instead of keeping the `EngineSessionState` inside `EngineSession`, we now always attach it to `EngineState` and also do not clear it anymore.
* If the content process gets killed we now just suspend affected `EngineSession` instances. They will automatically and lazily get restored from the last `EngineSessionState` once needed.
* On a content process crash we now mark the `EngineState` as crashed and suspend the `EngineSession`. We will not restore the `EngineSession` until explicitly restored by the application (Fenix shows UI to the user for that).

Once this lands we can also change the `AutoSave` behavior since we now get a new state pushed and know that we can save it. I filed #8308 for that.