### PR TITLE
Closes #8622: Reader page title may contain HTML entities

### DIFF
--- a/components/feature/readerview/src/main/assets/extensions/readerview/readerview.js
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/readerview.js
@@ -40,6 +40,7 @@ class ReaderView {
   show(doc, url, options = {fontSize: 4, fontType: "sans-serif", colorScheme: "light"}) {
     let result = new Readability(doc, {classesToPreserve: preservedClasses}).parse();
     result.language = doc.documentElement.lang;
+    document.title = result.title;
 
     let article = Object.assign(
       result,
@@ -55,8 +56,6 @@ class ReaderView {
     this.setFontSize(options.fontSize);
     this.setFontType(options.fontType);
     this.setColorScheme(options.colorScheme);
-
-    document.title = article.title;
   }
 
   /**


### PR DESCRIPTION
We need to escape the `article.title` (which is used in the HTML template) to prevent HTML injection, but the `document.title` doesn't need to be escaped. It's causing the problem described in https://github.com/mozilla-mobile/android-components/issues/8622.