### PR TITLE
No issue: publish git hash in published pom XML.

### DIFF
--- a/components/support/base/build.gradle
+++ b/components/support/base/build.gradle
@@ -8,6 +8,7 @@ apply plugin: 'kotlin-android-extensions'
 
 def generatedSrcDir = new File(buildDir, "generated/components/src/main/java")
 
+// This gitHash functionality is duplicated in publish.gradle.
 def getGitHash = { ->
     def stdout = new ByteArrayOutputStream()
     exec {

--- a/publish.gradle
+++ b/publish.gradle
@@ -14,6 +14,13 @@ static def getLocalPublicationTimestamp() {
     return date.format('yyyyMMddHHmmss')
 }
 
+static def getGitHash() {
+    String[] cmd = ['git', 'rev-parse', '--verify', 'HEAD'] // via https://stackoverflow.com/a/949391/2219998
+    def process = Runtime.getRuntime().exec(cmd)
+    process.waitFor()
+    return process.inputStream.getText()
+}
+
 ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg ->
     apply plugin: 'digital.wup.android-maven-publish'
 
@@ -53,6 +60,7 @@ ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg ->
                         connection = libVcsUrl
                         developerConnection = libVcsUrl
                         url = libUrl
+                        tag = getGitHash()
                     }
                 }
             }

--- a/publish.gradle
+++ b/publish.gradle
@@ -14,6 +14,7 @@ static def getLocalPublicationTimestamp() {
     return date.format('yyyyMMddHHmmss')
 }
 
+// This gitHash functionality is duplicated in :support-base build.gradle.
 static def getGitHash() {
     String[] cmd = ['git', 'rev-parse', '--verify', 'HEAD'] // via https://stackoverflow.com/a/949391/2219998
     def process = Runtime.getRuntime().exec(cmd)

--- a/publish.gradle
+++ b/publish.gradle
@@ -19,7 +19,7 @@ static def getGitHash() {
     String[] cmd = ['git', 'rev-parse', '--verify', 'HEAD'] // via https://stackoverflow.com/a/949391/2219998
     def process = Runtime.getRuntime().exec(cmd)
     process.waitFor()
-    return process.inputStream.getText()
+    return process.inputStream.getText().trim()
 }
 
 ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg ->


### PR DESCRIPTION
This is inspired by how GV publishes commit information in their build
POMs.
    
This commit will allow devs to map an ac version to the ac revision that
built it. This will also enable the tools/get_cross_repo_hashes.py script
to map fenix -> ac -> mc.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
