### PR TITLE
Issue #7719: Remove default headers for "User-Agent" and "Connection".

### DIFF
--- a/components/browser/engine-gecko-beta/src/androidTest/java/mozilla/components/browser/engine/gecko/fetch/geckoview/GeckoViewFetchTestCases.kt
+++ b/components/browser/engine-gecko-beta/src/androidTest/java/mozilla/components/browser/engine/gecko/fetch/geckoview/GeckoViewFetchTestCases.kt
@@ -43,12 +43,6 @@ class GeckoViewFetchTestCases : mozilla.components.tooling.fetch.tests.FetchTest
 
     @Test
     @UiThreadTest
-    override fun get200WithUserAgent() {
-        super.get200WithUserAgent()
-    }
-
-    @Test
-    @UiThreadTest
     override fun get200WithDuplicatedCacheControlRequestHeaders() {
         super.get200WithDuplicatedCacheControlRequestHeaders()
     }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
@@ -167,13 +167,6 @@ class GeckoViewFetchUnitTestCases : FetchTestCases() {
     }
 
     @Test
-    override fun get200WithUserAgent() {
-        mockRequest(mapOf("User-Agent" to "MozacFetch/"))
-        mockResponse(200)
-        super.get200WithUserAgent()
-    }
-
-    @Test
     override fun get302FollowRedirects() {
         mockResponse(200)
 

--- a/components/browser/engine-gecko-nightly/src/androidTest/java/mozilla/components/browser/engine/gecko/fetch/geckoview/GeckoViewFetchTestCases.kt
+++ b/components/browser/engine-gecko-nightly/src/androidTest/java/mozilla/components/browser/engine/gecko/fetch/geckoview/GeckoViewFetchTestCases.kt
@@ -43,12 +43,6 @@ class GeckoViewFetchTestCases : mozilla.components.tooling.fetch.tests.FetchTest
 
     @Test
     @UiThreadTest
-    override fun get200WithUserAgent() {
-        super.get200WithUserAgent()
-    }
-
-    @Test
-    @UiThreadTest
     override fun get200WithDuplicatedCacheControlRequestHeaders() {
         super.get200WithDuplicatedCacheControlRequestHeaders()
     }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
@@ -167,13 +167,6 @@ class GeckoViewFetchUnitTestCases : FetchTestCases() {
     }
 
     @Test
-    override fun get200WithUserAgent() {
-        mockRequest(mapOf("User-Agent" to "MozacFetch/"))
-        mockResponse(200)
-        super.get200WithUserAgent()
-    }
-
-    @Test
     override fun get302FollowRedirects() {
         mockResponse(200)
 

--- a/components/browser/engine-gecko/src/androidTest/java/mozilla/components/browser/engine/gecko/fetch/geckoview/GeckoViewFetchTestCases.kt
+++ b/components/browser/engine-gecko/src/androidTest/java/mozilla/components/browser/engine/gecko/fetch/geckoview/GeckoViewFetchTestCases.kt
@@ -43,12 +43,6 @@ class GeckoViewFetchTestCases : mozilla.components.tooling.fetch.tests.FetchTest
 
     @Test
     @UiThreadTest
-    override fun get200WithUserAgent() {
-        super.get200WithUserAgent()
-    }
-
-    @Test
-    @UiThreadTest
     override fun get200WithDuplicatedCacheControlRequestHeaders() {
         super.get200WithDuplicatedCacheControlRequestHeaders()
     }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
@@ -167,13 +167,6 @@ class GeckoViewFetchUnitTestCases : FetchTestCases() {
     }
 
     @Test
-    override fun get200WithUserAgent() {
-        mockRequest(mapOf("User-Agent" to "MozacFetch/"))
-        mockResponse(200)
-        super.get200WithUserAgent()
-    }
-
-    @Test
     override fun get302FollowRedirects() {
         mockResponse(200)
 

--- a/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Client.kt
+++ b/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Client.kt
@@ -105,13 +105,7 @@ abstract class Client {
 
         // Unfortunately some implementations will always send a not removable Accept-Language header. Let's override
         // it with a header that accepts everything.
-        "Accept-Language" to "*/*",
-
-        // Default User Agent. Clients are expected to append their own tokens if needed.
-        "User-Agent" to "MozacFetch/${BuildConfig.LIBRARY_VERSION}",
-
-        // We expect all clients to support and use keep-alive by default.
-        "Connection" to "keep-alive"
+        "Accept-Language" to "*/*"
     )
 
     companion object {

--- a/components/concept/fetch/src/test/java/mozilla/components/concept/fetch/ClientTest.kt
+++ b/components/concept/fetch/src/test/java/mozilla/components/concept/fetch/ClientTest.kt
@@ -8,20 +8,9 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ClientTest {
-    @Test
-    fun `Verify default user agent format`() {
-        val client = TestClient()
-
-        val userAgent = client.exposeDefaultHeaders()["User-Agent"]
-        assertNotNull(userAgent!!)
-
-        assertTrue(userAgent.matches("MozacFetch/[0-9]+\\.[0-9]+\\.[0-9]+".toRegex()))
-    }
-
     @Test
     fun `Expects gzip encoding default header`() {
         val client = TestClient()
@@ -38,15 +27,6 @@ class ClientTest {
         val accept = client.exposeDefaultHeaders().get("Accept")
         assertNotNull(accept!!)
         assertEquals("*/*", accept)
-    }
-
-    @Test
-    fun `Expects keep-alive connection default header`() {
-        val client = TestClient()
-
-        val connection = client.exposeDefaultHeaders().get("Connection")
-        assertNotNull(connection!!)
-        assertEquals("keep-alive", connection)
     }
 
     @Test

--- a/components/lib/fetch-httpurlconnection/src/main/java/mozilla/components/lib/fetch/httpurlconnection/HttpURLConnectionClient.kt
+++ b/components/lib/fetch-httpurlconnection/src/main/java/mozilla/components/lib/fetch/httpurlconnection/HttpURLConnectionClient.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.lib.fetch.httpurlconnection
 
+import mozilla.components.concept.fetch.BuildConfig
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Headers
 import mozilla.components.concept.fetch.MutableHeaders
@@ -32,6 +33,7 @@ class HttpURLConnectionClient : Client() {
 
         val connection = (URL(request.url).openConnection() as HttpURLConnection)
 
+        connection.setRequestProperty("User-Agent", "MozacFetch/${BuildConfig.LIBRARY_VERSION}")
         connection.setupWith(request)
         connection.addHeadersFrom(request, defaultHeaders = defaultHeaders)
         connection.addBodyFrom(request)

--- a/components/lib/fetch-okhttp/src/main/java/mozilla/components/lib/fetch/okhttp/OkHttpClient.kt
+++ b/components/lib/fetch-okhttp/src/main/java/mozilla/components/lib/fetch/okhttp/OkHttpClient.kt
@@ -5,6 +5,7 @@
 package mozilla.components.lib.fetch.okhttp
 
 import android.content.Context
+import mozilla.components.concept.fetch.BuildConfig
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Headers
 import mozilla.components.concept.fetch.MutableHeaders
@@ -38,6 +39,7 @@ class OkHttpClient(
         val requestClient = client.rebuildFor(request, context)
 
         val requestBuilder = createRequestBuilderWithBody(request)
+        requestBuilder.addHeader("User-Agent", "MozacFetch/${BuildConfig.LIBRARY_VERSION}")
         requestBuilder.addHeadersFrom(request, defaultHeaders = defaultHeaders)
 
         if (!request.useCaches) {

--- a/components/tooling/fetch-tests/src/main/java/mozilla/components/tooling/fetch/tests/FetchTestCases.kt
+++ b/components/tooling/fetch-tests/src/main/java/mozilla/components/tooling/fetch/tests/FetchTestCases.kt
@@ -179,24 +179,6 @@ abstract class FetchTestCases {
     }
 
     @Test
-    open fun get200WithUserAgent() {
-        withServerResponding(
-            MockResponse()
-        ) { client ->
-            val response = client.fetch(Request(rootUrl()))
-            assertEquals(200, response.status)
-
-            val request = takeRequest()
-            val names = request.headers.names()
-
-            assertTrue(names.contains("User-Agent"))
-
-            val userAgent = request.headers.get("User-Agent")
-            assertTrue(userAgent!!.startsWith("MozacFetch/"))
-        }
-    }
-
-    @Test
     open fun get200WithGzippedBody() {
         withServerResponding(
             MockResponse()


### PR DESCRIPTION
Fixing some issues we see when using the Gecko-based `Client`.