### PR TITLE
Close #8598: Adds ActivityDelegate to support the GeckoView delegate

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/activity/GeckoActivityDelegate.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/activity/GeckoActivityDelegate.kt
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.activity
+
+import android.app.PendingIntent
+import android.content.Intent
+import mozilla.components.concept.engine.activity.ActivityDelegate
+import mozilla.components.support.base.log.logger.Logger
+import org.mozilla.geckoview.GeckoResult
+import org.mozilla.geckoview.GeckoRuntime
+import java.lang.ref.WeakReference
+
+/**
+ * A wrapper for the [ActivityDelegate] to communicate with the Gecko-based delegate.
+ */
+internal class GeckoActivityDelegate(
+    private val delegateRef: WeakReference<ActivityDelegate>
+) : GeckoRuntime.ActivityDelegate {
+
+    private val logger = Logger(GeckoActivityDelegate::javaClass.name)
+
+    override fun onStartActivityForResult(intent: PendingIntent): GeckoResult<Intent> {
+        val result: GeckoResult<Intent> = GeckoResult()
+        val delegate = delegateRef.get()
+
+        if (delegate == null) {
+            logger.warn("No activity delegate attached. Cannot request FIDO auth.")
+
+            result.completeExceptionally(RuntimeException("Activity for result failed; no delegate attached."))
+
+            return result
+        }
+
+        delegate.startIntentSenderForResult(intent.intentSender) { data ->
+            if (data != null) {
+                result.complete(data)
+            } else {
+                result.completeExceptionally(RuntimeException("Activity for result failed."))
+            }
+        }
+        return result
+    }
+}

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -1725,7 +1725,7 @@ class GeckoEngineTest {
 
         whenever(runtime.settings).thenReturn(mockGeckoSetting)
         whenever(mockGeckoSetting.contentBlocking).thenReturn(mockGeckoContentBlockingSetting)
-        whenever(mockGeckoContentBlockingSetting.getEnhancedTrackingProtectionLevel()).thenReturn(
+        whenever(mockGeckoContentBlockingSetting.enhancedTrackingProtectionLevel).thenReturn(
             ContentBlocking.EtpLevel.STRICT
         )
         whenever(runtime.contentBlockingController).thenReturn(mockContentBlockingController)
@@ -1870,7 +1870,7 @@ class GeckoEngineTest {
 
         whenever(runtime.settings).thenReturn(mockGeckoSetting)
         whenever(mockGeckoSetting.contentBlocking).thenReturn(mockGeckoContentBlockingSetting)
-        whenever(mockGeckoContentBlockingSetting.getEnhancedTrackingProtectionLevel()).thenReturn(
+        whenever(mockGeckoContentBlockingSetting.enhancedTrackingProtectionLevel).thenReturn(
             ContentBlocking.EtpLevel.STRICT
         )
         whenever(runtime.contentBlockingController).thenReturn(mockContentBlockingController)
@@ -1924,6 +1924,30 @@ class GeckoEngineTest {
         verify(controller, times(2)).setDelegate(any())
 
         assert(handler1 == handler2)
+    }
+
+    @Test
+    fun `registerActivityDelegate sets delegate`() {
+        val runtime = mock<GeckoRuntime>()
+        val engine = GeckoEngine(context, runtime = runtime)
+
+        engine.registerActivityDelegate(mock())
+
+        verify(runtime).activityDelegate = any()
+    }
+
+    @Test
+    fun `unregisterActivityDelegate sets delegate to null`() {
+        val runtime = mock<GeckoRuntime>()
+        val engine = GeckoEngine(context, runtime = runtime)
+
+        engine.registerActivityDelegate(mock())
+
+        verify(runtime).activityDelegate = any()
+
+        engine.unregisterActivityDelegate()
+
+        verify(runtime).activityDelegate = null
     }
 
     private fun createSocialTrackersLogEntryList(): List<ContentBlockingController.LogEntry> {

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/activity/GeckoActivityDelegateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/activity/GeckoActivityDelegateTest.kt
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.activity
+
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.IntentSender
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.concept.engine.activity.ActivityDelegate
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mozilla.geckoview.GeckoResult
+import java.lang.ref.WeakReference
+
+@RunWith(AndroidJUnit4::class)
+class GeckoActivityDelegateTest {
+    lateinit var pendingIntent: PendingIntent
+
+    @Before
+    fun setup() {
+        pendingIntent = mock()
+        `when`(pendingIntent.intentSender).thenReturn(mock())
+    }
+
+    @Test
+    fun `onStartActivityForResult is completed successfully`() {
+        val delegate: ActivityDelegate = object : ActivityDelegate {
+            override fun startIntentSenderForResult(intent: IntentSender, onResult: (Intent?) -> Unit) {
+                onResult(mock())
+            }
+        }
+
+        val geckoActivityDelegate = GeckoActivityDelegate(WeakReference(delegate))
+        val result = geckoActivityDelegate.onStartActivityForResult(pendingIntent)
+
+        result.accept {
+            assertNotNull(it)
+        }
+    }
+
+    @Test
+    fun `onStartActivityForResult completes exceptionally on null response`() {
+        val delegate: ActivityDelegate = object : ActivityDelegate {
+            override fun startIntentSenderForResult(intent: IntentSender, onResult: (Intent?) -> Unit) {
+                onResult(null)
+            }
+        }
+
+        val geckoActivityDelegate = GeckoActivityDelegate(WeakReference(delegate))
+        val result = geckoActivityDelegate.onStartActivityForResult(pendingIntent)
+
+        result.exceptionally { throwable ->
+            assertEquals("Activity for result failed.", throwable.localizedMessage)
+            GeckoResult.fromValue(null)
+        }
+    }
+
+    @Test
+    fun `onStartActivityForResult completes exceptionally when there is no object attached to the weak reference`() {
+        val geckoActivityDelegate = GeckoActivityDelegate(WeakReference(null))
+        val result = geckoActivityDelegate.onStartActivityForResult(pendingIntent)
+
+        result.exceptionally { throwable ->
+            assertEquals("Activity for result failed; no delegate attached.", throwable.localizedMessage)
+            GeckoResult.fromValue(null)
+        }
+    }
+}

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -11,6 +11,7 @@ import androidx.annotation.MainThread
 import mozilla.components.concept.engine.content.blocking.TrackerLog
 import mozilla.components.concept.engine.content.blocking.TrackingProtectionExceptionStorage
 import mozilla.components.concept.base.profiler.Profiler
+import mozilla.components.concept.engine.activity.ActivityDelegate
 import mozilla.components.concept.engine.utils.EngineVersion
 import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
@@ -160,6 +161,19 @@ interface Engine : WebExtensionRuntime, DataCleanable {
     fun registerWebPushDelegate(
         webPushDelegate: WebPushDelegate
     ): WebPushHandler = throw UnsupportedOperationException("Web Push support is not available in this engine")
+
+    /**
+     * Registers an [ActivityDelegate] to be notified on activity events that are needed by the engine.
+     */
+    fun registerActivityDelegate(
+        activityDelegate: ActivityDelegate
+    ): Unit = throw UnsupportedOperationException("This engine does not have support for an Activity delegate.")
+
+    /**
+     * Un-registers the attached [ActivityDelegate] if one was added with [registerActivityDelegate].
+     */
+    fun unregisterActivityDelegate(): Unit =
+        throw UnsupportedOperationException("This engine does not have support for an Activity delegate.")
 
     /**
      * Fetch a list of trackers logged for a given [session] .

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/activity/ActivityDelegate.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/activity/ActivityDelegate.kt
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.activity
+
+import android.content.Intent
+import android.content.IntentSender
+
+/**
+ * Notifies applications or other components of engine events that require interaction with an Android Activity.
+ */
+interface ActivityDelegate {
+
+    /**
+     * Requests an [IntentSender] is started on behalf of the engine.
+     *
+     * @param intent The [IntentSender] to be started through an Android Activity.
+     * @param onResult The callback to be invoked when we receive the result with the intent data.
+     */
+    fun startIntentSenderForResult(intent: IntentSender, onResult: (Intent?) -> Unit) = Unit
+}

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -64,6 +64,7 @@ import mozilla.components.feature.prompts.login.LoginPickerView
 import mozilla.components.feature.prompts.share.DefaultShareDelegate
 import mozilla.components.feature.prompts.share.ShareDelegate
 import mozilla.components.lib.state.ext.flowScoped
+import mozilla.components.support.base.feature.ActivityResultHandler
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.base.feature.OnNeedToRequestPermissions
 import mozilla.components.support.base.feature.PermissionsFeature
@@ -126,7 +127,7 @@ class PromptFeature private constructor(
     private val loginPickerView: LoginPickerView? = null,
     private val onManageLogins: () -> Unit = {},
     onNeedToRequestPermissions: OnNeedToRequestPermissions
-) : LifecycleAwareFeature, PermissionsFeature, Prompter, UserInteractionHandler {
+) : LifecycleAwareFeature, PermissionsFeature, Prompter, ActivityResultHandler, UserInteractionHandler {
     // These three scopes have identical lifetimes. We do not yet have a way of combining scopes
     private var handlePromptScope: CoroutineScope? = null
     private var dismissPromptScope: CoroutineScope? = null
@@ -303,8 +304,8 @@ class PromptFeature private constructor(
      * @param requestCode The code of the app that requested the intent.
      * @param intent The result of the request.
      */
-    fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
-        filePicker.onActivityResult(requestCode, resultCode, intent)
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+        return filePicker.onActivityResult(requestCode, resultCode, data)
     }
 
     /**

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/file/FilePicker.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/file/FilePicker.kt
@@ -113,8 +113,9 @@ internal class FilePicker(
      * @param requestCode The code of the app that requested the intent.
      * @param intent The result of the request.
      */
-    fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
-        val request = getActivePromptRequest() ?: return
+    fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?): Boolean {
+        var resultHandled = false
+        val request = getActivePromptRequest() ?: return false
         if (requestCode == FILE_PICKER_ACTIVITY_REQUEST_CODE && request is File) {
             store.consumePromptFrom(sessionId) {
                 if (resultCode == RESULT_OK) {
@@ -123,10 +124,13 @@ internal class FilePicker(
                     request.onDismiss()
                 }
             }
+            resultHandled = true
         }
         if (request !is File) {
             logger.error("Invalid PromptRequest expected File but $request was provided")
         }
+
+        return resultHandled
     }
 
     private fun getActivePromptRequest(): PromptRequest? =

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/file/FilePickerTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/file/FilePickerTest.kt
@@ -254,6 +254,14 @@ class FilePickerTest {
     }
 
     @Test
+    fun `onActivityResult returns false if the request code is not the same`() {
+        val intent = Intent()
+        val result = filePicker.onActivityResult(10101, RESULT_OK, intent)
+
+        assertFalse(result)
+    }
+
+    @Test
     fun `onRequestPermissionsResult with FILE_PICKER_REQUEST and PERMISSION_GRANTED will call onPermissionsGranted`() {
         stubContext()
         filePicker = spy(filePicker)

--- a/components/support/base/src/main/java/mozilla/components/support/base/feature/ActivityResultHandler.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/feature/ActivityResultHandler.kt
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.base.feature
+
+import android.content.Intent
+import android.app.Activity
+
+/**
+ * Generic interface for fragments, activities, features and other components that want to handle
+ * the [Activity.onActivityResult] event.
+ */
+interface ActivityResultHandler {
+
+    /**
+     * Called when the activity we launched exists and we may want to handle the result.
+     *
+     * @return true if the result was consumed and no other component needs to be notified.
+     */
+    fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean
+}

--- a/components/support/base/src/main/java/mozilla/components/support/base/feature/ViewBoundFeatureWrapper.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/feature/ViewBoundFeatureWrapper.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.support.base.feature
 
+import android.content.Intent
 import android.view.View
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
@@ -138,7 +139,7 @@ class ViewBoundFeatureWrapper<T : LifecycleAwareFeature>() {
     }
 
     /**
-     * Convenient method for invoking [UserInteractionHandler.onBackPressed] on a wrapped
+     * Convenience method for invoking [UserInteractionHandler.onBackPressed] on a wrapped
      * [LifecycleAwareFeature] that implements [UserInteractionHandler]. Returns false if
      * the [LifecycleAwareFeature] was cleared already.
      */
@@ -153,6 +154,24 @@ class ViewBoundFeatureWrapper<T : LifecycleAwareFeature>() {
         }
 
         return feature.onBackPressed()
+    }
+
+    /**
+     * Convenience method for invoking [ActivityResultHandler.onActivityResult] on a wrapped
+     * [LifecycleAwareFeature] that implements [ActivityResultHandler]. Returns false if
+     * the [LifecycleAwareFeature] was cleared already.
+     */
+    @Synchronized
+    fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+        val feature = feature ?: return false
+
+        if (feature !is ActivityResultHandler) {
+            throw IllegalAccessError(
+                "Feature does not implement ${ActivityResultHandler::class.java.simpleName} interface"
+            )
+        }
+
+        return feature.onActivityResult(requestCode, resultCode, data)
     }
 
     @Synchronized

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -45,6 +45,15 @@ permalink: /changelog/
 
 * **service-nimbus**
   * Added a `NimbusDisabled` class to provide implementers who are not able to use Nimbus yet.
+  
+* **support-base**
+  * 🌟 Add an `ActivityResultHandler` for features that want to consume the result.
+  
+* **concept-engine**
+  * 🌟 Added a new `ActivityDelegate` for handling intent requests from the engine.
+  
+* **browser-engine-gecko(-nightly)**
+  * Added `GeckoActivityDelegate` for the GeckoView `activityDelegate`.
 
 * **feature-tabs**
   * ⚠️ **This is a breaking change**: Removed the `TabCounterToolbarButton#privateColor` attribute which are replaced by the `tabCounterTintColor` Android styleable attribute.


### PR DESCRIPTION
Added the `ActivityDelegate` with GeckoEngine support which will be used with a `WebAuthnFeature` component in the future.

GeckoView API docs [here](https://mozilla.github.io/geckoview/javadoc/mozilla-central/org/mozilla/geckoview/GeckoRuntime.ActivityDelegate.html).

Close #8598

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality content**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
