### PR TITLE
Issue #8744: Set search engine type when parsing.

### DIFF
--- a/components/feature/search/src/main/java/mozilla/components/feature/search/storage/BundledSearchEnginesStorage.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/storage/BundledSearchEnginesStorage.kt
@@ -204,7 +204,7 @@ private suspend fun loadSearchEnginesFromList(
     coroutineContext: CoroutineContext
 ): List<SearchEngine> {
     val assets = context.assets
-    val reader = SearchEngineReader()
+    val reader = SearchEngineReader(type = SearchEngine.Type.BUNDLED)
 
     val deferredSearchEngines = mutableListOf<Deferred<SearchEngine>>()
 

--- a/components/feature/search/src/main/java/mozilla/components/feature/search/storage/CustomSearchEnginesStorage.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/storage/CustomSearchEnginesStorage.kt
@@ -26,7 +26,7 @@ internal class CustomSearchEngineStorage(
     private val context: Context,
     private val coroutineContext: CoroutineContext = Dispatchers.IO
 ) : SearchMiddleware.CustomStorage {
-    private val reader = SearchEngineReader()
+    private val reader = SearchEngineReader(SearchEngine.Type.CUSTOM)
     private val writer = SearchEngineWriter()
 
     override suspend fun loadSearchEngineList(): List<SearchEngine> = withContext(coroutineContext) {

--- a/components/feature/search/src/main/java/mozilla/components/feature/search/storage/SearchEngineReader.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/storage/SearchEngineReader.kt
@@ -25,9 +25,14 @@ internal const val IMAGE_URI_PREFIX = "data:image/png;base64,"
 
 /**
  * A simple XML reader for search engine plugins.
+ *
+ * @param type the [SearchEngine.Type] that the read [SearchEngine]s will get assigned.
  */
-internal class SearchEngineReader {
+internal class SearchEngineReader(
+    private val type: SearchEngine.Type
+) {
     private class SearchEngineBuilder(
+        private val type: SearchEngine.Type,
         private val identifier: String
     ) {
         var resultsUrls: MutableList<String> = mutableListOf()
@@ -39,7 +44,7 @@ internal class SearchEngineReader {
             id = identifier,
             name = name!!,
             icon = icon!!,
-            type = SearchEngine.Type.CUSTOM,
+            type = type,
             resultUrls = resultsUrls,
             suggestUrl = suggestUrl
         )
@@ -58,7 +63,7 @@ internal class SearchEngineReader {
      */
     @Throws(IOException::class, XmlPullParserException::class)
     fun loadStream(identifier: String, stream: InputStream): SearchEngine {
-        val builder = SearchEngineBuilder(identifier)
+        val builder = SearchEngineBuilder(type, identifier)
 
         val parser = XmlPullParserFactory.newInstance().newPullParser()
         parser.setInput(InputStreamReader(stream, StandardCharsets.UTF_8))

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/storage/BundledSearchEnginesStorageTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/storage/BundledSearchEnginesStorageTest.kt
@@ -19,7 +19,6 @@ import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
 class BundledSearchEnginesStorageTest {
-
     @Test
     fun `Load search engines for en-US from assets`() = runBlocking {
         val storage = BundledSearchEnginesStorage(testContext)
@@ -175,5 +174,25 @@ class BundledSearchEnginesStorageTest {
                 throw AssertionError("Search engine $identifier in list")
             }
         }
+    }
+
+    @Test
+    fun `Verify values of Google search engine`() = runBlocking {
+        val storage = BundledSearchEnginesStorage(testContext)
+
+        val engines = storage.load(RegionState("US", "US"), Locale("en", "US"))
+        val searchEngines = engines.list
+
+        assertEquals(5, searchEngines.size)
+
+        val google = searchEngines.find { it.name == "Google" }
+        assertNotNull(google!!)
+
+        assertEquals("google-b-1-m", google.id)
+        assertEquals("Google", google.name)
+        assertEquals(SearchEngine.Type.BUNDLED, google.type)
+        assertNotNull(google.icon)
+        assertEquals("https://www.google.com/complete/search?client=firefox&q={searchTerms}", google.suggestUrl)
+        assertTrue(google.resultUrls.isNotEmpty())
     }
 }

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/storage/ParseSearchPluginsTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/storage/ParseSearchPluginsTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.feature.search.storage
 
 import android.text.TextUtils
+import mozilla.components.browser.state.search.SearchEngine
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -22,7 +23,9 @@ class ParseSearchPluginsTest(private val searchEngineIdentifier: String) {
     @Throws(Exception::class)
     fun parser() {
         val stream = FileInputStream(File(basePath, searchEngineIdentifier))
-        val searchEngine = SearchEngineReader().loadStream(searchEngineIdentifier, stream)
+        val searchEngine = SearchEngineReader(type = SearchEngine.Type.BUNDLED)
+            .loadStream(searchEngineIdentifier, stream)
+
         assertEquals(searchEngineIdentifier, searchEngine.id)
 
         assertNotNull(searchEngine.name)

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/storage/SearchEngineReaderTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/storage/SearchEngineReaderTest.kt
@@ -29,7 +29,7 @@ class SearchEngineReaderTest {
 
         val storage = CustomSearchEngineStorage(testContext)
         val writer = SearchEngineWriter()
-        val reader = SearchEngineReader()
+        val reader = SearchEngineReader(type = SearchEngine.Type.CUSTOM)
         val file = storage.getSearchFile(searchEngine.id)
         writer.saveSearchEngineXML(searchEngine, file)
         val readSearchEngine = reader.loadFile(searchEngine.id, file)
@@ -48,7 +48,7 @@ class SearchEngineReaderTest {
             type = SearchEngine.Type.CUSTOM,
             resultUrls = listOf("https://www.example.com/search")
         )
-        val reader = SearchEngineReader()
+        val reader = SearchEngineReader(type = SearchEngine.Type.CUSTOM)
         val invalidFile = AtomicFile(File("", ""))
         reader.loadFile(searchEngine.id, invalidFile)
     }


### PR DESCRIPTION
During the integration into Fenix I noticed that all `SearchEngines` have type `CUSTOM`. Oops. :)