### PR TITLE
For #7558 - Expose getBookmarkUrlForKeyword(String)

### DIFF
--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/BookmarksStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/BookmarksStorage.kt
@@ -35,6 +35,18 @@ interface BookmarksStorage : Storage {
     suspend fun getBookmarksWithUrl(url: String): List<BookmarkNode>
 
     /**
+     * Returns the URL for the provided search keyword, if one exists.
+     *
+     * @param searchTerms A string containing one or more words (first and second space delimited)
+     * which we'll try to match against a bookmark keyword.
+     *
+     * @return The bookmarked URL for the keyword, if set.
+     *  If [searchTerms] contains more words will return a valid URL only if the bookmark URL
+     *  contains a "%s" placeholder.
+     */
+    suspend fun getBookmarkUrlForKeyword(searchTerms: String): String?
+
+    /**
      * Searches bookmarks with a query string.
      *
      * @param query The query string to search.

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt
@@ -134,6 +134,11 @@ class BookmarksStorageSuggestionProviderTest {
             throw NotImplementedError()
         }
 
+        override suspend fun getBookmarkUrlForKeyword(searchTerms: String): String? {
+            // "Not needed for the test"
+            throw NotImplementedError()
+        }
+
         override suspend fun searchBookmarks(query: String, limit: Int): List<BookmarkNode> =
             synchronized(bookmarkMap) {
                 data class Hit(val key: String, val score: Int)

--- a/components/feature/intent/src/test/java/mozilla/components/feature/intent/processing/TabIntentProcessorTest.kt
+++ b/components/feature/intent/src/test/java/mozilla/components/feature/intent/processing/TabIntentProcessorTest.kt
@@ -19,6 +19,7 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
+import mozilla.components.concept.storage.BookmarksStorage
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.support.test.any
@@ -48,7 +49,10 @@ class TabIntentProcessorTest {
     private val session = mock<Session>()
     private val sessionUseCases = SessionUseCases(store, sessionManager)
     private val searchEngineManager = mock<SearchEngineManager>()
-    private val searchUseCases = SearchUseCases(testContext, store, searchEngineManager, sessionManager)
+    private val bookmarksStorage = mock<BookmarksStorage>()
+    private val searchUseCases = SearchUseCases(
+        testContext, store, searchEngineManager, sessionManager, bookmarksStorage
+    )
 
     @Before
     fun setup() {
@@ -255,7 +259,7 @@ class TabIntentProcessorTest {
         val engine = mock<Engine>()
         val sessionManager = spy(SessionManager(engine))
 
-        val searchUseCases = SearchUseCases(testContext, store, searchEngineManager, sessionManager)
+        val searchUseCases = SearchUseCases(testContext, store, searchEngineManager, sessionManager, bookmarksStorage)
         val sessionUseCases = SessionUseCases(store, sessionManager)
 
         val searchTerms = "mozilla android"
@@ -326,7 +330,7 @@ class TabIntentProcessorTest {
         val engine = mock<Engine>()
         val sessionManager = spy(SessionManager(engine))
 
-        val searchUseCases = SearchUseCases(testContext, store, searchEngineManager, sessionManager)
+        val searchUseCases = SearchUseCases(testContext, store, searchEngineManager, sessionManager, bookmarksStorage)
         val sessionUseCases = SessionUseCases(store, sessionManager)
 
         val searchTerms = "mozilla android"
@@ -385,7 +389,7 @@ class TabIntentProcessorTest {
         val engine = mock<Engine>()
         val sessionManager = spy(SessionManager(engine))
 
-        val searchUseCases = SearchUseCases(testContext, store, searchEngineManager, sessionManager)
+        val searchUseCases = SearchUseCases(testContext, store, searchEngineManager, sessionManager, bookmarksStorage)
         val sessionUseCases = SessionUseCases(store, sessionManager)
 
         val searchTerms = "mozilla android"

--- a/components/feature/search/build.gradle
+++ b/components/feature/search/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 
     implementation project(':browser-session')
     implementation project(':concept-engine')
+    implementation project(':concept-storage')
     implementation project(':support-utils')
 
     implementation Dependencies.kotlin_stdlib

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,12 @@ permalink: /changelog/
 * **feature-recentlyclosed**
   * Added a new [RecentlyClosedTabsStorage] and a [RecentlyClosedMiddleware] to maintain a list of restorable recently closed tabs.
 
+* **concept-storage**
+  * BookmarksStorage now exposes a new `getBookmarkUrlForKeyword` metod that allows querying bookmarks for if they have a particular keyword set. Also supports placeholders.
+
+* **feature-search**
+  * ⚠️ **This is a breaking change**: SearchUseCases now require a new parameter of type BookmarksStorage to be used to automatically recognize and load bookmarks depending on the user entered url (when that is a bookmark keyword).
+
 # 57.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v56.0.0...v57.0.0)
@@ -64,7 +70,6 @@ permalink: /changelog/
   * 🌟 Added support for persisting/restoring downloads see issue [#7762](https://github.com/mozilla-mobile/android-components/issues/7762).
   * 🌟 Added `DownloadStorage` for querying stored download metadata.
   * 🚒 Bug [issue #8190](https://github.com/mozilla-mobile/android-components/issues/8190) ArithmeticException: divide by zero in Download notification.
-  * 🚒 Bug [issue #8363](https://github.com/mozilla-mobile/android-components/issues/8363) IllegalStateException: Not allowed to start service Intent.
 
 
 * **ui-widgets**

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -30,6 +30,7 @@ import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.engine.EngineMiddleware
 import mozilla.components.browser.session.storage.SessionStorage
 import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.browser.storage.sync.PlacesBookmarksStorage
 import mozilla.components.browser.storage.sync.PlacesHistoryStorage
 import mozilla.components.browser.thumbnails.ThumbnailsMiddleware
 import mozilla.components.browser.thumbnails.storage.ThumbnailStorage
@@ -120,6 +121,9 @@ open class DefaultComponents(private val applicationContext: Context) {
     private val lazyHistoryStorage = lazy { PlacesHistoryStorage(applicationContext) }
     val historyStorage by lazy { lazyHistoryStorage.value }
 
+    private val lazyBookmarksStorage = lazy { PlacesBookmarksStorage(applicationContext) }
+    val bookmarksStorage by lazy { lazyBookmarksStorage.value }
+
     private val sessionStorage by lazy { SessionStorage(applicationContext, engine) }
 
     val permissionStorage by lazy { SitePermissionsStorage(applicationContext) }
@@ -195,7 +199,9 @@ open class DefaultComponents(private val applicationContext: Context) {
         }
     }
 
-    val searchUseCases by lazy { SearchUseCases(applicationContext, store, searchEngineManager, sessionManager) }
+    val searchUseCases by lazy {
+        SearchUseCases(applicationContext, store, searchEngineManager, sessionManager, bookmarksStorage)
+    }
     val defaultSearchUseCase by lazy {
         { searchTerms: String ->
             searchUseCases.defaultSearch.invoke(


### PR DESCRIPTION
This new method allows to query AS for if a String (containing one or more
words) is set as a keyword for an existing bookmark.

AS does not yet exposes the keyword in the "Bookmark"s objects so users will
not be able to see/add/modify keywords but with this new method they can be
used if they were set on another platform and then the bookmarks were synced
on an Android device.

The searchTerms for which we query bookmarks can have one or more words, with
the first followed by a space character.
If more words are used we'll try to:
- match the first word against a bookmark keyword
- use the rest of the String as a query parameter. Only if the bookmark url
contains "%s" as a placeholder that we can replace.
Otherwise "%s" (case insensitive) will be removed from the bookmark url.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks
- [x] **Tests**: This PR includes thorough tests
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md)
- [x] **Accessibility**: The code in this PR or does not include any user facing features

![BookmarkKeywordsInFenix](https://user-images.githubusercontent.com/11428869/92764534-2c7c9a80-f39d-11ea-8571-642194125028.gif)
[video demoing bookmark keywords in Fenix](https://drive.google.com/file/d/14Z9KEp8IgtkhQbs-dNjEgN_OKZNDmr83/view?usp=sharing)

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
