### PR TITLE
Chunk post-signing tasks 

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -296,16 +296,14 @@ projects:
     path: components/service/glean
     description: 'A client-side telemetry SDK for collecting metrics and sending them to the Mozilla telemetry service'
     publish: true
-# Temporarily disabled to work around automation limit:
-# https://github.com/mozilla-mobile/android-components/issues/8365
-#  service-pocket:
-#    path: components/service/pocket
-#    description: 'A library to communicate with the Pocket API'
-#    publish: true
-#  service-telemetry:
-#    path: components/service/telemetry
-#    description: 'A generic library for generating and sending telemetry pings from Android applications to the Mozilla telemetry service.'
-#    publish: true
+  service-pocket:
+    path: components/service/pocket
+    description: 'A library to communicate with the Pocket API'
+    publish: true
+  service-telemetry:
+    path: components/service/telemetry
+    description: 'A generic library for generating and sending telemetry pings from Android applications to the Mozilla telemetry service.'
+    publish: true
   support-base:
     path: components/support/base
     description: 'Base component containing building blocks for components.'
@@ -378,12 +376,10 @@ projects:
     path: components/lib/fetch-okhttp
     description: 'An implementation of lib-fetch based on OkHttp.'
     publish: true
-# Temporarily disabled to work around automation limit:
-# https://github.com/mozilla-mobile/android-components/issues/8365
-#  lib-jexl:
-#    path: components/lib/jexl
-#    description: 'Javascript Expression Language: Powerful context-based expression parser and evaluator.'
-#    publish: true
+  lib-jexl:
+    path: components/lib/jexl
+    description: 'Javascript Expression Language: Powerful context-based expression parser and evaluator.'
+    publish: true
   lib-nearby:
     path: components/lib/nearby
     description: 'A library for communication with nearby devices Android devices.'

--- a/taskcluster/ac_taskgraph/loader/__init__.py
+++ b/taskcluster/ac_taskgraph/loader/__init__.py
@@ -54,6 +54,9 @@ def component_grouping(config, tasks):
     tasks_for_all_components = [
         task for task in tasks
         if task.attributes.get('component') == 'all'
+        # We just want to depend on the task that waits on all chunks. This way
+        # we have a single dependency for that kind
+        and task.attributes.get("is_final_chunked_task", True)
     ]
     for (_, build_type), tasks in groups.iteritems():
         tasks.extend([
@@ -70,6 +73,12 @@ def build_type_grouping(config, tasks):
     for task in tasks:
         if task.kind not in config.get('kind-dependencies', []):
             continue
+
+        # We just want to depend on the task that waits on all chunks. This way
+        # we have a single dependency for that kind
+        if not task.attributes.get("is_final_chunked_task", True):
+            continue
+
         build_type = task.attributes.get('build-type')
 
         groups.setdefault(build_type, []).append(task)

--- a/taskcluster/ci/post-signing/kind.yml
+++ b/taskcluster/ci/post-signing/kind.yml
@@ -7,6 +7,7 @@ loader: ac_taskgraph.loader.all_dep:loader
 transforms:
     - ac_taskgraph.transforms.all_dep:transforms
     - ac_taskgraph.transforms.post_signing:transforms
+    - ac_taskgraph.transforms.chunk:transforms
     - taskgraph.transforms.task:transforms
 
 kind-dependencies:


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Fixes https://github.com/mozilla-mobile/android-components/issues/8365

I'm not super proud of this patch, but it does the job and produces the intended behavior. Let me explain. Unlike what we have in mozilla-central with the `dummy` tasks, reference-browser has a custom implementation. The `complete` and now the `post-signing` kinds use this implementation. Just like in mozilla-central: it chunks tasks once one reached the max number of dependencies. However, it also creates an "umbrella" task that depends on all chunks. This umbrella task is of the same kind. This specificity made `multi_dep` unhappy because it enforces the beetmover tasks to have one dependency per kind:

https://github.com/mozilla-mobile/android-components/blob/7f8475537a42ec77b933157b5e2b4f5ade07398a/taskcluster/ac_taskgraph/loader/multi_dep.py#L50-L52

So what I ended doing: I added an attribute to the chunk tasks in order to know which one is the final one (aka the "umbrella" one) so that it becomes the only dependency of that kind. I don't know if this is the most elegant way of solving this issue, but taskgraph-diff tells me it works as expected: Beetmover keep waiting on the `post-signing-nightly` task for instance, and that one waits on `post-signing-nightly-1` and `post-signing-nightly-2` which depend on the signing tasks. I didn't see any side effect. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
