### PR TITLE
Add Invalid coroutine dispatcher

### DIFF
--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlinx/coroutines/InvalidDispatcher.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlinx/coroutines/InvalidDispatcher.kt
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.ktx.kotlinx.coroutines
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Dummy dispatcher that forces you to pass in a dispatcher when launching a
+ * coroutine with `.launch`. Used to enforce always passing in a dispatcher.
+ */
+object InvalidDispatcher : CoroutineDispatcher() {
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        throw UnsupportedOperationException("The Invalid dispatcher cannot be used to run a coroutine. " +
+            "Specify a dispatcher in the launch() function instead.")
+    }
+
+    override fun toString(): String = "Invalid"
+}

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlinx/coroutines/InvalidDispatcherTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlinx/coroutines/InvalidDispatcherTest.kt
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.ktx.kotlinx.coroutines
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class InvalidDispatcherTest {
+
+    private val topScope = CoroutineScope(InvalidDispatcher)
+
+    @Throws(UnsupportedOperationException::class)
+    @Test
+    fun `invalid dispatcher should throw when launching`() = runBlocking {
+        topScope.launch {
+            fail()
+        }.join()
+    }
+
+    @Test
+    fun `using custom dispatcher should not throw`() = runBlocking {
+        topScope.launch(coroutineContext) {
+            assertTrue(true)
+        }.join()
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **support-ktx**
+  * 🌟 Added `InvalidDispatcher` helper for coroutines.
+
 # 57.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v56.0.0...v57.0.0)
@@ -34,7 +37,7 @@ permalink: /changelog/
 
 * **lib-push-firebase**
   * Removed non-essential dependency on `com.google.firebase:firebase-core`.
-  
+
 * **lib-crash**
   * Crash report timestamp is now set to when the crash occurred.
   * When breadcrumbs limit is reached, oldest breadcrumbs are dropped.


### PR DESCRIPTION
This is a helper class to enforce the `scope.launch(Dispatchers.Main/IO)` pattern in Fenix and other apps. When you create a coroutine scope with this dispatcher, launched coroutines will always throw immediately unless you override the dispatcher.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
