### PR TITLE
Upgrade Glean to v32.4.1

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,7 +29,7 @@ object Versions {
 
     const val mozilla_appservices = "63.0.0"
 
-    const val mozilla_glean = "32.4.0"
+    const val mozilla_glean = "32.4.1"
 
     const val material = "1.1.0"
     const val nearby = "17.0.0"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,9 +21,10 @@ permalink: /changelog/
   * Added `SessionManager.removeNormalSessions()` and `SessionManager.removePrivateSessions()`.
 
 * **service-glean**
-  * Glean was upgraded to v32.4.0
+  * Glean was upgraded to v32.4.1
     * Allow using quantity metric type outside of Gecko ([#1198](https://github.com/mozilla/glean/pull/1198))
-    * Update `glean_parser` to 1.28.5
+    * Update `glean_parser` to 1.28.6
+        * BUGFIX: Ensure Kotlin arguments are deterministically ordered
       * The `SUPERFLUOUS_NO_LINT` warning has been removed from the glinter. It likely did more harm than good, and makes it hard to make metrics.yaml files that pass across different versions of `glean_parser`.
       * Expired metrics will now produce a linter warning, `EXPIRED_METRIC`.
       * Expiry dates that are more than 730 days (~2 years) in the future will produce a linter warning, `EXPIRATION_DATE_TOO_FAR`.
@@ -31,6 +32,7 @@ permalink: /changelog/
       * New parser configs `custom_is_expired` and `custom_validate_expires` added. These are both functions that take the expires value of the metric and return a bool. (See `Metric.is_expired` and `Metric.validate_expires`). These will allow FOG to provide custom validation for its version-based `expires` values.
     * Add a limit of 250 pending ping files. ([#1217](https://github.com/mozilla/glean/pull/1217)).
     * Don't retry the ping uploader when waiting, sleep instead. This avoids a never-ending increase of the backoff time ([#1217](https://github.com/mozilla/glean/pull/1217)).
+    * BUGFIX: Transform ping directory size from bytes to kilobytes before accumulating to `glean.upload.pending_pings_directory_size`.
 
 * **feature-downloads**
   * 🚒 Bug fixed [issue #8585](https://github.com/mozilla-mobile/android-components/issues/8585) fixed regression files not been added to the downloads database system.


### PR DESCRIPTION
This cherry-picks the patch release of Glen onto this release branch.
The patch release fixes 2 things in Glean, one of them being how we accumulate data for an internal metric.
This should have no impact on any user-visible functionality (but makes our life easier in the analysis). 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
