### PR TITLE
samples-browser: Use SearchEngine from BrowserStore instead of SearchEngineManager.

### DIFF
--- a/components/browser/search/build.gradle
+++ b/components/browser/search/build.gradle
@@ -34,6 +34,7 @@ android {
 
 dependencies {
     implementation project(':support-ktx')
+    implementation project(':support-base')
 
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines

--- a/components/browser/search/src/main/java/mozilla/components/browser/search/DefaultSearchEngineProvider.kt
+++ b/components/browser/search/src/main/java/mozilla/components/browser/search/DefaultSearchEngineProvider.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.search
+
+/**
+ * Interface for a class that can provide a default search engine.
+ *
+ * This interface is a temporary workaround to allow applications to switch to the new API slowly.
+ * Once all consuming apps have been migrated this interface will be removed and all components
+ * will be migrated to use the state in `BrowserStore` directly.
+ *
+ * https://github.com/mozilla-mobile/android-components/issues/8686
+*/
+interface DefaultSearchEngineProvider {
+    /**
+     * Returns the default search engine for the user; or `null` if no default search engine is
+     * available.
+     */
+    fun getDefaultSearchEngine(): SearchEngine?
+
+    /**
+     * Returns the default search engine for that user; or `null` if no default search engine is
+     * available. Other than [getDefaultSearchEngine] this method may suspend.
+     */
+    suspend fun retrieveDefaultSearchEngine(): SearchEngine?
+}

--- a/components/browser/search/src/main/java/mozilla/components/browser/search/SearchEngine.kt
+++ b/components/browser/search/src/main/java/mozilla/components/browser/search/SearchEngine.kt
@@ -12,7 +12,7 @@ import java.util.Locale
 /**
  * A data class representing a search engine.
  */
-class SearchEngine internal constructor(
+class SearchEngine(
     val identifier: String,
     val name: String,
     val icon: Bitmap,

--- a/components/browser/search/src/main/java/mozilla/components/browser/search/ext/SearchEngineManager.kt
+++ b/components/browser/search/src/main/java/mozilla/components/browser/search/ext/SearchEngineManager.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.search.ext
+
+import android.content.Context
+import mozilla.components.browser.search.DefaultSearchEngineProvider
+import mozilla.components.browser.search.SearchEngine
+import mozilla.components.browser.search.SearchEngineManager
+
+/**
+ * Converts a [SearchEngineManager] to follow the [DefaultSearchEngineProvider] interface.
+ *
+ * This method is a temporary workaround to allow applications to switch to the new API slowly.
+ * Once all consuming apps have been migrated this extension will be removed and all components
+ * will be migrated to use `BrowserStore` directly.
+ *
+ * https://github.com/mozilla-mobile/android-components/issues/8686
+ */
+fun SearchEngineManager.toDefaultSearchEngineProvider(
+    context: Context
+) = object : DefaultSearchEngineProvider {
+    override fun getDefaultSearchEngine(): SearchEngine? {
+        return getDefaultSearchEngine(context)
+    }
+
+    override suspend fun retrieveDefaultSearchEngine(): SearchEngine? {
+        return getDefaultSearchEngineAsync(context)
+    }
+}

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/suggestions/SearchSuggestionClientTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/suggestions/SearchSuggestionClientTest.kt
@@ -8,6 +8,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.search.SearchEngineParser
+import mozilla.components.browser.search.ext.toDefaultSearchEngineProvider
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
@@ -103,7 +104,11 @@ class SearchSuggestionClientTest {
                 "google", "searchplugins/google-b-m.xml")
 
         val searchEngineManager: SearchEngineManager = mock()
-        val client = SearchSuggestionClient(testContext, searchEngineManager, GOOGLE_MOCK_RESPONSE)
+        val client = SearchSuggestionClient(
+            testContext,
+            searchEngineManager.toDefaultSearchEngineProvider(testContext),
+            GOOGLE_MOCK_RESPONSE
+        )
 
         runBlocking {
             `when`(searchEngineManager.getDefaultSearchEngineAsync(testContext)).thenReturn(searchEngine)

--- a/components/feature/awesomebar/build.gradle
+++ b/components/feature/awesomebar/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation project(':concept-storage')
 
     implementation project(':browser-search')
+    implementation project(':browser-session')
     implementation project(':browser-state')
     implementation project(':browser-icons')
 

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/AwesomeBarFeature.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/AwesomeBarFeature.kt
@@ -10,6 +10,7 @@ import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.view.View
 import mozilla.components.browser.icons.BrowserIcons
+import mozilla.components.browser.search.DefaultSearchEngineProvider
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.state.store.BrowserStore
@@ -121,7 +122,7 @@ class AwesomeBarFeature(
     @Suppress("LongParameterList")
     fun addSearchProvider(
         context: Context,
-        searchEngineManager: SearchEngineManager,
+        defaultSearchEngineProvider: DefaultSearchEngineProvider,
         searchUseCase: SearchUseCases.SearchUseCase,
         fetchClient: Client,
         limit: Int = 15,
@@ -131,7 +132,7 @@ class AwesomeBarFeature(
     ): AwesomeBarFeature {
         awesomeBar.addProviders(SearchSuggestionProvider(
             context,
-            searchEngineManager,
+            defaultSearchEngineProvider,
             searchUseCase,
             fetchClient,
             limit,
@@ -152,13 +153,13 @@ class AwesomeBarFeature(
      * @param showDescription whether or not to add the search engine name as description.
      */
     fun addSearchActionProvider(
-        searchEngineGetter: suspend () -> SearchEngine,
+        defaultSearchEngineProvider: DefaultSearchEngineProvider,
         searchUseCase: SearchUseCases.SearchUseCase,
         icon: Bitmap? = null,
         showDescription: Boolean = false
     ): AwesomeBarFeature {
         awesomeBar.addProviders(SearchActionProvider(
-            searchEngineGetter,
+            defaultSearchEngineProvider,
             searchUseCase,
             icon,
             showDescription

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchActionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchActionProvider.kt
@@ -5,6 +5,7 @@
 package mozilla.components.feature.awesomebar.provider
 
 import android.graphics.Bitmap
+import mozilla.components.browser.search.DefaultSearchEngineProvider
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.feature.search.SearchUseCases
@@ -16,7 +17,7 @@ private const val FIXED_ID = "@@@search.action.provider.fixed.id@@"
  * entered text and invokes a search with the given [SearchEngine] if clicked.
  */
 class SearchActionProvider(
-    private val searchEngineGetter: suspend () -> SearchEngine,
+    private val defaultSearchEngineProvider: DefaultSearchEngineProvider,
     private val searchUseCase: SearchUseCases.SearchUseCase,
     private val icon: Bitmap? = null,
     private val showDescription: Boolean = true
@@ -28,7 +29,8 @@ class SearchActionProvider(
             return emptyList()
         }
 
-        val searchEngine = searchEngineGetter()
+        val searchEngine = defaultSearchEngineProvider.retrieveDefaultSearchEngine()
+            ?: return emptyList()
 
         return listOf(AwesomeBar.Suggestion(
             provider = this,

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProvider.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.awesomebar.provider
 import android.content.Context
 import android.graphics.Bitmap
 import androidx.annotation.VisibleForTesting
+import mozilla.components.browser.search.DefaultSearchEngineProvider
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.search.suggestions.SearchSuggestionClient
@@ -96,7 +97,7 @@ class SearchSuggestionProvider private constructor(
      */
     constructor(
         context: Context,
-        searchEngineManager: SearchEngineManager,
+        defaultSearchEngineProvider: DefaultSearchEngineProvider,
         searchUseCase: SearchUseCases.SearchUseCase,
         fetchClient: Client,
         limit: Int = 15,
@@ -106,7 +107,7 @@ class SearchSuggestionProvider private constructor(
         showDescription: Boolean = true,
         filterExactMatch: Boolean = false
     ) : this (
-        SearchSuggestionClient(context, searchEngineManager) { url -> fetch(fetchClient, url) },
+        SearchSuggestionClient(context, defaultSearchEngineProvider) { url -> fetch(fetchClient, url) },
         searchUseCase,
         limit,
         mode,

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/AwesomeBarFeatureTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/AwesomeBarFeatureTest.kt
@@ -15,6 +15,7 @@ import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.feature.awesomebar.provider.ClipboardSuggestionProvider
 import mozilla.components.feature.awesomebar.provider.HistoryStorageSuggestionProvider
 import mozilla.components.feature.awesomebar.provider.SearchSuggestionProvider
+import mozilla.components.browser.search.ext.toDefaultSearchEngineProvider
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
@@ -127,11 +128,12 @@ class AwesomeBarFeatureTest {
 
         val context = testContext
         val searchEngineManager: SearchEngineManager = mock()
-        feature.addSearchProvider(context, searchEngineManager, mock(), mock())
+        val searchEngineProvider = searchEngineManager.toDefaultSearchEngineProvider(context)
+        feature.addSearchProvider(context, searchEngineProvider, mock(), mock())
 
         val provider = argumentCaptor<SearchSuggestionProvider>()
         verify(awesomeBar).addProviders(provider.capture())
-        assertSame(searchEngineManager, provider.value.client.searchEngineManager)
+        assertSame(searchEngineProvider, provider.value.client.defaultSearchEngineProvider)
     }
 
     @Test

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchActionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchActionProviderTest.kt
@@ -5,6 +5,8 @@
 package mozilla.components.feature.awesomebar.provider
 
 import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.search.DefaultSearchEngineProvider
+import mozilla.components.browser.search.SearchEngine
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -29,7 +31,10 @@ class SearchActionProviderTest {
     @Test
     fun `provider returns suggestion matching input`() {
         val provider = SearchActionProvider(
-            searchEngineGetter = { mock() },
+            defaultSearchEngineProvider = object : DefaultSearchEngineProvider {
+                override fun getDefaultSearchEngine(): SearchEngine? = mock()
+                override suspend fun retrieveDefaultSearchEngine(): SearchEngine? = mock()
+            },
             searchUseCase = mock()
         )
         val suggestions = runBlocking { provider.onInputChanged("firefox") }

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProviderTest.kt
@@ -12,6 +12,7 @@ import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.awesomebar.R
 import mozilla.components.feature.search.SearchUseCases
+import mozilla.components.browser.search.ext.toDefaultSearchEngineProvider
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
@@ -520,7 +521,13 @@ class SearchSuggestionProviderTest {
             val searchEngineManager: SearchEngineManager = mock()
             doReturn(searchEngine).`when`(searchEngineManager).getDefaultSearchEngineAsync(any(), any())
             val engine: Engine = mock()
-            val provider = SearchSuggestionProvider(testContext, searchEngineManager, mock(), HttpURLConnectionClient(), engine = engine)
+            val provider = SearchSuggestionProvider(
+                testContext,
+                searchEngineManager.toDefaultSearchEngineProvider(testContext),
+                mock(),
+                HttpURLConnectionClient(),
+                engine = engine
+            )
 
             try {
                 val suggestions = provider.onInputChanged("fire")

--- a/components/feature/intent/src/test/java/mozilla/components/feature/intent/processing/TabIntentProcessorTest.kt
+++ b/components/feature/intent/src/test/java/mozilla/components/feature/intent/processing/TabIntentProcessorTest.kt
@@ -20,6 +20,7 @@ import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 import mozilla.components.feature.search.SearchUseCases
+import mozilla.components.browser.search.ext.toDefaultSearchEngineProvider
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
@@ -48,7 +49,12 @@ class TabIntentProcessorTest {
     private val session = mock<Session>()
     private val sessionUseCases = SessionUseCases(store, sessionManager)
     private val searchEngineManager = mock<SearchEngineManager>()
-    private val searchUseCases = SearchUseCases(testContext, store, searchEngineManager, sessionManager)
+    private val searchUseCases = SearchUseCases(
+        testContext,
+        store,
+        searchEngineManager.toDefaultSearchEngineProvider(testContext),
+        sessionManager
+    )
 
     @Before
     fun setup() {
@@ -255,7 +261,12 @@ class TabIntentProcessorTest {
         val engine = mock<Engine>()
         val sessionManager = spy(SessionManager(engine))
 
-        val searchUseCases = SearchUseCases(testContext, store, searchEngineManager, sessionManager)
+        val searchUseCases = SearchUseCases(
+            testContext,
+            store,
+            searchEngineManager.toDefaultSearchEngineProvider(testContext),
+            sessionManager
+        )
         val sessionUseCases = SessionUseCases(store, sessionManager)
 
         val searchTerms = "mozilla android"
@@ -326,7 +337,12 @@ class TabIntentProcessorTest {
         val engine = mock<Engine>()
         val sessionManager = spy(SessionManager(engine))
 
-        val searchUseCases = SearchUseCases(testContext, store, searchEngineManager, sessionManager)
+        val searchUseCases = SearchUseCases(
+            testContext,
+            store,
+            searchEngineManager.toDefaultSearchEngineProvider(testContext),
+            sessionManager
+        )
         val sessionUseCases = SessionUseCases(store, sessionManager)
 
         val searchTerms = "mozilla android"
@@ -385,7 +401,12 @@ class TabIntentProcessorTest {
         val engine = mock<Engine>()
         val sessionManager = spy(SessionManager(engine))
 
-        val searchUseCases = SearchUseCases(testContext, store, searchEngineManager, sessionManager)
+        val searchUseCases = SearchUseCases(
+            testContext,
+            store,
+            searchEngineManager.toDefaultSearchEngineProvider(testContext),
+            sessionManager
+        )
         val sessionUseCases = SessionUseCases(store, sessionManager)
 
         val searchTerms = "mozilla android"

--- a/components/feature/search/build.gradle
+++ b/components/feature/search/build.gradle
@@ -40,7 +40,6 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 
 dependencies {
     api project(':browser-search')
-    api project(':browser-session')
 
     implementation project(':browser-session')
     implementation project(':concept-engine')

--- a/components/feature/search/src/main/java/mozilla/components/feature/search/ext/BrowserStore.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/ext/BrowserStore.kt
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.search.ext
+
+import mozilla.components.browser.search.DefaultSearchEngineProvider
+import mozilla.components.browser.search.SearchEngine
+import mozilla.components.browser.state.state.defaultSearchEngine
+import mozilla.components.browser.state.store.BrowserStore
+
+/**
+ * Converts a [BrowserStore] to follow the [DefaultSearchEngineProvider] interface.
+ *
+ * This method is a temporary workaround to allow applications to switch to the new API slowly.
+ * Once all consuming apps have been migrated this extension will be removed and all components
+ * will be migrated to use [BrowserStore] directly.
+ *
+ * https://github.com/mozilla-mobile/android-components/issues/8686
+ */
+fun BrowserStore.toDefaultSearchEngineProvider() = object : DefaultSearchEngineProvider {
+    override fun getDefaultSearchEngine(): SearchEngine? {
+        return state.search.defaultSearchEngine?.legacy()
+    }
+
+    override suspend fun retrieveDefaultSearchEngine(): SearchEngine? {
+        return getDefaultSearchEngine()
+    }
+}

--- a/components/feature/search/src/main/java/mozilla/components/feature/search/ext/SearchEngine.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/ext/SearchEngine.kt
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.search.ext
+
+import android.net.Uri
+import mozilla.components.browser.state.search.SearchEngine
+
+/**
+ * Converts a [SearchEngine] (from `browser-state`) to the legacy `SearchEngine` type from
+ * `browser-search`.
+ *
+ * This method is a temporary workaround to allow applications to switch to the new API slowly.
+ * Once all consuming apps have been migrated this extension will be removed and all components
+ * will be migrated to use only the new [SearchEngine] class.
+ *
+ * https://github.com/mozilla-mobile/android-components/issues/8686
+ */
+fun SearchEngine.legacy() = mozilla.components.browser.search.SearchEngine(
+    identifier = id,
+    name = name,
+    icon = icon,
+    resultsUris = resultUrls.map { Uri.parse(it) },
+    suggestUri = suggestUrl?.let { Uri.parse(it) }
+)

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/SearchUseCasesTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/SearchUseCasesTest.kt
@@ -12,6 +12,7 @@ import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.browser.search.ext.toDefaultSearchEngineProvider
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
@@ -40,7 +41,12 @@ class SearchUseCasesTest {
         searchEngineManager = mock()
         sessionManager = mock()
         store = mock()
-        useCases = SearchUseCases(testContext, store, searchEngineManager, sessionManager)
+        useCases = SearchUseCases(
+            testContext,
+            store,
+            searchEngineManager.toDefaultSearchEngineProvider(testContext),
+            sessionManager
+        )
     }
 
     @Test
@@ -82,7 +88,12 @@ class SearchUseCasesTest {
 
         var sessionCreatedForUrl: String? = null
 
-        val searchUseCases = SearchUseCases(testContext, store, searchEngineManager, sessionManager) { url ->
+        val searchUseCases = SearchUseCases(
+            testContext,
+            store,
+            searchEngineManager.toDefaultSearchEngineProvider(testContext),
+            sessionManager
+        ) { url ->
             sessionCreatedForUrl = url
             Session(url).also { createdSession = it }
         }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -14,6 +14,7 @@ import mozilla.components.feature.awesomebar.AwesomeBarFeature
 import mozilla.components.feature.awesomebar.provider.SearchSuggestionProvider
 import mozilla.components.feature.media.fullscreen.MediaFullscreenOrientationFeature
 import mozilla.components.feature.search.SearchFeature
+import mozilla.components.feature.search.ext.toDefaultSearchEngineProvider
 import mozilla.components.feature.session.FullScreenFeature
 import mozilla.components.feature.tabs.WindowFeature
 import mozilla.components.feature.tabs.toolbar.TabsToolbarFeature
@@ -53,8 +54,6 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
 
         TabsToolbarFeature(layout.toolbar, components.sessionManager, sessionId, ::showTabs)
 
-        val applicationContext = requireContext().applicationContext
-
         AwesomeBarFeature(layout.awesomeBar, layout.toolbar, layout.engineView, components.icons)
             .addHistoryProvider(
                 components.historyStorage,
@@ -67,14 +66,12 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                 components.tabsUseCases.selectTab
             )
             .addSearchActionProvider(
-                searchEngineGetter = suspend {
-                    components.searchEngineManager.getDefaultSearchEngine(applicationContext)
-                },
+                components.store.toDefaultSearchEngineProvider(),
                 searchUseCase = components.searchUseCases.defaultSearch
             )
             .addSearchProvider(
                 requireContext(),
-                components.searchEngineManager,
+                components.store.toDefaultSearchEngineProvider(),
                 components.searchUseCases.defaultSearch,
                 fetchClient = components.client,
                 mode = SearchSuggestionProvider.Mode.MULTIPLE_SUGGESTIONS,

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -9,8 +9,6 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.widget.Toast
 import androidx.core.content.ContextCompat
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import mozilla.components.browser.domains.autocomplete.ShippedDomainsProvider
@@ -24,7 +22,6 @@ import mozilla.components.browser.menu.item.BrowserMenuHighlightableItem
 import mozilla.components.browser.menu.item.BrowserMenuImageText
 import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
-import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.engine.EngineMiddleware
@@ -34,6 +31,7 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.storage.sync.PlacesHistoryStorage
 import mozilla.components.browser.thumbnails.ThumbnailsMiddleware
 import mozilla.components.browser.thumbnails.storage.ThumbnailStorage
+import mozilla.components.concept.base.crash.Breadcrumb
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.fetch.Client
@@ -61,6 +59,9 @@ import mozilla.components.feature.pwa.intent.TrustedWebActivityIntentProcessor
 import mozilla.components.feature.pwa.intent.WebAppIntentProcessor
 import mozilla.components.feature.readerview.ReaderViewMiddleware
 import mozilla.components.feature.search.SearchUseCases
+import mozilla.components.feature.search.ext.toDefaultSearchEngineProvider
+import mozilla.components.feature.search.middleware.SearchMiddleware
+import mozilla.components.feature.search.region.RegionMiddleware
 import mozilla.components.feature.session.HistoryDelegate
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.sitepermissions.SitePermissionsStorage
@@ -73,9 +74,6 @@ import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.lib.nearby.NearbyConnection
 import mozilla.components.service.digitalassetlinks.local.StatementApi
 import mozilla.components.service.digitalassetlinks.local.StatementRelationChecker
-import mozilla.components.concept.base.crash.Breadcrumb
-import mozilla.components.feature.search.middleware.SearchMiddleware
-import mozilla.components.feature.search.region.RegionMiddleware
 import mozilla.components.service.location.LocationService
 import org.mozilla.samples.browser.addons.AddonsActivity
 import org.mozilla.samples.browser.downloads.DownloadService
@@ -200,16 +198,10 @@ open class DefaultComponents(private val applicationContext: Context) {
         DefaultSupportedAddonsChecker(applicationContext, SupportedAddonsChecker.Frequency(1, TimeUnit.DAYS))
     }
 
-    // Search
-    val searchEngineManager by lazy {
-        SearchEngineManager().apply {
-            CoroutineScope(Dispatchers.IO).launch {
-                loadAsync(applicationContext).await()
-            }
-        }
+    val searchUseCases by lazy {
+        SearchUseCases(applicationContext, store, store.toDefaultSearchEngineProvider(), sessionManager)
     }
 
-    val searchUseCases by lazy { SearchUseCases(applicationContext, store, searchEngineManager, sessionManager) }
     val defaultSearchUseCase by lazy {
         { searchTerms: String ->
             searchUseCases.defaultSearch.invoke(


### PR DESCRIPTION
This migrates samples-browser to stop using SearchEngineManager. For that I hide the provider of the default search engine behind an interface. This is a temporary solution until we have all apps using the SearchEngine from BrowserStore. After that we can get rid of that and make all our components use BrowserStore directly.

I tested this in Fenix too and have a matching patch locally. Once this lands we should be able to migrate Reference Browser too.