### PR TITLE
Closes #8681: Do not retry to update an extension when an unrecoverable exception happens

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -297,12 +297,11 @@ class GeckoEngine(
                 newPermissions: Array<out String>,
                 newOrigins: Array<out String>
             ): GeckoResult<AllowOrDeny>? {
-                // NB: We don't have a user flow for handling updated origins so we ignore them for now.
                 val result = GeckoResult<AllowOrDeny>()
                 webExtensionDelegate.onUpdatePermissionRequest(
                     GeckoWebExtension(current, runtime),
                     GeckoWebExtension(updated, runtime),
-                    newPermissions.toList()
+                    newPermissions.toList() + newOrigins.toList()
                 ) {
                     allow -> if (allow) result.complete(AllowOrDeny.ALLOW) else result.complete(AllowOrDeny.DENY)
                 }

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -16,6 +16,7 @@ import mozilla.components.browser.engine.gecko.mediaquery.toGeckoValue
 import mozilla.components.browser.engine.gecko.profiler.Profiler
 import mozilla.components.browser.engine.gecko.util.SpeculativeSessionFactory
 import mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension
+import mozilla.components.browser.engine.gecko.webextension.GeckoWebExtensionException
 import mozilla.components.browser.engine.gecko.webnotifications.GeckoWebNotificationDelegate
 import mozilla.components.browser.engine.gecko.webpush.GeckoWebPushDelegate
 import mozilla.components.browser.engine.gecko.webpush.GeckoWebPushHandler
@@ -266,7 +267,7 @@ class GeckoEngine(
             onSuccess(updatedExtension)
             GeckoResult<Void>()
         }, { throwable ->
-            onError(extension.id, throwable)
+            onError(extension.id, GeckoWebExtensionException(throwable))
             GeckoResult<Void>()
         })
     }

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionException.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionException.kt
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.webextension
+
+import mozilla.components.concept.engine.webextension.WebExtensionException
+import org.mozilla.geckoview.WebExtension.InstallException
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_USER_CANCELED
+
+/**
+ * An unexpected gecko exception that occurs when trying to perform an action on the extension like
+ * (but not exclusively) installing/uninstalling, removing or updating.
+ */
+class GeckoWebExtensionException(throwable: Throwable) : WebExtensionException(throwable) {
+    override val isRecoverable: Boolean = throwable is InstallException &&
+            throwable.code == ERROR_USER_CANCELED
+}

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -24,6 +24,7 @@ import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionDelegate
+import mozilla.components.concept.engine.webextension.WebExtensionException
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.eq
@@ -63,11 +64,22 @@ import org.mozilla.geckoview.GeckoWebExecutor
 import org.mozilla.geckoview.MockWebExtension
 import org.mozilla.geckoview.StorageController
 import org.mozilla.geckoview.WebExtensionController
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_CORRUPT_FILE
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_FILE_ACCESS
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_INCORRECT_HASH
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_INCORRECT_ID
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_NETWORK_FAILURE
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_POSTPONED
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_SIGNEDSTATE_REQUIRED
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_UNEXPECTED_ADDON_TYPE
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_USER_CANCELED
 import org.mozilla.geckoview.WebPushController
 import org.robolectric.Robolectric
 import java.io.IOException
 import java.lang.Exception
 import org.mozilla.geckoview.WebExtension as GeckoWebExtension
+
+typealias GeckoInstallException = org.mozilla.geckoview.WebExtension.InstallException
 
 @RunWith(AndroidJUnit4::class)
 class GeckoEngineTest {
@@ -1208,8 +1220,55 @@ class GeckoEngineTest {
         )
         updateExtensionResult.completeExceptionally(expected)
 
-        assertSame(expected, throwable)
+        assertSame(expected, throwable!!.cause)
         assertNull(result)
+    }
+
+    @Test
+    fun `failures when updating MUST indicate if they are recoverable`() {
+        val runtime = mock<GeckoRuntime>()
+        val extensionController: WebExtensionController = mock()
+        val engine = GeckoEngine(context, runtime = runtime)
+
+        val extension = mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension(
+            mockNativeExtension(),
+            runtime
+        )
+        val performUpdate: (GeckoInstallException) -> WebExtensionException = { exception ->
+            val updateExtensionResult = GeckoResult<GeckoWebExtension>()
+            whenever(extensionController.update(any())).thenReturn(updateExtensionResult)
+            whenever(runtime.webExtensionController).thenReturn(extensionController)
+            var throwable: WebExtensionException? = null
+
+            engine.updateWebExtension(
+                extension,
+                onError = { _, e -> throwable = e as WebExtensionException }
+            )
+
+            updateExtensionResult.completeExceptionally(exception)
+            throwable!!
+        }
+
+        val unrecoverableExceptions = listOf(
+            mockGeckoInstallException(ERROR_NETWORK_FAILURE),
+            mockGeckoInstallException(ERROR_INCORRECT_HASH),
+            mockGeckoInstallException(ERROR_CORRUPT_FILE),
+            mockGeckoInstallException(ERROR_FILE_ACCESS),
+            mockGeckoInstallException(ERROR_SIGNEDSTATE_REQUIRED),
+            mockGeckoInstallException(ERROR_UNEXPECTED_ADDON_TYPE),
+            mockGeckoInstallException(ERROR_INCORRECT_ID),
+            mockGeckoInstallException(ERROR_POSTPONED)
+        )
+
+        unrecoverableExceptions.forEach { exception ->
+            assertFalse(performUpdate(exception).isRecoverable)
+        }
+
+        val recoverableExceptions = listOf(mockGeckoInstallException(ERROR_USER_CANCELED))
+
+        recoverableExceptions.forEach { exception ->
+            assertTrue(performUpdate(exception).isRecoverable)
+        }
     }
 
     @Test
@@ -1915,5 +1974,11 @@ class GeckoEngineTest {
             putString("locationURI", location)
         }
         return spy(MockWebExtension(bundle))
+    }
+
+    private fun mockGeckoInstallException(errorCode: Int): GeckoInstallException {
+        val exception = object : GeckoInstallException() {}
+        ReflectionUtils.setField(exception, "code", errorCode)
+        return exception
     }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -298,12 +298,11 @@ class GeckoEngine(
                 newPermissions: Array<out String>,
                 newOrigins: Array<out String>
             ): GeckoResult<AllowOrDeny>? {
-                // NB: We don't have a user flow for handling updated origins so we ignore them for now.
                 val result = GeckoResult<AllowOrDeny>()
                 webExtensionDelegate.onUpdatePermissionRequest(
                     GeckoWebExtension(current, runtime),
                     GeckoWebExtension(updated, runtime),
-                    newPermissions.toList()
+                    newPermissions.toList() + newOrigins.toList()
                 ) {
                     allow -> if (allow) result.complete(AllowOrDeny.ALLOW) else result.complete(AllowOrDeny.DENY)
                 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -17,6 +17,7 @@ import mozilla.components.browser.engine.gecko.mediaquery.toGeckoValue
 import mozilla.components.browser.engine.gecko.profiler.Profiler
 import mozilla.components.browser.engine.gecko.util.SpeculativeSessionFactory
 import mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension
+import mozilla.components.browser.engine.gecko.webextension.GeckoWebExtensionException
 import mozilla.components.browser.engine.gecko.webnotifications.GeckoWebNotificationDelegate
 import mozilla.components.browser.engine.gecko.webpush.GeckoWebPushDelegate
 import mozilla.components.browser.engine.gecko.webpush.GeckoWebPushHandler
@@ -267,7 +268,7 @@ class GeckoEngine(
             onSuccess(updatedExtension)
             GeckoResult<Void>()
         }, { throwable ->
-            onError(extension.id, throwable)
+            onError(extension.id, GeckoWebExtensionException(throwable))
             GeckoResult<Void>()
         })
     }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionException.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionException.kt
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.webextension
+
+import mozilla.components.concept.engine.webextension.WebExtensionException
+import org.mozilla.geckoview.WebExtension.InstallException
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_USER_CANCELED
+
+/**
+ * An unexpected gecko exception that occurs when trying to perform an action on the extension like
+ * (but not exclusively) installing/uninstalling, removing or updating..
+ */
+class GeckoWebExtensionException(throwable: Throwable) : WebExtensionException(throwable) {
+    override val isRecoverable: Boolean = throwable is InstallException &&
+            throwable.code == ERROR_USER_CANCELED
+}

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -877,6 +877,7 @@ class GeckoEngineTest {
         val currentExtension = mockNativeExtension("test", "uri")
         val updatedExtension = mockNativeExtension("testUpdated", "uri")
         val updatedPermissions = arrayOf("p1", "p2")
+        val hostPermissions = arrayOf("p3", "p4")
         val webExtensionsDelegate: WebExtensionDelegate = mock()
         val engine = GeckoEngine(context, runtime = runtime)
         engine.registerWebExtensionDelegate(webExtensionsDelegate)
@@ -885,7 +886,48 @@ class GeckoEngineTest {
         verify(webExtensionController).promptDelegate = geckoDelegateCaptor.capture()
 
         val result = geckoDelegateCaptor.value.onUpdatePrompt(
-            currentExtension, updatedExtension, updatedPermissions, emptyArray()
+            currentExtension, updatedExtension, updatedPermissions, hostPermissions
+        )
+        assertNotNull(result)
+
+        val currentExtensionCaptor = argumentCaptor<WebExtension>()
+        val updatedExtensionCaptor = argumentCaptor<WebExtension>()
+        val onPermissionsGrantedCaptor = argumentCaptor<((Boolean) -> Unit)>()
+        verify(webExtensionsDelegate).onUpdatePermissionRequest(
+            currentExtensionCaptor.capture(),
+            updatedExtensionCaptor.capture(),
+            eq(updatedPermissions.toList() + hostPermissions.toList()),
+            onPermissionsGrantedCaptor.capture()
+        )
+        val current =
+            currentExtensionCaptor.value as mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension
+        assertEquals(currentExtension, current.nativeExtension)
+        val updated =
+            updatedExtensionCaptor.value as mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension
+        assertEquals(updatedExtension, updated.nativeExtension)
+
+        onPermissionsGrantedCaptor.value.invoke(true)
+        assertEquals(GeckoResult.ALLOW, result)
+    }
+
+    @Test
+    fun `web extension delegate handles update prompt with empty host permissions`() {
+        val runtime: GeckoRuntime = mock()
+        val webExtensionController: WebExtensionController = mock()
+        whenever(runtime.webExtensionController).thenReturn(webExtensionController)
+
+        val currentExtension = mockNativeExtension("test", "uri")
+        val updatedExtension = mockNativeExtension("testUpdated", "uri")
+        val updatedPermissions = arrayOf("p1", "p2")
+        val webExtensionsDelegate: WebExtensionDelegate = mock()
+        val engine = GeckoEngine(context, runtime = runtime)
+        engine.registerWebExtensionDelegate(webExtensionsDelegate)
+
+        val geckoDelegateCaptor = argumentCaptor<WebExtensionController.PromptDelegate>()
+        verify(webExtensionController).promptDelegate = geckoDelegateCaptor.capture()
+
+        val result = geckoDelegateCaptor.value.onUpdatePrompt(
+                currentExtension, updatedExtension, updatedPermissions, emptyArray()
         )
         assertNotNull(result)
 
@@ -899,10 +941,10 @@ class GeckoEngineTest {
             onPermissionsGrantedCaptor.capture()
         )
         val current =
-            currentExtensionCaptor.value as mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension
+                currentExtensionCaptor.value as mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension
         assertEquals(currentExtension, current.nativeExtension)
         val updated =
-            updatedExtensionCaptor.value as mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension
+                updatedExtensionCaptor.value as mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension
         assertEquals(updatedExtension, updated.nativeExtension)
 
         onPermissionsGrantedCaptor.value.invoke(true)

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -24,6 +24,7 @@ import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionDelegate
+import mozilla.components.concept.engine.webextension.WebExtensionException
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.eq
@@ -62,12 +63,22 @@ import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoWebExecutor
 import org.mozilla.geckoview.MockWebExtension
 import org.mozilla.geckoview.StorageController
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_CORRUPT_FILE
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_FILE_ACCESS
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_INCORRECT_HASH
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_INCORRECT_ID
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_NETWORK_FAILURE
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_POSTPONED
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_SIGNEDSTATE_REQUIRED
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_UNEXPECTED_ADDON_TYPE
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_USER_CANCELED
 import org.mozilla.geckoview.WebExtensionController
 import org.mozilla.geckoview.WebPushController
 import org.robolectric.Robolectric
 import java.io.IOException
-import java.lang.Exception
 import org.mozilla.geckoview.WebExtension as GeckoWebExtension
+
+typealias GeckoInstallException = org.mozilla.geckoview.WebExtension.InstallException
 
 @RunWith(AndroidJUnit4::class)
 class GeckoEngineTest {
@@ -1208,8 +1219,56 @@ class GeckoEngineTest {
         )
         updateExtensionResult.completeExceptionally(expected)
 
-        assertSame(expected, throwable)
+        assertSame(expected, throwable!!.cause)
         assertNull(result)
+    }
+
+    @Test
+    fun `failures when updating MUST indicate if they are recoverable`() {
+        val runtime = mock<GeckoRuntime>()
+        val extensionController: WebExtensionController = mock()
+        val engine = GeckoEngine(context, runtime = runtime)
+
+        val extension = mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension(
+            mockNativeExtension(),
+            runtime
+        )
+        val performUpdate: (GeckoInstallException) -> WebExtensionException = { exception ->
+            val updateExtensionResult = GeckoResult<GeckoWebExtension>()
+            whenever(extensionController.update(any())).thenReturn(updateExtensionResult)
+            whenever(runtime.webExtensionController).thenReturn(extensionController)
+            var throwable: WebExtensionException? = null
+
+            engine.updateWebExtension(
+                extension,
+                onError = { _, e -> throwable = e as WebExtensionException
+                }
+            )
+
+            updateExtensionResult.completeExceptionally(exception)
+            throwable!!
+        }
+
+        val unrecoverableExceptions = listOf(
+            mockGeckoInstallException(ERROR_NETWORK_FAILURE),
+            mockGeckoInstallException(ERROR_INCORRECT_HASH),
+            mockGeckoInstallException(ERROR_CORRUPT_FILE),
+            mockGeckoInstallException(ERROR_FILE_ACCESS),
+            mockGeckoInstallException(ERROR_SIGNEDSTATE_REQUIRED),
+            mockGeckoInstallException(ERROR_UNEXPECTED_ADDON_TYPE),
+            mockGeckoInstallException(ERROR_INCORRECT_ID),
+            mockGeckoInstallException(ERROR_POSTPONED)
+        )
+
+        unrecoverableExceptions.forEach { exception ->
+            assertFalse(performUpdate(exception).isRecoverable)
+        }
+
+        val recoverableExceptions = listOf(mockGeckoInstallException(ERROR_USER_CANCELED))
+
+        recoverableExceptions.forEach { exception ->
+            assertTrue(performUpdate(exception).isRecoverable)
+        }
     }
 
     @Test
@@ -1918,5 +1977,11 @@ class GeckoEngineTest {
             putString("locationURI", location)
         }
         return spy(MockWebExtension(bundle))
+    }
+
+    private fun mockGeckoInstallException(errorCode: Int): GeckoInstallException {
+        val exception = object : GeckoInstallException() {}
+        ReflectionUtils.setField(exception, "code", errorCode)
+        return exception
     }
 }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -297,12 +297,11 @@ class GeckoEngine(
                 newPermissions: Array<out String>,
                 newOrigins: Array<out String>
             ): GeckoResult<AllowOrDeny>? {
-                // NB: We don't have a user flow for handling updated origins so we ignore them for now.
                 val result = GeckoResult<AllowOrDeny>()
                 webExtensionDelegate.onUpdatePermissionRequest(
                     GeckoWebExtension(current, runtime),
                     GeckoWebExtension(updated, runtime),
-                    newPermissions.toList()
+                    newPermissions.toList() + newOrigins.toList()
                 ) {
                     allow -> if (allow) result.complete(AllowOrDeny.ALLOW) else result.complete(AllowOrDeny.DENY)
                 }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -16,6 +16,7 @@ import mozilla.components.browser.engine.gecko.mediaquery.toGeckoValue
 import mozilla.components.browser.engine.gecko.profiler.Profiler
 import mozilla.components.browser.engine.gecko.util.SpeculativeSessionFactory
 import mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension
+import mozilla.components.browser.engine.gecko.webextension.GeckoWebExtensionException
 import mozilla.components.browser.engine.gecko.webnotifications.GeckoWebNotificationDelegate
 import mozilla.components.browser.engine.gecko.webpush.GeckoWebPushDelegate
 import mozilla.components.browser.engine.gecko.webpush.GeckoWebPushHandler
@@ -266,7 +267,7 @@ class GeckoEngine(
             onSuccess(updatedExtension)
             GeckoResult<Void>()
         }, { throwable ->
-            onError(extension.id, throwable)
+            onError(extension.id, GeckoWebExtensionException(throwable))
             GeckoResult<Void>()
         })
     }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionException.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionException.kt
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.webextension
+
+import mozilla.components.concept.engine.webextension.WebExtensionException
+import org.mozilla.geckoview.WebExtension.InstallException
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_USER_CANCELED
+
+/**
+ * An unexpected gecko exception that occurs when trying to perform an action on the extension like
+ * (but not exclusively) installing/uninstalling, removing or updating.
+ */
+class GeckoWebExtensionException(throwable: Throwable) : WebExtensionException(throwable) {
+    override val isRecoverable: Boolean = throwable is InstallException &&
+            throwable.code == ERROR_USER_CANCELED
+}

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -468,3 +468,9 @@ class DisabledFlags internal constructor(val value: Int) {
  * Returns whether or not the extension is disabled because it is unsupported.
  */
 fun WebExtension.isUnsupported() = getMetadata()?.disabledFlags?.contains(DisabledFlags.APP_SUPPORT) == true
+
+/**
+ * An unexpected event that occurs when trying to perform an action on the extension like
+ * (but not exclusively) installing/uninstalling, removing or updating.
+ */
+open class WebExtensionException(throwable: Throwable, open val isRecoverable: Boolean = true) : Exception(throwable)

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/worker/Extensions.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/worker/Extensions.kt
@@ -6,8 +6,15 @@ package mozilla.components.feature.addons.worker
 
 import java.io.IOException
 import kotlinx.coroutines.CancellationException
+import mozilla.components.concept.engine.webextension.WebExtensionException
+
 /**
  * Indicates if an exception should be reported to the crash reporter.
  */
-internal fun Exception.shouldReport(): Boolean =
-        cause !is IOException && cause !is CancellationException && this !is CancellationException
+internal fun Exception.shouldReport(): Boolean {
+    val isRecoverable = (this as? WebExtensionException)?.isRecoverable ?: true
+    return cause !is IOException &&
+            cause !is CancellationException &&
+            this !is CancellationException &&
+            isRecoverable
+}

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/worker/ExtensionsTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/worker/ExtensionsTest.kt
@@ -6,8 +6,10 @@ package mozilla.components.feature.addons.worker
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
 import java.io.IOException
 import kotlinx.coroutines.CancellationException
+import mozilla.components.concept.engine.webextension.WebExtensionException
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -27,5 +29,15 @@ class ExtensionsTest {
     @Test
     fun `shouldReport - when cause the exception is a CancellationException must NOT be reported`() {
         assertFalse(CancellationException().shouldReport())
+    }
+
+    @Test
+    fun `shouldReport - when the exception isRecoverable must be reported`() {
+        assertTrue(WebExtensionException(java.lang.Exception(), isRecoverable = true).shouldReport())
+    }
+
+    @Test
+    fun `shouldReport - when the exception NOT isRecoverable must NOT be reported`() {
+        assertFalse(WebExtensionException(java.lang.Exception(), isRecoverable = false).shouldReport())
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **feature-addons**
+  * 🚒 Bug fixed [issue #8681](https://github.com/mozilla-mobile/android-components/issues/8681) Fenix was consuming a lot of extra space on disk, when an add-on update requires a new permission, more info can be found [here](https://github.com/mozilla-mobile/android-components/issues/8681)
+  ```
+
 * All components
  * Updated to Kotlin 1.4.10 and Coroutines 1.3.9.
  * Updated to Android Gradle plugin 4.0.1 (downstream projects need to update too).
@@ -58,7 +62,7 @@ permalink: /changelog/
   * 🚒 Bug fixed [issue #8585](https://github.com/mozilla-mobile/android-components/issues/8585) fixed regression files not been added to the downloads database system.
   * 🌟 Added new use cases for removing individual downloads (`removeDownload`) and all downloads (`removeAllDownloads`).
   * 🌟 Added support for new download [GeckoView API](https://mozilla.github.io/geckoview/javadoc/mozilla-central/org/mozilla/geckoview/GeckoSession.ContentDelegate.html#onExternalResponse-org.mozilla.geckoview.GeckoSession-org.mozilla.geckoview.GeckoResult-).
-  
+
 * **service-glean**
   * Glean was upgraded to v32.4.1
     * Update `glean_parser` to 1.28.6


### PR DESCRIPTION
Before adding a completed solution, I wanted to show you this approach and see what do you think.

The issue that the GV team described on [bug 1670503](https://bugzilla.mozilla.org/show_bug.cgi?id=1670503), was caused because, we were incrementally retrying to update when we were trying to update an exception that required an extra permission and as a result user's interaction, subsequently this caused that multiple files were created in the intent and never got purged. 

The approach here it's just to only retry if we get an exception code that indicates that the failure was due to a 
situational thing like an network error. The whole list of exceptions can be found [here](https://searchfox.org/mozilla-central/source/mobile/android/geckoview/src/main/java/org/mozilla/geckoview/WebExtension.java#1385 ), so far this is the only one that I think we can recover from.
 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
