### PR TITLE
Closes #8724: onPageStart/Stop ignore initial loads of about:blank

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -87,6 +87,7 @@ class GeckoEngineSession(
     internal lateinit var geckoSession: GeckoSession
     internal var currentUrl: String? = null
     internal var lastLoadRequestUri: String? = null
+    internal var pageLoadingUrl: String? = null
     internal var scrollY: Int = 0
 
     internal var job: Job = Job()
@@ -599,6 +600,14 @@ class GeckoEngineSession(
             // This log statement is temporary and parsed by FNPRMS for performance measurements. It can be
             // removed once FNPRMS is replaced: https://github.com/mozilla-mobile/android-components/issues/8662
             fnprmsLogger.info("handleMessage GeckoView:PageStart uri=") // uri intentionally blank
+
+            pageLoadingUrl = url
+
+            // Ignore initial load of about:blank (see https://github.com/mozilla-mobile/android-components/issues/403)
+            if (initialLoad && url == ABOUT_BLANK) {
+                return
+            }
+
             notifyObservers {
                 onProgress(PROGRESS_START)
                 onLoadingStateChange(true)
@@ -612,6 +621,12 @@ class GeckoEngineSession(
             // by the time we reach here, any new request will come from web content.
             // If it comes from the chrome, loadUrl(url) or loadData(string) will set it to
             // false.
+
+            // Ignore initial load of about:blank (see https://github.com/mozilla-mobile/android-components/issues/403)
+            if (initialLoad && pageLoadingUrl == ABOUT_BLANK) {
+                return
+            }
+
             notifyObservers {
                 onProgress(PROGRESS_STOP)
                 onLoadingStateChange(false)

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -557,9 +557,19 @@ class GeckoEngineSessionTest {
                 geckoSessionProvider = geckoSessionProvider)
 
         var observedSecurityChange = false
+        var progressObserved = false
+        var loadingStateChangeObserved = false
         engineSession.register(object : EngineSession.Observer {
             override fun onSecurityChange(secure: Boolean, host: String?, issuer: String?) {
                 observedSecurityChange = true
+            }
+
+            override fun onProgress(progress: Int) {
+                progressObserved = true
+            }
+
+            override fun onLoadingStateChange(loading: Boolean) {
+                loadingStateChangeObserved = true
             }
         })
 
@@ -572,6 +582,22 @@ class GeckoEngineSessionTest {
         progressDelegate.value.onSecurityChange(mock(),
                 MockSecurityInformation("https://www.mozilla.org"))
         assertTrue(observedSecurityChange)
+
+        progressDelegate.value.onPageStart(mock(), "about:blank")
+        assertFalse(progressObserved)
+        assertFalse(loadingStateChangeObserved)
+
+        progressDelegate.value.onPageStop(mock(), true)
+        assertFalse(progressObserved)
+        assertFalse(loadingStateChangeObserved)
+
+        progressDelegate.value.onPageStart(mock(), "https://www.mozilla.org")
+        assertTrue(progressObserved)
+        assertTrue(loadingStateChangeObserved)
+
+        progressDelegate.value.onPageStop(mock(), true)
+        assertTrue(progressObserved)
+        assertTrue(loadingStateChangeObserved)
     }
 
     @Test


### PR DESCRIPTION
See #8724: This is the same workaround we already applied for `onLocationChange` and `onSecurityChange`. We forgot to apply for `onPageStart`/`onPageStop` meaning we get our observers invoked unnecessarily and only partially e.g. we get loading state changes, but never a url change notified. 

This can cause unneeded UI rendering and incorrect telemetry. On the incorrect telemetry part: This happens because it's possible to see two loading state changes for the same session, one for about:blank (loading=true, then loading=false), the second one for the actual session url (also loading=true, then loading=false). The session and observers "don't know" the first ones are for about:blank which we're skipping for earlier and later about:blank events. So, this is mostly keeping things consistent :). But the workaround in general is still 🙈 .