### PR TITLE
Close #8823 allow data urls to be downloaded using the new gv download api

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -797,7 +797,7 @@ class GeckoEngineSession(
                     url = url,
                     mimeType = contentType
                 )
-                val response = webResponse.toResponse(isBlobUri = url.startsWith("blob:"))
+                val response = webResponse.toResponse()
 
                 notifyObservers {
                     onExternalResource(

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchClient.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchClient.kt
@@ -62,7 +62,7 @@ class GeckoViewFetchClient(
                 fetchFlags += GeckoWebExecutor.FETCH_FLAGS_NO_REDIRECTS
             }
             val webResponse = executor.fetch(webRequest, fetchFlags).poll(readTimeOutMillis)
-            webResponse?.toResponse(request.isBlobUri()) ?: throw IOException("Fetch failed with null response")
+            webResponse?.toResponse() ?: throw IOException("Fetch failed with null response")
         } catch (e: TimeoutException) {
             throw SocketTimeoutException()
         } catch (e: WebRequestError) {
@@ -103,11 +103,13 @@ private fun WebRequest.Builder.addBodyFrom(request: Request): WebRequest.Builder
     return this
 }
 
-internal fun WebResponse.toResponse(isBlobUri: Boolean): Response {
+internal fun WebResponse.toResponse(): Response {
+    val isBlobUri = uri.startsWith("blob:")
+    val isDataUri = uri.startsWith("data:")
     val headers = translateHeaders(this)
-    // We use the same API for blobs and HTTP requests, but blobs won't receive a status code.
+    // We use the same API for blobs,data URLs and HTTP requests, but blobs won't receive a status code.
     // If no exception is thrown we assume success.
-    val status = if (isBlobUri) SUCCESS else statusCode
+    val status = if (isBlobUri || isDataUri) SUCCESS else statusCode
     return Response(
         uri,
         status,

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
@@ -265,8 +265,13 @@ class GeckoViewFetchUnitTestCases : FetchTestCases() {
     @Test
     fun toResponseMustReturn200ForBlobUrls() {
         val builder = WebResponse.Builder("blob:https://mdn.mozillademos.org/d518464c-5075-9046-aef2-9c313214ed53").statusCode(0).build()
+        assertEquals(Response.SUCCESS, builder.toResponse().status)
+    }
 
-        assertEquals(Response.SUCCESS, builder.toResponse(isBlobUri = true).status)
+    @Test
+    fun toResponseMustReturn200ForDataUrls() {
+        val builder = WebResponse.Builder("data:,Hello%2C%20World!").statusCode(0).build()
+        assertEquals(Response.SUCCESS, builder.toResponse().status)
     }
 
     private fun mockRequest(headerMap: Map<String, String>? = null, body: String? = null, method: String = "GET") {

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -804,7 +804,7 @@ class GeckoEngineSession(
                     url = url,
                     mimeType = contentType
                 )
-                val response = webResponse.toResponse(isBlobUri = url.startsWith("blob:"))
+                val response = webResponse.toResponse()
 
                 notifyObservers {
                     onExternalResource(

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchClient.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchClient.kt
@@ -62,7 +62,7 @@ class GeckoViewFetchClient(
                 fetchFlags += GeckoWebExecutor.FETCH_FLAGS_NO_REDIRECTS
             }
             val webResponse = executor.fetch(webRequest, fetchFlags).poll(readTimeOutMillis)
-            webResponse?.toResponse(request.isBlobUri()) ?: throw IOException("Fetch failed with null response")
+            webResponse?.toResponse() ?: throw IOException("Fetch failed with null response")
         } catch (e: TimeoutException) {
             throw SocketTimeoutException()
         } catch (e: WebRequestError) {
@@ -103,11 +103,13 @@ private fun WebRequest.Builder.addBodyFrom(request: Request): WebRequest.Builder
     return this
 }
 
-internal fun WebResponse.toResponse(isBlobUri: Boolean): Response {
+internal fun WebResponse.toResponse(): Response {
+    val isDataUri = uri.startsWith("data:")
+    val isBlobUri = uri.startsWith("blob:")
     val headers = translateHeaders(this)
-    // We use the same API for blobs and HTTP requests, but blobs won't receive a status code.
+    // We use the same API for blobs, data URLs and HTTP requests, but blobs won't receive a status code.
     // If no exception is thrown we assume success.
-    val status = if (isBlobUri) SUCCESS else statusCode
+    val status = if (isBlobUri || isDataUri) SUCCESS else statusCode
     return Response(
         uri,
         status,

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
@@ -265,8 +265,13 @@ class GeckoViewFetchUnitTestCases : FetchTestCases() {
     @Test
     fun toResponseMustReturn200ForBlobUrls() {
         val builder = WebResponse.Builder("blob:https://mdn.mozillademos.org/d518464c-5075-9046-aef2-9c313214ed53").statusCode(0).build()
+        assertEquals(Response.SUCCESS, builder.toResponse().status)
+    }
 
-        assertEquals(Response.SUCCESS, builder.toResponse(isBlobUri = true).status)
+    @Test
+    fun toResponseMustReturn200ForDataUrls() {
+        val builder = WebResponse.Builder("data:,Hello%2C%20World!").statusCode(0).build()
+        assertEquals(Response.SUCCESS, builder.toResponse().status)
     }
 
     private fun mockRequest(headerMap: Map<String, String>? = null, body: String? = null, method: String = "GET") {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **feature-downloads**
+  * 🚒 Bug fixed [issue #8823](https://github.com/mozilla-mobile/android-components/issues/8823) Downloads for data URLs were failing on nightly and beta more details in the [Fenix issue](https://github.com/mozilla-mobile/fenix/issues/16228#issuecomment-717976737).
+
 # 64.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v63.0.0...v64.0.0)


### PR DESCRIPTION
When we moved to the new [GeckoView api](https://github.com/mozilla-mobile/android-components/commit/449abd4010c159fa90dddac00d4db7cfa002aecd), we gained the functionality of downloading data URLs that the [previous API didn't provided and we handled ourself](https://github.com/mozilla-mobile/android-components/blob/e0d106e217e18a4ac4b96e29182162ce212b552b/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Client.kt#L56), but we have to do some adjustments for it, as it doesn't have the same info as a HTTP request, like `response.status` or `headers`, for data URIs we have to do not do [checks for these fields](https://github.com/mozilla-mobile/android-components/blob/487ead50bcb98047e8ee7db6cf5633314b7862b0/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt#L615)   


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
