### PR TITLE
For #8565 - New RepostPrompt that inform if users don't proceeed with reload

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -459,6 +459,35 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         return geckoResult
     }
 
+    override fun onRepostConfirmPrompt(
+        session: GeckoSession,
+        prompt: PromptDelegate.RepostConfirmPrompt
+    ): GeckoResult<PromptResponse>? {
+        val geckoResult = GeckoResult<PromptResponse>()
+
+        val onConfirm: () -> Unit = {
+            if (!prompt.isComplete) {
+                geckoResult.complete(prompt.confirm(AllowOrDeny.ALLOW))
+            }
+        }
+        val onCancel: () -> Unit = {
+            if (!prompt.isComplete) {
+                geckoResult.complete(prompt.confirm(AllowOrDeny.DENY))
+                geckoEngineSession.notifyObservers { onRepostPromptCancelled() }
+            }
+        }
+
+        geckoEngineSession.notifyObservers {
+            onPromptRequest(
+                PromptRequest.Repost(
+                    onConfirm,
+                    onCancel
+                )
+            )
+        }
+        return geckoResult
+    }
+
     private fun GeckoChoice.toChoice(): Choice {
         val choiceChildren = items?.map { it.toChoice() }?.toTypedArray()
         // On the GeckoView docs states that label is a @NonNull, but on run-time

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -1096,6 +1096,98 @@ class GeckoPromptDelegateTest {
     }
 
     @Test
+    fun `onRepostConfirmPrompt must provide a Repost PromptRequest`() {
+        val mockSession = GeckoEngineSession(runtime)
+        var request: PromptRequest.Repost = mock()
+        var onPositiveButtonWasCalled = false
+        var onNegativeButtonWasCalled = false
+
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                request = promptRequest as PromptRequest.Repost
+            }
+        })
+
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+
+        var geckoResult = promptDelegate.onRepostConfirmPrompt(mock(), GeckoRepostPrompt())
+        geckoResult!!.accept {
+            onPositiveButtonWasCalled = true
+        }
+        request.onConfirm()
+        assertTrue(onPositiveButtonWasCalled)
+
+        geckoResult = promptDelegate.onRepostConfirmPrompt(mock(), GeckoRepostPrompt())
+        geckoResult!!.accept {
+            onNegativeButtonWasCalled = true
+        }
+        request.onDismiss()
+        assertTrue(onNegativeButtonWasCalled)
+    }
+
+    @Test
+    fun `onRepostConfirmPrompt will not be able to complete multiple times`() {
+        val mockSession = GeckoEngineSession(runtime)
+        var request: PromptRequest.Repost = mock()
+
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                request = promptRequest as PromptRequest.Repost
+            }
+        })
+
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+
+        var prompt = mock<GeckoRepostPrompt>()
+        promptDelegate.onRepostConfirmPrompt(mock(), prompt)
+        doReturn(false).`when`(prompt).isComplete
+        request.onConfirm()
+        verify(prompt).confirm(any())
+
+        prompt = mock()
+        promptDelegate.onRepostConfirmPrompt(mock(), prompt)
+        doReturn(true).`when`(prompt).isComplete
+        request.onConfirm()
+        verify(prompt, never()).confirm(any())
+
+        prompt = mock()
+        promptDelegate.onRepostConfirmPrompt(mock(), prompt)
+        doReturn(false).`when`(prompt).isComplete
+        request.onDismiss()
+        verify(prompt).confirm(any())
+
+        prompt = mock()
+        promptDelegate.onRepostConfirmPrompt(mock(), prompt)
+        doReturn(true).`when`(prompt).isComplete
+        request.onDismiss()
+        verify(prompt, never()).confirm(any())
+    }
+
+    @Test
+    fun `onRepostConfirmPrompt will inform listeners when it is being dismissed`() {
+        val mockSession = GeckoEngineSession(runtime)
+        var onRepostPromptCancelledCalled = false
+        var request: PromptRequest.Repost = mock()
+
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                request = promptRequest as PromptRequest.Repost
+            }
+
+            override fun onRepostPromptCancelled() {
+                onRepostPromptCancelledCalled = true
+            }
+        })
+        val prompt = mock<GeckoRepostPrompt>()
+        doReturn(false).`when`(prompt).isComplete
+
+        GeckoPromptDelegate(mockSession).onRepostConfirmPrompt(mock(), prompt)
+        request.onDismiss()
+
+        assertTrue(onRepostPromptCancelledCalled)
+    }
+
+    @Test
     fun `dismissSafely do nothing if the prompt is already dismissed`() {
         val prompt = spy(GeckoAlertPrompt())
         val geckoResult = mock<GeckoResult<GeckoSession.PromptDelegate.PromptResponse>>()
@@ -1175,6 +1267,8 @@ class GeckoPromptDelegateTest {
     ) : GeckoSession.PromptDelegate.AutocompleteRequest<Autocomplete.LoginSaveOption>(login)
 
     class GeckoAuthOptions : GeckoSession.PromptDelegate.AuthPrompt.AuthOptions()
+
+    class GeckoRepostPrompt : GeckoSession.PromptDelegate.RepostConfirmPrompt()
 
     private fun GeckoSession.PromptDelegate.BasePrompt.getGeckoResult(): GeckoBundle {
         val javaClass = GeckoSession.PromptDelegate.BasePrompt::class.java

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -459,6 +459,35 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         return geckoResult
     }
 
+    override fun onRepostConfirmPrompt(
+        session: GeckoSession,
+        prompt: PromptDelegate.RepostConfirmPrompt
+    ): GeckoResult<PromptResponse>? {
+        val geckoResult = GeckoResult<PromptResponse>()
+
+        val onConfirm: () -> Unit = {
+            if (!prompt.isComplete) {
+                geckoResult.complete(prompt.confirm(AllowOrDeny.ALLOW))
+            }
+        }
+        val onCancel: () -> Unit = {
+            if (!prompt.isComplete) {
+                geckoResult.complete(prompt.confirm(AllowOrDeny.DENY))
+                geckoEngineSession.notifyObservers { onRepostPromptCancelled() }
+            }
+        }
+
+        geckoEngineSession.notifyObservers {
+            onPromptRequest(
+                PromptRequest.Repost(
+                    onConfirm,
+                    onCancel
+                )
+            )
+        }
+        return geckoResult
+    }
+
     private fun GeckoChoice.toChoice(): Choice {
         val choiceChildren = items?.map { it.toChoice() }?.toTypedArray()
         // On the GeckoView docs states that label is a @NonNull, but on run-time

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -77,6 +77,11 @@ abstract class EngineSession(
         fun onPromptRequest(promptRequest: PromptRequest) = Unit
 
         /**
+         * User cancelled a repost prompt. Page will not be reloaded.
+         */
+        fun onRepostPromptCancelled() = Unit
+
+        /**
          * The engine received a request to open or close a window.
          *
          * @param windowRequest the request to describing the required window action.

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
@@ -289,6 +289,20 @@ sealed class PromptRequest {
         override val onDismiss: () -> Unit
     ) : PromptRequest(), Dismissible
 
+    /**
+     * Value type that represents a request for a repost prompt.
+     *
+     * This prompt is shown whenever refreshing or navigating to a page needs resubmitting
+     * POST data that has been submitted already.
+     *
+     * @property onConfirm callback to notify that the user wants to refresh the webpage.
+     * @property onDismiss callback to notify that the user wants stay in the current webpage and not refresh it.
+     */
+    data class Repost(
+        val onConfirm: () -> Unit,
+        override val onDismiss: () -> Unit
+    ) : PromptRequest(), Dismissible
+
     interface Dismissible {
         val onDismiss: () -> Unit
     }

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt
@@ -177,5 +177,21 @@ class PromptRequestTest {
         assertEquals(loginSelectRequest.logins, listOf(login))
         loginSelectRequest.onConfirm(login)
         loginSelectRequest.onDismiss()
+
+        // Now testing that a Repost PromptRequest can be successfully instantiated
+        var onAcceptWasCalled = false
+        var onDismissWasCalled = false
+        val repostRequest = PromptRequest.Repost(
+            onConfirm = {
+                onAcceptWasCalled = true
+            },
+            onDismiss = {
+                onDismissWasCalled = true
+            }
+        )
+        repostRequest.onConfirm()
+        assertTrue(onAcceptWasCalled)
+        repostRequest.onDismiss()
+        assertTrue(onDismissWasCalled)
     }
 }

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -32,6 +32,7 @@ import mozilla.components.concept.engine.prompt.PromptRequest.File
 import mozilla.components.concept.engine.prompt.PromptRequest.MenuChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.MultipleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.Popup
+import mozilla.components.concept.engine.prompt.PromptRequest.Repost
 import mozilla.components.concept.engine.prompt.PromptRequest.SaveLoginPrompt
 import mozilla.components.concept.engine.prompt.PromptRequest.SelectLoginPrompt
 import mozilla.components.concept.engine.prompt.PromptRequest.Share
@@ -407,6 +408,8 @@ class PromptFeature private constructor(
                                 it.onConfirmNeutralButton(!isCheckBoxChecked)
                         }
                     }
+
+                    is Repost -> it.onConfirm()
                 }
             } catch (e: ClassCastException) {
                 throw IllegalArgumentException(
@@ -621,6 +624,23 @@ class PromptFeature private constructor(
                 }
             }
 
+            is Repost -> {
+                val title = container.context.getString(R.string.mozac_feature_prompt_repost_title)
+                val message = container.context.getString(R.string.mozac_feature_prompt_repost_message)
+                val positiveAction =
+                    container.context.getString(R.string.mozac_feature_prompt_repost_positive_button_text)
+                val negativeAction =
+                    container.context.getString(R.string.mozac_feature_prompt_repost_negative_button_text)
+
+                ConfirmDialogFragment.newInstance(
+                    sessionId = session.id,
+                    title = title,
+                    message = message,
+                    positiveButtonText = positiveAction,
+                    negativeButtonText = negativeAction
+                )
+            }
+
             else -> throw InvalidParameterException("Not valid prompt request type")
         }
 
@@ -650,7 +670,7 @@ class PromptFeature private constructor(
             is SaveLoginPrompt,
             is SelectLoginPrompt,
             is Share -> true
-            is Alert, is TextPrompt, is Confirm -> promptAbuserDetector.shouldShowMoreDialogs
+            is Alert, is TextPrompt, is Confirm, is Repost -> promptAbuserDetector.shouldShowMoreDialogs
         }
     }
 }

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/ConfirmDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/ConfirmDialogFragment.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.prompts.dialog
 import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 
 internal const val KEY_POSITIVE_BUTTON = "KEY_POSITIVE_BUTTON"
@@ -20,8 +21,10 @@ internal const val KEY_NEGATIVE_BUTTON = "KEY_NEGATIVE_BUTTON"
  */
 internal class ConfirmDialogFragment : PromptDialogFragment() {
 
-    private val positiveButtonText: String by lazy { safeArguments.getString(KEY_POSITIVE_BUTTON)!! }
-    private val negativeButtonText: String by lazy { safeArguments.getString(KEY_NEGATIVE_BUTTON)!! }
+    @VisibleForTesting
+    internal val positiveButtonText: String by lazy { safeArguments.getString(KEY_POSITIVE_BUTTON)!! }
+    @VisibleForTesting
+    internal val negativeButtonText: String by lazy { safeArguments.getString(KEY_NEGATIVE_BUTTON)!! }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val builder = AlertDialog.Builder(requireContext())

--- a/components/feature/prompts/src/main/res/values/strings.xml
+++ b/components/feature/prompts/src/main/res/values/strings.xml
@@ -90,4 +90,12 @@
     <string name="mozac_feature_prompts_collapse_logins_content_description">Collapse suggested logins</string>
     <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
     <string name="mozac_feature_prompts_saved_logins">Suggested logins</string>
+
+    <!-- Strings shown in a dialog that appear when users try to refresh a certain kind of webpages -->
+    <string name="mozac_feature_prompt_repost_title">Resend data to this site?</string>
+    <string name="mozac_feature_prompt_repost_message">Refreshing this page could duplicate recent actions, such as sending a payment or posting a comment twice.</string>
+    <!-- Pressing this will dismiss the dialog and reload the page sending again the previous data -->
+    <string name="mozac_feature_prompt_repost_positive_button_text">Resend data</string>
+    <!-- Pressing this will dismiss the dialog and not refresh the webpage -->
+    <string name="mozac_feature_prompt_repost_negative_button_text">Cancel</string>
 </resources>

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SwipeRefreshFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SwipeRefreshFeatureTest.kt
@@ -73,6 +73,15 @@ class SwipeRefreshFeatureTest {
     }
 
     @Test
+    fun `onRepostPromptCancelled should dismiss the refresh indicator`() {
+        mockLayout.isRefreshing = true
+
+        refreshFeature.onRepostPromptCancelled()
+
+        verify(mockLayout).isRefreshing = false
+    }
+
+    @Test
     fun `onLoadingStateChanged should update the SwipeRefreshLayout`() {
         refreshFeature.onLoadingStateChanged(false)
         verify(mockLayout).isRefreshing = false

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,9 @@ permalink: /changelog/
 * **browser-toolbar**
   * 🌟 Added API to add a click listener to the iconView.
 
+* **feature-prompts**
+  * The repost prompt now has different text and will also dismiss the pull to refresh throbber.
+
 # 62.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v61.0.0...v62.0.0)


### PR DESCRIPTION
The prompt for a repost request was previously an instance of Confirm, type
used for many other requests.
We'll now use a new Repost type that allows easily identifying the particular
scenario for a repost request, prompt that will now show a slightly different
text and will notify engine observers of "onRepostPromptCancelled" when users
asked to refresh the page but then cancelled that operation in the repost
prompt, callback used to hide the pull to refresh throbber.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR does not include any user facing features.

![newRepostPrompt](https://user-images.githubusercontent.com/11428869/95854240-55f36200-0d5f-11eb-9987-cf5d859c2c0a.gif)
[video](https://drive.google.com/file/d/1Ihpstd8L5k7lg4XsdDQuj6YaqQhdE9gu/view?usp=sharing)

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
