### PR TITLE
Closes #8529: Dispatch a generic InitAction from BrowserStore

### DIFF
--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -1161,6 +1161,6 @@ class SessionManagerTest {
 
         assertTrue(captor.allValues[0] is TabListAction.RestoreAction)
         assertTrue(captor.allValues[1] is LastAccessAction.UpdateLastAccessAction)
-        assertEquals(123, store.state.tabs[0].lastAccess)
+        assertEquals(123, (captor.allValues[1] as LastAccessAction.UpdateLastAccessAction).lastAccess)
     }
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/middleware/TabsRemovedMiddlewareTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/middleware/TabsRemovedMiddlewareTest.kt
@@ -31,7 +31,6 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
-import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
@@ -50,10 +49,10 @@ class TabsRemovedMiddlewareTest {
         val middleware = TabsRemovedMiddleware(scope)
 
         val tab = createTab("https://www.mozilla.org", id = "1")
-        val store = spy(BrowserStore(
+        val store = BrowserStore(
             initialState = BrowserState(tabs = listOf(tab)),
             middleware = listOf(middleware, ConsumeRemoveTabActionsMiddleware())
-        ))
+        )
 
         val engineSession = linkEngineSession(store, tab.id)
         store.dispatch(TabListAction.RemoveTabAction(tab.id)).joinBlocking()
@@ -71,10 +70,10 @@ class TabsRemovedMiddlewareTest {
         val tab1 = createTab("https://www.mozilla.org", id = "1", private = false)
         val tab2 = createTab("https://www.firefox.com", id = "2", private = false)
         val tab3 = createTab("https://www.getpocket.com", id = "3", private = true)
-        val store = spy(BrowserStore(
+        val store = BrowserStore(
             initialState = BrowserState(tabs = listOf(tab1, tab2, tab3)),
             middleware = listOf(middleware, ConsumeRemoveTabActionsMiddleware())
-        ))
+        )
 
         val engineSession1 = linkEngineSession(store, tab1.id)
         val engineSession2 = linkEngineSession(store, tab2.id)
@@ -99,10 +98,10 @@ class TabsRemovedMiddlewareTest {
         val tab1 = createTab("https://www.mozilla.org", id = "1", private = true)
         val tab2 = createTab("https://www.firefox.com", id = "2", private = true)
         val tab3 = createTab("https://www.getpocket.com", id = "3", private = false)
-        val store = spy(BrowserStore(
+        val store = BrowserStore(
             initialState = BrowserState(tabs = listOf(tab1, tab2, tab3)),
             middleware = listOf(middleware, ConsumeRemoveTabActionsMiddleware())
-        ))
+        )
 
         val engineSession1 = linkEngineSession(store, tab1.id)
         val engineSession2 = linkEngineSession(store, tab2.id)
@@ -127,10 +126,10 @@ class TabsRemovedMiddlewareTest {
         val tab1 = createTab("https://www.mozilla.org", id = "1", private = true)
         val tab2 = createTab("https://www.firefox.com", id = "2", private = false)
         val tab3 = createCustomTab("https://www.getpocket.com", id = "3")
-        val store = spy(BrowserStore(
+        val store = BrowserStore(
             initialState = BrowserState(tabs = listOf(tab1, tab2), customTabs = listOf(tab3)),
             middleware = listOf(middleware, ConsumeRemoveTabActionsMiddleware())
-        ))
+        )
 
         val engineSession1 = linkEngineSession(store, tab1.id)
         val engineSession2 = linkEngineSession(store, tab2.id)
@@ -153,10 +152,10 @@ class TabsRemovedMiddlewareTest {
         val middleware = TabsRemovedMiddleware(scope)
 
         val tab = createCustomTab("https://www.mozilla.org", id = "1")
-        val store = spy(BrowserStore(
+        val store = BrowserStore(
             initialState = BrowserState(customTabs = listOf(tab)),
             middleware = listOf(middleware, ConsumeRemoveTabActionsMiddleware())
-        ))
+        )
 
         val engineSession = linkEngineSession(store, tab.id)
         store.dispatch(CustomTabListAction.RemoveCustomTabAction(tab.id)).joinBlocking()
@@ -174,10 +173,10 @@ class TabsRemovedMiddlewareTest {
         val tab1 = createCustomTab("https://www.mozilla.org", id = "1")
         val tab2 = createCustomTab("https://www.firefox.com", id = "2")
         val tab3 = createTab("https://www.getpocket.com", id = "3")
-        val store = spy(BrowserStore(
+        val store = BrowserStore(
             initialState = BrowserState(customTabs = listOf(tab1, tab2), tabs = listOf(tab3)),
             middleware = listOf(middleware, ConsumeRemoveTabActionsMiddleware())
-        ))
+        )
 
         val engineSession1 = linkEngineSession(store, tab1.id)
         val engineSession2 = linkEngineSession(store, tab2.id)

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/middleware/TrimMemoryMiddlewareTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/middleware/TrimMemoryMiddlewareTest.kt
@@ -24,7 +24,6 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 
@@ -50,46 +49,44 @@ class TrimMemoryMiddlewareTest {
         engineSessionStateTheVerge = mock()
         engineSessionStateTwitch = mock()
 
-        store = Mockito.spy(
-            BrowserStore(
-                middleware = listOf(
-                    TrimMemoryMiddleware(),
-                    SuspendMiddleware(scope)
+        store = BrowserStore(
+            middleware = listOf(
+                TrimMemoryMiddleware(),
+                SuspendMiddleware(scope)
+            ),
+            initialState = BrowserState(
+                tabs = listOf(
+                    createTab("https://www.mozilla.org", id = "mozilla"),
+                    createTab("https://www.theverge.com/", id = "theverge").copy(
+                        engineState = EngineState(
+                            engineSession = engineSessionTheVerge,
+                            engineSessionState = engineSessionStateTheVerge,
+                            engineObserver = mock())
+                    ),
+                    createTab(
+                        "https://www.reddit.com/r/firefox/",
+                        id = "reddit",
+                        private = true
+                    ).copy(
+                        engineState = EngineState(
+                            engineSession = engineSessionReddit,
+                            engineSessionState = engineSessionStateReddit,
+                            engineObserver = mock()
+                        )
+                    ),
+                    createTab("https://github.com/", id = "github")
                 ),
-                initialState = BrowserState(
-                    tabs = listOf(
-                        createTab("https://www.mozilla.org", id = "mozilla"),
-                        createTab("https://www.theverge.com/", id = "theverge").copy(
-                            engineState = EngineState(
-                                engineSession = engineSessionTheVerge,
-                                engineSessionState = engineSessionStateTheVerge,
-                                engineObserver = mock())
-                        ),
-                        createTab(
-                            "https://www.reddit.com/r/firefox/",
-                            id = "reddit",
-                            private = true
-                        ).copy(
-                            engineState = EngineState(
-                                engineSession = engineSessionReddit,
-                                engineSessionState = engineSessionStateReddit,
-                                engineObserver = mock()
-                            )
-                        ),
-                        createTab("https://github.com/", id = "github")
+                customTabs = listOf(
+                    createCustomTab("https://www.twitch.tv/", id = "twitch").copy(
+                        engineState = EngineState(
+                            engineSession = engineSessionTwitch,
+                            engineSessionState = engineSessionStateTwitch,
+                            engineObserver = mock()
+                        )
                     ),
-                    customTabs = listOf(
-                        createCustomTab("https://www.twitch.tv/", id = "twitch").copy(
-                            engineState = EngineState(
-                                engineSession = engineSessionTwitch,
-                                engineSessionState = engineSessionStateTwitch,
-                                engineObserver = mock()
-                            )
-                        ),
-                        createCustomTab("https://twitter.com/home", id = "twitter")
-                    ),
-                    selectedTabId = "reddit"
-                )
+                    createCustomTab("https://twitter.com/home", id = "twitter")
+                ),
+                selectedTabId = "reddit"
             )
         )
     }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -47,6 +47,14 @@ import mozilla.components.lib.state.Action
 sealed class BrowserAction : Action
 
 /**
+ * [BrowserAction] dispatched to indicate that the store is initialized and
+ * ready to use. This action is dispatched automatically before any other
+ * action is processed. Its main purpose is to trigger initialization logic
+ * in middlewares. The action itself has no effect on the [BrowserState].
+ */
+object InitAction : BrowserAction()
+
+/**
  * [BrowserAction] implementations to react to system events.
  */
 sealed class SystemAction : BrowserAction() {

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
@@ -11,6 +11,7 @@ import mozilla.components.browser.state.action.CrashAction
 import mozilla.components.browser.state.action.CustomTabListAction
 import mozilla.components.browser.state.action.DownloadAction
 import mozilla.components.browser.state.action.EngineAction
+import mozilla.components.browser.state.action.InitAction
 import mozilla.components.browser.state.action.MediaAction
 import mozilla.components.browser.state.action.ReaderAction
 import mozilla.components.browser.state.action.SearchAction
@@ -37,6 +38,7 @@ import mozilla.components.lib.state.Action
 internal object BrowserStateReducer {
     fun reduce(state: BrowserState, action: BrowserAction): BrowserState {
         return when (action) {
+            is InitAction -> state
             is ContainerAction -> ContainerReducer.reduce(state, action)
             is RecentlyClosedAction -> RecentlyClosedReducer.reduce(state, action)
             is ContentAction -> ContentStateReducer.reduce(state, action)

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabSessionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabSessionState.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.state.state
 
+import mozilla.components.concept.engine.EngineSession
 import java.util.UUID
 
 /**
@@ -48,16 +49,23 @@ data class CustomTabSessionState(
 /**
  * Convenient function for creating a custom tab.
  */
+@Suppress("LongParameterList")
 fun createCustomTab(
     url: String,
     id: String = UUID.randomUUID().toString(),
     config: CustomTabConfig = CustomTabConfig(),
-    contextId: String? = null
+    contextId: String? = null,
+    engineSession: EngineSession? = null,
+    crashed: Boolean = false
 ): CustomTabSessionState {
     return CustomTabSessionState(
         id = id,
         content = ContentState(url),
         config = config,
-        contextId = contextId
+        contextId = contextId,
+        engineState = EngineState(
+            engineSession = engineSession,
+            crashed = crashed
+        )
     )
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabSessionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabSessionState.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.state.state
 
 import android.graphics.Bitmap
+import mozilla.components.concept.engine.EngineSession
 import java.util.UUID
 
 /**
@@ -68,7 +69,9 @@ fun createTab(
     thumbnail: Bitmap? = null,
     contextId: String? = null,
     lastAccess: Long = 0L,
-    source: SessionState.Source = SessionState.Source.NONE
+    source: SessionState.Source = SessionState.Source.NONE,
+    engineSession: EngineSession? = null,
+    crashed: Boolean = false
 ): TabSessionState {
     return TabSessionState(
         id = id,
@@ -83,6 +86,10 @@ fun createTab(
         readerState = readerState,
         contextId = contextId,
         lastAccess = lastAccess,
-        source = source
+        source = source,
+        engineState = EngineState(
+            engineSession = engineSession,
+            crashed = crashed
+        )
     )
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/store/BrowserStore.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/store/BrowserStore.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.state.store
 
 import mozilla.components.browser.state.action.BrowserAction
+import mozilla.components.browser.state.action.InitAction
 import mozilla.components.browser.state.reducer.BrowserStateReducer
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.state.BrowserState
@@ -41,5 +42,7 @@ class BrowserStore(
         ) {
             throw IllegalArgumentException("Duplicate tabs found")
         }
+
+        dispatch(InitAction)
     }
 }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/store/BrowserStoreTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/store/BrowserStoreTest.kt
@@ -5,11 +5,16 @@
 package mozilla.components.browser.state.store
 
 import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.state.action.BrowserAction
+import mozilla.components.browser.state.action.InitAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.createTab
+import mozilla.components.lib.state.Middleware
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class BrowserStoreTest {
@@ -55,5 +60,21 @@ class BrowserStoreTest {
 
         assertEquals(1, store.state.tabs.size)
         assertEquals(tab.id, store.state.selectedTabId)
+    }
+
+    @Test
+    fun `Dispatches init action when created`() {
+        var initActionObserved = false
+        val testMiddleware: Middleware<BrowserState, BrowserAction> = { _, next, action ->
+            if (action == InitAction) {
+                initActionObserved = true
+            }
+
+            next(action)
+        }
+
+        val store = BrowserStore(middleware = listOf(testMiddleware))
+        store.waitUntilIdle()
+        assertTrue(initActionObserved)
     }
 }

--- a/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FxaWebChannelFeatureTest.kt
+++ b/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FxaWebChannelFeatureTest.kt
@@ -6,8 +6,6 @@ package mozilla.components.feature.accounts
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
-import mozilla.components.browser.state.action.EngineAction
-import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
@@ -26,7 +24,6 @@ import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.eq
-import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.whenever
@@ -91,10 +88,10 @@ class FxaWebChannelFeatureTest {
         val serverConfig: ServerConfig = mock()
         val controller: WebExtensionController = mock()
 
-        val tab = createTab("https://www.mozilla.org", id = "test-tab")
-        val store = spy(BrowserStore(initialState = BrowserState(tabs = listOf(tab))))
-        store.dispatch(EngineAction.LinkEngineSessionAction(tab.id, engineSession)).joinBlocking()
-        store.dispatch(TabListAction.SelectTabAction(tab.id)).joinBlocking()
+        val tab = createTab("https://www.mozilla.org", id = "test-tab", engineSession = engineSession)
+        val store = spy(
+            BrowserStore(initialState = BrowserState(tabs = listOf(tab), selectedTabId = tab.id))
+        )
 
         val webchannelFeature = FxaWebChannelFeature(testContext, null, engine, store, accountManager, serverConfig)
         webchannelFeature.extensionController = controller
@@ -703,10 +700,14 @@ class FxaWebChannelFeatureTest {
         val serverConfig: ServerConfig = mock()
         WebExtensionController.installedExtensions[FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID] = ext
 
-        val tab = createTab("https://www.mozilla.org", id = "test-tab")
-        val store = spy(BrowserStore(initialState = BrowserState(tabs = listOf(tab))))
-        store.dispatch(EngineAction.LinkEngineSessionAction(tab.id, engineSession)).joinBlocking()
-        store.dispatch(TabListAction.SelectTabAction(tab.id)).joinBlocking()
+        val tab = createTab(
+            url = "https://www.mozilla.org",
+            id = "test-tab",
+            engineSession = engineSession
+        )
+        val store = spy(BrowserStore(
+            initialState = BrowserState(tabs = listOf(tab), selectedTabId = tab.id))
+        )
 
         whenever(accountManager.supportedSyncEngines()).thenReturn(expectedEngines)
         whenever(port.engineSession).thenReturn(engineSession)

--- a/components/feature/containers/src/main/java/mozilla/components/feature/containers/ContainerStorage.kt
+++ b/components/feature/containers/src/main/java/mozilla/components/feature/containers/ContainerStorage.kt
@@ -15,12 +15,11 @@ import mozilla.components.browser.state.state.ContainerState.Icon
 import mozilla.components.feature.containers.db.ContainerDatabase
 import mozilla.components.feature.containers.db.ContainerEntity
 import mozilla.components.feature.containers.db.toContainerEntity
-import java.util.UUID
 
 /**
  * A storage implementation for organizing containers (contextual identities).
  */
-internal class ContainerStorage(context: Context) {
+internal class ContainerStorage(context: Context) : ContainerMiddleware.Storage {
 
     @VisibleForTesting
     internal var database: Lazy<ContainerDatabase> =
@@ -30,8 +29,8 @@ internal class ContainerStorage(context: Context) {
     /**
      * Adds a new [Container].
      */
-    suspend fun addContainer(
-        contextId: String = UUID.randomUUID().toString(),
+    override suspend fun addContainer(
+        contextId: String,
         name: String,
         color: Color,
         icon: Icon
@@ -49,7 +48,7 @@ internal class ContainerStorage(context: Context) {
     /**
      * Returns a [Flow] list of all the [Container] instances.
      */
-    fun getContainers(): Flow<List<Container>> {
+    override fun getContainers(): Flow<List<Container>> {
         return containerDao.getContainers().map { list ->
             list.map { entity -> entity.toContainer() }
         }
@@ -67,7 +66,7 @@ internal class ContainerStorage(context: Context) {
     /**
      * Removes the given [Container].
      */
-    suspend fun removeContainer(container: Container) {
+    override suspend fun removeContainer(container: Container) {
         containerDao.deleteContainer(container.toContainerEntity())
     }
 }

--- a/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
+++ b/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
@@ -96,14 +96,19 @@ class ReaderViewFeatureTest {
     fun `extension page is reloaded if install finishes after initial load`() {
         val engine: Engine = mock()
         val engineSession: EngineSession = mock()
-
-        val tab = createTab("https://www.mozilla.org", id = "test-tab")
-        val store = spy(BrowserStore(initialState = BrowserState(tabs = listOf(tab))))
+        val tab = createTab(
+            url = "https://www.mozilla.org",
+            id = "test-tab",
+            readerState = ReaderState(active = true),
+            engineSession = engineSession
+        )
+        val store = spy(BrowserStore(
+            initialState = BrowserState(
+                tabs = listOf(tab),
+                selectedTabId = tab.id)
+            )
+        )
         val readerViewFeature = ReaderViewFeature(testContext, engine, store, mock())
-        store.dispatch(EngineAction.LinkEngineSessionAction(tab.id, engineSession)).joinBlocking()
-        store.dispatch(TabListAction.SelectTabAction(tab.id)).joinBlocking()
-        store.dispatch(ReaderAction.UpdateReaderActiveAction(tab.id, true)).joinBlocking()
-
         readerViewFeature.start()
 
         val onSuccess = argumentCaptor<((WebExtension) -> Unit)>()
@@ -125,11 +130,17 @@ class ReaderViewFeatureTest {
         val view: ReaderViewControlsView = mock()
         val engineSession: EngineSession = mock()
         val controller: WebExtensionController = mock()
-
-        val tab = createTab("https://www.mozilla.org", id = "test-tab")
-        val store = spy(BrowserStore(initialState = BrowserState(tabs = listOf(tab))))
-        store.dispatch(EngineAction.LinkEngineSessionAction(tab.id, engineSession)).joinBlocking()
-        store.dispatch(TabListAction.SelectTabAction(tab.id)).joinBlocking()
+        val tab = createTab(
+            url = "https://www.mozilla.org",
+            id = "test-tab",
+            engineSession = engineSession
+        )
+        val store = spy(BrowserStore(
+            initialState = BrowserState(
+                tabs = listOf(tab),
+                selectedTabId = tab.id)
+            )
+        )
 
         val readerViewFeature = spy(ReaderViewFeature(testContext, engine, store, view))
         readerViewFeature.extensionController = controller
@@ -273,12 +284,18 @@ class ReaderViewFeatureTest {
     fun `show reader view updates state`() {
         val engine: Engine = mock()
         val engineSession: EngineSession = mock()
-        val tab = createTab("https://www.mozilla.org", id = "test-tab")
-        val store = spy(BrowserStore(initialState = BrowserState(tabs = listOf(tab))))
+        val tab = createTab(
+            url = "https://www.mozilla.org",
+            id = "test-tab",
+            engineSession = engineSession
+        )
+        val store = spy(BrowserStore(
+            initialState = BrowserState(
+                tabs = listOf(tab),
+                selectedTabId = tab.id)
+            )
+        )
         val readerViewFeature = ReaderViewFeature(testContext, engine, store, mock())
-        store.dispatch(EngineAction.LinkEngineSessionAction(tab.id, engineSession)).joinBlocking()
-        store.dispatch(TabListAction.SelectTabAction(tab.id)).joinBlocking()
-
         readerViewFeature.showReaderView()
         verify(store).dispatch(ReaderAction.UpdateReaderActiveAction(tab.id, true))
     }
@@ -316,14 +333,19 @@ class ReaderViewFeatureTest {
     @Test
     fun `hide reader view updates state`() {
         val engine: Engine = mock()
-        val engineSession: EngineSession = mock()
-        val tab = createTab("https://www.mozilla.org", id = "test-tab", readerState = ReaderState(active = true))
-        val store = spy(BrowserStore(initialState = BrowserState(tabs = listOf(tab))))
-        val readerViewFeature = ReaderViewFeature(testContext, engine, store, mock())
-        store.dispatch(EngineAction.LinkEngineSessionAction(tab.id, engineSession)).joinBlocking()
-        store.dispatch(TabListAction.SelectTabAction(tab.id)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        val tab = createTab(
+            url = "https://www.mozilla.org",
+            id = "test-tab",
+            readerState = ReaderState(active = true)
+        )
 
+        val store = spy(BrowserStore(
+            initialState = BrowserState(
+                tabs = listOf(tab),
+                selectedTabId = tab.id)
+            )
+        )
+        val readerViewFeature = ReaderViewFeature(testContext, engine, store, mock())
         readerViewFeature.hideReaderView()
         verify(store).dispatch(ReaderAction.UpdateReaderActiveAction(tab.id, false))
         verify(store).dispatch(ReaderAction.UpdateReaderableAction(tab.id, false))
@@ -437,11 +459,17 @@ class ReaderViewFeatureTest {
         val engineSession: EngineSession = mock()
         val ext: WebExtension = mock()
         val controller: WebExtensionController = mock()
-
-        val tab = createTab("https://www.mozilla.org", id = "test-tab")
-        val store = spy(BrowserStore(initialState = BrowserState(tabs = listOf(tab))))
-        store.dispatch(EngineAction.LinkEngineSessionAction(tab.id, engineSession)).joinBlocking()
-        store.dispatch(TabListAction.SelectTabAction(tab.id)).joinBlocking()
+        val tab = createTab(
+            url = "https://www.mozilla.org",
+            id = "test-tab",
+            engineSession = engineSession
+        )
+        val store = spy(BrowserStore(
+            initialState = BrowserState(
+                tabs = listOf(tab),
+                selectedTabId = tab.id)
+            )
+        )
 
         WebExtensionController.installedExtensions[ReaderViewFeature.READER_VIEW_EXTENSION_ID] = ext
 
@@ -479,11 +507,17 @@ class ReaderViewFeatureTest {
         val engineSession: EngineSession = mock()
         val ext: WebExtension = mock()
         val controller: WebExtensionController = mock()
-
-        val tab = createTab("https://www.mozilla.org", id = "test-tab")
-        val store = spy(BrowserStore(initialState = BrowserState(tabs = listOf(tab))))
-        store.dispatch(EngineAction.LinkEngineSessionAction(tab.id, engineSession)).joinBlocking()
-        store.dispatch(TabListAction.SelectTabAction(tab.id)).joinBlocking()
+        val tab = createTab(
+            url = "https://www.mozilla.org",
+            id = "test-tab",
+            engineSession = engineSession
+        )
+        val store = spy(BrowserStore(
+            initialState = BrowserState(
+                tabs = listOf(tab),
+                selectedTabId = tab.id)
+            )
+        )
 
         WebExtensionController.installedExtensions[ReaderViewFeature.READER_VIEW_EXTENSION_ID] = ext
 

--- a/components/feature/recentlyclosed/src/test/java/mozilla/components/feature/recentlyclosed/RecentlyClosedMiddlewareTest.kt
+++ b/components/feature/recentlyclosed/src/test/java/mozilla/components/feature/recentlyclosed/RecentlyClosedMiddlewareTest.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
-import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.RecentlyClosedAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.BrowserState
@@ -19,19 +18,19 @@ import mozilla.components.browser.state.state.ClosedTabSessionState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Engine
-import mozilla.components.lib.state.MiddlewareContext
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.whenever
 import org.junit.After
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 
@@ -39,7 +38,6 @@ import org.mockito.Mockito.verifyNoMoreInteractions
 @RunWith(AndroidJUnit4::class)
 class RecentlyClosedMiddlewareTest {
     lateinit var store: BrowserStore
-    lateinit var context: MiddlewareContext<BrowserState, BrowserAction>
     lateinit var engine: Engine
 
     private val dispatcher = TestCoroutineDispatcher()
@@ -53,10 +51,7 @@ class RecentlyClosedMiddlewareTest {
     @Before
     fun setup() {
         store = mock()
-        context = mock()
         engine = mock()
-
-        whenever(context.store).thenReturn(store)
     }
 
     // Test tab
@@ -71,20 +66,19 @@ class RecentlyClosedMiddlewareTest {
     fun `closed tab storage stores the provided tab on add tab action`() =
         runBlockingTest {
             val storage: RecentlyClosedTabsStorage = mock()
-            val middleware = Mockito.spy(RecentlyClosedMiddleware(testContext, 5, engine, scope))
+            val middleware = spy(RecentlyClosedMiddleware(testContext, 5, engine, scope))
+            whenever(middleware.recentlyClosedTabsStorage).thenReturn(storage)
+
             val store = BrowserStore(
                 initialState = BrowserState(),
                 middleware = listOf(middleware)
             )
 
-            whenever(middleware.recentlyClosedTabsStorage).thenReturn(storage)
-
-            store.dispatch(RecentlyClosedAction.AddClosedTabsAction(listOf(closedTab)))
-                .joinBlocking()
-
+            store.dispatch(RecentlyClosedAction.AddClosedTabsAction(listOf(closedTab))).joinBlocking()
             dispatcher.advanceUntilIdle()
+            store.waitUntilIdle()
 
-            verify(middleware.recentlyClosedTabsStorage).addTabsToCollectionWithMax(
+            verify(storage).addTabsToCollectionWithMax(
                 listOf(closedTab), 5
             )
         }
@@ -93,10 +87,12 @@ class RecentlyClosedMiddlewareTest {
     fun `closed tab storage adds a normal tab removed with TabListAction`() =
         runBlockingTest {
             val storage: RecentlyClosedTabsStorage = mock()
-            val middleware = Mockito.spy(RecentlyClosedMiddleware(testContext, 5, engine, scope))
+            val middleware = spy(RecentlyClosedMiddleware(testContext, 5, engine, scope))
+            whenever(middleware.recentlyClosedTabsStorage).thenReturn(storage)
+
             val tab = createTab("https://www.mozilla.org", private = false, id = "1234")
 
-            val store = Mockito.spy(
+            val store = spy(
                 BrowserStore(
                     initialState = BrowserState(
                         tabs = listOf(tab)
@@ -104,22 +100,20 @@ class RecentlyClosedMiddlewareTest {
                     middleware = listOf(middleware)
                 )
             )
-            whenever(context.store).thenReturn(store)
-            whenever(middleware.recentlyClosedTabsStorage).thenReturn(storage)
 
             store.dispatch(TabListAction.RemoveTabAction("1234")).joinBlocking()
-
             dispatcher.advanceUntilIdle()
+            store.waitUntilIdle()
 
             val closedTabCaptor = argumentCaptor<List<ClosedTab>>()
-            verify(middleware.recentlyClosedTabsStorage).addTabsToCollectionWithMax(
+            verify(storage).addTabsToCollectionWithMax(
                 closedTabCaptor.capture(),
                 eq(5)
             )
-            Assert.assertEquals(1, closedTabCaptor.value.size)
-            Assert.assertEquals(tab.content.title, closedTabCaptor.value[0].title)
-            Assert.assertEquals(tab.content.url, closedTabCaptor.value[0].url)
-            Assert.assertEquals(
+            assertEquals(1, closedTabCaptor.value.size)
+            assertEquals(tab.content.title, closedTabCaptor.value[0].title)
+            assertEquals(tab.content.url, closedTabCaptor.value[0].url)
+            assertEquals(
                 tab.engineState.engineSessionState,
                 closedTabCaptor.value[0].engineSessionState
             )
@@ -129,10 +123,12 @@ class RecentlyClosedMiddlewareTest {
     fun `closed tab storage does not add a private tab removed with TabListAction`() =
         runBlockingTest {
             val storage: RecentlyClosedTabsStorage = mock()
-            val middleware = Mockito.spy(RecentlyClosedMiddleware(testContext, 5, engine, scope))
+            val middleware = spy(RecentlyClosedMiddleware(testContext, 5, engine, scope))
+            whenever(middleware.recentlyClosedTabsStorage).thenReturn(storage)
+
             val tab = createTab("https://www.mozilla.org", private = true, id = "1234")
 
-            val store = Mockito.spy(
+            val store = spy(
                 BrowserStore(
                     initialState = BrowserState(
                         tabs = listOf(tab)
@@ -140,12 +136,10 @@ class RecentlyClosedMiddlewareTest {
                     middleware = listOf(middleware)
                 )
             )
-            whenever(context.store).thenReturn(store)
-            whenever(middleware.recentlyClosedTabsStorage).thenReturn(storage)
 
             store.dispatch(TabListAction.RemoveTabAction("1234")).joinBlocking()
-
             dispatcher.advanceUntilIdle()
+            store.waitUntilIdle()
 
             verifyNoMoreInteractions(middleware.recentlyClosedTabsStorage)
         }
@@ -154,11 +148,13 @@ class RecentlyClosedMiddlewareTest {
     fun `closed tab storage adds all normals tab removed with TabListAction RemoveAllNormalTabsAction`() =
         runBlockingTest {
             val storage: RecentlyClosedTabsStorage = mock()
-            val middleware = Mockito.spy(RecentlyClosedMiddleware(testContext, 5, engine, scope))
+            val middleware = spy(RecentlyClosedMiddleware(testContext, 5, engine, scope))
+            whenever(middleware.recentlyClosedTabsStorage).thenReturn(storage)
+
             val tab = createTab("https://www.mozilla.org", private = false, id = "1234")
             val tab2 = createTab("https://www.firefox.com", private = true, id = "3456")
 
-            val store = Mockito.spy(
+            val store = spy(
                 BrowserStore(
                     initialState = BrowserState(
                         tabs = listOf(tab, tab2)
@@ -166,36 +162,36 @@ class RecentlyClosedMiddlewareTest {
                     middleware = listOf(middleware)
                 )
             )
-            whenever(context.store).thenReturn(store)
-            whenever(middleware.recentlyClosedTabsStorage).thenReturn(storage)
 
             store.dispatch(TabListAction.RemoveAllNormalTabsAction).joinBlocking()
-
             dispatcher.advanceUntilIdle()
+            store.waitUntilIdle()
 
             val closedTabCaptor = argumentCaptor<List<ClosedTab>>()
-            verify(middleware.recentlyClosedTabsStorage).addTabsToCollectionWithMax(
+            verify(storage).addTabsToCollectionWithMax(
                 closedTabCaptor.capture(),
                 eq(5)
             )
-            Assert.assertEquals(1, closedTabCaptor.value.size)
-            Assert.assertEquals(tab.content.title, closedTabCaptor.value[0].title)
-            Assert.assertEquals(tab.content.url, closedTabCaptor.value[0].url)
-            Assert.assertEquals(
+            assertEquals(1, closedTabCaptor.value.size)
+            assertEquals(tab.content.title, closedTabCaptor.value[0].title)
+            assertEquals(tab.content.url, closedTabCaptor.value[0].url)
+            assertEquals(
                 tab.engineState.engineSessionState,
                 closedTabCaptor.value[0].engineSessionState
             )
         }
 
     @Test
-    fun `closed tab storage adds all normals tab and no private tabs removed with TabListAction RemoveAllTabsAction`() =
+    fun `closed tab storage adds all normal tabs and no private tabs removed with TabListAction RemoveAllTabsAction`() =
         runBlockingTest {
             val storage: RecentlyClosedTabsStorage = mock()
-            val middleware = Mockito.spy(RecentlyClosedMiddleware(testContext, 5, engine, scope))
+            val middleware = spy(RecentlyClosedMiddleware(testContext, 5, engine, scope))
+            whenever(middleware.recentlyClosedTabsStorage).thenReturn(storage)
+
             val tab = createTab("https://www.mozilla.org", private = false, id = "1234")
             val tab2 = createTab("https://www.firefox.com", private = true, id = "3456")
 
-            val store = Mockito.spy(
+            val store = spy(
                 BrowserStore(
                     initialState = BrowserState(
                         tabs = listOf(tab, tab2)
@@ -203,22 +199,20 @@ class RecentlyClosedMiddlewareTest {
                     middleware = listOf(middleware)
                 )
             )
-            whenever(context.store).thenReturn(store)
-            whenever(middleware.recentlyClosedTabsStorage).thenReturn(storage)
 
             store.dispatch(TabListAction.RemoveAllTabsAction).joinBlocking()
-
             dispatcher.advanceUntilIdle()
+            store.waitUntilIdle()
 
             val closedTabCaptor = argumentCaptor<List<ClosedTab>>()
-            verify(middleware.recentlyClosedTabsStorage).addTabsToCollectionWithMax(
+            verify(storage).addTabsToCollectionWithMax(
                 closedTabCaptor.capture(),
                 eq(5)
             )
-            Assert.assertEquals(1, closedTabCaptor.value.size)
-            Assert.assertEquals(tab.content.title, closedTabCaptor.value[0].title)
-            Assert.assertEquals(tab.content.url, closedTabCaptor.value[0].url)
-            Assert.assertEquals(
+            assertEquals(1, closedTabCaptor.value.size)
+            assertEquals(tab.content.title, closedTabCaptor.value[0].title)
+            assertEquals(tab.content.url, closedTabCaptor.value[0].url)
+            assertEquals(
                 tab.engineState.engineSessionState,
                 closedTabCaptor.value[0].engineSessionState
             )
@@ -228,15 +222,10 @@ class RecentlyClosedMiddlewareTest {
     fun `fetch the tabs from the recently closed storage and load into browser state on initialize tab state action`() =
         runBlockingTest {
             val storage: RecentlyClosedTabsStorage = mock()
-            val middleware = Mockito.spy(RecentlyClosedMiddleware(testContext, 5, engine, scope))
-            val store = Mockito.spy(
-                BrowserStore(
-                    initialState = BrowserState(),
-                    middleware = listOf(middleware)
-                )
-            )
-
+            val middleware = spy(RecentlyClosedMiddleware(testContext, 5, engine, scope))
             whenever(middleware.recentlyClosedTabsStorage).thenReturn(storage)
+
+            val store = BrowserStore(initialState = BrowserState(), middleware = listOf(middleware))
             whenever(storage.getTabs()).thenReturn(
                 flow {
                     emit(listOf(closedTab))
@@ -244,18 +233,20 @@ class RecentlyClosedMiddlewareTest {
             )
 
             store.dispatch(RecentlyClosedAction.InitializeRecentlyClosedState).joinBlocking()
-
             dispatcher.advanceUntilIdle()
+            store.waitUntilIdle()
 
             verify(storage).getTabs()
-            Assert.assertEquals(closedTab, store.state.closedTabs[0])
+            assertEquals(closedTab, store.state.closedTabs[0])
         }
 
     @Test
     fun `recently closed storage removes the provided tab on remove tab action`() =
         runBlockingTest {
             val storage: RecentlyClosedTabsStorage = mock()
-            val middleware = Mockito.spy(RecentlyClosedMiddleware(testContext, 5, engine, scope))
+            val middleware = spy(RecentlyClosedMiddleware(testContext, 5, engine, scope))
+            whenever(middleware.recentlyClosedTabsStorage).thenReturn(storage)
+
             val store = BrowserStore(
                 initialState = BrowserState(
                     closedTabs = listOf(
@@ -265,10 +256,9 @@ class RecentlyClosedMiddlewareTest {
                 middleware = listOf(middleware)
             )
 
-            whenever(middleware.recentlyClosedTabsStorage).thenReturn(storage)
-
-            store.dispatch(RecentlyClosedAction.RemoveClosedTabAction(closedTab))
-                .joinBlocking()
+            store.dispatch(RecentlyClosedAction.RemoveClosedTabAction(closedTab)).joinBlocking()
+            dispatcher.advanceUntilIdle()
+            store.waitUntilIdle()
 
             verify(storage).removeTab(closedTab)
         }
@@ -277,7 +267,8 @@ class RecentlyClosedMiddlewareTest {
     fun `recently closed storage removes all tabs on remove all tabs action`() =
         runBlockingTest {
             val storage: RecentlyClosedTabsStorage = mock()
-            val middleware = Mockito.spy(RecentlyClosedMiddleware(testContext, 5, engine, scope))
+            val middleware = spy(RecentlyClosedMiddleware(testContext, 5, engine, scope))
+            whenever(middleware.recentlyClosedTabsStorage).thenReturn(storage)
             val store = BrowserStore(
                 initialState = BrowserState(
                     closedTabs = listOf(
@@ -287,9 +278,9 @@ class RecentlyClosedMiddlewareTest {
                 middleware = listOf(middleware)
             )
 
-            whenever(middleware.recentlyClosedTabsStorage).thenReturn(storage)
-
             store.dispatch(RecentlyClosedAction.RemoveAllClosedTabAction).joinBlocking()
+            dispatcher.advanceUntilIdle()
+            store.waitUntilIdle()
 
             verify(storage).removeAllTabs()
         }

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/WindowFeatureTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/WindowFeatureTest.kt
@@ -7,7 +7,6 @@ package mozilla.components.feature.tabs
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import mozilla.components.browser.state.action.ContentAction
-import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.createTab
@@ -35,6 +34,7 @@ class WindowFeatureTest {
     val coroutinesTestRule = MainCoroutineRule(testDispatcher)
 
     private lateinit var store: BrowserStore
+    private lateinit var engineSession: EngineSession
     private lateinit var tabsUseCases: TabsUseCases
     private lateinit var addTabUseCase: TabsUseCases.AddNewTabUseCase
     private lateinit var addPrivateTabUseCase: TabsUseCases.AddNewPrivateTabUseCase
@@ -44,9 +44,10 @@ class WindowFeatureTest {
 
     @Before
     fun setup() {
+        engineSession = mock()
         store = spy(BrowserStore(BrowserState(
             tabs = listOf(
-                createTab(id = tabId, url = "https://www.mozilla.org"),
+                createTab(id = tabId, url = "https://www.mozilla.org", engineSession = engineSession),
                 createTab(id = privateTabId, url = "https://www.mozilla.org", private = true)
             ),
             selectedTabId = tabId
@@ -95,9 +96,6 @@ class WindowFeatureTest {
     fun `handles request to close window`() {
         val feature = WindowFeature(store, tabsUseCases)
         feature.start()
-
-        val engineSession: EngineSession = mock()
-        store.dispatch(EngineAction.LinkEngineSessionAction(tabId, engineSession))
 
         val windowRequest: WindowRequest = mock()
         whenever(windowRequest.type).thenReturn(WindowRequest.Type.CLOSE)


### PR DESCRIPTION
This introduces a new `InitAction` which is dispatched when the Store is ready before other actions are being processed. In middlewares we can now "observe" this action and trigger initialization logic.