### PR TITLE
Bump taskgraph to the latest version

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,7 +7,7 @@ tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: cab4565345d0d0effa66f18fe91335dd6d744031
+              revision: 32c7e914db92719dc1c508f4c08a02ac75e94105
           trustDomain: mobile
       in:
           $let:
@@ -295,6 +295,14 @@ tasks:
                                         type: 'directory'
                                         path: '/builds/worker/artifacts'
                                         expires: {$fromNow: '1 year'}
+                                    'public/docker-contexts':
+                                        type: 'directory'
+                                        path: '/builds/worker/checkouts/src/docker-contexts'
+                                        # This needs to be at least the deadline of the
+                                        # decision task + the docker-image task deadlines.
+                                        # It is set to a week to allow for some time for
+                                        # debugging, but they are not useful long-term.
+                                        expires: {$fromNow: '7 day'}
 
                             extra:
                                 $merge:

--- a/taskcluster/docker/android-build/Dockerfile
+++ b/taskcluster/docker/android-build/Dockerfile
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# %ARG DOCKER_IMAGE_PARENT
+ARG DOCKER_IMAGE_PARENT
 FROM $DOCKER_IMAGE_PARENT
 
 MAINTAINER Johan Lorenzo <jlorenzo+tc@mozilla.com>

--- a/taskcluster/docker/ui-tests/Dockerfile
+++ b/taskcluster/docker/ui-tests/Dockerfile
@@ -1,4 +1,4 @@
-# %ARG DOCKER_IMAGE_PARENT
+ARG DOCKER_IMAGE_PARENT
 FROM $DOCKER_IMAGE_PARENT
 
 LABEL authors="Richard Pappalardo <rpappalax@gmail.com>, Aaron Train <atrain@mozilla.com>"


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

I wasn't able to run taskgraph locally on this repo, anymore. The docker changes were caused by https://hg.mozilla.org/ci/taskgraph/rev/004bada4f170794a94ad43b84dd7562946305d22 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
