### PR TITLE
Issue #8721: Use fragment as default lifecylceowner in consumeFlow

### DIFF
--- a/components/lib/state/src/main/java/mozilla/components/lib/state/ext/Fragment.kt
+++ b/components/lib/state/src/main/java/mozilla/components/lib/state/ext/Fragment.kt
@@ -72,11 +72,12 @@ fun <S : State, A : Action> Fragment.consumeFrom(store: Store<S, A>, block: (S) 
  * and resume the [Store] subscription. With that an application can, for example, automatically
  * stop updating the UI if the application is in the background. Once the [Lifecycle] switches back
  * to at least STARTED state then the latest [State] and further will be passed to the [Flow] again.
+ * By default, the fragment itself is used as a [LifecycleOwner].
  */
 @ExperimentalCoroutinesApi // Flow
 fun <S : State, A : Action> Fragment.consumeFlow(
     from: Store<S, A>,
-    owner: LifecycleOwner? = null,
+    owner: LifecycleOwner? = this,
     block: suspend (Flow<S>) -> Unit
 ) {
     val fragment = this


### PR DESCRIPTION
This is just changing the default lifecylce owner of the `consumeFlow` so that in fragments we can write `consumeFlow(store)` instead of `consumeFlow(store, this)` as we likely always want to pause/resume with the fragment by default.