### PR TITLE
Closes #7976: Use different port for article and reader pages

### DIFF
--- a/components/feature/readerview/src/main/assets/extensions/readerview/readerview.js
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/readerview.js
@@ -346,7 +346,7 @@ function connectNativePort() {
   let id = url.searchParams.get("id");
   let baseUrl = browser.runtime.getURL("/");
 
-  let port = browser.runtime.connectNative("mozacReaderview");
+  let port = browser.runtime.connectNative("mozacReaderviewActive");
   port.onMessage.addListener((message) => {
     switch (message.action) {
       case 'show':

--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewMiddleware.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewMiddleware.kt
@@ -15,7 +15,7 @@ import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_EXTENSION_ID
 import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_EXTENSION_URL
-import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_MESSAGING_ID
+import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_CONTENT_PORT
 import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.MiddlewareContext
 import mozilla.components.support.webextensions.WebExtensionController
@@ -31,7 +31,7 @@ class ReaderViewMiddleware : Middleware<BrowserState, BrowserAction> {
     internal var extensionController = WebExtensionController(
         READER_VIEW_EXTENSION_ID,
         READER_VIEW_EXTENSION_URL,
-        READER_VIEW_MESSAGING_ID
+        READER_VIEW_CONTENT_PORT
     )
 
     override fun invoke(
@@ -48,7 +48,7 @@ class ReaderViewMiddleware : Middleware<BrowserState, BrowserAction> {
     /**
      * Processes the action before it is dispatched to the store.
      *
-     * @param store a reference to the [MiddlewareStore].
+     * @param context a reference to the [MiddlewareContext].
      * @param action the action to process.
      * @return true if the original action should be processed, otherwise false.
      */

--- a/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
+++ b/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
@@ -22,6 +22,10 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.webextension.MessageHandler
 import mozilla.components.concept.engine.webextension.Port
 import mozilla.components.concept.engine.webextension.WebExtension
+import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_ACTIVE_CONTENT_PORT
+import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_CONTENT_PORT
+import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_EXTENSION_ID
+import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_EXTENSION_URL
 import mozilla.components.feature.readerview.view.ReaderViewControlsBar
 import mozilla.components.feature.readerview.view.ReaderViewControlsView
 import mozilla.components.support.test.any
@@ -93,22 +97,29 @@ class ReaderViewFeatureTest {
     }
 
     @Test
-    fun `extension page is reloaded if install finishes after initial load`() {
+    fun `start registers content message handlers for selected session`() {
         val engine: Engine = mock()
+        val view: ReaderViewControlsView = mock()
         val engineSession: EngineSession = mock()
+        val controller = spy(WebExtensionController(
+            READER_VIEW_EXTENSION_ID,
+            READER_VIEW_EXTENSION_URL,
+            READER_VIEW_CONTENT_PORT
+        ))
         val tab = createTab(
             url = "https://www.mozilla.org",
             id = "test-tab",
-            readerState = ReaderState(active = true),
             engineSession = engineSession
         )
-        val store = spy(BrowserStore(
+        val store = BrowserStore(
             initialState = BrowserState(
                 tabs = listOf(tab),
-                selectedTabId = tab.id)
+                selectedTabId = tab.id
             )
         )
-        val readerViewFeature = ReaderViewFeature(testContext, engine, store, mock())
+
+        val readerViewFeature = ReaderViewFeature(testContext, engine, store, view)
+        readerViewFeature.extensionController = controller
         readerViewFeature.start()
 
         val onSuccess = argumentCaptor<((WebExtension) -> Unit)>()
@@ -119,34 +130,9 @@ class ReaderViewFeatureTest {
             onSuccess.capture(),
             onError.capture()
         )
-
         onSuccess.value.invoke(mock())
-        verify(engineSession).reload()
-    }
-
-    @Test
-    fun `start registers content message handler for selected session`() {
-        val engine: Engine = mock()
-        val view: ReaderViewControlsView = mock()
-        val engineSession: EngineSession = mock()
-        val controller: WebExtensionController = mock()
-        val tab = createTab(
-            url = "https://www.mozilla.org",
-            id = "test-tab",
-            engineSession = engineSession
-        )
-        val store = spy(BrowserStore(
-            initialState = BrowserState(
-                tabs = listOf(tab),
-                selectedTabId = tab.id)
-            )
-        )
-
-        val readerViewFeature = spy(ReaderViewFeature(testContext, engine, store, view))
-        readerViewFeature.extensionController = controller
-
-        readerViewFeature.start()
-        verify(controller).registerContentMessageHandler(eq(engineSession), any(), any())
+        verify(controller).registerContentMessageHandler(eq(engineSession), any(), eq(READER_VIEW_ACTIVE_CONTENT_PORT))
+        verify(controller).registerContentMessageHandler(eq(engineSession), any(), eq(READER_VIEW_CONTENT_PORT))
     }
 
     @Test
@@ -216,16 +202,15 @@ class ReaderViewFeatureTest {
     fun `connects content script port when required`() {
         val engine: Engine = mock()
         val tab = createTab("https://www.mozilla.org", id = "test-tab")
-        val store = BrowserStore(initialState = BrowserState(tabs = listOf(tab)))
+        val store = BrowserStore(initialState = BrowserState(tabs = listOf(tab), selectedTabId = tab.id))
         val readerViewFeature = spy(ReaderViewFeature(testContext, engine, store, mock()))
         readerViewFeature.start()
-        verify(readerViewFeature).connectReaderViewContentScript()
 
         store.dispatch(ReaderAction.UpdateReaderConnectRequiredAction(tab.id, true)).joinBlocking()
         testDispatcher.advanceUntilIdle()
         val tabCaptor = argumentCaptor<TabSessionState>()
-        verify(readerViewFeature, times(2)).connectReaderViewContentScript(tabCaptor.capture())
-        assertEquals(tab.id, tabCaptor.allValues[1].id)
+        verify(readerViewFeature).connectReaderViewContentScript(tabCaptor.capture())
+        assertEquals(tab.id, tabCaptor.value.id)
     }
 
     @Test
@@ -321,8 +306,8 @@ class ReaderViewFeatureTest {
         val port = mock<Port>()
         val message = argumentCaptor<JSONObject>()
         val readerViewFeature = prepareFeatureForTest(
-            port,
-            createTab("https://www.mozilla.org", id = "test-tab", readerState = ReaderState(active = true))
+            readerActivePort = port,
+            tab = createTab("https://www.mozilla.org", id = "test-tab", readerState = ReaderState(active = true))
         )
 
         readerViewFeature.hideReaderView()
@@ -368,7 +353,7 @@ class ReaderViewFeatureTest {
         val port = mock<Port>()
         val message = argumentCaptor<JSONObject>()
 
-        val readerViewFeature = prepareFeatureForTest(port)
+        val readerViewFeature = prepareFeatureForTest(readerActivePort = port)
         val prefs = testContext.getSharedPreferences(ReaderViewFeature.SHARED_PREF_NAME, Context.MODE_PRIVATE)
 
         readerViewFeature.config.colorScheme = ReaderViewFeature.ColorScheme.DARK
@@ -388,7 +373,7 @@ class ReaderViewFeatureTest {
         val port = mock<Port>()
         val message = argumentCaptor<JSONObject>()
 
-        val readerViewFeature = prepareFeatureForTest(port)
+        val readerViewFeature = prepareFeatureForTest(readerActivePort = port)
         val prefs = testContext.getSharedPreferences(ReaderViewFeature.SHARED_PREF_NAME, Context.MODE_PRIVATE)
 
         readerViewFeature.config.fontType = ReaderViewFeature.FontType.SANSSERIF
@@ -408,7 +393,7 @@ class ReaderViewFeatureTest {
         val port = mock<Port>()
         val message = argumentCaptor<JSONObject>()
 
-        val readerViewFeature = prepareFeatureForTest(port)
+        val readerViewFeature = prepareFeatureForTest(readerActivePort = port)
         val prefs = testContext.getSharedPreferences(ReaderViewFeature.SHARED_PREF_NAME, Context.MODE_PRIVATE)
 
         readerViewFeature.config.fontSize = 4
@@ -484,7 +469,11 @@ class ReaderViewFeatureTest {
         val messageHandler = argumentCaptor<MessageHandler>()
         val message = argumentCaptor<JSONObject>()
         readerViewFeature.start()
-        verify(controller).registerContentMessageHandler(eq(engineSession), messageHandler.capture(), any())
+        store.dispatch(ReaderAction.UpdateReaderConnectRequiredAction(tab.id, true)).joinBlocking()
+        testDispatcher.advanceUntilIdle()
+        verify(controller).registerContentMessageHandler(
+            eq(engineSession), messageHandler.capture(), eq(READER_VIEW_ACTIVE_CONTENT_PORT)
+        )
 
         messageHandler.value.onPortConnected(port)
         verify(port).postMessage(message.capture())
@@ -519,7 +508,7 @@ class ReaderViewFeatureTest {
             )
         )
 
-        WebExtensionController.installedExtensions[ReaderViewFeature.READER_VIEW_EXTENSION_ID] = ext
+        WebExtensionController.installedExtensions[READER_VIEW_EXTENSION_ID] = ext
 
         val port: Port = mock()
         whenever(port.engineSession).thenReturn(engineSession)
@@ -532,8 +521,12 @@ class ReaderViewFeatureTest {
         val messageHandler = argumentCaptor<MessageHandler>()
         val message = argumentCaptor<JSONObject>()
         readerViewFeature.start()
-        verify(controller).registerContentMessageHandler(eq(engineSession), messageHandler.capture(), any())
 
+        store.dispatch(ReaderAction.UpdateReaderConnectRequiredAction(tab.id, true)).joinBlocking()
+        testDispatcher.advanceUntilIdle()
+        verify(controller).registerContentMessageHandler(
+            eq(engineSession), messageHandler.capture(), eq(READER_VIEW_ACTIVE_CONTENT_PORT)
+        )
         messageHandler.value.onPortConnected(port)
 
         val readerStateMessage = JSONObject()
@@ -547,7 +540,8 @@ class ReaderViewFeatureTest {
     }
 
     private fun prepareFeatureForTest(
-        port: Port,
+        contentPort: Port? = null,
+        readerActivePort: Port? = null,
         tab: TabSessionState = createTab("https://www.mozilla.org", id = "test-tab"),
         engineSession: EngineSession = mock(),
         controller: WebExtensionController? = null
@@ -559,7 +553,14 @@ class ReaderViewFeatureTest {
         store.dispatch(TabListAction.SelectTabAction(tab.id)).joinBlocking()
 
         val ext: WebExtension = mock()
-        whenever(ext.getConnectedPort(eq(ReaderViewFeature.READER_VIEW_MESSAGING_ID), any())).thenReturn(port)
+        contentPort?.let {
+            whenever(ext.getConnectedPort(eq(ReaderViewFeature.READER_VIEW_CONTENT_PORT), any()))
+                .thenReturn(contentPort)
+        }
+        readerActivePort?.let {
+            whenever(ext.getConnectedPort(eq(ReaderViewFeature.READER_VIEW_ACTIVE_CONTENT_PORT), any()))
+                .thenReturn(readerActivePort)
+        }
         WebExtensionController.installedExtensions[ReaderViewFeature.READER_VIEW_EXTENSION_ID] = ext
 
         val feature = ReaderViewFeature(testContext, engine, store, mock())


### PR DESCRIPTION
This refactors reader view to use two different ports/messaging channels. One for communicating with regular pages and one for active reader pages. This was a leftover from the very first version where we didn't have extension page support and had to transform the existing DOM. Using the same port name causes the problem described in https://github.com/mozilla-mobile/android-components/issues/7976#issue-673131926. There's no guarantee that the port to the original content page disconnects before the new one (with the same name) to the reader page connects.

In addition to separating the messaging, this PR includes some cleanup:
- `WebExtensionController.install` now invokes the success callback if the extension is already installed. This is in line with how the underlying API works
- The workaround to refresh the reader page opened on startup is no longer needed as was removed