### PR TITLE
Revert Gradle, Android Gradle Plugin and Kotlin upgrade.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,8 +204,6 @@ subprojects {
 
                 packagingOptions {
                     exclude 'META-INF/atomicfu.kotlin_module'
-                    exclude 'META-INF/AL2.0'
-                    exclude 'META-INF/LGPL2.1'
                 }
 
                 aaptOptions {
@@ -222,32 +220,6 @@ subprojects {
                         jvmTarget = "1.8"
                     }
                 }
-            }
-
-            configurations {
-                // There's an interaction between Gradle's resolution of dependencies with different types
-                // (@jar, @aar) for `implementation` and `testImplementation` and with Android Studio's built-in
-                // JUnit test runner.  The runtime classpath in the built-in JUnit test runner gets the
-                // dependency from the `implementation`, which is type @aar, and therefore the JNA dependency
-                // doesn't provide the JNI dispatch libraries in the correct Java resource directories.  I think
-                // what's happening is that @aar type in `implementation` resolves to the @jar type in
-                // `testImplementation`, and that it wins the dependency resolution battle.
-                //
-                // A workaround is to add a new configuration which depends on the @jar type and to reference
-                // the underlying JAR file directly in `testImplementation`.  This JAR file doesn't resolve to
-                // the @aar type in `implementation`.  This works when invoked via `gradle`, but also sets the
-                // correct runtime classpath when invoked with Android Studio's built-in JUnit test runner.
-                // Success!
-                jnaForTest
-                // Robolectric, through `com.google.android.apps.common.testing.accessibility.framework`
-                // depends on an old version of protobuf that conflict with the Application Services one.
-                // See: https://github.com/mozilla/application-services/issues/2952
-                all*.exclude group: 'com.google.protobuf', module: 'protobuf-java'
-            }
-
-            dependencies {
-                jnaForTest Dependencies.thirdparty_jna
-                testImplementation files(configurations.jnaForTest.copyRecursive().files)
             }
 
             if (project.hasProperty("coverage") && project.name != "support-test") {
@@ -269,11 +241,11 @@ subprojects {
                     def javaDebugTree = fileTree(dir: "$project.buildDir/intermediates/classes/debug", excludes: fileFilter)
                     def mainSrc = "$project.projectDir/src/main/java"
 
-                    sourceDirectories.setFrom(files([mainSrc]))
-                    classDirectories.setFrom(files([kotlinDebugTree, javaDebugTree]))
-                    executionData.setFrom(fileTree(dir: project.buildDir, includes: [
+                    sourceDirectories = files([mainSrc])
+                    classDirectories = files([kotlinDebugTree, javaDebugTree])
+                    executionData = fileTree(dir: project.buildDir, includes: [
                             'jacoco/testDebugUnitTest.exec', 'outputs/code-coverage/connected/*coverage.ec'
-                    ]))
+                    ])
                 }
 
                 android {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -4,8 +4,8 @@
 
 // Synchronized version numbers for dependencies used by (some) modules
 object Versions {
-    const val kotlin = "1.4.10"
-    const val coroutines = "1.3.9"
+    const val kotlin = "1.3.71"
+    const val coroutines = "1.3.5"
 
     const val junit = "4.12"
     const val robolectric = "4.1"
@@ -15,9 +15,9 @@ object Versions {
     const val mockwebserver = "3.10.0"
 
     const val dokka = "0.9.17"
-    const val android_gradle_plugin = "4.0.1"
+    const val android_gradle_plugin = "3.5.3"
     const val android_maven_publish_plugin = "3.6.2"
-    const val lint = "27.0.1"
+    const val lint = "26.3.2"
     const val detekt = "1.9.1"
 
     const val sentry = "1.7.21"
@@ -29,7 +29,7 @@ object Versions {
 
     const val mozilla_appservices = "63.0.0"
 
-    const val mozilla_glean = "33.0.4"
+    const val mozilla_glean = "32.4.1"
 
     const val material = "1.1.0"
     const val nearby = "17.0.0"

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegateTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegateTest.kt
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.webnotifications
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doNothing
+import java.lang.IllegalStateException
+import org.mozilla.geckoview.WebNotification as GeckoViewWebNotification
+
+@RunWith(AndroidJUnit4::class)
+class GeckoWebNotificationDelegateTest {
+
+    @Test
+    fun `register background message handler`() {
+        val webNotificationDelegate: WebNotificationDelegate = mock()
+        val geckoViewWebNotification: GeckoViewWebNotification = mock()
+        val geckoWebNotificationDelegate = GeckoWebNotificationDelegate(webNotificationDelegate)
+        var message: String? = null
+
+        doNothing().`when`(webNotificationDelegate).onShowNotification(any())
+        try {
+            geckoWebNotificationDelegate.onShowNotification(geckoViewWebNotification)
+        } catch (e: IllegalStateException) {
+            message = e.localizedMessage
+        }
+
+        assertEquals(message, "tag must not be null")
+        message = null
+
+        doNothing().`when`(webNotificationDelegate).onCloseNotification(any())
+        try {
+            geckoWebNotificationDelegate.onCloseNotification(geckoViewWebNotification)
+        } catch (e: IllegalStateException) {
+            message = e.localizedMessage
+        }
+
+        assertEquals(message, "tag must not be null")
+    }
+}

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegateTest.kt
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.webnotifications
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doNothing
+import java.lang.IllegalStateException
+import org.mozilla.geckoview.WebNotification as GeckoViewWebNotification
+
+@RunWith(AndroidJUnit4::class)
+class GeckoWebNotificationDelegateTest {
+
+    @Test
+    fun `register background message handler`() {
+        val webNotificationDelegate: WebNotificationDelegate = mock()
+        val geckoViewWebNotification: GeckoViewWebNotification = mock()
+        val geckoWebNotificationDelegate = GeckoWebNotificationDelegate(webNotificationDelegate)
+        var message: String? = null
+
+        doNothing().`when`(webNotificationDelegate).onShowNotification(any())
+        try {
+            geckoWebNotificationDelegate.onShowNotification(geckoViewWebNotification)
+        } catch (e: IllegalStateException) {
+            message = e.localizedMessage
+        }
+
+        assertEquals(message, "tag must not be null")
+        message = null
+
+        doNothing().`when`(webNotificationDelegate).onCloseNotification(any())
+        try {
+            geckoWebNotificationDelegate.onCloseNotification(geckoViewWebNotification)
+        } catch (e: IllegalStateException) {
+            message = e.localizedMessage
+        }
+
+        assertEquals(message, "tag must not be null")
+    }
+}

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegateTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegateTest.kt
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.webnotifications
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doNothing
+import java.lang.IllegalStateException
+import org.mozilla.geckoview.WebNotification as GeckoViewWebNotification
+
+@RunWith(AndroidJUnit4::class)
+class GeckoWebNotificationDelegateTest {
+
+    @Test
+    fun `register background message handler`() {
+        val webNotificationDelegate: WebNotificationDelegate = mock()
+        val geckoViewWebNotification: GeckoViewWebNotification = mock()
+        val geckoWebNotificationDelegate = GeckoWebNotificationDelegate(webNotificationDelegate)
+        var message: String? = null
+
+        doNothing().`when`(webNotificationDelegate).onShowNotification(any())
+        try {
+            geckoWebNotificationDelegate.onShowNotification(geckoViewWebNotification)
+        } catch (e: IllegalStateException) {
+            message = e.localizedMessage
+        }
+
+        assertEquals(message, "tag must not be null")
+        message = null
+
+        doNothing().`when`(webNotificationDelegate).onCloseNotification(any())
+        try {
+            geckoWebNotificationDelegate.onCloseNotification(geckoViewWebNotification)
+        } catch (e: IllegalStateException) {
+            message = e.localizedMessage
+        }
+
+        assertEquals(message, "tag must not be null")
+    }
+}

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/matcher/UrlMatcher.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/matcher/UrlMatcher.kt
@@ -215,7 +215,7 @@ class UrlMatcher {
                 jsonReader -> loadCategories(jsonReader, categoryMap)
             }
 
-            var whiteList: WhiteList?
+            var whiteList: WhiteList? = null
             JsonReader(white).use { jsonReader -> whiteList = WhiteList.fromJson(jsonReader) }
             return UrlMatcher(enabledCategories, supportedCategories, categoryMap, whiteList)
         }

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/pipeline/IconResourceComparator.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/pipeline/IconResourceComparator.kt
@@ -60,7 +60,7 @@ private fun IconRequest.Resource.Type.rank(): Int {
 }
 
 private val IconRequest.Resource.maxSize: Int
-    get() = sizes.asSequence().map { size -> size.minLength }.maxOrNull() ?: 0
+    get() = sizes.asSequence().map { size -> size.minLength }.max() ?: 0
 
 private val IconRequest.Resource.isContainerType: Boolean
     get() = mimeType != null && containerTypes.contains(mimeType)

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/utils/Utils.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/utils/Utils.kt
@@ -15,7 +15,7 @@ internal fun List<Pair<Int, Int>>.findBestSize(targetSize: Int, maxSize: Int, ma
         x >= targetSize && y >= targetSize && x <= maxSize && y <= maxSize
     }.filter { (x, y) ->
         x == y
-    }.minByOrNull { (x, _) ->
+    }.minBy { (x, _) ->
         x
     }
 
@@ -33,7 +33,7 @@ internal fun List<Pair<Int, Int>>.findBestSize(targetSize: Int, maxSize: Int, ma
             downScaledY >= targetSize &&
             downScaledX <= maxSize &&
             downScaledY <= maxSize
-    }.minByOrNull { (x, _) ->
+    }.minBy { (x, _) ->
         x
     }
 
@@ -51,7 +51,7 @@ internal fun List<Pair<Int, Int>>.findBestSize(targetSize: Int, maxSize: Int, ma
             upscaledY >= targetSize &&
             upscaledX <= maxSize &&
             upscaledY <= maxSize
-    }.maxByOrNull { (x, _) ->
+    }.maxBy { (x, _) ->
         x
     }
 

--- a/components/browser/storage-memory/src/main/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorage.kt
+++ b/components/browser/storage-memory/src/main/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorage.kt
@@ -117,7 +117,7 @@ class InMemoryHistoryStorage : HistoryStorage {
         }
         // Calculate maxScore so that we can invert our scoring.
         // Lower Levenshtein distance should produce a higher score.
-        val maxScore = urlMatches.maxByOrNull { it.score }?.score ?: return@synchronized listOf()
+        val maxScore = urlMatches.maxBy { it.score }?.score ?: return@synchronized listOf()
 
         // TODO exclude non-matching results entirely? Score that implies complete mismatch.
         matchedUrls.asSequence().sortedBy { it.value }.map {
@@ -126,8 +126,8 @@ class InMemoryHistoryStorage : HistoryStorage {
     }
 
     override fun getAutocompleteSuggestion(query: String): HistoryAutocompleteResult? = synchronized(pages) {
-        return segmentAwareDomainMatch(query, pages.keys)?.let { urlMatch ->
-            HistoryAutocompleteResult(
+        segmentAwareDomainMatch(query, pages.keys)?.let { urlMatch ->
+            return HistoryAutocompleteResult(
                 query, urlMatch.matchedSegment, urlMatch.url, AUTOCOMPLETE_SOURCE_NAME, pages.size)
         }
     }

--- a/components/browser/storage-sync/build.gradle
+++ b/components/browser/storage-sync/build.gradle
@@ -23,6 +23,27 @@ android {
     }
 }
 
+configurations {
+    // There's an interaction between Gradle's resolution of dependencies with different types
+    // (@jar, @aar) for `implementation` and `testImplementation` and with Android Studio's built-in
+    // JUnit test runner.  The runtime classpath in the built-in JUnit test runner gets the
+    // dependency from the `implementation`, which is type @aar, and therefore the JNA dependency
+    // doesn't provide the JNI dispatch libraries in the correct Java resource directories.  I think
+    // what's happening is that @aar type in `implementation` resolves to the @jar type in
+    // `testImplementation`, and that it wins the dependency resolution battle.
+    //
+    // A workaround is to add a new configuration which depends on the @jar type and to reference
+    // the underlying JAR file directly in `testImplementation`.  This JAR file doesn't resolve to
+    // the @aar type in `implementation`.  This works when invoked via `gradle`, but also sets the
+    // correct runtime classpath when invoked with Android Studio's built-in JUnit test runner.
+    // Success!
+    jnaForTest
+    // Robolectric, through `com.google.android.apps.common.testing.accessibility.framework`
+    // depends on an old version of protobuf that conflict with the Application Services one.
+    // See: https://github.com/mozilla/application-services/issues/2952
+    all*.exclude group: 'com.google.protobuf', module: 'protobuf-java'
+}
+
 dependencies {
     // These dependencies are part of this module's public API.
     api(Dependencies.mozilla_places) {
@@ -46,6 +67,9 @@ dependencies {
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+
+    jnaForTest Dependencies.thirdparty_jna
+    testImplementation files(configurations.jnaForTest.copyRecursive().files)
 
     testImplementation Dependencies.mozilla_places
     testImplementation Dependencies.mozilla_remote_tabs

--- a/components/concept/menu/src/main/java/mozilla/components/concept/menu/ext/MenuCandidate.kt
+++ b/components/concept/menu/src/main/java/mozilla/components/concept/menu/ext/MenuCandidate.kt
@@ -54,7 +54,7 @@ fun List<MenuCandidate>.findNestedMenuCandidate(id: Int): NestedMenuCandidate? =
 /**
  * Select the highlight with the highest priority.
  */
-fun Sequence<MenuEffect>.max() = maxByOrNull {
+fun Sequence<MenuEffect>.max() = maxBy {
     // Select the highlight with the highest priority
     when (it) {
         is HighPriorityHighlightEffect -> 2

--- a/components/feature/addons/src/main/res/layout/mozac_feature_addons_item.xml
+++ b/components/feature/addons/src/main/res/layout/mozac_feature_addons_item.xml
@@ -17,7 +17,6 @@
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/add_on_icon"
         style="@style/Mozac.Widgets.Favicon"
-        tools:ignore="RequiredSize"
         android:layout_alignParentStart="true"
         android:layout_marginTop="16dp"
         android:importantForAccessibility="no"

--- a/components/feature/addons/src/main/res/layout/mozac_feature_addons_unsupported_item.xml
+++ b/components/feature/addons/src/main/res/layout/mozac_feature_addons_unsupported_item.xml
@@ -15,7 +15,6 @@
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/add_on_icon"
         style="@style/Mozac.Widgets.Favicon"
-        tools:ignore="RequiredSize"
         android:importantForAccessibility="no"
         app:srcCompat="@drawable/mozac_ic_extensions"
         app:tint="?android:attr/textColorPrimary" />

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt
@@ -154,7 +154,7 @@ class BookmarksStorageSuggestionProviderTest {
                 }
                 // Calculate maxScore so that we can invert our scoring.
                 // Lower Levenshtein distance should produce a higher score.
-                urlMatches.maxByOrNull { it.score }?.score
+                urlMatches.maxBy { it.score }?.score
                     ?: return@synchronized listOf()
 
                 // TODO exclude non-matching results entirely? Score that implies complete mismatch.

--- a/components/feature/media/src/main/AndroidManifest.xml
+++ b/components/feature/media/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
-    <application />
+    <application>
+        <service android:name=".service.MediaService" />
+    </application>
 
 </manifest>

--- a/components/feature/push/src/main/java/mozilla/components/feature/push/Connection.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/Connection.kt
@@ -220,7 +220,8 @@ internal class RustPushConnection(
         // Query for the scope so that we can notify observers who the decrypted message is for.
         val scope = pushApi.dispatchInfoForChid(channelId)?.scope
 
-        if (scope != null) {
+        scope?.let {
+
             if (body == null) {
                 return DecryptedMessage(scope, null)
             }
@@ -234,8 +235,6 @@ internal class RustPushConnection(
             )
 
             return DecryptedMessage(scope, data)
-        } else {
-            return null
         }
     }
 

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/feature/WebAppSiteControlsFeature.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/feature/WebAppSiteControlsFeature.kt
@@ -143,7 +143,7 @@ class WebAppSiteControlsFeature(
         } else {
             @Suppress("Deprecation")
             Notification.Builder(applicationContext).apply {
-                setPriority(Notification.PRIORITY_MIN)
+                setPriority(NotificationCompat.PRIORITY_MIN)
             }
         }
         if (icon != null && SDK_INT >= Build.VERSION_CODES.M) {

--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/MozillaSocorroService.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/MozillaSocorroService.kt
@@ -108,7 +108,7 @@ class MozillaSocorroService(
         packageInfo?.let {
             if (versionName == DEFAULT_VERSION_NAME) {
                 try {
-                    versionName = packageInfo.versionName ?: DEFAULT_VERSION_NAME
+                    versionName = packageInfo.versionName
                 } catch (e: IllegalStateException) {
                     logger.error("failed to get application version")
                 }

--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/ui/AbstractCrashListActivity.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/ui/AbstractCrashListActivity.kt
@@ -19,10 +19,11 @@ abstract class AbstractCrashListActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         setTitle(R.string.mozac_lib_crash_activity_title)
+        setContentView(R.layout.mozac_lib_crash_activity_crashlist)
 
         if (savedInstanceState == null) {
             supportFragmentManager.beginTransaction()
-                .add(android.R.id.content, CrashListFragment())
+                .add(R.id.container, CrashListFragment())
                 .commit()
         }
     }

--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/ui/CrashListAdapter.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/ui/CrashListAdapter.kt
@@ -86,9 +86,9 @@ internal class CrashListAdapter(
         val text = StringBuilder()
 
         text.append(crashWithReports.crash.uuid)
-        text.appendLine()
+        text.appendln()
         text.append(crashWithReports.crash.stacktrace.lines().first())
-        text.appendLine()
+        text.appendln()
 
         crashWithReports.reports.forEach { report ->
             val service = crashReporter.getCrashReporterServiceById(report.serviceId)
@@ -96,13 +96,13 @@ internal class CrashListAdapter(
             text.append(service?.name ?: report.serviceId)
             text.append(": ")
             text.append(service?.createCrashReportUrl(report.reportId) ?: "<No URL>")
-            text.appendLine()
+            text.appendln()
         }
 
         text.append("----")
-        text.appendLine()
+        text.appendln()
         text.append(crashWithReports.crash.stacktrace)
-        text.appendLine()
+        text.appendln()
 
         val intent = Intent(Intent.ACTION_SEND)
         intent.type = "text/plain"

--- a/components/lib/crash/src/main/res/layout/mozac_lib_crash_activity_crashlist.xml
+++ b/components/lib/crash/src/main/res/layout/mozac_lib_crash_activity_crashlist.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    android:id="@+id/container"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</FrameLayout>

--- a/components/lib/jexl/src/main/java/mozilla/components/lib/jexl/ast/nodes.kt
+++ b/components/lib/jexl/src/main/java/mozilla/components/lib/jexl/ast/nodes.kt
@@ -177,7 +177,7 @@ private fun buildNodeDescription(
     append(" ( $name )")
 
     withinHeader()
-    appendLine()
+    appendln()
 
     block()
 }

--- a/components/lib/jexl/src/main/java/mozilla/components/lib/jexl/lexer/Lexer.kt
+++ b/components/lib/jexl/src/main/java/mozilla/components/lib/jexl/lexer/Lexer.kt
@@ -100,7 +100,7 @@ internal class Lexer(private val grammar: Grammar) {
 
     @Suppress("ReturnCount")
     private fun isElement(input: LexerInput, elements: Map<String, GrammarElement>): Boolean {
-        val max = elements.keys.map { it.length }.maxOrNull() ?: return false
+        val max = elements.keys.map { it.length }.max() ?: return false
 
         for (steps in max downTo 1) {
             val candidate = input.peekRange(steps)

--- a/components/service/digitalassetlinks/src/main/java/mozilla/components/service/digitalassetlinks/AndroidAssetFinder.kt
+++ b/components/service/digitalassetlinks/src/main/java/mozilla/components/service/digitalassetlinks/AndroidAssetFinder.kt
@@ -4,7 +4,6 @@
 
 package mozilla.components.service.digitalassetlinks
 
-import android.annotation.SuppressLint
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.Signature
@@ -85,7 +84,6 @@ class AndroidAssetFinder {
         }
     }
 
-    @SuppressLint("PackageManagerGetSignatures")
     private fun PackageManager.getPackageSignatureInfo(packageName: String): PackageInfo? {
         return try {
             if (SDK_INT >= Build.VERSION_CODES.P) {

--- a/components/service/experiments/src/main/java/mozilla/components/service/experiments/ExperimentEvaluator.kt
+++ b/components/service/experiments/src/main/java/mozilla/components/service/experiments/ExperimentEvaluator.kt
@@ -148,6 +148,9 @@ internal class ExperimentEvaluator(
         diceRoll: Int,
         branches: List<Experiment.Branch>
     ): Experiment.Branch {
+        assert(diceRoll >= 0) { "Dice roll should be >= 0." }
+        assert(branches.isNotEmpty()) { "Branches list should not be empty." }
+
         var value = diceRoll
         for (branch in branches) {
             if (value < branch.ratio) {
@@ -156,6 +159,7 @@ internal class ExperimentEvaluator(
             value -= branch.ratio
         }
 
+        assert(false) { "Should have found matching branch." }
         return branches.last()
     }
 

--- a/components/service/experiments/src/main/java/mozilla/components/service/experiments/Experiments.kt
+++ b/components/service/experiments/src/main/java/mozilla/components/service/experiments/Experiments.kt
@@ -165,6 +165,8 @@ open class ExperimentsInternalAPI internal constructor() {
      */
     @Synchronized
     internal fun onExperimentsUpdated(serverState: ExperimentsSnapshot) {
+        assert(experimentsLoaded) { "Experiments should have been loaded." }
+
         experimentsResult = serverState
         storage.save(serverState)
 
@@ -206,6 +208,8 @@ open class ExperimentsInternalAPI internal constructor() {
      */
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun findAndStartActiveExperiment() {
+        assert(activeExperiment == null) { "Should not have an active experiment" }
+
         evaluator.findActiveExperiment(context, experimentsResult.experiments)?.let {
             logger.info("""Activating experiment - id="${it.experiment.id}", branch="${it.branch}"""")
             activeExperiment = it
@@ -219,6 +223,8 @@ open class ExperimentsInternalAPI internal constructor() {
      * telemetry via Glean.
      */
     private fun stopActiveExperiment() {
+        assert(activeExperiment != null) { "Should have an active experiment" }
+
         activeExperiment?.let {
             Glean.setExperimentInactive(it.experiment.id)
         }
@@ -235,6 +241,8 @@ open class ExperimentsInternalAPI internal constructor() {
         context: Context,
         experiments: List<Experiment>
     ): ActiveExperiment? {
+        assert(activeExperiment == null) { "Should not have an active experiment" }
+
         val activeExperiment = ActiveExperiment.load(context, experiments)
 
         activeExperiment?.let {

--- a/components/service/experiments/src/test/java/mozilla/components/service/experiments/ExperimentEvaluatorTest.kt
+++ b/components/service/experiments/src/test/java/mozilla/components/service/experiments/ExperimentEvaluatorTest.kt
@@ -766,6 +766,24 @@ class ExperimentEvaluatorTest {
         assertEquals("3", e.selectBranchByWeight(6, branches).name)
     }
 
+    @Test(expected = AssertionError::class)
+    fun `test selectBranchByWeight() asserts upper out-of-bounds`() {
+        val branches = listOf(
+            Experiment.Branch("1", 2)
+        )
+        val evaluator = ExperimentEvaluator()
+        evaluator.selectBranchByWeight(2, branches)
+    }
+
+    @Test(expected = AssertionError::class)
+    fun `test selectBranchByWeight() asserts lower out-of-bounds`() {
+        val branches = listOf(
+            Experiment.Branch("1", 2)
+        )
+        val evaluator = ExperimentEvaluator()
+        evaluator.selectBranchByWeight(2, branches)
+    }
+
     @Test
     fun `test pickActiveBranch()`() {
         val e = ExperimentEvaluator()

--- a/components/service/firefox-accounts/build.gradle
+++ b/components/service/firefox-accounts/build.gradle
@@ -27,6 +27,23 @@ android {
     }
 }
 
+configurations {
+    // There's an interaction between Gradle's resolution of dependencies with different types
+    // (@jar, @aar) for `implementation` and `testImplementation` and with Android Studio's built-in
+    // JUnit test runner.  The runtime classpath in the built-in JUnit test runner gets the
+    // dependency from the `implementation`, which is type @aar, and therefore the JNA dependency
+    // doesn't provide the JNI dispatch libraries in the correct Java resource directories.  I think
+    // what's happening is that @aar type in `implementation` resolves to the @jar type in
+    // `testImplementation`, and that it wins the dependency resolution battle.
+    //
+    // A workaround is to add a new configuration which depends on the @jar type and to reference
+    // the underlying JAR file directly in `testImplementation`.  This JAR file doesn't resolve to
+    // the @aar type in `implementation`.  This works when invoked via `gradle`, but also sets the
+    // correct runtime classpath when invoked with Android Studio's built-in JUnit test runner.
+    // Success!
+    jnaForTest
+}
+
 dependencies {
     // Types defined in concept-sync are part of the public API of this module.
     api project(':concept-sync')
@@ -53,6 +70,9 @@ dependencies {
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_coroutines
+
+    jnaForTest Dependencies.thirdparty_jna
+    testImplementation files(configurations.jnaForTest.copyRecursive().files)
 
     testImplementation Dependencies.mozilla_full_megazord_forUnitTests
     testImplementation Dependencies.kotlin_reflect

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sharing/AccountSharing.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sharing/AccountSharing.kt
@@ -4,7 +4,6 @@
 
 package mozilla.components.service.fxa.sharing
 
-import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.content.Context
 import android.content.pm.PackageManager
@@ -173,7 +172,6 @@ object AccountSharing {
      * but not signature rotation.
      * @return A certificate SHA256 fingerprint, if one could be reliably obtained.
      */
-    @SuppressLint("PackageManagerGetSignatures")
     fun getSignaturePreAPI28(packageManager: PackageManager, packageName: String): String? {
         // For older APIs, we use the deprecated `signatures` field, which isn't aware of certificate rotation.
         val packageInfo = try {

--- a/components/service/sync-logins/build.gradle
+++ b/components/service/sync-logins/build.gradle
@@ -27,6 +27,23 @@ android {
     }
 }
 
+configurations {
+    // There's an interaction between Gradle's resolution of dependencies with different types
+    // (@jar, @aar) for `implementation` and `testImplementation` and with Android Studio's built-in
+    // JUnit test runner.  The runtime classpath in the built-in JUnit test runner gets the
+    // dependency from the `implementation`, which is type @aar, and therefore the JNA dependency
+    // doesn't provide the JNI dispatch libraries in the correct Java resource directories.  I think
+    // what's happening is that @aar type in `implementation` resolves to the @jar type in
+    // `testImplementation`, and that it wins the dependency resolution battle.
+    //
+    // A workaround is to add a new configuration which depends on the @jar type and to reference
+    // the underlying JAR file directly in `testImplementation`.  This JAR file doesn't resolve to
+    // the @aar type in `implementation`.  This works when invoked via `gradle`, but also sets the
+    // correct runtime classpath when invoked with Android Studio's built-in JUnit test runner.
+    // Success!
+    jnaForTest
+}
+
 dependencies {
     // Parts of this dependency are typealiase'd or are otherwise part of this module's public API.
     api(Dependencies.mozilla_sync_logins) {
@@ -58,6 +75,8 @@ dependencies {
     testImplementation Dependencies.testing_coroutines
     testImplementation project(':support-test')
 
+    jnaForTest Dependencies.thirdparty_jna
+    testImplementation files(configurations.jnaForTest.copyRecursive().files)
     testImplementation Dependencies.mozilla_glean_forUnitTests
     testImplementation Dependencies.mozilla_full_megazord_forUnitTests
 }

--- a/components/support/migration/build.gradle
+++ b/components/support/migration/build.gradle
@@ -39,6 +39,23 @@ android {
     }
 }
 
+configurations {
+    // There's an interaction between Gradle's resolution of dependencies with different types
+    // (@jar, @aar) for `implementation` and `testImplementation` and with Android Studio's built-in
+    // JUnit test runner.  The runtime classpath in the built-in JUnit test runner gets the
+    // dependency from the `implementation`, which is type @aar, and therefore the JNA dependency
+    // doesn't provide the JNI dispatch libraries in the correct Java resource directories.  I think
+    // what's happening is that @aar type in `implementation` resolves to the @jar type in
+    // `testImplementation`, and that it wins the dependency resolution battle.
+    //
+    // A workaround is to add a new configuration which depends on the @jar type and to reference
+    // the underlying JAR file directly in `testImplementation`.  This JAR file doesn't resolve to
+    // the @aar type in `implementation`.  This works when invoked via `gradle`, but also sets the
+    // correct runtime classpath when invoked with Android Studio's built-in JUnit test runner.
+    // Success!
+    jnaForTest
+}
+
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions.freeCompilerArgs += [
             "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi"
@@ -78,6 +95,8 @@ dependencies {
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 
+    jnaForTest Dependencies.thirdparty_jna
+    testImplementation files(configurations.jnaForTest.copyRecursive().files)
     testImplementation Dependencies.mozilla_full_megazord_forUnitTests
     testImplementation Dependencies.mozilla_glean_forUnitTests
 }

--- a/components/support/rustlog/build.gradle
+++ b/components/support/rustlog/build.gradle
@@ -27,6 +27,23 @@ android {
     }
 }
 
+configurations {
+    // There's an interaction between Gradle's resolution of dependencies with different types
+    // (@jar, @aar) for `implementation` and `testImplementation` and with Android Studio's built-in
+    // JUnit test runner.  The runtime classpath in the built-in JUnit test runner gets the
+    // dependency from the `implementation`, which is type @aar, and therefore the JNA dependency
+    // doesn't provide the JNI dispatch libraries in the correct Java resource directories.  I think
+    // what's happening is that @aar type in `implementation` resolves to the @jar type in
+    // `testImplementation`, and that it wins the dependency resolution battle.
+    //
+    // A workaround is to add a new configuration which depends on the @jar type and to reference
+    // the underlying JAR file directly in `testImplementation`.  This JAR file doesn't resolve to
+    // the @aar type in `implementation`.  This works when invoked via `gradle`, but also sets the
+    // correct runtime classpath when invoked with Android Studio's built-in JUnit test runner.
+    // Success!
+    jnaForTest
+}
+
 dependencies {
     implementation Dependencies.mozilla_rustlog
 
@@ -38,6 +55,8 @@ dependencies {
     testImplementation Dependencies.mozilla_rustlog
     testImplementation project(':support-test')
 
+    jnaForTest Dependencies.thirdparty_jna
+    testImplementation files(configurations.jnaForTest.copyRecursive().files)
     testImplementation Dependencies.mozilla_full_megazord_forUnitTests
 
     testImplementation Dependencies.testing_junit

--- a/components/tooling/detekt/build.gradle
+++ b/components/tooling/detekt/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation Dependencies.tools_detekt_test
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-    // Gradle keeps warning about different Kotlin versions being on the classpath. I am unsure
-    // how to resolve that and if it is even resolvable in this cross-library setup. Anyhow,
-    // since it is only a warning I am going to suppress them for this project specifically.
-    kotlinOptions.allWarningsAsErrors = false
-}
-
 tasks.register("lintRelease") {
     doLast {
         // Do nothing. We execute the same set of tasks for all our modules in parallel on taskcluster.

--- a/components/tooling/glean-gradle-plugin/build.gradle
+++ b/components/tooling/glean-gradle-plugin/build.gradle
@@ -13,13 +13,6 @@ repositories {
     mavenCentral()
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-    // Gradle keeps warning about different Kotlin versions being on the classpath. I am unsure
-    // how to resolve that and if it is even resolvable in this cross-library setup. Anyhow,
-    // since it is only a warning I am going to suppress them for this project specifically.
-    kotlinOptions.allWarningsAsErrors = false
-}
-
 dependencies {
     implementation gradleApi()
     implementation localGroovy()

--- a/components/tooling/lint/build.gradle
+++ b/components/tooling/lint/build.gradle
@@ -10,16 +10,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
   compileOnly Dependencies.tools_lintapi
-
-  // Force the usage of /our/ Kotlin version and not what we get transitively from the lint
-  // dependencies. Otherwise we end up with a warning that there are multiple versions on the
-  // classpath.
   compileOnly Dependencies.kotlin_stdlib
-  compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.kotlin}"
-  compileOnly Dependencies.kotlin_reflect
-  testImplementation Dependencies.kotlin_stdlib
-  testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.kotlin}"
-  testImplementation Dependencies.kotlin_reflect
 
   testImplementation Dependencies.tools_lint
   testImplementation Dependencies.tools_linttests

--- a/components/tooling/lint/src/main/java/mozilla/components/tooling/lint/AndroidSrcXmlDetector.kt
+++ b/components/tooling/lint/src/main/java/mozilla/components/tooling/lint/AndroidSrcXmlDetector.kt
@@ -9,6 +9,7 @@ import com.android.SdkConstants.FQCN_IMAGE_BUTTON
 import com.android.SdkConstants.FQCN_IMAGE_VIEW
 import com.android.SdkConstants.IMAGE_BUTTON
 import com.android.SdkConstants.IMAGE_VIEW
+import com.android.annotations.VisibleForTesting
 import com.android.resources.ResourceFolderType
 import com.android.tools.lint.detector.api.Category
 import com.android.tools.lint.detector.api.Implementation
@@ -17,7 +18,6 @@ import com.android.tools.lint.detector.api.ResourceXmlDetector
 import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.XmlContext
-import com.google.common.annotations.VisibleForTesting
 import org.w3c.dom.Element
 
 /**

--- a/components/tooling/lint/src/main/java/mozilla/components/tooling/lint/ImageViewAndroidTintXmlDetector.kt
+++ b/components/tooling/lint/src/main/java/mozilla/components/tooling/lint/ImageViewAndroidTintXmlDetector.kt
@@ -9,6 +9,7 @@ import com.android.SdkConstants.FQCN_IMAGE_BUTTON
 import com.android.SdkConstants.FQCN_IMAGE_VIEW
 import com.android.SdkConstants.IMAGE_BUTTON
 import com.android.SdkConstants.IMAGE_VIEW
+import com.android.annotations.VisibleForTesting
 import com.android.resources.ResourceFolderType
 import com.android.tools.lint.detector.api.Category
 import com.android.tools.lint.detector.api.Implementation
@@ -17,7 +18,6 @@ import com.android.tools.lint.detector.api.ResourceXmlDetector
 import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.XmlContext
-import com.google.common.annotations.VisibleForTesting
 import org.w3c.dom.Element
 
 /**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,8 +20,7 @@ permalink: /changelog/
   * 🌟 Added new use cases for removing individual downloads (`removeDownload`) and all downloads (`removeAllDownloads`).
 
 * **service-glean**
-  * Glean was upgraded to v33.0.0
-    * ⚠️ **This is a breaking change**: Updated to the Android Gradle Plugin v4.0.1 and Gradle 6.5.1. Projects using older versions of these components will need to update in order to use newer versions of the Glean SDK.
+  * Glean was upgraded to v32.4.1
     * Update `glean_parser` to 1.28.6
       * BUGFIX: Ensure Kotlin arguments are deterministically ordered
     * BUGFIX: Transform ping directory size from bytes to kilobytes before accumulating to `glean.upload.pending_pings_directory_size`
@@ -81,6 +80,7 @@ permalink: /changelog/
   * Added `SessionManager.removeNormalSessions()` and `SessionManager.removePrivateSessions()`.
 * **feature-downloads**
   * 🚒 Bug fixed [issue #8456](https://github.com/mozilla-mobile/android-components/issues/8456) Crash SQLiteConstraintException UNIQUE constraint failed: downloads.id (code 1555).
+
 * **service-glean**
   * Glean was upgraded to v32.4.0
     * Allow using quantity metric type outside of Gecko ([#1198](https://github.com/mozilla/glean/pull/1198))

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.launch
 import mozilla.appservices.Megazord
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.state.action.SystemAction
+import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.addons.update.GlobalAddonDependencyProvider
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.service.glean.Glean
@@ -45,7 +46,7 @@ class SampleApplication : Application() {
             return
         }
 
-        val httpClient = ConceptFetchHttpUploader(lazy { HttpURLConnectionClient() })
+        val httpClient = ConceptFetchHttpUploader(lazy { HttpURLConnectionClient() as Client })
         val config = Configuration(httpClient = httpClient)
         // IMPORTANT: the following lines initialize the Glean SDK but disable upload
         // of pings. If, for testing purposes, upload is required to be on, change the

--- a/samples/browser/src/main/res/layout/fragment_add_on_settings.xml
+++ b/samples/browser/src/main/res/layout/fragment_add_on_settings.xml
@@ -5,12 +5,10 @@
 
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <mozilla.components.concept.engine.EngineView
-        tools:ignore="Instantiatable"
         android:id="@+id/addonSettingsEngineView"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/samples/browser/src/main/res/layout/fragment_browser.xml
+++ b/samples/browser/src/main/res/layout/fragment_browser.xml
@@ -51,7 +51,6 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent">
             <mozilla.components.concept.engine.EngineView
-                tools:ignore="Instantiatable"
                 android:id="@+id/engineView"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent" />

--- a/samples/crash/src/main/java/org/mozilla/samples/crash/CrashApplication.kt
+++ b/samples/crash/src/main/java/org/mozilla/samples/crash/CrashApplication.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.sink.AndroidLogSink
+import mozilla.components.concept.fetch.Client
 import mozilla.components.lib.crash.Crash
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.lib.crash.service.CrashReporterService
@@ -52,7 +53,7 @@ class CrashApplication : Application() {
         ).install(this)
 
         // Initialize Glean for recording by the GleanCrashReporterService
-        val httpClient = ConceptFetchHttpUploader(lazy { HttpURLConnectionClient() })
+        val httpClient = ConceptFetchHttpUploader(lazy { HttpURLConnectionClient() as Client })
         val config = Configuration(httpClient = httpClient)
         Glean.initialize(applicationContext, uploadEnabled = true, configuration = config)
     }

--- a/samples/firefox-accounts/src/main/AndroidManifest.xml
+++ b/samples/firefox-accounts/src/main/AndroidManifest.xml
@@ -34,5 +34,6 @@
                     android:scheme="fxaclient" />
             </intent-filter>
         </activity>
+        <activity android:name=".ScanActivity"></activity>
     </application>
 </manifest>


### PR DESCRIPTION
Reverts the commits from PR #8360. Squashed into a single commit.

We've hit a roadblock in Fenix https://github.com/mozilla-mobile/fenix/pull/15687. To unblock AC/GV updates I think its best to back this out, resolve the problems and then try again.