### PR TITLE
Closes #8323: Add-on permission dialog does not prompt  for host permissions

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/PermissionsDialogFragment.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/PermissionsDialogFragment.kt
@@ -183,12 +183,11 @@ class PermissionsDialogFragment : AppCompatDialogFragment() {
     internal fun buildPermissionsText(): String {
         var permissionsText =
             getString(R.string.mozac_feature_addons_permissions_dialog_subtitle) + "\n\n"
-        val permissions = addon.translatePermissions()
+        val permissions = addon.translatePermissions(requireContext())
 
         permissions.forEachIndexed { index, item ->
             val brakeLine = if (index + 1 != permissions.size) "\n\n" else ""
-            val permissionText = requireContext().getString(item)
-            permissionsText += "• $permissionText $brakeLine"
+            permissionsText += "• $item $brakeLine"
         }
         return permissionsText
     }

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/update/AddonUpdater.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/update/AddonUpdater.kt
@@ -207,7 +207,7 @@ class DefaultAddonUpdater(
     ) {
         logger.info("onUpdatePermissionRequest $current")
 
-        val shouldGrantWithoutPrompt = Addon.localizePermissions(newPermissions).isEmpty()
+        val shouldGrantWithoutPrompt = Addon.localizePermissions(newPermissions, applicationContext).isEmpty()
         val shouldShowNotification =
                 updateStatusStorage.isPreviouslyAllowed(applicationContext, updated.id) || shouldGrantWithoutPrompt
 
@@ -306,7 +306,7 @@ class DefaultAddonUpdater(
 
     @VisibleForTesting
     internal fun createContentText(newPermissions: List<String>): String {
-        val validNewPermissions = Addon.localizePermissions(newPermissions)
+        val validNewPermissions = Addon.localizePermissions(newPermissions, applicationContext)
 
         val string = if (validNewPermissions.size == 1) {
             R.string.mozac_feature_addons_updater_notification_content_singular
@@ -317,7 +317,7 @@ class DefaultAddonUpdater(
         var permissionIndex = 1
         val permissionsText =
                 validNewPermissions.joinToString(separator = "\n") {
-                "${permissionIndex++}-${applicationContext.getString(it)}"
+                "${permissionIndex++}-$it"
             }
         return "$contentText:\n $permissionsText"
     }

--- a/components/feature/addons/src/main/res/values/strings.xml
+++ b/components/feature/addons/src/main/res/values/strings.xml
@@ -7,6 +7,24 @@
     <string name="mozac_feature_addons_permissions_privacy_description">Read and modify privacy settings</string>
     <!-- Description for all_urls add-on permission. -->
     <string name="mozac_feature_addons_permissions_all_urls_description">Access your data for all websites</string>
+    <!-- Description for giving an add-on access to users's data on one site. %1$s  will be replaced by the DNS host name for which a web extension is requesting access (e.g., www.mozilla.org). -->
+    <string name="mozac_feature_addons_permissions_one_site_description">Access your data for %1$s</string>
+    <!-- Description for giving an add-on access to users's data in multiple sites in the domain %1$s. %1$s will be replaced by the DNS domain for which a web extension is requesting access (e.g., mozilla.org). -->
+    <string name="mozac_feature_addons_permissions_sites_in_domain_description">Access your data for sites in the %1$s domain</string>
+    <!-- When an add-on requires access to more than 4 sites, for example the add-on requires access for 5 sites. We will show the first 4 sites in individual entries, as in mozac_feature_addons_permissions_one_site_description,
+     then we will show another collapsed entry saying "Access your data on 1 other site". This entry it's for the singular case, when the add-on is only accessing one extra site. -->
+    <string name="mozac_feature_addons_permissions_one_extra_site_description" tools:ignore="PluralsCandidate">Access your data on 1 other site</string>
+    <!-- When an add-on requires access to more than 4 sites, for example the add-on requires access for 6 sites. We will show the first 4 sites in individual entries, as in mozac_feature_addons_permissions_one_site_description,
+     then we will show another collapsed entry saying "Access your data on 2 other sites". This entry it's for the plural case, when the add-on is accessing more than one extra site.
+     %1$d will be replaced by an integer indicating the number of additional hosts for which this web extension is requesting permission. -->
+    <string name="mozac_feature_addons_permissions_extra_sites_description" tools:ignore="PluralsCandidate">Access your data on %1$d other sites</string>
+    <!-- When an add-on requires access to more than 4 domains, for example the add-on requires access for 5 domains. We will show the first 4 domains in individual entries, as in mozac_feature_addons_permissions_sites_in_domain_description,
+      then we will show another collapsed entry saying "Access your data on 1 other domain". This entry it's for the singular case, when the add-on is only accessing one extra domain. -->
+    <string name="mozac_feature_addons_permissions_one_extra_domain_description" tools:ignore="PluralsCandidate">Access your data on 1 other domain</string>
+    <!-- When an add-on requires access to more than 4 domains, for example the add-on requires access for 6 domains. We will show the first 4 domains in individual entries, as in mozac_feature_addons_permissions_sites_in_domain_description,
+     then we will show another collapsed entry saying "Access your data on 2 other domains". This entry it's for the plural case, when the add-on is accessing more than one extra domain.
+     %1$d will be replaced by an integer indicating the number of additional domains for which this web extension is requesting permission. -->
+    <string name="mozac_feature_addons_permissions_extra_domains_description_plural" tools:ignore="PluralsCandidate">Access your data on %1$d other domains</string>
     <!-- Description for tabs add-on permission. -->
     <string name="mozac_feature_addons_permissions_tabs_description">Access browser tabs</string>
     <!-- Description for unlimited_storage permission. -->

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -34,6 +34,10 @@ permalink: /changelog/
 * **feature-syncedtabs**
   * Added support for indicators to synced tabs `AwesomeBar` suggestions.
 
+* **feature-addons**
+  * ⚠️ **This is a breaking change**: The `Addon.translatePermissions` now requires a `context` object and returns a list of localized strings instead of a list of id string resources.
+  * 🚒 Bug fixed [issue #8323](https://github.com/mozilla-mobile/android-components/issues/8323) Add-on permission dialog does not prompt for host permissions.
+
 # 58.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v57.0.0...v58.0.0)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -177,7 +177,7 @@ open class DefaultComponents(private val applicationContext: Context) {
         AddonCollectionProvider(
             applicationContext,
             client,
-            collectionName = "3204bb44a6ef44d39ee34917f28055",
+            collectionName = "83a9cccfe6e24a34bd7b155ff9ee32",
             maxCacheAgeInMinutes = DAY_IN_MINUTES
         )
     }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/PermissionsDetailsActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/PermissionsDetailsActivity.kt
@@ -37,9 +37,7 @@ class PermissionsDetailsActivity : AppCompatActivity(), View.OnClickListener {
     private fun bindPermissions(addon: Addon) {
         val recyclerView = findViewById<RecyclerView>(R.id.add_ons_permissions)
         recyclerView.layoutManager = LinearLayoutManager(this)
-        val sortedPermissions = addon.translatePermissions().map { stringId ->
-            getString(stringId)
-        }.sorted()
+        val sortedPermissions = addon.translatePermissions(this).sorted()
         recyclerView.adapter = AddonPermissionsAdapter(sortedPermissions)
     }
 


### PR DESCRIPTION
Adapted algorithm from the [desktop implementation](https://searchfox.org/mozilla-central/source/toolkit/components/extensions/Extension.jsm#1488-1568) docs related to host permissions [[1]](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#Host_permissions) [[2]](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns)

Fenix pr https://github.com/mozilla-mobile/fenix/pull/15002

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
