### PR TITLE
Close #8776: Add rate-limit override to Push features

### DIFF
--- a/components/feature/accounts-push/build.gradle
+++ b/components/feature/accounts-push/build.gradle
@@ -27,6 +27,12 @@ android {
     }
 }
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach() {
+    kotlinOptions.freeCompilerArgs += [
+            "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi"
+    ]
+}
+
 dependencies {
     implementation project(':service-firefox-accounts')
     implementation project(':support-ktx')

--- a/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/AccountObserverTest.kt
+++ b/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/AccountObserverTest.kt
@@ -12,6 +12,7 @@ import mozilla.components.concept.sync.DeviceConstellation
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.feature.push.AutoPushFeature
 import mozilla.components.feature.push.AutoPushSubscription
+import mozilla.components.feature.push.PushConfig
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
@@ -40,11 +41,13 @@ class AccountObserverTest {
     private val pushScope: String = "testScope"
     private val account: OAuthAccount = mock()
     private val constellation: DeviceConstellation = mock()
+    private val config: PushConfig = mock()
 
     @Before
     fun setup() {
         `when`(accountManager.authenticatedAccount()).thenReturn(account)
         `when`(account.deviceConstellation()).thenReturn(constellation)
+        `when`(pushFeature.config).thenReturn(config)
     }
 
     @Test
@@ -107,6 +110,7 @@ class AccountObserverTest {
 
         observer.onAuthenticated(account, AuthType.Signin)
 
+        verify(pushFeature).config
         verify(pushFeature).subscribe(eq(pushScope), nullable(), any(), any())
         verify(constellation).registerDeviceObserver(any(), any(), anyBoolean())
 
@@ -139,6 +143,8 @@ class AccountObserverTest {
             mock(),
             false
         )
+
+        verify(pushFeature).config
 
         observer.onAuthenticated(account, AuthType.Existing)
 
@@ -180,8 +186,6 @@ class AccountObserverTest {
         observer.onLoggedOut()
 
         verify(pushFeature).unsubscribe(eq(pushScope), any(), any())
-
-        verifyNoMoreInteractions(pushFeature)
     }
 
     @Test
@@ -197,6 +201,7 @@ class AccountObserverTest {
         observer.onAuthenticationProblems()
         observer.onProfileUpdated(mock())
 
+        verify(pushFeature).config
         verifyNoMoreInteractions(pushFeature)
     }
 

--- a/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/ConstellationObserverTest.kt
+++ b/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/ConstellationObserverTest.kt
@@ -26,7 +26,7 @@ class ConstellationObserverTest {
 
     @Test
     fun `do nothing if subscription has not expired`() {
-        val observer = ConstellationObserver(context, push, verifier)
+        val observer = ConstellationObserver(push, verifier)
 
         observer.onDevicesUpdate(state)
 
@@ -42,7 +42,7 @@ class ConstellationObserverTest {
 
     @Test
     fun `do nothing if verifier is false`() {
-        val observer = ConstellationObserver(context, push, verifier)
+        val observer = ConstellationObserver(push, verifier)
 
         observer.onDevicesUpdate(state)
 
@@ -63,7 +63,7 @@ class ConstellationObserverTest {
 
     @Test
     fun `invoke registration renewal`() {
-        val observer = ConstellationObserver(context, push, verifier)
+        val observer = ConstellationObserver(push, verifier)
 
         `when`(state.currentDevice).thenReturn(device)
         `when`(device.subscriptionExpired).thenReturn(true)

--- a/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/FxaPushSupportFeatureTest.kt
+++ b/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/FxaPushSupportFeatureTest.kt
@@ -18,22 +18,24 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.Mockito.`when`
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class FxaPushSupportFeatureTest {
 
+    private val pushFeature: AutoPushFeature = mock()
+    private val accountManager: FxaAccountManager = mock()
+
     @Before
     fun setup() {
         preference(testContext).edit().remove(PREF_FXA_SCOPE).apply()
+        `when`(pushFeature.config).thenReturn(mock())
     }
 
     @Test
     fun `account observer registered`() {
-        val accountManager: FxaAccountManager = mock()
-        val pushFeature: AutoPushFeature = mock()
-
         FxaPushSupportFeature(testContext, accountManager, pushFeature)
 
         verify(accountManager).register(any())
@@ -42,9 +44,6 @@ class FxaPushSupportFeatureTest {
 
     @Test
     fun `feature generates and caches a scope`() {
-        val accountManager: FxaAccountManager = mock()
-        val pushFeature: AutoPushFeature = mock()
-
         FxaPushSupportFeature(testContext, accountManager, pushFeature)
 
         assertTrue(preference(testContext).contains(PREF_FXA_SCOPE))
@@ -52,9 +51,6 @@ class FxaPushSupportFeatureTest {
 
     @Test
     fun `feature does not generate a scope if one already exists`() {
-        val accountManager: FxaAccountManager = mock()
-        val pushFeature: AutoPushFeature = mock()
-
         preference(testContext).edit().putString(PREF_FXA_SCOPE, "testScope").apply()
 
         FxaPushSupportFeature(testContext, accountManager, pushFeature)
@@ -65,9 +61,6 @@ class FxaPushSupportFeatureTest {
 
     @Test
     fun `feature generates a partially predictable push scope`() {
-        val accountManager: FxaAccountManager = mock()
-        val pushFeature: AutoPushFeature = mock()
-
         FxaPushSupportFeature(testContext, accountManager, pushFeature)
 
         val cachedScope = preference(testContext).getString(PREF_FXA_SCOPE, "")

--- a/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/VerificationDelegateTest.kt
+++ b/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/VerificationDelegateTest.kt
@@ -105,6 +105,18 @@ class VerificationDelegateTest {
         assertEquals(1, lastVerifiedPref.second)
     }
 
+    @Test
+    fun `rate-limiting disabled short circuits check`() {
+        val timestamp = System.currentTimeMillis()
+        lastVerifiedPref = Pair(timestamp, 501)
+
+        val verifier = VerificationDelegate(testContext, true)
+
+        val result = verifier.allowedToRenew()
+
+        assertTrue(result)
+    }
+
     companion object {
         var lastVerifiedPref: Pair<Long, Int>
             get() {

--- a/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
@@ -63,11 +63,11 @@ import kotlin.coroutines.CoroutineContext
  * </code>
  *
  */
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("TooManyFunctions", "LargeClass", "LongParameterList")
 class AutoPushFeature(
     private val context: Context,
     private val service: PushService,
-    config: PushConfig,
+    val config: PushConfig,
     coroutineContext: CoroutineContext = Executors.newSingleThreadExecutor().asCoroutineDispatcher(),
     private val connection: PushConnection = RustPushConnection(
         senderId = config.senderId,
@@ -300,7 +300,7 @@ class AutoPushFeature(
     internal fun tryVerifySubscriptions() {
         logger.info("Trying to check validity of push subscriptions.")
 
-        if (shouldVerifyNow()) {
+        if (config.disableRateLimit || shouldVerifyNow()) {
             logger.info("Checking now..")
 
             verifyActiveSubscriptions()
@@ -412,10 +412,12 @@ data class AutoPushSubscriptionChanged(
  * @param serverHost The sync server address.
  * @param protocol The socket protocol to use when communicating with the server.
  * @param serviceType The push services that the AutoPush server supports.
+ * @param disableRateLimit A flag to disable our rate-limit logic. This is useful when debugging.
  */
 data class PushConfig(
     val senderId: String,
     val serverHost: String = "updates.push.services.mozilla.com",
     val protocol: Protocol = Protocol.HTTPS,
-    val serviceType: ServiceType = ServiceType.FCM
+    val serviceType: ServiceType = ServiceType.FCM,
+    val disableRateLimit: Boolean = false
 )

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureTest.kt
@@ -412,6 +412,25 @@ class AutoPushFeatureTest {
     }
 
     @Test
+    fun `initialize does execute verifyActiveSubscription with rate-limiting disabled`() = runBlockingTest {
+        val feature = spy(
+            AutoPushFeature(
+                context = testContext,
+                service = mock(),
+                config = PushConfig(senderId = "push-test", disableRateLimit = true),
+                coroutineContext = coroutineContext,
+                connection = mock()
+            )
+        )
+
+        lastVerified = System.currentTimeMillis() - SKIP_INTERVAL
+
+        feature.initialize()
+
+        verify(feature).verifyActiveSubscriptions()
+    }
+
+    @Test
     fun `verification always happens on first attempt`() = runBlockingTest {
         val feature = spy(
             AutoPushFeature(

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,13 @@ permalink: /changelog/
   * Adds optional `PreferredColorScheme` param to `GeckoEngineView`
   * On `GeckoView` init call `coverUntilFirstPaint()` with `PreferredColorScheme`
 
+* **feature-push**
+  * Added `disableRateLimit` to `PushConfig` to allow for easier debugging of push during development.
+  * Made `AutoPushFeature` aware of the `PushConfig.disableRateLimit` flag.
+
+* **feature-accounts-push**
+  * Made `FxaPushSupportFeature` aware of the `PushConfig.disableRateLimit` flag.
+
 # 64.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v63.0.0...v64.0.0)


### PR DESCRIPTION
When debugging push, it can be quite tedious to manually reset the
state of our DDOS protection code. Here, we introduce an override flag
into the `PushConfig` that can be used by the `PushFeature` and
`FxaPushSupportFeature`.

cc: @jrconlin

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
