### PR TITLE
Mergify: Add rule for squashing PR

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -29,7 +29,7 @@ pull_request_rules:
       merge:
         method: rebase
         strict: smart
-  - name: Needs landing - Merge
+  - name: Needs landing - Rebase
     conditions:
       - status-success=complete-pr
       - label=🛬 needs landing
@@ -40,4 +40,16 @@ pull_request_rules:
     actions:
       merge:
         method: rebase
+        strict: smart
+  - name: Needs landing - Squash
+    conditions:
+      - status-success=complete-pr
+      - label=🛬 needs landing (squash)
+      - "#approved-reviews-by>=1"
+      - -draft
+      - label!=work in progress
+      - label!=do not land
+    actions:
+      merge:
+        method: squash
         strict: smart


### PR DESCRIPTION
This adds a new rule: If a PR has the label `🛬 needs landing (squash)` then the changes will be squashed and landed (instead of only rebased). This is useful for PRs that may contain a bunch of follow-up changes in separate commits that we do not want to land individually.