### PR TITLE
Closes #8715: Pass and empty map to loadUrl() instead of null.

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -146,7 +146,12 @@ class GeckoEngineSession(
             initialLoadRequest = LoadRequest(url, parent, flags, additionalHeaders)
         }
         @Suppress("DEPRECATION") // https://github.com/mozilla-mobile/android-components/issues/8710
-        geckoSession.loadUri(url, (parent as? GeckoEngineSession)?.geckoSession, flags.value, additionalHeaders)
+        geckoSession.loadUri(
+            url,
+            (parent as? GeckoEngineSession)?.geckoSession,
+            flags.value,
+            additionalHeaders ?: emptyMap()
+        )
     }
 
     /**

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -400,7 +400,7 @@ class GeckoEngineSessionTest {
             "http://mozilla.org",
             null as GeckoSession?,
             GeckoSession.LOAD_FLAGS_NONE,
-            null as Map<String, String>?
+            emptyMap()
         )
 
         engineSession.loadUrl("http://www.mozilla.org", flags = LoadUrlFlags.select(LoadUrlFlags.EXTERNAL))
@@ -408,7 +408,7 @@ class GeckoEngineSessionTest {
             "http://www.mozilla.org",
             null as GeckoSession?,
             GeckoSession.LOAD_FLAGS_EXTERNAL,
-            null as Map<String, String>?
+            emptyMap()
         )
 
         engineSession.loadUrl("http://www.mozilla.org", parent = parentEngineSession)
@@ -416,7 +416,7 @@ class GeckoEngineSessionTest {
             "http://www.mozilla.org",
             parentEngineSession.geckoSession,
             GeckoSession.LOAD_FLAGS_NONE,
-            null as Map<String, String>?
+            emptyMap()
         )
 
         val extraHeaders = mapOf("X-Extra-Header" to "true")
@@ -486,7 +486,7 @@ class GeckoEngineSessionTest {
             "http://mozilla.org",
             null as GeckoSession?,
             GeckoSession.LOAD_FLAGS_NONE,
-            null
+            emptyMap()
         )
 
         // Subsequent reloads should simply call reload on the gecko session.
@@ -1372,7 +1372,7 @@ class GeckoEngineSessionTest {
             "https://mozilla.org",
             null as GeckoSession?,
             GeckoSession.LOAD_FLAGS_NONE,
-            null as Map<String, String>?
+            emptyMap()
         )
     }
 
@@ -2602,7 +2602,7 @@ class GeckoEngineSessionTest {
         // loadUrl(url: String)
         engineSession.loadUrl(fakeUrl)
         verify(geckoSession).loadUri(
-            fakeUrl, null as GeckoSession?, GeckoSession.LOAD_FLAGS_NONE, null as Map<String, String>?
+            fakeUrl, null as GeckoSession?, GeckoSession.LOAD_FLAGS_NONE, emptyMap()
         )
         fakePageLoad(false)
 


### PR DESCRIPTION
GeckoView switched to a new `Loader`-based API and the old methods have been migrated under the hood to use that.
However it seems like this breaks when passing in `null` for the headers.

I filed a GeckoView bug for that:
https://bugzilla.mozilla.org/show_bug.cgi?id=1671571

I considered just switching to the new API (Issue #8710), but it's not straight-forward to write a unit test
for the `Loader`-based API. I filed another GeckoView issue for that:
https://bugzilla.mozilla.org/show_bug.cgi?id=1671578
