### PR TITLE
Issue #8076: Set add-on collection page size to max and allow sorting

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
@@ -39,6 +39,7 @@ internal const val COLLECTION_FILE_NAME_PREFIX = "mozilla_components_addon_colle
 internal const val COLLECTION_FILE_NAME = "${COLLECTION_FILE_NAME_PREFIX}_%s.json"
 internal const val MINUTE_IN_MS = 60 * 1000
 internal const val DEFAULT_READ_TIMEOUT_IN_SECONDS = 20L
+internal const val PAGE_SIZE = 50
 
 /**
  * Provide access to the AMO collections API.
@@ -63,6 +64,7 @@ class AddonCollectionProvider(
     private val serverURL: String = DEFAULT_SERVER_URL,
     private val collectionUser: String = DEFAULT_COLLECTION_USER,
     private val collectionName: String = DEFAULT_COLLECTION_NAME,
+    private val sortOption: SortOption = SortOption.POPULARITY_DESC,
     private val maxCacheAgeInMinutes: Long = -1
 ) : AddonsProvider {
 
@@ -121,7 +123,9 @@ class AddonCollectionProvider(
     private fun fetchAvailableAddons(readTimeoutInSeconds: Long?): List<Addon> {
         client.fetch(
             Request(
-                url = "$serverURL/$API_VERSION/accounts/account/$collectionUser/collections/$collectionName/addons",
+                url = "$serverURL/$API_VERSION/accounts/account/$collectionUser/collections/$collectionName/addons" +
+                    "?page_size=$PAGE_SIZE" +
+                    "&sort=${sortOption.value}",
                 readTimeout = Pair(readTimeoutInSeconds ?: DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
             )
         )
@@ -237,6 +241,19 @@ class AddonCollectionProvider(
 
         return COLLECTION_FILE_NAME.format(collection).sanitizeFileName()
     }
+}
+
+/**
+ * Represents possible sort options for the recommended add-ons from
+ * the configured add-on collection.
+ */
+enum class SortOption(val value: String) {
+    POPULARITY("popularity"),
+    POPULARITY_DESC("-popularity"),
+    NAME("name"),
+    NAME_DESC("-name"),
+    DATE_ADDED("added"),
+    DATE_ADDED_DESC("-added")
 }
 
 internal fun JSONObject.getAddons(): List<Addon> {

--- a/components/feature/addons/src/test/java/AddonCollectionProviderTest.kt
+++ b/components/feature/addons/src/test/java/AddonCollectionProviderTest.kt
@@ -118,7 +118,8 @@ class AddonCollectionProviderTest {
         // Authors
         assertTrue(addon.authors.isEmpty())
         verify(client).fetch(Request(
-            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/7e8d6dc651b54ab385fb8791bf9dac/addons",
+            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
+                "7e8d6dc651b54ab385fb8791bf9dac/addons?page_size=$PAGE_SIZE&sort=${SortOption.POPULARITY_DESC.value}",
             readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
         ))
 
@@ -133,7 +134,8 @@ class AddonCollectionProviderTest {
         val provider = spy(AddonCollectionProvider(testContext, client = mockedClient))
         provider.getAvailableAddons(readTimeoutInSeconds = 5)
         verify(mockedClient).fetch(Request(
-            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/7e8d6dc651b54ab385fb8791bf9dac/addons",
+            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
+                "7e8d6dc651b54ab385fb8791bf9dac/addons?page_size=$PAGE_SIZE&sort=${SortOption.POPULARITY_DESC.value}",
             readTimeout = Pair(5, TimeUnit.SECONDS)
         ))
         Unit
@@ -331,11 +333,110 @@ class AddonCollectionProviderTest {
 
         provider.getAvailableAddons()
         verify(mockedClient).fetch(Request(
-            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/$collectionName/addons",
+            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
+                "$collectionName/addons?page_size=$PAGE_SIZE&sort=${SortOption.POPULARITY_DESC.value}",
             readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
         ))
 
         assertEquals(COLLECTION_FILE_NAME.format(collectionName), provider.getCacheFileName())
+    }
+
+    @Test
+    fun `collection sort option can be specified`() = runBlocking {
+        val mockedClient = prepareClient()
+
+        val collectionName = "collection123"
+        AddonCollectionProvider(
+            testContext,
+            client = mockedClient,
+            collectionName = collectionName,
+            sortOption = SortOption.POPULARITY
+        ).also {
+            it.getAvailableAddons()
+        }
+
+        verify(mockedClient).fetch(Request(
+            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
+                "$collectionName/addons?page_size=$PAGE_SIZE&sort=${SortOption.POPULARITY.value}",
+            readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
+        ))
+
+        AddonCollectionProvider(
+            testContext,
+            client = mockedClient,
+            collectionName = collectionName,
+            sortOption = SortOption.POPULARITY_DESC
+        ).also {
+            it.getAvailableAddons()
+        }
+
+        verify(mockedClient).fetch(Request(
+            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
+                "$collectionName/addons?page_size=$PAGE_SIZE&sort=${SortOption.POPULARITY_DESC.value}",
+            readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
+        ))
+
+        AddonCollectionProvider(
+            testContext,
+            client = mockedClient,
+            collectionName = collectionName,
+            sortOption = SortOption.NAME
+        ).also {
+            it.getAvailableAddons()
+        }
+
+        verify(mockedClient).fetch(Request(
+            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
+                "$collectionName/addons?page_size=$PAGE_SIZE&sort=${SortOption.NAME.value}",
+            readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
+        ))
+
+        AddonCollectionProvider(
+            testContext,
+            client = mockedClient,
+            collectionName = collectionName,
+            sortOption = SortOption.NAME_DESC
+        ).also {
+            it.getAvailableAddons()
+        }
+
+        verify(mockedClient).fetch(Request(
+            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
+                "$collectionName/addons?page_size=$PAGE_SIZE&sort=${SortOption.NAME_DESC.value}",
+            readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
+        ))
+
+        AddonCollectionProvider(
+            testContext,
+            client = mockedClient,
+            collectionName = collectionName,
+            sortOption = SortOption.DATE_ADDED
+        ).also {
+            it.getAvailableAddons()
+        }
+
+        verify(mockedClient).fetch(Request(
+            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
+                "$collectionName/addons?page_size=$PAGE_SIZE&sort=${SortOption.DATE_ADDED.value}",
+            readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
+        ))
+
+        AddonCollectionProvider(
+            testContext,
+            client = mockedClient,
+            collectionName = collectionName,
+            sortOption = SortOption.DATE_ADDED_DESC
+        ).also {
+            it.getAvailableAddons()
+        }
+
+        verify(mockedClient).fetch(Request(
+            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
+                "$collectionName/addons?page_size=$PAGE_SIZE&sort=${SortOption.DATE_ADDED_DESC.value}",
+            readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
+        ))
+
+        Unit
     }
 
     @Test
@@ -352,7 +453,9 @@ class AddonCollectionProviderTest {
         provider.getAvailableAddons()
         verify(mockedClient).fetch(Request(
             url = "https://addons.mozilla.org/api/v4/accounts/account/" +
-                "$collectionUser/collections/$collectionName/addons",
+                "$collectionUser/collections/$collectionName/addons" +
+                "?page_size=$PAGE_SIZE" +
+                "&sort=${SortOption.POPULARITY_DESC.value}",
             readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
         ))
 
@@ -374,7 +477,9 @@ class AddonCollectionProviderTest {
         provider.getAvailableAddons()
         verify(mockedClient).fetch(Request(
             url = "https://addons.mozilla.org/api/v4/accounts/account/" +
-                "$DEFAULT_COLLECTION_USER/collections/$DEFAULT_COLLECTION_NAME/addons",
+                "$DEFAULT_COLLECTION_USER/collections/$DEFAULT_COLLECTION_NAME/addons" +
+                "?page_size=$PAGE_SIZE" +
+                "&sort=${SortOption.POPULARITY_DESC.value}",
             readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
         ))
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,7 +27,9 @@ permalink: /changelog/
 * **feature-webcompat-reporter**
   * Added the ability to automatically add a screenshot as well as more technical details when submitting a WebCompat report.
 * **feature-addons**
-  * ⚠️ This is a breaking change for call sites that don't rely on named arguments: `AddonCollectionProvider` now supports configuring a custom collection owner (via AMO user ID or name).
+  * ⚠️ This is a breaking change for call sites that don't rely on named arguments: 
+    * `AddonCollectionProvider` now supports configuring a custom collection owner (via AMO user ID or name).
+    * `AddonCollectionProvider` now supports configuring the sort order of recommended collections, defaulting to sorting descending by popularity
   ```kotlin
    val addonCollectionProvider by lazy {
         AddonCollectionProvider(
@@ -35,6 +37,7 @@ permalink: /changelog/
             client,
             collectionUser = "16314372"
             collectionName = "myCollection",
+            sortOption = SortOption.NAME
             maxCacheAgeInMinutes = DAY_IN_MINUTES
         )
     }


### PR DESCRIPTION
Sets the page_size parameter to 50 for fetching add-ons and introduces a parameter to configure sorting.