### PR TITLE
Closes #8619: Add maximum length for Socorro crash report stack trace

### DIFF
--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/MozillaSocorroService.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/MozillaSocorroService.kt
@@ -13,6 +13,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.content.pm.PackageInfoCompat
 import mozilla.components.lib.crash.Crash
 import mozilla.components.concept.base.crash.Breadcrumb
+import mozilla.components.support.base.ext.getStacktraceAsString
 import mozilla.components.support.base.log.logger.Logger
 import org.json.JSONArray
 import org.json.JSONException
@@ -26,8 +27,6 @@ import java.io.FileReader
 import java.io.IOException
 import java.io.InputStreamReader
 import java.io.OutputStream
-import java.io.PrintWriter
-import java.io.StringWriter
 import java.net.HttpURLConnection
 import java.net.URL
 import java.nio.channels.Channels
@@ -488,14 +487,9 @@ class MozillaSocorroService(
     }
 
     private fun getExceptionStackTrace(throwable: Throwable, isCaughtException: Boolean): String {
-        val stringWriter = StringWriter()
-        val printWriter = PrintWriter(stringWriter)
-        throwable.printStackTrace(printWriter)
-        printWriter.flush()
-
         return when (isCaughtException) {
-            true -> "$INFO_PREFIX $stringWriter"
-            false -> stringWriter.toString()
+            true -> "$INFO_PREFIX ${throwable.getStacktraceAsString()}"
+            false -> throwable.getStacktraceAsString()
         }
     }
 }

--- a/components/support/base/src/main/java/mozilla/components/support/base/ext/Throwable.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/ext/Throwable.kt
@@ -8,14 +8,15 @@ import java.io.PrintWriter
 import java.io.StringWriter
 
 private const val STACK_TRACE_INITIAL_BUFFER_SIZE = 256
+private const val STACK_TRACE_MAX_LENGTH = 100000
 
 /**
  * Returns a formatted string of the [Throwable.stackTrace].
  */
-fun Throwable.getStacktraceAsString(): String {
+fun Throwable.getStacktraceAsString(stackTraceMaxLength: Int = STACK_TRACE_MAX_LENGTH): String {
     val sw = StringWriter(STACK_TRACE_INITIAL_BUFFER_SIZE)
     val pw = PrintWriter(sw, false)
     printStackTrace(pw)
     pw.flush()
-    return sw.toString()
+    return sw.toString().take(stackTraceMaxLength)
 }

--- a/components/support/base/src/test/java/mozilla/components/support/base/ext/ThrowableTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/ext/ThrowableTest.kt
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.base.ext
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.lang.RuntimeException
+
+class ThrowableTest {
+    @Test
+    fun `throwable stack trace to string is limited to max length`() {
+        val throwable = RuntimeException("TEST ONLY")
+
+        assertEquals(throwable.getStacktraceAsString(1).length, 1)
+        assertEquals(throwable.getStacktraceAsString(10).length, 10)
+    }
+
+    @Test
+    fun `throwable stack trace to string works correctly`() {
+        val throwable = RuntimeException("TEST ONLY")
+
+        assert(throwable.getStacktraceAsString().contains("mozilla.components.support.base.ext.ThrowableTest.throwable stack trace to string works correctly(ThrowableTest.kt:"))
+    }
+}


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
