### PR TITLE
Bug 1667367 - Move AC nightlies from 1pm UTC to 2:30pm

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -10,5 +10,5 @@ jobs:
           treeherder-symbol: nightly-D
           target-tasks-method: nightly
       when:
-          - {hour: 13, minute: 0}
+          - {hour: 14, minute: 30}
           - {hour: 19, minute: 0}


### PR DESCRIPTION
Fixes #8473. See https://github.com/mozilla-mobile/android-components/issues/8473#issuecomment-699026977


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
