### PR TITLE
Close #8531: Use synchronized block in PushConnection init check

### DIFF
--- a/components/feature/push/src/main/java/mozilla/components/feature/push/Connection.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/Connection.kt
@@ -246,7 +246,8 @@ internal class RustPushConnection(
         pushApi.close()
     }
 
-    override fun isInitialized() = api != null
+    @GuardedBy("this")
+    override fun isInitialized() = synchronized(this) { api != null }
 }
 
 /**


### PR DESCRIPTION
This was the only call that did not have the initialisation check around
it. It may have been the cause for a race seen in Fenix send tab, but we
should fix this regardless to always ensure synchronization.

No tests are added since there isn't a consistent way to test a block is
synchronized.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
