### PR TITLE
Fragment.consumeFrom(), Fragment.consumeFlow(): Use isDetached instead of isAdded.

### DIFF
--- a/components/lib/state/src/main/java/mozilla/components/lib/state/ext/Fragment.kt
+++ b/components/lib/state/src/main/java/mozilla/components/lib/state/ext/Fragment.kt
@@ -44,7 +44,7 @@ fun <S : State, A : Action> Fragment.consumeFrom(store: Store<S, A>, block: (S) 
             // without a `Context` and this can cause a variety of issues/crashes.
             // See: https://github.com/mozilla-mobile/android-components/issues/4125
             //
-            // To avoid this, we check whether the fragment is added. If it's not added then we run
+            // To avoid this, we check whether the fragment is detached. If it's detached then we run
             // in exactly that moment between fragment detach and view detach.
             // It would be better if we could use `viewLifecycleOwner` which is bound to
             // onCreateView() and onDestroyView() of the fragment. But:
@@ -54,7 +54,11 @@ fun <S : State, A : Action> Fragment.consumeFrom(store: Store<S, A>, block: (S) 
             //   See: https://github.com/mozilla-mobile/android-components/issues/3828
             // Once those two issues get resolved we can remove the `isAdded` check and use
             // `viewLifecycleOwner.lifecycleScope` instead of the view scope.
-            if (fragment.isAdded) {
+            //
+            // In a previous version we used `isAdded` here. But in certain situations it reported
+            // false even though the fragment was not detached. Therefore we switched to explicitly
+            // check with `isDetached`.
+            if (!fragment.isDetached) {
                 block(state)
             }
         }
@@ -91,7 +95,7 @@ fun <S : State, A : Action> Fragment.consumeFlow(
             .filter {
                 // We ignore state updates if the fragment is not added anymore.
                 // See comment in [consumeFrom] above.
-                fragment.isAdded
+                !fragment.isDetached
             }
 
         block(flow)

--- a/components/lib/state/src/test/java/mozilla/components/lib/state/ext/FragmentKtTest.kt
+++ b/components/lib/state/src/test/java/mozilla/components/lib/state/ext/FragmentKtTest.kt
@@ -94,7 +94,7 @@ class FragmentKtTest {
 
     @Test
     @Synchronized
-    fun `consumeFrom does not run when fragment is not added`() {
+    fun `consumeFrom does not run when fragment is detached`() {
         val fragment = mock<Fragment>()
         val view = mock<View>()
         val owner = MockedLifecycleOwner(Lifecycle.State.STARTED)
@@ -110,7 +110,7 @@ class FragmentKtTest {
         doReturn(view).`when`(fragment).view
         doReturn(owner.lifecycle).`when`(fragment).lifecycle
 
-        doReturn(true).`when`(fragment).isAdded
+        doReturn(false).`when`(fragment).isDetached
 
         fragment.consumeFrom(store) { state ->
             receivedValue = state.counter
@@ -130,7 +130,7 @@ class FragmentKtTest {
         assertTrue(latch.await(1, TimeUnit.SECONDS))
         assertEquals(25, receivedValue)
 
-        doReturn(false).`when`(fragment).isAdded
+        doReturn(true).`when`(fragment).isDetached
 
         latch = CountDownLatch(1)
         store.dispatch(TestAction.IncrementAction).joinBlocking()
@@ -142,7 +142,7 @@ class FragmentKtTest {
         assertFalse(latch.await(1, TimeUnit.SECONDS))
         assertEquals(25, receivedValue)
 
-        doReturn(true).`when`(fragment).isAdded
+        doReturn(false).`when`(fragment).isDetached
 
         latch = CountDownLatch(1)
         store.dispatch(TestAction.IncrementAction).joinBlocking()


### PR DESCRIPTION
Using consumeFlow() in Fenix I noticed that in certain situations `isAdded` returns `false` even though
the `Fragment` is not detached and we have an `Activity` context. This problem goes away when we
explicitly check with `isDetached` - which also still works around the issue why we had this check
in the first place.