### PR TITLE
Closes #8406: Create separate usecases for removing all normal/private tabs.

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -259,6 +259,40 @@ class SessionManager(
     }
 
     /**
+     * Removes all normal (non-private) sessions (excluding custom tabs).
+     *
+     * Avoid calling this method directly and use `TabsUseCases.removeNormalTabs` instead.
+     */
+    fun removeNormalSessions() {
+        // This method was introduced to map the removal of all normal tabs to a single action to
+        // be dispatched on the store. Since we didn't want to introduce a new
+        // SessionManager.Observer function, we map this internally to multiple normal removes.
+        // https://github.com/mozilla-mobile/android-components/issues/8406
+        sessions.filter { !it.private }.forEach {
+            delegate.remove(it)
+        }
+
+        store?.syncDispatch(TabListAction.RemoveAllNormalTabsAction)
+    }
+
+    /**
+     * Removes all private sessions (excluding custom tabs).
+     *
+     * Avoid calling this method directly and use `TabsUseCases.removePrivateTabs` instead.
+     */
+    fun removePrivateSessions() {
+        // This method was introduced to map the removal of all normal tabs to a single action to
+        // be dispatched on the store. Since we didn't want to introduce a new
+        // SessionManager.Observer function, we map this internally to multiple normal removes.
+        // https://github.com/mozilla-mobile/android-components/issues/8406
+        sessions.filter { it.private }.forEach {
+            delegate.remove(it)
+        }
+
+        store?.syncDispatch(TabListAction.RemoveAllPrivateTabsAction)
+    }
+
+    /**
      * Removes all sessions including CustomTab sessions.
      */
     fun removeAll() {

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
@@ -224,17 +224,31 @@ class TabsUseCases(
         }
     }
 
-    class RemoveAllTabsOfTypeUseCase internal constructor(
+    /**
+     * Use case for removing all normal (non-private) tabs.
+     */
+    class RemoveNormalTabsUseCase internal constructor(
         private val sessionManager: SessionManager
     ) {
-
         /**
-         * @param private pass true if only private tabs should be removed otherwise normal tabs will be removed
+         * Removes all normal (non-private) tabs.
          */
-        operator fun invoke(private: Boolean) {
-            sessionManager.sessions.filter { it.private == private }.forEach {
-                sessionManager.remove(it)
-            }
+        operator fun invoke() {
+            sessionManager.removeNormalSessions()
+        }
+    }
+
+    /**
+     * Use case for removing all private tabs.
+     */
+    class RemovePrivateTabsUseCase internal constructor(
+        private val sessionManager: SessionManager
+    ) {
+        /**
+         * Removes all private tabs.
+         */
+        operator fun invoke() {
+            sessionManager.removePrivateSessions()
         }
     }
 
@@ -243,9 +257,6 @@ class TabsUseCases(
     val addTab: AddNewTabUseCase by lazy { AddNewTabUseCase(store, sessionManager) }
     val addPrivateTab: AddNewPrivateTabUseCase by lazy { AddNewPrivateTabUseCase(store, sessionManager) }
     val removeAllTabs: RemoveAllTabsUseCase by lazy { RemoveAllTabsUseCase(sessionManager) }
-    val removeAllTabsOfType: RemoveAllTabsOfTypeUseCase by lazy {
-        RemoveAllTabsOfTypeUseCase(
-            sessionManager
-        )
-    }
+    val removeNormalTabs: RemoveNormalTabsUseCase by lazy { RemoveNormalTabsUseCase(sessionManager) }
+    val removePrivateTabs: RemovePrivateTabsUseCase by lazy { RemovePrivateTabsUseCase(sessionManager) }
 }

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
@@ -230,7 +230,7 @@ class TabsUseCasesTest {
     }
 
     @Test
-    fun `RemoveAllTabsOfTypeUseCase will remove sessions for particular type of tabs private or normal`() {
+    fun `RemoveNormalTabsUseCase and RemovePrivateTabsUseCase will remove sessions for particular type of tabs private or normal`() {
         val sessionManager = spy(SessionManager(mock()))
         val useCases = TabsUseCases(BrowserStore(), sessionManager)
 
@@ -241,7 +241,7 @@ class TabsUseCasesTest {
         useCases.addTab("https://www.mozilla.org")
         assertEquals(3, sessionManager.size)
 
-        useCases.removeAllTabsOfType(private = false)
+        useCases.removeNormalTabs.invoke()
         assertEquals(2, sessionManager.all.size)
 
         useCases.addPrivateTab("https://www.mozilla.org")
@@ -249,10 +249,10 @@ class TabsUseCasesTest {
         useCases.addTab("https://www.mozilla.org")
         assertEquals(5, sessionManager.size)
 
-        useCases.removeAllTabsOfType(private = true)
+        useCases.removePrivateTabs.invoke()
         assertEquals(3, sessionManager.size)
 
-        useCases.removeAllTabsOfType(private = false)
+        useCases.removeNormalTabs.invoke()
         assertEquals(1, sessionManager.size)
 
         assertTrue(sessionManager.all[0].isCustomTabSession())

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,11 @@ permalink: /changelog/
 
 * **browser-engine-gecko**, **browser-engine-gecko-beta**, **browser-engine-gecko-nightly**
   * 🚒 Bug fixed [issue #8431](https://github.com/mozilla-mobile/android-components/issues/8431) update `Session.trackerBlockingEnabled` and `SessionState#trackingProtection#enabled` with the initial tracking protection state.
+* **feature-tabs**
+  * Added `TabsUseCases.removeNormalTabs()` and `TabsUseCases.removePrivateTabs()`.
+  * ⚠️ **This is a breaking change**: Removed `TabsUseCases.removeAllTabsOfType()`.
+* **browser-session**
+  * Added `SessionManager.removeNormalSessions()` and `SessionManager.removePrivateSessions()`.
 
 # 59.0.0
 
@@ -25,7 +30,6 @@ permalink: /changelog/
 
 * **feature-downloads**
   * 🚒 Bug fixed [issue #8354](https://github.com/mozilla-mobile/android-components/issues/8354) Do not restart FAILED downloads.
-
 * **browser-tabstray**
   * Removed the `BrowserTabsTray` that was deprecated in previous releases.
 * **service-telemetry**
@@ -44,7 +48,6 @@ permalink: /changelog/
     * Handle ping registration off the main thread. This removes a potential blocking call ([#1132](https://github.com/mozilla/glean/pull/1132)).
 * **feature-syncedtabs**
   * Added support for indicators to synced tabs `AwesomeBar` suggestions.
-
 * **feature-addons**
   * ⚠️ **This is a breaking change**: The `Addon.translatePermissions` now requires a `context` object and returns a list of localized strings instead of a list of id string resources.
   * 🚒 Bug fixed [issue #8323](https://github.com/mozilla-mobile/android-components/issues/8323) Add-on permission dialog does not prompt for host permissions.


### PR DESCRIPTION
Undo (https://github.com/mozilla-mobile/android-components/issues/8406) will be much easier to implement if there's a single action for removing all normal/private tabs instead of mapping this to multiple `remove` calls.