### PR TITLE
Issue #8535, #7304: Prevent dispatching individual actions to restore tabs

### DIFF
--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -4,27 +4,22 @@
 
 package mozilla.components.browser.session
 
-import mozilla.components.browser.state.action.BrowserAction
-import mozilla.components.browser.state.action.TabListAction
-import mozilla.components.browser.state.action.LastAccessAction
+import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.state.CustomTabConfig
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.state.recover.toRecoverableTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.support.test.any
-import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyString
-
 import org.mockito.Mockito.`when`
-import org.mockito.Mockito.calls
-import org.mockito.Mockito.inOrder
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.reset
@@ -1144,11 +1139,9 @@ class SessionManagerTest {
 
     @Test
     fun `WHEN restoring a session THEN dispatch updates to store`() {
-        val store = spy(BrowserStore())
-        val inOrder = inOrder(store)
+        val store = BrowserStore()
         val manager = SessionManager(mock(), store)
-        val session = Session("http://www.mozilla.org")
-        val captor = argumentCaptor<BrowserAction>()
+        val session = Session(id = "test123", initialUrl = "http://www.mozilla.org")
 
         manager.restore(SessionManager.Snapshot(listOf(
             SessionManager.Snapshot.Item(
@@ -1157,10 +1150,8 @@ class SessionManagerTest {
             )
         ), 0))
 
-        inOrder.verify(store, calls(2)).dispatch(captor.capture())
-
-        assertTrue(captor.allValues[0] is TabListAction.RestoreAction)
-        assertTrue(captor.allValues[1] is LastAccessAction.UpdateLastAccessAction)
-        assertEquals(123, (captor.allValues[1] as LastAccessAction.UpdateLastAccessAction).lastAccess)
+        val restoredTab = store.state.findTab(session.id)
+        assertNotNull(restoredTab!!)
+        assertEquals(123, restoredTab.lastAccess)
     }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -55,6 +55,11 @@ sealed class BrowserAction : Action
 object InitAction : BrowserAction()
 
 /**
+ * [BrowserAction] to indicate that restoring [BrowserState] is complete.
+ */
+object RestoreCompleteAction : BrowserAction()
+
+/**
  * [BrowserAction] implementations to react to system events.
  */
 sealed class SystemAction : BrowserAction() {

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
@@ -19,6 +19,7 @@ import mozilla.components.browser.state.action.SystemAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.action.LastAccessAction
 import mozilla.components.browser.state.action.RecentlyClosedAction
+import mozilla.components.browser.state.action.RestoreCompleteAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
 import mozilla.components.browser.state.action.UndoAction
 import mozilla.components.browser.state.action.WebExtensionAction
@@ -39,6 +40,7 @@ internal object BrowserStateReducer {
     fun reduce(state: BrowserState, action: BrowserAction): BrowserState {
         return when (action) {
             is InitAction -> state
+            is RestoreCompleteAction -> state.copy(restoreComplete = true)
             is ContainerAction -> ContainerReducer.reduce(state, action)
             is RecentlyClosedAction -> RecentlyClosedReducer.reduce(state, action)
             is ContentAction -> ContentStateReducer.reduce(state, action)

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/BrowserState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/BrowserState.kt
@@ -23,6 +23,8 @@ import mozilla.components.lib.state.State
  * @property search the state of search for this browser state.
  * @property downloads Downloads ([DownloadState]s) mapped to their IDs.
  * @property undoHistory History of recently closed tabs to support "undo" (Requires UndoMiddleware).
+ * @property restoreComplete Whether or not restoring [BrowserState] has completed. This can be used
+ * on application startup e.g. as an indicator that tabs have been restored.
  */
 data class BrowserState(
     val tabs: List<TabSessionState> = emptyList(),
@@ -34,5 +36,6 @@ data class BrowserState(
     val media: MediaState = MediaState(),
     val downloads: Map<String, DownloadState> = emptyMap(),
     val search: SearchState = SearchState(),
-    val undoHistory: UndoHistoryState = UndoHistoryState()
+    val undoHistory: UndoHistoryState = UndoHistoryState(),
+    val restoreComplete: Boolean = false
 ) : State

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/store/BrowserStoreTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/store/BrowserStoreTest.kt
@@ -7,12 +7,15 @@ package mozilla.components.browser.state.store
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.InitAction
+import mozilla.components.browser.state.action.RestoreCompleteAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.lib.state.Middleware
+import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -76,5 +79,17 @@ class BrowserStoreTest {
         val store = BrowserStore(middleware = listOf(testMiddleware))
         store.waitUntilIdle()
         assertTrue(initActionObserved)
+    }
+
+    @Test
+    fun `RestoreCompleteAction updates state`() {
+        val store = BrowserStore()
+        assertFalse(store.state.restoreComplete)
+
+        store.dispatch(RestoreCompleteAction).joinBlocking()
+        assertTrue(store.state.restoreComplete)
+
+        store.dispatch(RestoreCompleteAction).joinBlocking()
+        assertTrue(store.state.restoreComplete)
     }
 }


### PR DESCRIPTION
First draft to validate performance impact. Instead of dispatching individual actions to update the state of the restored tab we make sure that the initial state is correct, based on the Snapshot.

`RestoreAction` is already a "bulk action", but tabs didn't include the full initial state and subsequent actions were required, which is fixed here.

