### PR TITLE
Closes #8769 mark shimmed resources as blocked

### DIFF
--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -1792,7 +1792,6 @@ class GeckoEngineTest {
         assertTrue(trackerLog.blockedCategories.contains(TrackingCategory.FINGERPRINTING))
         assertTrue(trackerLog.blockedCategories.contains(TrackingCategory.CRYPTOMINING))
         assertTrue(trackerLog.blockedCategories.contains(TrackingCategory.MOZILLA_SOCIAL))
-        assertTrue(trackerLog.blockedCategories.contains(TrackingCategory.SHIMMED))
 
         assertTrue(trackerLog.loadedCategories.contains(TrackingCategory.SCRIPTS_AND_SUB_RESOURCES))
         assertTrue(trackerLog.loadedCategories.contains(TrackingCategory.FINGERPRINTING))
@@ -1816,6 +1815,39 @@ class GeckoEngineTest {
         )
 
         assertTrue(onErrorCalled)
+    }
+
+    @Test
+    fun `shimmed content MUST be categorized as blocked`() {
+        val runtime = mock<GeckoRuntime>()
+        val engine = spy(GeckoEngine(context, runtime = runtime))
+        val mockSession = mock<GeckoEngineSession>()
+        val mockGeckoSetting = mock<GeckoRuntimeSettings>()
+        val mockGeckoContentBlockingSetting = mock<ContentBlocking.Settings>()
+        var trackersLog: List<TrackerLog>? = null
+
+        val mockContentBlockingController = mock<ContentBlockingController>()
+        val logEntriesResult = GeckoResult<List<ContentBlockingController.LogEntry>>()
+
+        val engineSetting = DefaultSettings()
+        engineSetting.trackingProtectionPolicy = TrackingProtectionPolicy.strict()
+
+        whenever(engine.settings).thenReturn(engineSetting)
+        whenever(runtime.settings).thenReturn(mockGeckoSetting)
+        whenever(mockGeckoSetting.contentBlocking).thenReturn(mockGeckoContentBlockingSetting)
+
+        whenever(runtime.contentBlockingController).thenReturn(mockContentBlockingController)
+        whenever(mockContentBlockingController.getLog(any())).thenReturn(logEntriesResult)
+
+        engine.getTrackersLog(mockSession, onSuccess = { trackersLog = it })
+
+        logEntriesResult.complete(createShimmedEntryList())
+
+        val trackerLog = trackersLog!!.first()
+        assertEquals("www.tracker.com", trackerLog.url)
+        assertTrue(trackerLog.blockedCategories.contains(TrackingCategory.SCRIPTS_AND_SUB_RESOURCES))
+        assertTrue(trackerLog.blockedCategories.contains(TrackingCategory.MOZILLA_SOCIAL))
+        assertTrue(trackerLog.loadedCategories.isEmpty())
     }
 
     @Test
@@ -1970,7 +2002,6 @@ class GeckoEngineTest {
         val blockedFingerprintingContent = createBlockingData(Event.BLOCKED_FINGERPRINTING_CONTENT)
         val blockedCyptominingContent = createBlockingData(Event.BLOCKED_CRYPTOMINING_CONTENT)
         val blockedSocialContent = createBlockingData(Event.BLOCKED_SOCIALTRACKING_CONTENT)
-        val shimmedContent = createBlockingData(Event.REPLACED_TRACKING_CONTENT)
 
         val loadedTrackingLevel1Content = createBlockingData(Event.LOADED_LEVEL_1_TRACKING_CONTENT)
         val loadedTrackingLevel2Content = createBlockingData(Event.LOADED_LEVEL_2_TRACKING_CONTENT)
@@ -1990,8 +2021,7 @@ class GeckoEngineTest {
             blockedSocialContent,
             loadedSocialContent,
             loadedCookieSocialTracker,
-            blockedCookieSocialTracker,
-            shimmedContent
+            blockedCookieSocialTracker
         )
 
         val addLogSecondEntry = object : ContentBlockingController.LogEntry() {}
@@ -2004,9 +2034,29 @@ class GeckoEngineTest {
         return listOf(addLogEntry, addLogSecondEntry)
     }
 
-    private fun createBlockingData(category: Int): ContentBlockingController.LogEntry.BlockingData {
+    private fun createShimmedEntryList(): List<ContentBlockingController.LogEntry> {
+        val addLogEntry = object : ContentBlockingController.LogEntry() {}
+
+        ReflectionUtils.setField(addLogEntry, "origin", "www.tracker.com")
+        val shimmedContent = createBlockingData(Event.REPLACED_TRACKING_CONTENT, 2)
+        val loadedTrackingLevel1Content = createBlockingData(Event.LOADED_LEVEL_1_TRACKING_CONTENT)
+        val loadedSocialContent = createBlockingData(Event.LOADED_SOCIALTRACKING_CONTENT)
+
+        val contentBlockingList = listOf(
+                loadedTrackingLevel1Content,
+                loadedSocialContent,
+                shimmedContent
+        )
+
+        ReflectionUtils.setField(addLogEntry, "blockingData", contentBlockingList)
+
+        return listOf(addLogEntry)
+    }
+
+    private fun createBlockingData(category: Int, count: Int = 0): ContentBlockingController.LogEntry.BlockingData {
         val blockingData = object : ContentBlockingController.LogEntry.BlockingData() {}
         ReflectionUtils.setField(blockingData, "category", category)
+        ReflectionUtils.setField(blockingData, "count", count)
         return blockingData
     }
 

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -364,13 +364,6 @@ abstract class EngineSession(
              */
             SCRIPTS_AND_SUB_RESOURCES(1 shl 31),
 
-            /**
-             * Indicates that content that would have been blocked has instead been replaced with a shim.
-             * This category is only used for categorization purposes ie. for checking the state of blocked content.
-             * It can not be used to actively configure a tracking protection policy.
-             */
-            SHIMMED(NONE.id),
-
             RECOMMENDED(AD.id + ANALYTICS.id + SOCIAL.id + TEST.id + MOZILLA_SOCIAL.id +
                 CRYPTOMINING.id + FINGERPRINTING.id),
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,9 @@ permalink: /changelog/
 * **browser-engine-gecko**, **browser-engine-gecko-beta**, **browser-engine-gecko-nightly**
   * Exposes GeckoView `CompositorController#ClearColor` as Setting
 
+* **concept-engine**
+  * ⚠️ Removed `TrackingCategory`.`SHIMMED`, for user usability reasons, we are going to mark SHIMMED categories as blocked, to follow the same pattern as Firefox desktop for more information see [#8769](https://github.com/mozilla-mobile/android-components/issues/8769)
+
 # 63.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v62.0.0...v63.0.0)


### PR DESCRIPTION
After talking with some members of the privacy team, they indicated us that they are not going to show they shimmed resources as a separate entries on the desktop UI, they are just going to show them in the blocked category, as it's much easier for user  and we should follow the same pattern, for this reason we are going to remove the SHIMMED category until is needed, and change the SHIMMED resources to blocked.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
