### PR TITLE
Closes #8548: Display icons of temporary extensions

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -370,6 +370,10 @@ class GeckoWebExtension(
     override fun isAllowedInPrivateBrowsing(): Boolean {
         return isBuiltIn() || nativeExtension.metaData.allowedInPrivateBrowsing
     }
+
+    override suspend fun loadIcon(size: Int): Bitmap? {
+        return null // Not yet supported
+    }
 }
 
 /**

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.engine.gecko.webextension
 
 import android.graphics.Bitmap
+import androidx.annotation.VisibleForTesting
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.browser.engine.gecko.await
 import mozilla.components.concept.engine.EngineSession
@@ -370,6 +371,15 @@ class GeckoWebExtension(
 
     override fun isAllowedInPrivateBrowsing(): Boolean {
         return isBuiltIn() || nativeExtension.metaData.allowedInPrivateBrowsing
+    }
+
+    override suspend fun loadIcon(size: Int): Bitmap? {
+        return getIcon(size).await()
+    }
+
+    @VisibleForTesting
+    internal fun getIcon(size: Int): GeckoResult<Bitmap> {
+        return nativeExtension.metaData.icon.getBitmap(size)
     }
 }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -548,6 +548,42 @@ class GeckoWebExtensionTest {
         assertFalse(webExtensionWithoutPrivateBrowsing.isAllowedInPrivateBrowsing())
     }
 
+    @Test
+    fun `loadIcon tries to load icon from metadata`() {
+        val runtime: GeckoRuntime = mock()
+        whenever(runtime.webExtensionController).thenReturn(mock())
+        val bundle = GeckoBundle()
+        bundle.putString("webExtensionId", "id")
+        bundle.putString("locationURI", "uri")
+
+        val metaDataBundle = GeckoBundle()
+        val emptyIconBundle = GeckoBundle()
+        metaDataBundle.putBoolean("enabled", true)
+        metaDataBundle.putStringArray("disabledFlags", emptyArray())
+        metaDataBundle.putBundle("icons", emptyIconBundle)
+        bundle.putBundle("metaData", metaDataBundle)
+        val nativeWebExtensionWithoutIcon = MockWebExtension(bundle)
+        val webExtensionWithoutIcon = GeckoWebExtension(nativeWebExtensionWithoutIcon, runtime)
+
+        var iconLoadComplete = false
+        var result = webExtensionWithoutIcon.getIcon(48)
+        assertNotNull(result)
+        result.accept { iconLoadComplete = true }
+        assertTrue(iconLoadComplete)
+
+        iconLoadComplete = false
+        val iconBundle = GeckoBundle()
+        iconBundle.putString("48", "test")
+        metaDataBundle.putBundle("icons", iconBundle)
+        val nativeWebExtensionWithIcon = MockWebExtension(bundle)
+        val webExtensionWithIcon = GeckoWebExtension(nativeWebExtensionWithIcon, runtime)
+
+        result = webExtensionWithIcon.getIcon(48)
+        assertNotNull(result)
+        result.accept { iconLoadComplete = true }
+        assertFalse(iconLoadComplete)
+    }
+
     private fun mockNativeExtension(useBundle: GeckoBundle? = null): WebExtension {
         val bundle = useBundle ?: GeckoBundle().apply {
             putString("webExtensionId", "id")

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -370,6 +370,10 @@ class GeckoWebExtension(
     override fun isAllowedInPrivateBrowsing(): Boolean {
         return isBuiltIn() || nativeExtension.metaData.allowedInPrivateBrowsing
     }
+
+    override suspend fun loadIcon(size: Int): Bitmap? {
+        return null // Not yet supported
+    }
 }
 
 /**

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.concept.engine.webextension
 
+import android.graphics.Bitmap
 import android.net.Uri
 import mozilla.components.concept.engine.EngineSession
 import org.json.JSONObject
@@ -170,6 +171,15 @@ abstract class WebExtension(
      * Checks whether or not this extension is allowed in private browsing.
      */
     abstract fun isAllowedInPrivateBrowsing(): Boolean
+
+    /**
+     * Returns the icon of this extension as specified in the extension's manifest:
+     * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons
+     *
+     * @param size the desired size of the icon. The returned icon will be the closest
+     * available icon to the provided size.
+     */
+    abstract suspend fun loadIcon(size: Int): Bitmap?
 }
 
 /**

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
@@ -5,6 +5,7 @@
 package mozilla.components.feature.addons
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.os.Parcelable
 import androidx.core.net.toUri
 import kotlinx.android.parcel.Parcelize
@@ -95,6 +96,8 @@ data class Addon(
      * options page (options_ui in the extension's manifest).
      * @property allowedInPrivateBrowsing true if this addon should be allowed to run in private
      * browsing pages, false otherwise.
+     * @property icon the icon of the installed extension, only used for temporary extensions
+     * as we get the icon from AMO otherwise, see [iconUrl].
      */
     @Parcelize
     data class InstalledState(
@@ -105,7 +108,8 @@ data class Addon(
         val enabled: Boolean = false,
         val supported: Boolean = true,
         val disabledAsUnsupported: Boolean = false,
-        val allowedInPrivateBrowsing: Boolean = false
+        val allowedInPrivateBrowsing: Boolean = false,
+        val icon: Bitmap? = null
     ) : Parcelable
 
     /**

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
@@ -244,13 +244,17 @@ class AddonsManagerAdapter(
                 val iconBitmap = addonCollectionProvider.getAddonIconBitmap(addon)
                 val timeToFetch: Double = (System.currentTimeMillis() - startTime) / 1000.0
                 val isFromCache = timeToFetch < 1
-                iconBitmap?.let {
+                if (iconBitmap != null) {
                     scope.launch(Main) {
                         if (isFromCache) {
-                            iconView.setImageDrawable(BitmapDrawable(iconView.resources, it))
+                            iconView.setImageDrawable(BitmapDrawable(iconView.resources, iconBitmap))
                         } else {
-                            setWithCrossFadeAnimation(iconView, it)
+                            setWithCrossFadeAnimation(iconView, iconBitmap)
                         }
+                    }
+                } else if (addon.installedState?.icon != null) {
+                    scope.launch(Main) {
+                        iconView.setImageDrawable(BitmapDrawable(iconView.resources, addon.installedState.icon))
                     }
                 }
             } catch (e: IOException) {


### PR DESCRIPTION
Displays icons of temporary installed extensions (installed via web-ext). Our Addons class is immutable and only carrying data so I didn't want to add a lambda to it (similar to our implementation in `Action`), especially as it has to remain Parcelable. So, I implemented this as part of `AddonManager` instead, plus a bunch of tests :).