### PR TITLE
Fragment.consumeFrom()/consumeFlow(): Explicitly check for activity and view being available.

### DIFF
--- a/components/lib/state/src/main/java/mozilla/components/lib/state/ext/Fragment.kt
+++ b/components/lib/state/src/main/java/mozilla/components/lib/state/ext/Fragment.kt
@@ -44,9 +44,9 @@ fun <S : State, A : Action> Fragment.consumeFrom(store: Store<S, A>, block: (S) 
             // without a `Context` and this can cause a variety of issues/crashes.
             // See: https://github.com/mozilla-mobile/android-components/issues/4125
             //
-            // To avoid this, we check whether the fragment is detached. If it's detached then we run
-            // in exactly that moment between fragment detach and view detach.
-            // It would be better if we could use `viewLifecycleOwner` which is bound to
+            // To avoid this, we check whether the fragment still has an activity and a view
+            // attached. If not then we run in exactly that moment between fragment detach and view
+            // detach. It would be better if we could use `viewLifecycleOwner` which is bound to
             // onCreateView() and onDestroyView() of the fragment. But:
             // - `viewLifecycleOwner` is only available in alpha versions of AndroidX currently.
             // - We found a bug where `viewLifecycleOwner.lifecycleScope` is not getting cancelled
@@ -55,10 +55,10 @@ fun <S : State, A : Action> Fragment.consumeFrom(store: Store<S, A>, block: (S) 
             // Once those two issues get resolved we can remove the `isAdded` check and use
             // `viewLifecycleOwner.lifecycleScope` instead of the view scope.
             //
-            // In a previous version we used `isAdded` here. But in certain situations it reported
-            // false even though the fragment was not detached. Therefore we switched to explicitly
-            // check with `isDetached`.
-            if (!fragment.isDetached) {
+            // In a previous version we tried using `isAdded` and `isDetached` here. But in certain
+            // situations they reported true/false in situations where no activity was attached to
+            // the fragment. Therefore we switched to explicitly check for the activity and view here.
+            if (fragment.activity != null && fragment.view != null) {
                 block(state)
             }
         }
@@ -93,9 +93,10 @@ fun <S : State, A : Action> Fragment.consumeFlow(
         val flow = from
             .flow(owner)
             .filter {
-                // We ignore state updates if the fragment is not added anymore.
+                // We ignore state updates if the fragment does not have an activity or view
+                // attached anymore.
                 // See comment in [consumeFrom] above.
-                !fragment.isDetached
+                fragment.activity != null && fragment.view != null
             }
 
         block(flow)

--- a/components/lib/state/src/test/java/mozilla/components/lib/state/ext/FragmentKtTest.kt
+++ b/components/lib/state/src/test/java/mozilla/components/lib/state/ext/FragmentKtTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.lib.state.ext
 
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
@@ -50,7 +51,7 @@ class FragmentKtTest {
         var latch = CountDownLatch(1)
 
         doNothing().`when`(view).addOnAttachStateChangeListener(onAttachListener.capture())
-        doReturn(true).`when`(fragment).isAdded
+        doReturn(mock<FragmentActivity>()).`when`(fragment).activity
         doReturn(view).`when`(fragment).view
         doReturn(owner.lifecycle).`when`(fragment).lifecycle
 
@@ -107,10 +108,9 @@ class FragmentKtTest {
         var receivedValue = 0
         var latch = CountDownLatch(1)
 
+        doReturn(mock<FragmentActivity>()).`when`(fragment).activity
         doReturn(view).`when`(fragment).view
         doReturn(owner.lifecycle).`when`(fragment).lifecycle
-
-        doReturn(false).`when`(fragment).isDetached
 
         fragment.consumeFrom(store) { state ->
             receivedValue = state.counter
@@ -130,7 +130,7 @@ class FragmentKtTest {
         assertTrue(latch.await(1, TimeUnit.SECONDS))
         assertEquals(25, receivedValue)
 
-        doReturn(true).`when`(fragment).isDetached
+        doReturn(null).`when`(fragment).activity
 
         latch = CountDownLatch(1)
         store.dispatch(TestAction.IncrementAction).joinBlocking()
@@ -142,7 +142,7 @@ class FragmentKtTest {
         assertFalse(latch.await(1, TimeUnit.SECONDS))
         assertEquals(25, receivedValue)
 
-        doReturn(false).`when`(fragment).isDetached
+        doReturn(mock<FragmentActivity>()).`when`(fragment).activity
 
         latch = CountDownLatch(1)
         store.dispatch(TestAction.IncrementAction).joinBlocking()
@@ -166,7 +166,7 @@ class FragmentKtTest {
         var latch = CountDownLatch(1)
 
         doNothing().`when`(view).addOnAttachStateChangeListener(onAttachListener.capture())
-        doReturn(true).`when`(fragment).isAdded
+        doReturn(mock<FragmentActivity>()).`when`(fragment).activity
         doReturn(view).`when`(fragment).view
         doReturn(owner.lifecycle).`when`(fragment).lifecycle
 
@@ -228,7 +228,7 @@ class FragmentKtTest {
         var latch = CountDownLatch(1)
 
         doNothing().`when`(view).addOnAttachStateChangeListener(onAttachListener.capture())
-        doReturn(true).`when`(fragment).isAdded
+        doReturn(mock<FragmentActivity>()).`when`(fragment).activity
         doReturn(view).`when`(fragment).view
         doReturn(fragmentLifecycleOwner.lifecycle).`when`(fragment).lifecycle
 


### PR DESCRIPTION
Testing in Fenix right now...