### PR TITLE
Closes #8312:Adds support for ContentDelegate#onExternalResponse

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchClient.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchClient.kt
@@ -103,7 +103,6 @@ private fun WebRequest.Builder.addBodyFrom(request: Request): WebRequest.Builder
     return this
 }
 
-@VisibleForTesting
 internal fun WebResponse.toResponse(isBlobUri: Boolean): Response {
     val headers = translateHeaders(this)
     // We use the same API for blobs and HTTP requests, but blobs won't receive a status code.

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
@@ -70,6 +70,7 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory
 import mozilla.components.concept.engine.content.blocking.Tracker
+import mozilla.components.concept.fetch.Response
 import java.io.StringReader
 
 @RunWith(AndroidJUnit4::class)
@@ -442,7 +443,8 @@ class SystemEngineViewTest {
                 contentType: String?,
                 cookie: String?,
                 userAgent: String?,
-                isPrivate: Boolean
+                isPrivate: Boolean,
+                response: Response?
             ) {
                 assertEquals("https://download.mozilla.org", url)
                 assertEquals("image.png", fileName)

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -35,6 +35,7 @@ import mozilla.components.concept.engine.media.RecordingDevice
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.window.WindowRequest
+import mozilla.components.concept.fetch.Response
 import mozilla.components.lib.state.Store
 import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.ktx.android.net.isInScope
@@ -203,7 +204,8 @@ internal class EngineObserver(
         contentType: String?,
         cookie: String?,
         userAgent: String?,
-        isPrivate: Boolean
+        isPrivate: Boolean,
+        response: Response?
     ) {
         // We want to avoid negative contentLength values
         // For more info see https://bugzilla.mozilla.org/show_bug.cgi?id=1632594
@@ -217,7 +219,8 @@ internal class EngineObserver(
             INITIATED,
             userAgent,
             Environment.DIRECTORY_DOWNLOADS,
-            private = isPrivate
+            private = isPrivate,
+            response = response
         )
 
         store?.dispatch(ContentAction.UpdateDownloadAction(

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -28,6 +28,7 @@ import mozilla.components.concept.engine.media.Media
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.window.WindowRequest
+import mozilla.components.concept.fetch.Response
 import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.test.any
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
@@ -700,7 +701,7 @@ class EngineObserverTest {
     @Test
     fun `onExternalResource will update the store`() {
         val store = BrowserStore()
-
+        val response = mock<Response>()
         val sessionManager = SessionManager(engine = mock(), store = store)
 
         val session = Session("https://www.mozilla.org", id = "test-tab").also {
@@ -715,7 +716,8 @@ class EngineObserverTest {
                 userAgent = "userAgent",
                 contentType = "text/plain",
                 isPrivate = true,
-                contentLength = 100L)
+                contentLength = 100L,
+                response = response)
 
         store.waitUntilIdle()
 
@@ -727,6 +729,7 @@ class EngineObserverTest {
         assertEquals("text/plain", tab.content.download?.contentType)
         assertEquals(100L, tab.content.download?.contentLength)
         assertEquals(true, tab.content.download?.private)
+        assertEquals(response, tab.content.download?.response)
     }
 
     @Test

--- a/components/browser/state/build.gradle
+++ b/components/browser/state/build.gradle
@@ -33,6 +33,10 @@ dependencies {
     implementation project(':support-utils')
     implementation project(':support-ktx')
 
+    // We expose this as API because we are using Response in our public API and do not want every
+    // consumer to have to manually import "concept-fetch".
+    api project(':concept-fetch')
+
     implementation Dependencies.androidx_browser
     implementation Dependencies.kotlin_coroutines
     implementation Dependencies.kotlin_stdlib

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadState.kt
@@ -5,8 +5,7 @@
 package mozilla.components.browser.state.state.content
 
 import android.os.Environment
-import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import mozilla.components.concept.fetch.Response
 import java.util.UUID
 
 /**
@@ -26,10 +25,10 @@ import java.util.UUID
  * @property id The unique identifier of this download.
  * @property private Indicates if the download was created from a private session.
  * @property createdTime A timestamp when the download was created.
- * @
+ * @property response A response object associated with this request, when provided can be
+ * used instead of performing a manual a download.
  */
 @Suppress("Deprecation")
-@Parcelize
 data class DownloadState(
     val url: String,
     val fileName: String? = null,
@@ -44,8 +43,9 @@ data class DownloadState(
     val id: String = UUID.randomUUID().toString(),
     val sessionId: String? = null,
     val private: Boolean = false,
-    val createdTime: Long = System.currentTimeMillis()
-) : Parcelable {
+    val createdTime: Long = System.currentTimeMillis(),
+    val response: Response? = null
+) {
     val filePath: String get() =
         Environment.getExternalStoragePublicDirectory(destinationDirectory).path + "/" + fileName
 

--- a/components/concept/engine/build.gradle
+++ b/components/concept/engine/build.gradle
@@ -27,7 +27,6 @@ android {
 
 dependencies {
     implementation project(':support-ktx')
-
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.androidx_annotation
     implementation Dependencies.kotlin_coroutines
@@ -37,6 +36,7 @@ dependencies {
     api project(':support-base')
     api project(':browser-errorpages')
     api project(':concept-storage')
+    api project(':concept-fetch')
 
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.androidx_test_junit

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -18,6 +18,7 @@ import mozilla.components.concept.engine.media.RecordingDevice
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.window.WindowRequest
+import mozilla.components.concept.fetch.Response
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
 
@@ -133,6 +134,8 @@ abstract class EngineSession(
          * @param cookie The cookie related to request.
          * @param userAgent The user agent of the engine.
          * @param isPrivate Indicates if the download was requested from a private session.
+         * @param response A response object associated with this request, when provided can be
+         * used instead of performing a manual a download.
          */
         @Suppress("LongParameterList")
         fun onExternalResource(
@@ -142,7 +145,8 @@ abstract class EngineSession(
             contentType: String? = null,
             cookie: String? = null,
             userAgent: String? = null,
-            isPrivate: Boolean = false
+            isPrivate: Boolean = false,
+            response: Response? = null
         ) = Unit
 
         /**

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
@@ -607,7 +607,7 @@ abstract class AbstractFetchDownloadService : Service() {
         }
 
         val request = Request(download.url.sanitizeURL(), headers = headers, cookiePolicy = cookiePolicy)
-        val response = httpClient.fetch(request)
+        val response = download.response ?: httpClient.fetch(request)
         logger.debug("Fetching download for ${currentDownloadJobState.state.id} ")
 
         // If we are resuming a download and the response does not contain a CONTENT_RANGE

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt
@@ -106,6 +106,13 @@ class DownloadUtilsTest {
         assertEquals("file.txt", DownloadUtils.guessFileName(null, null, "http://example.com/file.txt", "text/html"))
     }
 
+    @Test
+    fun sanitizeMimeType() {
+        assertEquals("application/pdf", DownloadUtils.sanitizeMimeType("application/pdf; qs=0.001"))
+        assertEquals("application/pdf", DownloadUtils.sanitizeMimeType("application/pdf"))
+        assertEquals(null, DownloadUtils.sanitizeMimeType(null))
+    }
+
     companion object {
         private val CONTENT_DISPOSITION_TYPES = listOf("attachment", "inline")
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **browser-state**
+  * ⚠️ **This is a breaking change**: `DownloadState` doesn't support [Parcelable](https://developer.android.com/reference/android/os/Parcelable) anymore.
+
 * **feature-downloads**
   * 🚒 Bug fixed [issue #8585](https://github.com/mozilla-mobile/android-components/issues/8585) fixed regression files not been added to the downloads database system.
 


### PR DESCRIPTION
I just need to add a new test to `AbstractFetchDownloadService` and some additional sanity check tests, but I would like to get an early feedback.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
