### PR TITLE
Close #8775: Add logging to push verification

### DIFF
--- a/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
@@ -289,6 +289,8 @@ class AutoPushFeature(
                     subscriptionChanges.forEach { sub ->
                         notifyObservers { onSubscriptionChanged(sub.scope) }
                     }
+                } else {
+                    logger.info("No change to subscriptions. Doing nothing.")
                 }
             }
         }
@@ -296,9 +298,11 @@ class AutoPushFeature(
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun tryVerifySubscriptions() {
-        logger.info("Checking validity of push subscriptions.")
+        logger.info("Trying to check validity of push subscriptions.")
 
         if (shouldVerifyNow()) {
+            logger.info("Checking now..")
+
             verifyActiveSubscriptions()
 
             prefLastVerified = System.currentTimeMillis()
@@ -361,6 +365,8 @@ internal inline fun exceptionHandler(crossinline onError: (PushError) -> Unit) =
 
     if (isFatal) {
         onError(PushError.Rust(e, e.message.orEmpty()))
+    } else {
+        Logger.warn("Non-fatal error occurred in AutoPushFeature.", e)
     }
 }
 


### PR DESCRIPTION
Added some additional logging during the subscription verification step where we are currently doing some debugging.

Closes #8775

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
