### PR TITLE
Incorrect getTopFrecuentSites parameter - For https://github.com/mozilla-mobile/fenix/issues/14724

### DIFF
--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/DefaultTopSitesStorage.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/DefaultTopSitesStorage.kt
@@ -78,7 +78,7 @@ class DefaultTopSitesStorage(
             // Get twice the required size to buffer for duplicate entries with
             // existing pinned sites
             val frecentSites = historyStorage
-                .getTopFrecentSites(numSitesRequired * 2)
+                .getTopFrecentSites(totalSites)
                 .map { it.toTopSite() }
                 .filter { !pinnedSites.hasUrl(it.url) }
                 .take(numSitesRequired)

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/DefaultTopSitesStorage.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/DefaultTopSitesStorage.kt
@@ -75,7 +75,7 @@ class DefaultTopSitesStorage(
         topSites.addAll(pinnedSites)
 
         if (includeFrecent && numSitesRequired > 0) {
-            // Get twice the required size to buffer for duplicate entries with
+            // Get 'totalSites' sites for duplicate entries with
             // existing pinned sites
             val frecentSites = historyStorage
                 .getTopFrecentSites(totalSites)


### PR DESCRIPTION
If we want 16 top sites, and have 14 pinned, getting (16-14) * 2=2 * 2=4 is invalid because those 4 can be rejected if they are duplicates (from the 14 pinned).
We need to get all 16 sites, in case 14 are duplicated.

Fixes https://github.com/mozilla-mobile/fenix/issues/14724

No tests needed and no user facing features, just a parameter fix.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
