### PR TITLE
Issue #3265: Add support for "undo" functionality.

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -15,6 +15,7 @@ import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.action.LastAccessAction
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.state.ReaderState
+import mozilla.components.browser.state.state.recover.RecoverableTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
@@ -164,6 +165,33 @@ class SessionManager(
         store?.syncDispatch(TabListAction.AddMultipleTabsAction(
             tabs = sessions.map { it.toTabSessionState() }
         ))
+    }
+
+    /**
+     * Restores the given list of [RecoverableTab].
+     */
+    fun restore(tabs: List<RecoverableTab>) {
+        // As a workaround we squint here and pretend this is a Snapshot..
+
+        val items = tabs.map {
+            Snapshot.Item(
+                session = Session(
+                    id = it.id,
+                    initialUrl = it.url,
+                    contextId = it.contextId
+                ).apply {
+                    title = it.title
+                    parentId = it.parentId
+                },
+                engineSessionState = it.state,
+                readerState = it.readerState,
+                lastAccess = it.lastAccess
+            )
+        }
+
+        val snapshot = Snapshot(items, NO_SELECTION)
+
+        restore(snapshot, updateSelection = false)
     }
 
     /**

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/undo/UndoMiddleware.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/undo/UndoMiddleware.kt
@@ -1,0 +1,132 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.undo
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.action.BrowserAction
+import mozilla.components.browser.state.action.TabListAction
+import mozilla.components.browser.state.action.UndoAction
+import mozilla.components.browser.state.selector.findTab
+import mozilla.components.browser.state.selector.normalTabs
+import mozilla.components.browser.state.selector.privateTabs
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.SessionState
+import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.browser.state.state.recover.toRecoverableTab
+import mozilla.components.lib.state.Middleware
+import mozilla.components.lib.state.MiddlewareContext
+import mozilla.components.support.base.log.logger.Logger
+import java.util.UUID
+import mozilla.components.support.base.coroutines.Dispatchers as MozillaDispatchers
+
+/**
+ * [Middleware] implementation that adds removed tabs to [BrowserState.undoHistory] for a short
+ * amount of time ([clearAfterMillis]). Dispatching [UndoAction.RestoreRecoverableTabs] will restore
+ * the tabs from [BrowserState.undoHistory].
+ */
+class UndoMiddleware(
+    private val sessionManagerLookup: () -> SessionManager,
+    private val clearAfterMillis: Long = 5000, // For comparison: a LENGTH_LONG Snackbar takes 2750.
+    private val mainScope: CoroutineScope = CoroutineScope(Dispatchers.Main),
+    private val waitScope: CoroutineScope = CoroutineScope(MozillaDispatchers.Cached)
+) : Middleware<BrowserState, BrowserAction> {
+    private val logger = Logger("UndoMiddleware")
+    private var clearJob: Job? = null
+
+    override fun invoke(
+        context: MiddlewareContext<BrowserState, BrowserAction>,
+        next: (BrowserAction) -> Unit,
+        action: BrowserAction
+    ) {
+        val state = context.state
+
+        when (action) {
+            // Remember removed tabs
+            is TabListAction.RemoveAllNormalTabsAction -> onTabsRemoved(
+                context, state.normalTabs, state.selectedTabId
+            )
+            is TabListAction.RemoveAllPrivateTabsAction -> onTabsRemoved(
+                context, state.privateTabs, state.selectedTabId
+            )
+            is TabListAction.RemoveAllTabsAction -> onTabsRemoved(
+                context, state.tabs, state.selectedTabId
+            )
+            is TabListAction.RemoveTabAction -> state.findTab(action.tabId)?.let {
+                onTabsRemoved(context, listOf(it), state.selectedTabId)
+            }
+
+            // Restore
+            is UndoAction.RestoreRecoverableTabs -> restore(context.state)
+        }
+
+        next(action)
+    }
+
+    private fun onTabsRemoved(
+        context: MiddlewareContext<BrowserState, BrowserAction>,
+        tabs: List<SessionState>,
+        selectedTabId: String?
+    ) {
+        clearJob?.cancel()
+
+        val recoverableTabs = tabs.mapNotNull {
+            it as? TabSessionState
+        }.map {
+            it.toRecoverableTab()
+        }
+
+        if (recoverableTabs.isEmpty()) {
+            logger.debug("No recoverable tabs to add to undo history.")
+            return
+        }
+
+        val tag = UUID.randomUUID().toString()
+
+        val selectionToRestore = selectedTabId?.let { recoverableTabs.find { it.id == selectedTabId }?.id }
+
+        context.dispatch(
+            UndoAction.AddRecoverableTabs(tag, recoverableTabs, selectionToRestore)
+        )
+
+        val store = context.store
+
+        clearJob = waitScope.launch {
+            delay(clearAfterMillis)
+            store.dispatch(UndoAction.ClearRecoverableTabs(tag))
+        }
+    }
+
+    private fun restore(state: BrowserState) = mainScope.launch {
+        clearJob?.cancel()
+
+        // Since we have to restore into SessionManager (until we can nuke it from orbit and only use BrowserStore),
+        // this is a bit crude. For example we do not restore into the previous position. The goal is to make this
+        // nice once we can restore directly into BrowserState.
+
+        val sessionManager = sessionManagerLookup.invoke()
+
+        val undoHistory = state.undoHistory
+        val tabs = undoHistory.tabs
+        if (tabs.isEmpty()) {
+            logger.debug("No recoverable tabs for undo.")
+            return@launch
+        }
+
+        sessionManager.restore(tabs)
+
+        // Restore the previous selection if needed.
+        undoHistory.selectedTabId?.let { tabId ->
+            val tab = sessionManager.findSessionById(tabId)
+            if (tab != null) {
+                sessionManager.select(tab)
+            }
+        }
+    }
+}

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -8,6 +8,8 @@ import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.action.LastAccessAction
 import mozilla.components.browser.state.state.CustomTabConfig
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.browser.state.state.recover.toRecoverableTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.support.test.any
@@ -284,6 +286,34 @@ class SessionManagerTest {
         assertEquals("1", manager.sessions[3].contextId)
 
         verify(observer).onSessionsRestored()
+    }
+
+    @Test
+    fun `Restore list of RecoverableTab`() {
+        val sessionManager = SessionManager(mock())
+
+        val mozilla = createTab("https://www.mozilla.org", id = "mozilla")
+        val pocket = createTab("https://getpocket.com", id = "pocket")
+        val wikipedia = createTab("https://www.wikipedia.org", id = "wikipedia", parent = mozilla)
+
+        assertEquals(0, sessionManager.size)
+
+        sessionManager.restore(listOf(
+            mozilla.toRecoverableTab(),
+            pocket.toRecoverableTab(),
+            wikipedia.toRecoverableTab()
+        ))
+
+        assertEquals(3, sessionManager.size)
+        assertNull(sessionManager.selectedSession)
+
+        assertEquals("https://www.mozilla.org", sessionManager.sessions[0].url)
+        assertEquals("https://getpocket.com", sessionManager.sessions[1].url)
+        assertEquals("https://www.wikipedia.org", sessionManager.sessions[2].url)
+
+        assertNull(sessionManager.sessions[0].parentId)
+        assertNull(sessionManager.sessions[1].parentId)
+        assertEquals("mozilla", sessionManager.sessions[2].parentId)
     }
 
     @Test

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/undo/UndoMiddlewareTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/undo/UndoMiddlewareTest.kt
@@ -1,0 +1,258 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.undo
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.action.UndoAction
+import mozilla.components.browser.state.selector.selectedTab
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
+import mozilla.components.support.test.mock
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class UndoMiddlewareTest {
+    private lateinit var testDispatcher: TestCoroutineDispatcher
+
+    @Before
+    fun setUp() {
+        testDispatcher = TestCoroutineDispatcher()
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        testDispatcher.cleanupTestCoroutines()
+    }
+
+    @Test
+    fun `Undo scenario - Removing single tab`() {
+        val lookup = SessionManagerLookup()
+        val store = BrowserStore(middleware = listOf(
+            UndoMiddleware(lookup, clearAfterMillis = 60000)
+        ))
+        val manager = SessionManager(engine = mock(), store = store).apply {
+            lookup.sessionManager = this
+        }
+
+        val mozilla = Session("https://www.mozilla.org")
+        val pocket = Session("https://getpocket.com")
+
+        manager.add(mozilla)
+        manager.add(pocket)
+
+        assertEquals(2, manager.size)
+        assertEquals(2, store.state.tabs.size)
+        assertEquals("https://www.mozilla.org", manager.selectedSessionOrThrow.url)
+        assertEquals("https://www.mozilla.org", store.state.selectedTab!!.content.url)
+
+        manager.remove(mozilla)
+
+        assertEquals(1, manager.size)
+        assertEquals(1, store.state.tabs.size)
+        assertEquals("https://getpocket.com", manager.selectedSessionOrThrow.url)
+        assertEquals("https://getpocket.com", store.state.selectedTab!!.content.url)
+
+        testDispatcher.withDispatchingPaused {
+            // We need to pause the test dispatcher here to avoid it dispatching immediately.
+            // Otherwise we deadlock the test here when we wait for the store to complete and
+            // at the same time the middleware dispatches a coroutine on the dispatcher which will
+            // also block on the store in SessionManager.restore().
+            store.dispatch(UndoAction.RestoreRecoverableTabs).joinBlocking()
+        }
+
+        store.waitUntilIdle()
+
+        assertEquals(2, manager.size)
+        assertEquals(2, store.state.tabs.size)
+        assertEquals("https://www.mozilla.org", manager.selectedSessionOrThrow.url)
+        assertEquals("https://www.mozilla.org", store.state.selectedTab!!.content.url)
+    }
+
+    @Test
+    fun `Undo scenario - Removing all normal tabs`() {
+        val lookup = SessionManagerLookup()
+        val store = BrowserStore(middleware = listOf(
+            UndoMiddleware(lookup, clearAfterMillis = 60000)
+        ))
+        val manager = SessionManager(engine = mock(), store = store).apply {
+            lookup.sessionManager = this
+        }
+
+        val mozilla = Session("https://www.mozilla.org")
+        val pocket = Session("https://getpocket.com")
+        val reddit = Session("https://reddit.com/r/firefox", private = true)
+
+        manager.add(mozilla)
+        manager.add(pocket)
+        manager.add(reddit)
+        manager.select(pocket)
+
+        assertEquals(3, manager.size)
+        assertEquals(3, store.state.tabs.size)
+        assertEquals("https://getpocket.com", manager.selectedSessionOrThrow.url)
+        assertEquals("https://getpocket.com", store.state.selectedTab!!.content.url)
+
+        manager.removeNormalSessions()
+
+        assertEquals(1, manager.size)
+        assertEquals(1, store.state.tabs.size)
+        assertNull(manager.selectedSession)
+        assertNull(store.state.selectedTab)
+
+        testDispatcher.withDispatchingPaused {
+            // We need to pause the test dispatcher here to avoid it dispatching immediately.
+            // Otherwise we deadlock the test here when we wait for the store to complete and
+            // at the same time the middleware dispatches a coroutine on the dispatcher which will
+            // also block on the store in SessionManager.restore().
+            store.dispatch(UndoAction.RestoreRecoverableTabs).joinBlocking()
+        }
+
+        store.waitUntilIdle()
+
+        assertEquals(3, manager.size)
+        assertEquals(3, store.state.tabs.size)
+        assertEquals("https://getpocket.com", manager.selectedSessionOrThrow.url)
+        assertEquals("https://getpocket.com", store.state.selectedTab!!.content.url)
+    }
+
+    @Test
+    fun `Undo History in State is written`() {
+        val lookup = SessionManagerLookup()
+        val store = BrowserStore(middleware = listOf(
+            UndoMiddleware(lookup, clearAfterMillis = 60000)
+        ))
+        val manager = SessionManager(engine = mock(), store = store).apply {
+            lookup.sessionManager = this
+        }
+
+        val mozilla = Session("https://www.mozilla.org", id = "mozilla")
+        val pocket = Session("https://getpocket.com", id = "pocket")
+        val reddit = Session("https://reddit.com/r/firefox", private = true, id = "reddit")
+
+        manager.add(mozilla)
+        manager.add(pocket)
+        manager.add(reddit)
+        manager.select(pocket)
+
+        assertNull(store.state.undoHistory.selectedTabId)
+        assertTrue(store.state.undoHistory.tabs.isEmpty())
+        assertEquals(3, store.state.tabs.size)
+
+        manager.removePrivateSessions()
+
+        assertNull(store.state.undoHistory.selectedTabId)
+        assertEquals(1, store.state.undoHistory.tabs.size)
+        assertEquals("https://reddit.com/r/firefox", store.state.undoHistory.tabs[0].url)
+        assertEquals(2, store.state.tabs.size)
+
+        manager.removeNormalSessions()
+
+        assertEquals("pocket", store.state.undoHistory.selectedTabId)
+        assertEquals(2, store.state.undoHistory.tabs.size)
+        assertEquals("https://www.mozilla.org", store.state.undoHistory.tabs[0].url)
+        assertEquals("https://getpocket.com", store.state.undoHistory.tabs[1].url)
+        assertEquals(0, store.state.tabs.size)
+
+        testDispatcher.withDispatchingPaused {
+            // We need to pause the test dispatcher here to avoid it dispatching immediately.
+            // Otherwise we deadlock the test here when we wait for the store to complete and
+            // at the same time the middleware dispatches a coroutine on the dispatcher which will
+            // also block on the store in SessionManager.restore().
+            store.dispatch(UndoAction.RestoreRecoverableTabs).joinBlocking()
+        }
+
+        assertNull(store.state.undoHistory.selectedTabId)
+        assertTrue(store.state.undoHistory.tabs.isEmpty())
+        assertEquals(0, store.state.undoHistory.tabs.size)
+        assertEquals(2, store.state.tabs.size)
+        assertEquals("https://www.mozilla.org", store.state.tabs[0].content.url)
+        assertEquals("https://getpocket.com", store.state.tabs[1].content.url)
+    }
+
+    @Test
+    fun `Undo History gets cleared after time`() {
+        val waitDispatcher = TestCoroutineDispatcher()
+        val waitScope = CoroutineScope(waitDispatcher)
+
+        val lookup = SessionManagerLookup()
+        val store = BrowserStore(middleware = listOf(
+            UndoMiddleware(lookup, clearAfterMillis = 60000, waitScope = waitScope)
+        ))
+        val manager = SessionManager(engine = mock(), store = store).apply {
+            lookup.sessionManager = this
+        }
+
+        val mozilla = Session("https://www.mozilla.org", id = "mozilla")
+        val pocket = Session("https://getpocket.com", id = "pocket")
+        val reddit = Session("https://reddit.com/r/firefox", private = true, id = "reddit")
+
+        manager.add(mozilla)
+        manager.add(pocket)
+        manager.add(reddit)
+        manager.select(pocket)
+
+        assertEquals(3, manager.size)
+        assertEquals(3, store.state.tabs.size)
+        assertEquals("https://getpocket.com", manager.selectedSessionOrThrow.url)
+        assertEquals("https://getpocket.com", store.state.selectedTab!!.content.url)
+
+        manager.removeNormalSessions()
+
+        assertEquals(1, manager.size)
+        assertEquals("https://reddit.com/r/firefox", manager.sessions[0].url)
+        assertEquals("pocket", store.state.undoHistory.selectedTabId)
+        assertEquals(2, store.state.undoHistory.tabs.size)
+        assertEquals("https://www.mozilla.org", store.state.undoHistory.tabs[0].url)
+        assertEquals("https://getpocket.com", store.state.undoHistory.tabs[1].url)
+
+        waitDispatcher.advanceTimeBy(70000)
+        waitDispatcher.advanceUntilIdle()
+        store.waitUntilIdle()
+
+        assertNull(store.state.undoHistory.selectedTabId)
+        assertTrue(store.state.undoHistory.tabs.isEmpty())
+        assertEquals(1, manager.size)
+        assertEquals("https://reddit.com/r/firefox", manager.sessions[0].url)
+
+        testDispatcher.withDispatchingPaused {
+            // We need to pause the test dispatcher here to avoid it dispatching immediately.
+            // Otherwise we deadlock the test here when we wait for the store to complete and
+            // at the same time the middleware dispatches a coroutine on the dispatcher which will
+            // also block on the store in SessionManager.restore().
+            store.dispatch(UndoAction.RestoreRecoverableTabs).joinBlocking()
+        }
+
+        assertEquals(1, manager.size)
+        assertEquals("https://reddit.com/r/firefox", manager.sessions[0].url)
+    }
+}
+
+private class SessionManagerLookup : () -> SessionManager {
+    lateinit var sessionManager: SessionManager
+
+    override operator fun invoke(): SessionManager {
+        return sessionManager
+    }
+}
+
+private fun TestCoroutineDispatcher.withDispatchingPaused(block: () -> Unit) {
+    pauseDispatcher()
+    block()
+    resumeDispatcher()
+    advanceUntilIdle()
+}

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -24,6 +24,8 @@ import mozilla.components.browser.state.state.WebExtensionState
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.state.content.FindResultState
 import mozilla.components.browser.state.state.SearchState
+import mozilla.components.browser.state.state.UndoHistoryState
+import mozilla.components.browser.state.state.recover.RecoverableTab
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
@@ -156,6 +158,32 @@ sealed class TabListAction : BrowserAction() {
      * Removes all non-private [TabSessionState]s.
      */
     object RemoveAllNormalTabsAction : TabListAction()
+}
+
+/**
+ * [BrowserAction] implementations dealing with "undo" after removing a tab.
+ */
+sealed class UndoAction : BrowserAction() {
+    /**
+     * Adds the list of [tabs] to [UndoHistoryState] with the given [tag].
+     */
+    data class AddRecoverableTabs(
+        val tag: String,
+        val tabs: List<RecoverableTab>,
+        val selectedTabId: String?
+    ) : UndoAction()
+
+    /**
+     * Clears the tabs from [UndoHistoryState] for the given [tag].
+     */
+    data class ClearRecoverableTabs(
+        val tag: String
+    ) : UndoAction()
+
+    /**
+     * Restores the tabs in [UndoHistoryState].
+     */
+    object RestoreRecoverableTabs : UndoAction()
 }
 
 /**
@@ -687,7 +715,7 @@ sealed class ReaderAction : BrowserAction() {
         ReaderAction()
 
     /**
-     * Updates the [ReaderState.readerBaseUrl].
+     * Updates the [ReaderState.baseUrl].
      */
     data class UpdateReaderBaseUrlAction(val tabId: String, val baseUrl: String) : ReaderAction()
 

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
@@ -19,6 +19,7 @@ import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.action.LastAccessAction
 import mozilla.components.browser.state.action.RecentlyClosedAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
+import mozilla.components.browser.state.action.UndoAction
 import mozilla.components.browser.state.action.WebExtensionAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.CustomTabSessionState
@@ -51,6 +52,7 @@ internal object BrowserStateReducer {
             is SearchAction -> SearchReducer.reduce(state, action)
             is CrashAction -> CrashReducer.reduce(state, action)
             is LastAccessAction -> LastAccessReducer.reduce(state, action)
+            is UndoAction -> UndoReducer.reduce(state, action)
         }
     }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/UndoReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/UndoReducer.kt
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.reducer
+
+import mozilla.components.browser.state.action.UndoAction
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.UndoHistoryState
+
+internal object UndoReducer {
+    /**
+     * [UndoAction] Reducer function for modifying the [UndoHistoryState] used to undo the removal
+     * of tabs.
+     */
+    fun reduce(state: BrowserState, action: UndoAction): BrowserState {
+        return when (action) {
+            is UndoAction.AddRecoverableTabs -> {
+                // A middleware will take care of observing tabs getting removed and will then
+                // dispatch an this action to remember those tabs. We only remember the last set
+                // of tabs that got removed and replace them here.
+                state.copy(
+                    undoHistory = UndoHistoryState(action.tag, action.tabs, action.selectedTabId)
+                )
+            }
+
+            is UndoAction.RestoreRecoverableTabs -> {
+                // The actual restore is handled by a middleware. Here we only need to clear the
+                // state since we assume it got restored.
+                state.copy(
+                    undoHistory = UndoHistoryState()
+                )
+            }
+
+            is UndoAction.ClearRecoverableTabs -> {
+                if (action.tag == state.undoHistory.tag) {
+                    state.copy(
+                        undoHistory = UndoHistoryState()
+                    )
+                } else {
+                    state
+                }
+            }
+        }
+    }
+}

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/BrowserState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/BrowserState.kt
@@ -22,6 +22,7 @@ import mozilla.components.lib.state.State
  * @property media The state of all media elements and playback states for all tabs.
  * @property search the state of search for this browser state.
  * @property downloads Downloads ([DownloadState]s) mapped to their IDs.
+ * @property undoHistory History of recently closed tabs to support "undo" (Requires UndoMiddleware).
  */
 data class BrowserState(
     val tabs: List<TabSessionState> = emptyList(),
@@ -32,5 +33,6 @@ data class BrowserState(
     val extensions: Map<String, WebExtensionState> = emptyMap(),
     val media: MediaState = MediaState(),
     val downloads: Map<String, DownloadState> = emptyMap(),
-    val search: SearchState = SearchState()
+    val search: SearchState = SearchState(),
+    val undoHistory: UndoHistoryState = UndoHistoryState()
 ) : State

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabSessionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabSessionState.kt
@@ -21,6 +21,7 @@ import java.util.UUID
  * that contains the overridden values for this tab.
  * @property readerState the [ReaderState] of this tab.
  * @property contextId the session context ID of this tab.
+ * @param lastAccess The last time this tab was selected (requires LastAccessMiddleware).
  */
 data class TabSessionState(
     override val id: String = UUID.randomUUID().toString(),

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/UndoHistoryState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/UndoHistoryState.kt
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.state
+
+import mozilla.components.browser.state.state.recover.RecoverableTab
+
+/**
+ * State keeping track of removed tabs to allow "undo".
+ *
+ * Currently the undo history only saves the tabs from the last remove operation. This is so far
+ * "good enough" since we also only show one undo snackbar for the last operation in the UI.
+ *
+ * @param tag A tag (usually a UUID) identifying this specific undo state. This tag can be used to
+ * avoid removing/restoring the wrong state in a multi-threaded environment.
+ * @param tabs List of previously removed tabs.
+ * @param selectedTabId Id of the tab in [tabs] that was selected and should get reselected on restore.
+ */
+data class UndoHistoryState(
+    val tag: String = "",
+    val tabs: List<RecoverableTab> = emptyList(),
+    val selectedTabId: String? = null
+)

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/recover/RecoverableTab.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/recover/RecoverableTab.kt
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.state.recover
+
+import mozilla.components.browser.state.state.ReaderState
+import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.concept.engine.EngineSessionState
+
+/**
+ * A tab that is no longer open and in the list of tabs, but that can be restored (recovered) at
+ * any time.
+ *
+ * The values of this data class are usually filled with the values of a [TabSessionState] when
+ * getting closed.
+ *
+ * @param id Unique ID identifying this tba.
+ * @param parentId The unique ID of the parent tab if this tab was opened from another tab (e.g. via
+ * the context menu).
+ * @param url The last URL of this tab.
+ * @param title The last title of this tab (or an empty String).
+ * @param contextId The context ID ("container") this tab used (or null).
+ * @param state The [EngineSessionState] needed for restoring the previous state of this tab.
+ * @param readerState The last [ReaderState] of the tab.
+ * @param lastAccess The last time this tab was selected.
+ */
+data class RecoverableTab(
+    val id: String,
+    val parentId: String?,
+    val url: String,
+    val title: String,
+    val contextId: String?,
+    val state: EngineSessionState?,
+    val readerState: ReaderState,
+    val lastAccess: Long
+)
+
+/**
+ * Creates a [RecoverableTab] from this [TabSessionState].
+ */
+fun TabSessionState.toRecoverableTab() = RecoverableTab(
+    id = id,
+    parentId = parentId,
+    url = content.url,
+    title = content.title,
+    contextId = contextId,
+    state = engineState.engineSessionState,
+    readerState = readerState,
+    lastAccess = lastAccess
+)

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
@@ -8,6 +8,7 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.state.state.SessionState.Source
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.action.EngineAction
+import mozilla.components.browser.state.action.UndoAction
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
@@ -252,6 +253,20 @@ class TabsUseCases(
         }
     }
 
+    /**
+     * Use case for restoring removed tabs ("undo").
+     */
+    class UndoTabRemovalUseCase(
+        private val store: BrowserStore
+    ) {
+        /**
+         * Restores the list of tabs in the undo history.
+         */
+        operator fun invoke() {
+            store.dispatch(UndoAction.RestoreRecoverableTabs)
+        }
+    }
+
     val selectTab: SelectTabUseCase by lazy { DefaultSelectTabUseCase(sessionManager) }
     val removeTab: RemoveTabUseCase by lazy { DefaultRemoveTabUseCase(sessionManager) }
     val addTab: AddNewTabUseCase by lazy { AddNewTabUseCase(store, sessionManager) }
@@ -259,4 +274,5 @@ class TabsUseCases(
     val removeAllTabs: RemoveAllTabsUseCase by lazy { RemoveAllTabsUseCase(sessionManager) }
     val removeNormalTabs: RemoveNormalTabsUseCase by lazy { RemoveNormalTabsUseCase(sessionManager) }
     val removePrivateTabs: RemovePrivateTabsUseCase by lazy { RemovePrivateTabsUseCase(sessionManager) }
+    val undo by lazy { UndoTabRemovalUseCase(store) }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,11 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **browser-session**
+  * Added "undo" functionality via `UndoMiddleware`.
+* **feature-tabs**
+  * Added `TabsUseCases.UndoTabRemovalUseCase` for undoing the removal of tabs.
+
 # 60.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v59.0.0...v60.0.0)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -29,6 +29,7 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.engine.EngineMiddleware
 import mozilla.components.browser.session.storage.SessionStorage
+import mozilla.components.browser.session.undo.UndoMiddleware
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.storage.sync.PlacesHistoryStorage
 import mozilla.components.browser.thumbnails.ThumbnailsMiddleware
@@ -131,7 +132,8 @@ open class DefaultComponents(private val applicationContext: Context) {
             MediaMiddleware(applicationContext, MediaService::class.java),
             DownloadMiddleware(applicationContext, DownloadService::class.java),
             ReaderViewMiddleware(),
-            ThumbnailsMiddleware(thumbnailStorage)
+            ThumbnailsMiddleware(thumbnailStorage),
+            UndoMiddleware(::sessionManagerLookup)
         ) + EngineMiddleware.create(engine, ::findSessionById))
     }
 
@@ -139,6 +141,10 @@ open class DefaultComponents(private val applicationContext: Context) {
 
     private fun findSessionById(tabId: String): Session? {
         return sessionManager.findSessionById(tabId)
+    }
+
+    private fun sessionManagerLookup(): SessionManager {
+        return sessionManager
     }
 
     val sessionManager by lazy {


### PR DESCRIPTION
This is not the fancy version yet since we still need to restore into SessionManager. Once it is gone and
we rely on BrowserStore only, then we can make this better.

However moving this functionality into AC now helps us:
- It will be easier to migrate to a better undo functionality since this code is already in AC.
- Other code can interact with the "undo" actions. For example "recently closed tabs" now will
  only contain a tab if the removal was not undone.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
