### PR TITLE
Issue #8744: Update search terminology.

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -975,7 +975,7 @@ sealed class SearchAction : BrowserAction() {
         val regionSearchEngines: List<SearchEngine>,
         val customSearchEngines: List<SearchEngine>,
         val hiddenSearchEngines: List<SearchEngine>,
-        val defaultSearchEngineId: String?,
+        val userSelectedSearchEngineId: String?,
         val regionDefaultSearchEngineId: String
     ) : SearchAction()
 
@@ -990,9 +990,9 @@ sealed class SearchAction : BrowserAction() {
     data class RemoveCustomSearchEngineAction(val searchEngineId: String) : SearchAction()
 
     /**
-     * Updates [BrowserState.search] to update [SearchState.defaultSearchEngineId].
+     * Updates [BrowserState.search] to update [SearchState.userSelectedSearchEngineId].
      */
-    data class SetDefaultSearchEngineAction(val searchEngineId: String) : SearchAction()
+    data class SelectSearchEngineAction(val searchEngineId: String) : SearchAction()
 
     /**
      * Shows a previously hidden, bundled search engine in [SearchState.regionSearchEngines] again

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/SearchReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/SearchReducer.kt
@@ -18,7 +18,7 @@ internal object SearchReducer {
             is SearchAction.SetRegionAction -> state.setRegion(action)
             is SearchAction.UpdateCustomSearchEngineAction -> state.updateCustomSearchEngine(action)
             is SearchAction.RemoveCustomSearchEngineAction -> state.removeSearchEngine(action)
-            is SearchAction.SetDefaultSearchEngineAction -> state.setDefaultSearchEngineAction(action)
+            is SearchAction.SelectSearchEngineAction -> state.selectSearchEngine(action)
             is SearchAction.ShowSearchEngineAction -> state.showSearchEngine(action)
             is SearchAction.HideSearchEngineAction -> state.hideSearchEngine(action)
         }
@@ -31,7 +31,7 @@ private fun BrowserState.setSearchEngines(
     return copy(search = search.copy(
         regionSearchEngines = action.regionSearchEngines,
         customSearchEngines = action.customSearchEngines,
-        defaultSearchEngineId = action.defaultSearchEngineId,
+        userSelectedSearchEngineId = action.userSelectedSearchEngineId,
         regionDefaultSearchEngineId = action.regionDefaultSearchEngineId,
         hiddenSearchEngines = action.hiddenSearchEngines,
         complete = true
@@ -71,13 +71,13 @@ private fun BrowserState.removeSearchEngine(
     ))
 }
 
-private fun BrowserState.setDefaultSearchEngineAction(
-    action: SearchAction.SetDefaultSearchEngineAction
+private fun BrowserState.selectSearchEngine(
+    action: SearchAction.SelectSearchEngineAction
 ): BrowserState {
     // We allow setting an ID of a search engine that is not in the state since loading the search
     // engines may happen asynchronously and the search engine may not be loaded yet at this point.
     return copy(search = search.copy(
-        defaultSearchEngineId = action.searchEngineId
+        userSelectedSearchEngineId = action.searchEngineId
     ))
 }
 

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/SearchState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/SearchState.kt
@@ -11,10 +11,11 @@ import mozilla.components.browser.state.search.SearchEngine
  * Value type that represents the state of search.
  *
  * @property region The region of the user.
- * @property regionSearchEngines The list of [SearchEngine]s for the "home" region of the user.
- * @property customSearchEngines The list of custom [SearchEngine]s of the user.
- * @property hiddenSearchEngines The list of [SearchEngine]s the user has explicitly hidden.
- * @property defaultSearchEngineId The ID of default [SearchEngine]
+ * @property regionSearchEngines The list of bundled [SearchEngine]s for the "home" region of the user.
+ * @property customSearchEngines The list of custom [SearchEngine]s, added by the user.
+ * @property hiddenSearchEngines The list of bundled [SearchEngine]s the user has explicitly hidden.
+ * @property userSelectedSearchEngineId The ID of the default [SearchEngine] selected by the user. Or
+ * `null` if the user hasn't made an explicit choice.
  * @property regionDefaultSearchEngineId The ID of the default [SearchEngine] of the "home" region
  * of the user.
  * @property complete Flag that indicates whether loading the list of search engines has completed.
@@ -25,7 +26,7 @@ data class SearchState(
     val regionSearchEngines: List<SearchEngine> = emptyList(),
     val customSearchEngines: List<SearchEngine> = emptyList(),
     val hiddenSearchEngines: List<SearchEngine> = emptyList(),
-    val defaultSearchEngineId: String? = null,
+    val userSelectedSearchEngineId: String? = null,
     val regionDefaultSearchEngineId: String? = null,
     val complete: Boolean = false
 )
@@ -37,13 +38,15 @@ val SearchState.searchEngines: List<SearchEngine>
     get() = (regionSearchEngines + customSearchEngines)
 
 /**
- * The default search engine of the user.
+ * The primary search engine to be used by default for searches. This will either be the user
+ * selected search engine, if the user has made an explicit choice, or the default search engine for
+ * the user's region.
  */
-val SearchState.defaultSearchEngine: SearchEngine?
+val SearchState.selectedOrDefaultSearchEngine: SearchEngine?
     get() {
         // Does the user have a default search engine set and is it in the list of available search engines?
-        if (defaultSearchEngineId != null) {
-            searchEngines.find { engine -> defaultSearchEngineId == engine.id }?.let { return it }
+        if (userSelectedSearchEngineId != null) {
+            searchEngines.find { engine -> userSelectedSearchEngineId == engine.id }?.let { return it }
         }
 
         // Do we have a default search engine for the region of the user and is it available?

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/SearchActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/SearchActionTest.kt
@@ -42,7 +42,7 @@ class SearchActionTest {
             regionSearchEngines = searchEngineList,
             regionDefaultSearchEngineId = "id2",
             customSearchEngines = emptyList(),
-            defaultSearchEngineId = null,
+            userSelectedSearchEngineId = null,
             hiddenSearchEngines = emptyList()
         )).joinBlocking()
 
@@ -76,7 +76,7 @@ class SearchActionTest {
             customSearchEngines = searchEngineList,
             regionSearchEngines = emptyList(),
             regionDefaultSearchEngineId = "default",
-            defaultSearchEngineId = null,
+            userSelectedSearchEngineId = null,
             hiddenSearchEngines = emptyList()
         )).joinBlocking()
 
@@ -167,7 +167,7 @@ class SearchActionTest {
     }
 
     @Test
-    fun `SetDefaultSearchEngineAction sets a default search engine id`() {
+    fun `SelectSearchEngineAction sets a default search engine id`() {
         val searchEngine = SearchEngine(
             id = "id1",
             name = "search1",
@@ -183,17 +183,17 @@ class SearchActionTest {
             )
         )
 
-        assertNull(store.state.search.defaultSearchEngineId)
+        assertNull(store.state.search.userSelectedSearchEngineId)
 
-        store.dispatch(SearchAction.SetDefaultSearchEngineAction(searchEngine.id)).joinBlocking()
-        assertEquals(searchEngine.id, store.state.search.defaultSearchEngineId)
+        store.dispatch(SearchAction.SelectSearchEngineAction(searchEngine.id)).joinBlocking()
+        assertEquals(searchEngine.id, store.state.search.userSelectedSearchEngineId)
 
-        assertEquals(searchEngine.id, store.state.search.defaultSearchEngineId)
+        assertEquals(searchEngine.id, store.state.search.userSelectedSearchEngineId)
 
-        store.dispatch(SearchAction.SetDefaultSearchEngineAction("unrecognized_id")).joinBlocking()
+        store.dispatch(SearchAction.SelectSearchEngineAction("unrecognized_id")).joinBlocking()
         // We allow setting an ID of a search engine that is not in the state since loading happens
         // asynchronously and the search engine may not be loaded yet.
-        assertEquals("unrecognized_id", store.state.search.defaultSearchEngineId)
+        assertEquals("unrecognized_id", store.state.search.userSelectedSearchEngineId)
     }
 
     @Test

--- a/components/feature/search/src/main/java/mozilla/components/feature/search/ext/BrowserStore.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/ext/BrowserStore.kt
@@ -8,7 +8,7 @@ import mozilla.components.browser.search.DefaultSearchEngineProvider
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.state.BrowserState
-import mozilla.components.browser.state.state.defaultSearchEngine
+import mozilla.components.browser.state.state.selectedOrDefaultSearchEngine
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.lib.state.Store
 
@@ -23,7 +23,7 @@ import mozilla.components.lib.state.Store
  */
 fun BrowserStore.toDefaultSearchEngineProvider() = object : DefaultSearchEngineProvider {
     override fun getDefaultSearchEngine(): SearchEngine? {
-        return state.search.defaultSearchEngine?.legacy()
+        return state.search.selectedOrDefaultSearchEngine?.legacy()
     }
 
     override suspend fun retrieveDefaultSearchEngine(): SearchEngine? {
@@ -36,12 +36,12 @@ fun BrowserStore.toDefaultSearchEngineProvider() = object : DefaultSearchEngineP
  * `RegionMiddleware` and `SearchMiddleware`) and invokes [block] with the default search engine
  * (or `null` if no default could be loaded).
  */
-fun BrowserStore.waitForDefaultSearchEngine(
+fun BrowserStore.waitForSelectedOrDefaultSearchEngine(
     block: (mozilla.components.browser.state.search.SearchEngine?) -> Unit
 ) {
     // Did we already load the search state? In that case we can invoke `block` immediately.
     if (state.search.complete) {
-        block(state.search.defaultSearchEngine)
+        block(state.search.selectedOrDefaultSearchEngine)
         return
     }
 
@@ -49,7 +49,7 @@ fun BrowserStore.waitForDefaultSearchEngine(
     var subscription: Store.Subscription<BrowserState, BrowserAction>? = null
     subscription = observeManually { state ->
         if (state.search.complete) {
-            block(state.search.defaultSearchEngine)
+            block(state.search.selectedOrDefaultSearchEngine)
             subscription!!.unsubscribe()
         }
     }

--- a/components/feature/search/src/main/java/mozilla/components/feature/search/middleware/SearchMiddleware.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/middleware/SearchMiddleware.kt
@@ -45,7 +45,7 @@ class SearchMiddleware(
             is SearchAction.SetRegionAction -> loadSearchEngines(context.store, action.regionState)
             is SearchAction.UpdateCustomSearchEngineAction -> saveCustomSearchEngine(action)
             is SearchAction.RemoveCustomSearchEngineAction -> removeCustomSearchEngine(action)
-            is SearchAction.SetDefaultSearchEngineAction -> updateDefaultSearchEngine(action)
+            is SearchAction.SelectSearchEngineAction -> updateSearchEngineSelection(action)
         }
 
         next(action)
@@ -61,7 +61,7 @@ class SearchMiddleware(
         region: RegionState
     ) = scope.launch {
         val regionBundle = async(ioDispatcher) { bundleStorage.load(region, coroutineContext = ioDispatcher) }
-        val defaultSearchEngineId = async(ioDispatcher) { metadataStorage.getDefaultSearchEngineId() }
+        val userSelectedSearchEngineId = async(ioDispatcher) { metadataStorage.getUserSelectedSearchEngineId() }
         val customSearchEngines = async(ioDispatcher) { customStorage.loadSearchEngineList() }
         val hiddenSearchEngineIds = async(ioDispatcher) { metadataStorage.getHiddenSearchEngines() }
 
@@ -78,7 +78,7 @@ class SearchMiddleware(
         val action = SearchAction.SetSearchEnginesAction(
             regionSearchEngines = filteredRegionSearchEngines,
             regionDefaultSearchEngineId = regionBundle.await().defaultSearchEngineId,
-            defaultSearchEngineId = defaultSearchEngineId.await(),
+            userSelectedSearchEngineId = userSelectedSearchEngineId.await(),
             customSearchEngines = customSearchEngines.await(),
             hiddenSearchEngines = hiddenSearchEngines
         )
@@ -86,10 +86,10 @@ class SearchMiddleware(
         store.dispatch(action)
     }
 
-    private fun updateDefaultSearchEngine(
-        action: SearchAction.SetDefaultSearchEngineAction
+    private fun updateSearchEngineSelection(
+        action: SearchAction.SelectSearchEngineAction
     ) = scope.launch {
-        metadataStorage.setDefaultSearchEngineId(action.searchEngineId)
+        metadataStorage.setUserSelectedSearchEngineId(action.searchEngineId)
     }
 
     private fun removeCustomSearchEngine(
@@ -164,12 +164,12 @@ class SearchMiddleware(
          * Gets the ID of the default search engine the user has picked. Returns `null` if the user
          * has not made a choice.
          */
-        suspend fun getDefaultSearchEngineId(): String?
+        suspend fun getUserSelectedSearchEngineId(): String?
 
         /**
          * Sets the ID of the default search engine the user has picked.
          */
-        suspend fun setDefaultSearchEngineId(id: String)
+        suspend fun setUserSelectedSearchEngineId(id: String)
 
         /**
          * Sets the list of IDs of hidden search engines.

--- a/components/feature/search/src/main/java/mozilla/components/feature/search/storage/SearchMetadataStorage.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/storage/SearchMetadataStorage.kt
@@ -11,7 +11,7 @@ import mozilla.components.feature.search.middleware.SearchMiddleware
 
 private const val PREFERENCE_FILE = "mozac_feature_search_metadata"
 
-private const val PREFERENCE_KEY_DEFAULT_SEARCH_ENGINE_ID = "default_search_engine"
+private const val PREFERENCE_KEY_USER_SELECTED_SEARCH_ENGINE_ID = "user_selected_search_engine"
 private const val PREFERENCE_KEY_HIDDEN_SEARCH_ENGINES = "hidden_search_engines"
 
 /**
@@ -30,16 +30,16 @@ internal class SearchMetadataStorage(
      * Gets the ID of the default search engine the user has picked. Returns `null` if the user
      * has not made a choice.
      */
-    override suspend fun getDefaultSearchEngineId(): String? {
-        return preferences.value.getString(PREFERENCE_KEY_DEFAULT_SEARCH_ENGINE_ID, null)
+    override suspend fun getUserSelectedSearchEngineId(): String? {
+        return preferences.value.getString(PREFERENCE_KEY_USER_SELECTED_SEARCH_ENGINE_ID, null)
     }
 
     /**
      * Sets the ID of the default search engine the user has picked.
      */
-    override suspend fun setDefaultSearchEngineId(id: String) {
+    override suspend fun setUserSelectedSearchEngineId(id: String) {
         preferences.value.edit()
-            .putString(PREFERENCE_KEY_DEFAULT_SEARCH_ENGINE_ID, id)
+            .putString(PREFERENCE_KEY_USER_SELECTED_SEARCH_ENGINE_ID, id)
             .apply()
     }
 

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/ext/BrowserStoreKtTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/ext/BrowserStoreKtTest.kt
@@ -32,7 +32,7 @@ class BrowserStoreKtTest {
                             type = SearchEngine.Type.BUNDLED
                         )
                     ),
-                    defaultSearchEngineId = "google",
+                    userSelectedSearchEngineId = "google",
                     complete = true
                 )
             )
@@ -40,7 +40,7 @@ class BrowserStoreKtTest {
 
         val latch = CountDownLatch(1)
 
-        store.waitForDefaultSearchEngine { searchEngine ->
+        store.waitForSelectedOrDefaultSearchEngine { searchEngine ->
             assertNotNull(searchEngine)
             assertEquals("google", searchEngine!!.id)
             latch.countDown()
@@ -55,7 +55,7 @@ class BrowserStoreKtTest {
 
         val latch = CountDownLatch(1)
 
-        store.waitForDefaultSearchEngine { searchEngine ->
+        store.waitForSelectedOrDefaultSearchEngine { searchEngine ->
             assertNotNull(searchEngine)
             assertEquals("google", searchEngine!!.id)
             latch.countDown()
@@ -70,7 +70,7 @@ class BrowserStoreKtTest {
                     type = SearchEngine.Type.BUNDLED
                 )
             ),
-            defaultSearchEngineId = null,
+            userSelectedSearchEngineId = null,
             regionDefaultSearchEngineId = "google",
             customSearchEngines = emptyList(),
             hiddenSearchEngines = emptyList()
@@ -85,14 +85,14 @@ class BrowserStoreKtTest {
 
         val latch = CountDownLatch(1)
 
-        store.waitForDefaultSearchEngine { searchEngine ->
+        store.waitForSelectedOrDefaultSearchEngine { searchEngine ->
             assertNull(searchEngine)
             latch.countDown()
         }
 
         store.dispatch(SearchAction.SetSearchEnginesAction(
             regionSearchEngines = listOf(),
-            defaultSearchEngineId = null,
+            userSelectedSearchEngineId = null,
             regionDefaultSearchEngineId = "default",
             customSearchEngines = emptyList(),
             hiddenSearchEngines = emptyList()

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/middleware/SearchMiddlewareTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/middleware/SearchMiddlewareTest.kt
@@ -110,13 +110,13 @@ class SearchMiddlewareTest {
         wait(store, dispatcher)
 
         assertTrue(store.state.search.customSearchEngines.isNotEmpty())
-        assertNull(store.state.search.defaultSearchEngineId)
+        assertNull(store.state.search.userSelectedSearchEngineId)
     }
 
     @Test
     fun `Loads default search engine ID`() {
         val storage = SearchMetadataStorage(testContext)
-        runBlocking { storage.setDefaultSearchEngineId("test-id") }
+        runBlocking { storage.setUserSelectedSearchEngineId("test-id") }
 
         val middleware = SearchMiddleware(
             testContext,
@@ -135,7 +135,7 @@ class SearchMiddlewareTest {
 
         wait(store, dispatcher)
 
-        assertEquals("test-id", store.state.search.defaultSearchEngineId)
+        assertEquals("test-id", store.state.search.userSelectedSearchEngineId)
     }
 
     @Test
@@ -157,13 +157,13 @@ class SearchMiddlewareTest {
 
             wait(store, dispatcher)
 
-            assertNull(store.state.search.defaultSearchEngineId)
+            assertNull(store.state.search.userSelectedSearchEngineId)
 
-            store.dispatch(SearchAction.SetDefaultSearchEngineAction(id)).joinBlocking()
+            store.dispatch(SearchAction.SelectSearchEngineAction(id)).joinBlocking()
 
             wait(store, dispatcher)
 
-            assertEquals(id, store.state.search.defaultSearchEngineId)
+            assertEquals(id, store.state.search.userSelectedSearchEngineId)
         }
 
         run {
@@ -180,7 +180,7 @@ class SearchMiddlewareTest {
 
             wait(store, dispatcher)
 
-            assertEquals(id, store.state.search.defaultSearchEngineId)
+            assertEquals(id, store.state.search.userSelectedSearchEngineId)
         }
     }
 


### PR DESCRIPTION
The term "default" is somewhat overloaded and can mean multiple things. With this patch I introduce the
term "selected search engine" (similar to tabs) to indicate a search engine that was explicitly selected
by the user as their default. This will hopefully make it less ambiguous.