### PR TITLE
Step back to GV nightly 83.0.20200922094538

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -6,7 +6,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Nightly Version.
      */
-    const val nightly_version = "83.0.20200929094055"
+    const val nightly_version = "83.0.20200922094538"
 
     /**
      * GeckoView Beta Version.


### PR DESCRIPTION
Stepping back to last working GV Nightly so we can unblock A-C and Fenix Nightlies.