### PR TITLE
Close #8040: Move ImageLoader to support-base

### DIFF
--- a/components/browser/icons/build.gradle
+++ b/components/browser/icons/build.gradle
@@ -44,6 +44,7 @@ tasks.register("updateBuiltInExtensionVersion", Copy) { task ->
 }
 
 dependencies {
+    implementation project(':concept-base')
     implementation project(':concept-engine')
     implementation project(':concept-fetch')
     implementation project(':browser-state')

--- a/components/browser/tabstray/build.gradle
+++ b/components/browser/tabstray/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     implementation project(':ui-icons')
     implementation project(':ui-colors')
-    implementation project(':support-base')
+    implementation project(':concept-base')
     implementation project(':support-images')
     implementation project(':support-ktx')
 

--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabViewHolder.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabViewHolder.kt
@@ -16,8 +16,8 @@ import mozilla.components.browser.tabstray.thumbnail.TabThumbnailView
 import mozilla.components.concept.tabstray.Tab
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.support.base.observer.Observable
-import mozilla.components.support.images.ImageLoadRequest
-import mozilla.components.support.images.loader.ImageLoader
+import mozilla.components.concept.base.images.ImageLoadRequest
+import mozilla.components.concept.base.images.ImageLoader
 import mozilla.components.support.ktx.android.util.dpToPx
 import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
 
@@ -99,7 +99,8 @@ class DefaultTabViewHolder(
             val thumbnailSize = THUMBNAIL_SIZE.dpToPx(thumbnailView.context.resources.displayMetrics)
             thumbnailLoader.loadIntoView(
                 thumbnailView,
-                ImageLoadRequest(id = tab.id, size = thumbnailSize))
+                ImageLoadRequest(id = tab.id, size = thumbnailSize)
+            )
         } else if (tab.thumbnail != null) {
             thumbnailView.setImageBitmap(tab.thumbnail)
         }

--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsAdapter.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsAdapter.kt
@@ -11,7 +11,7 @@ import mozilla.components.concept.tabstray.Tabs
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
-import mozilla.components.support.images.loader.ImageLoader
+import mozilla.components.concept.base.images.ImageLoader
 
 /**
  * Function responsible for creating a `TabViewHolder` in the `TabsAdapter`.

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/DefaultTabViewHolderTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/DefaultTabViewHolderTest.kt
@@ -13,8 +13,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.tabstray.Tab
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.support.base.observer.ObserverRegistry
-import mozilla.components.support.images.ImageLoadRequest
-import mozilla.components.support.images.loader.ImageLoader
+import mozilla.components.concept.base.images.ImageLoadRequest
+import mozilla.components.concept.base.images.ImageLoader
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock

--- a/components/browser/thumbnails/build.gradle
+++ b/components/browser/thumbnails/build.gradle
@@ -35,8 +35,9 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 dependencies {
     implementation project(':browser-state')
     implementation project(':concept-engine')
-    implementation project(':support-images')
+    implementation project(':concept-base')
     implementation project(':support-ktx')
+    implementation project(':support-images')
 
     implementation Dependencies.androidx_annotation
     implementation Dependencies.androidx_core_ktx

--- a/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/loader/ThumbnailLoader.kt
+++ b/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/loader/ThumbnailLoader.kt
@@ -15,8 +15,8 @@ import kotlinx.coroutines.launch
 import mozilla.components.browser.thumbnails.R
 import mozilla.components.browser.thumbnails.storage.ThumbnailStorage
 import mozilla.components.support.images.CancelOnDetach
-import mozilla.components.support.images.ImageLoadRequest
-import mozilla.components.support.images.loader.ImageLoader
+import mozilla.components.concept.base.images.ImageLoadRequest
+import mozilla.components.concept.base.images.ImageLoader
 import java.lang.ref.WeakReference
 
 /**

--- a/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/storage/ThumbnailStorage.kt
+++ b/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/storage/ThumbnailStorage.kt
@@ -18,8 +18,8 @@ import mozilla.components.browser.thumbnails.R
 import mozilla.components.browser.thumbnails.utils.ThumbnailDiskCache
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.images.DesiredSize
-import mozilla.components.support.images.ImageLoadRequest
-import mozilla.components.support.images.ImageSaveRequest
+import mozilla.components.concept.base.images.ImageLoadRequest
+import mozilla.components.concept.base.images.ImageSaveRequest
 import mozilla.components.support.images.decoder.AndroidImageDecoder
 import java.util.concurrent.Executors
 

--- a/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/utils/ThumbnailDiskCache.kt
+++ b/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/utils/ThumbnailDiskCache.kt
@@ -8,8 +8,8 @@ import android.content.Context
 import android.graphics.Bitmap
 import com.jakewharton.disklrucache.DiskLruCache
 import mozilla.components.support.base.log.logger.Logger
-import mozilla.components.support.images.ImageLoadRequest
-import mozilla.components.support.images.ImageSaveRequest
+import mozilla.components.concept.base.images.ImageLoadRequest
+import mozilla.components.concept.base.images.ImageSaveRequest
 import java.io.File
 import java.io.IOException
 

--- a/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/loader/ThumbnailLoaderTest.kt
+++ b/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/loader/ThumbnailLoaderTest.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.thumbnails.R
 import mozilla.components.browser.thumbnails.storage.ThumbnailStorage
-import mozilla.components.support.images.ImageLoadRequest
+import mozilla.components.concept.base.images.ImageLoadRequest
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock

--- a/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/storage/ThumbnailStorageTest.kt
+++ b/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/storage/ThumbnailStorageTest.kt
@@ -8,7 +8,7 @@ import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
-import mozilla.components.support.images.ImageLoadRequest
+import mozilla.components.concept.base.images.ImageLoadRequest
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext

--- a/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/utils/ThumbnailDiskCacheTest.kt
+++ b/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/utils/ThumbnailDiskCacheTest.kt
@@ -6,7 +6,7 @@ package mozilla.components.browser.thumbnails.utils
 
 import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.support.images.ImageLoadRequest
+import mozilla.components.concept.base.images.ImageLoadRequest
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext

--- a/components/concept/base/build.gradle
+++ b/components/concept/base/build.gradle
@@ -27,6 +27,7 @@ android {
 dependencies {
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
+    implementation Dependencies.androidx_annotation
 
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric

--- a/components/concept/base/src/main/java/mozilla/components/concept/base/images/ImageLoader.kt
+++ b/components/concept/base/src/main/java/mozilla/components/concept/base/images/ImageLoader.kt
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.support.images.loader
+package mozilla.components.concept.base.images
 
 import android.graphics.drawable.Drawable
 import android.widget.ImageView
 import androidx.annotation.MainThread
-import mozilla.components.support.images.ImageLoadRequest
 
 /**
  * A loader that can load an image from an ID directly into an [ImageView].

--- a/components/concept/base/src/main/java/mozilla/components/concept/base/images/ImageRequest.kt
+++ b/components/concept/base/src/main/java/mozilla/components/concept/base/images/ImageRequest.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.support.images
+package mozilla.components.concept.base.images
 
 import androidx.annotation.Px
 

--- a/components/support/images/build.gradle
+++ b/components/support/images/build.gradle
@@ -37,7 +37,6 @@ android {
 dependencies {
     implementation project(':support-base')
 
-    implementation Dependencies.androidx_annotation
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,9 @@ permalink: /changelog/
 * **feature-customtabs**
   * The drawable for the Action button icon in custom tabs is now scaled to 24dp width an 24dp height.
 
+* **support-images**
+  * ⚠️ **This is a breaking change**: `ImageLoader` and `ImageRequest` have moved to the `concept-base` component.
+
 # 61.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v60.0.0...v61.0.0)

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -72,6 +72,7 @@ dependencies {
     implementation project(':concept-tabstray')
     implementation project(':concept-toolbar')
     implementation project(':concept-storage')
+    implementation project(':concept-base')
 
     implementation project(':browser-awesomebar')
     implementation project(':browser-engine-system')
@@ -123,7 +124,6 @@ dependencies {
 
     implementation project(':support-utils')
     implementation project(':feature-downloads')
-    implementation project(':support-images')
     implementation project(':support-ktx')
     implementation project(':support-webextensions')
     implementation project(':support-rustlog')


### PR DESCRIPTION
The `ImageLoader` API is public and we should have it in a better place. Now that we have the `concept-base` component, we can put it there.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
