### PR TITLE
Closes #8800: Allow notifications from web extensions

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegate.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegate.kt
@@ -21,6 +21,16 @@ internal class GeckoWebNotificationDelegate(
     }
 
     private fun GeckoViewWebNotification.toWebNotification(): WebNotification {
-        return WebNotification(title, tag, text, source, imageUrl, textDirection, lang, requireInteraction)
+        return WebNotification(
+            title = title,
+            tag = tag,
+            body = text,
+            sourceUrl = source,
+            iconUrl = imageUrl,
+            direction = textDirection,
+            lang = lang,
+            requireInteraction = requireInteraction,
+            triggeredByWebExtension = source == null
+        )
     }
 }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegateTest.kt
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.webnotifications
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.concept.engine.webnotifications.WebNotification
+import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
+import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.verify
+import org.mozilla.geckoview.MockWebNotification
+import org.mozilla.geckoview.WebNotification as GeckoViewWebNotification
+
+@RunWith(AndroidJUnit4::class)
+class GeckoWebNotificationDelegateTest {
+
+    @Test
+    fun `onShowNotification is forwarded to delegate`() {
+        val webNotificationDelegate: WebNotificationDelegate = mock()
+        val geckoViewWebNotification: GeckoViewWebNotification = MockWebNotification(
+            title = "title",
+            tag = "tag",
+            cookie = "cookie",
+            text = "text",
+            imageUrl = "imageUrl",
+            textDirection = "textDirection",
+            lang = "lang",
+            requireInteraction = true,
+            source = "source"
+        )
+        val geckoWebNotificationDelegate = GeckoWebNotificationDelegate(webNotificationDelegate)
+
+        val notificationCaptor = argumentCaptor<WebNotification>()
+        geckoWebNotificationDelegate.onShowNotification(geckoViewWebNotification)
+        verify(webNotificationDelegate).onShowNotification(notificationCaptor.capture())
+
+        val notification = notificationCaptor.value
+        assertEquals(notification.title, geckoViewWebNotification.title)
+        assertEquals(notification.tag, geckoViewWebNotification.tag)
+        assertEquals(notification.body, geckoViewWebNotification.text)
+        assertEquals(notification.sourceUrl, geckoViewWebNotification.source)
+        assertEquals(notification.iconUrl, geckoViewWebNotification.imageUrl)
+        assertEquals(notification.direction, geckoViewWebNotification.textDirection)
+        assertEquals(notification.lang, geckoViewWebNotification.lang)
+        assertEquals(notification.requireInteraction, geckoViewWebNotification.requireInteraction)
+        assertFalse(notification.triggeredByWebExtension)
+    }
+
+    @Test
+    fun `onCloseNotification is forwarded to delegate`() {
+        val webNotificationDelegate: WebNotificationDelegate = mock()
+        val geckoViewWebNotification: GeckoViewWebNotification = MockWebNotification(
+            title = "title",
+            tag = "tag",
+            cookie = "cookie",
+            text = "text",
+            imageUrl = "imageUrl",
+            textDirection = "textDirection",
+            lang = "lang",
+            requireInteraction = true,
+            source = "source"
+        )
+        val geckoWebNotificationDelegate = GeckoWebNotificationDelegate(webNotificationDelegate)
+
+        val notificationCaptor = argumentCaptor<WebNotification>()
+        geckoWebNotificationDelegate.onCloseNotification(geckoViewWebNotification)
+        verify(webNotificationDelegate).onCloseNotification(notificationCaptor.capture())
+
+        val notification = notificationCaptor.value
+        assertEquals(notification.title, geckoViewWebNotification.title)
+        assertEquals(notification.tag, geckoViewWebNotification.tag)
+        assertEquals(notification.body, geckoViewWebNotification.text)
+        assertEquals(notification.sourceUrl, geckoViewWebNotification.source)
+        assertEquals(notification.iconUrl, geckoViewWebNotification.imageUrl)
+        assertEquals(notification.direction, geckoViewWebNotification.textDirection)
+        assertEquals(notification.lang, geckoViewWebNotification.lang)
+        assertEquals(notification.requireInteraction, geckoViewWebNotification.requireInteraction)
+    }
+
+    @Test
+    fun `notification without a source are from web extensions`() {
+        val webNotificationDelegate: WebNotificationDelegate = mock()
+        val geckoViewWebNotification: GeckoViewWebNotification = MockWebNotification(
+            title = "title",
+            tag = "tag",
+            cookie = "cookie",
+            text = "text",
+            imageUrl = "imageUrl",
+            textDirection = "textDirection",
+            lang = "lang",
+            requireInteraction = true,
+            source = ""
+        )
+        val geckoWebNotificationDelegate = GeckoWebNotificationDelegate(webNotificationDelegate)
+
+        val notificationCaptor = argumentCaptor<WebNotification>()
+        geckoWebNotificationDelegate.onShowNotification(geckoViewWebNotification)
+        verify(webNotificationDelegate).onShowNotification(notificationCaptor.capture())
+
+        val notification = notificationCaptor.value
+        assertEquals(notification.title, geckoViewWebNotification.title)
+        assertEquals(notification.tag, geckoViewWebNotification.tag)
+        assertEquals(notification.body, geckoViewWebNotification.text)
+        assertEquals(notification.sourceUrl, geckoViewWebNotification.source)
+        assertEquals(notification.iconUrl, geckoViewWebNotification.imageUrl)
+        assertEquals(notification.direction, geckoViewWebNotification.textDirection)
+        assertEquals(notification.lang, geckoViewWebNotification.lang)
+        assertEquals(notification.requireInteraction, geckoViewWebNotification.requireInteraction)
+        assertTrue(notification.triggeredByWebExtension)
+    }
+}

--- a/components/browser/engine-gecko-nightly/src/test/java/org/mozilla/geckoview/MockWebNotification.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/org/mozilla/geckoview/MockWebNotification.kt
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.geckoview
+
+class MockWebNotification(
+    title: String,
+    tag: String,
+    cookie: String,
+    text: String,
+    imageUrl: String,
+    textDirection: String,
+    lang: String,
+    requireInteraction: Boolean,
+    source: String
+) : WebNotification(title, tag, cookie, text, imageUrl, textDirection, lang, requireInteraction, source)

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webnotifications/WebNotification.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webnotifications/WebNotification.kt
@@ -17,6 +17,8 @@ package mozilla.components.concept.engine.webnotifications
  * @property lang language of the notification.
  * @property requireInteraction Preference flag that indicates the notification should remain.
  * @property timestamp Time when the notification was created.
+ * @property triggeredByWebExtension True if this notification was triggered by a
+ * web extension, otherwise false.
  */
 data class WebNotification(
     val title: String?,
@@ -27,5 +29,6 @@ data class WebNotification(
     val direction: String?,
     val lang: String?,
     val requireInteraction: Boolean,
-    val timestamp: Long = System.currentTimeMillis()
+    val timestamp: Long = System.currentTimeMillis(),
+    val triggeredByWebExtension: Boolean = false
 )

--- a/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/WebNotificationFeatureTest.kt
+++ b/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/WebNotificationFeatureTest.kt
@@ -128,4 +128,32 @@ class WebNotificationFeatureTest {
 
         verify(notificationManager, never()).notify(eq(testNotification.tag), eq(NOTIFICATION_ID), any())
     }
+
+    @Test
+    fun `notifications always allowed for web extensions`() = runBlockingTest {
+        val webExtensionNotification = WebNotification(
+            "Mozilla",
+            "mozilla.org",
+            "Notification body",
+            "mozilla.org",
+            "https://mozilla.org/image.ico",
+            "rtl",
+            "en",
+            false,
+            triggeredByWebExtension = true
+        )
+
+        val feature = WebNotificationFeature(
+            context,
+            engine,
+            browserIcons,
+            android.R.drawable.ic_dialog_alert,
+            permissionsStorage,
+            null,
+            coroutineContext
+        )
+
+        feature.onShowNotification(webExtensionNotification)
+        verify(notificationManager).notify(eq(testNotification.tag), eq(NOTIFICATION_ID), any())
+    }
 }


### PR DESCRIPTION
Fix as described in https://github.com/mozilla-mobile/android-components/issues/8800#issue-729855680.

We didn't have any tests for `GeckoWebNotificationDelegate` 😱 . Reason is that the tests in the original PR were introduced in our engine-gecko (Release, not Nightly) module and got deleted in a subsequent merge day. I've written new tests for it now which also mock and assert the actual notification.