### PR TITLE
Issue #8744: Save search engine ID and name when user selects search engine.

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -1025,6 +1025,7 @@ sealed class SearchAction : BrowserAction() {
         val additionalSearchEngines: List<SearchEngine>,
         val additionalAvailableSearchEngines: List<SearchEngine>,
         val userSelectedSearchEngineId: String?,
+        val userSelectedSearchEngineName: String?,
         val regionDefaultSearchEngineId: String
     ) : SearchAction()
 
@@ -1039,9 +1040,13 @@ sealed class SearchAction : BrowserAction() {
     data class RemoveCustomSearchEngineAction(val searchEngineId: String) : SearchAction()
 
     /**
-     * Updates [BrowserState.search] to update [SearchState.userSelectedSearchEngineId].
+     * Updates [BrowserState.search] to update [SearchState.userSelectedSearchEngineId] and
+     * [SearchState.userSelectedSearchEngineName].
      */
-    data class SelectSearchEngineAction(val searchEngineId: String) : SearchAction()
+    data class SelectSearchEngineAction(
+        val searchEngineId: String,
+        val searchEngineName: String?
+    ) : SearchAction()
 
     /**
      * Shows a previously hidden, bundled search engine in [SearchState.regionSearchEngines] again

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/SearchReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/SearchReducer.kt
@@ -34,6 +34,7 @@ private fun BrowserState.setSearchEngines(
         regionSearchEngines = action.regionSearchEngines,
         customSearchEngines = action.customSearchEngines,
         userSelectedSearchEngineId = action.userSelectedSearchEngineId,
+        userSelectedSearchEngineName = action.userSelectedSearchEngineName,
         regionDefaultSearchEngineId = action.regionDefaultSearchEngineId,
         hiddenSearchEngines = action.hiddenSearchEngines,
         additionalSearchEngines = action.additionalSearchEngines,
@@ -81,7 +82,8 @@ private fun BrowserState.selectSearchEngine(
     // We allow setting an ID of a search engine that is not in the state since loading the search
     // engines may happen asynchronously and the search engine may not be loaded yet at this point.
     return copy(search = search.copy(
-        userSelectedSearchEngineId = action.searchEngineId
+        userSelectedSearchEngineId = action.searchEngineId,
+        userSelectedSearchEngineName = action.searchEngineName
     ))
 }
 

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/SearchState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/SearchState.kt
@@ -20,6 +20,8 @@ import mozilla.components.browser.state.search.SearchEngine
  * @property hiddenSearchEngines The list of bundled [SearchEngine]s the user has explicitly hidden.
  * @property userSelectedSearchEngineId The ID of the default [SearchEngine] selected by the user. Or
  * `null` if the user hasn't made an explicit choice.
+ * @property userSelectedSearchEngineName The name of the default [SearchEngine] selected by the user.
+ * Or `null` if the user hasn't made an explicit choice.
  * @property regionDefaultSearchEngineId The ID of the default [SearchEngine] of the "home" region
  * of the user.
  * @property complete Flag that indicates whether loading the list of search engines has completed.
@@ -33,6 +35,7 @@ data class SearchState(
     val additionalAvailableSearchEngines: List<SearchEngine> = emptyList(),
     val hiddenSearchEngines: List<SearchEngine> = emptyList(),
     val userSelectedSearchEngineId: String? = null,
+    val userSelectedSearchEngineName: String? = null,
     val regionDefaultSearchEngineId: String? = null,
     val complete: Boolean = false
 )
@@ -57,9 +60,15 @@ val SearchState.availableSearchEngines: List<SearchEngine>
  */
 val SearchState.selectedOrDefaultSearchEngine: SearchEngine?
     get() {
-        // Does the user have a default search engine set and is it in the list of available search engines?
+        // Does the user have a default search engine id set and is it in the list of available search engines?
         if (userSelectedSearchEngineId != null) {
             searchEngines.find { engine -> userSelectedSearchEngineId == engine.id }?.let { return it }
+        }
+
+        // Did we save a default search engine name for this user and can we find it in the list of
+        // available search engines?
+        if (userSelectedSearchEngineName != null) {
+            searchEngines.find { engine -> userSelectedSearchEngineName == engine.name }?.let { return it }
         }
 
         // Do we have a default search engine for the region of the user and is it available?

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/SearchActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/SearchActionTest.kt
@@ -43,6 +43,7 @@ class SearchActionTest {
             regionDefaultSearchEngineId = "id2",
             customSearchEngines = emptyList(),
             userSelectedSearchEngineId = null,
+            userSelectedSearchEngineName = null,
             hiddenSearchEngines = emptyList(),
             additionalSearchEngines = emptyList(),
             additionalAvailableSearchEngines = emptyList()
@@ -79,6 +80,7 @@ class SearchActionTest {
             regionSearchEngines = emptyList(),
             regionDefaultSearchEngineId = "default",
             userSelectedSearchEngineId = null,
+            userSelectedSearchEngineName = null,
             hiddenSearchEngines = emptyList(),
             additionalSearchEngines = emptyList(),
             additionalAvailableSearchEngines = emptyList()
@@ -189,12 +191,12 @@ class SearchActionTest {
 
         assertNull(store.state.search.userSelectedSearchEngineId)
 
-        store.dispatch(SearchAction.SelectSearchEngineAction(searchEngine.id)).joinBlocking()
+        store.dispatch(SearchAction.SelectSearchEngineAction(searchEngine.id, null)).joinBlocking()
         assertEquals(searchEngine.id, store.state.search.userSelectedSearchEngineId)
 
         assertEquals(searchEngine.id, store.state.search.userSelectedSearchEngineId)
 
-        store.dispatch(SearchAction.SelectSearchEngineAction("unrecognized_id")).joinBlocking()
+        store.dispatch(SearchAction.SelectSearchEngineAction("unrecognized_id", null)).joinBlocking()
         // We allow setting an ID of a search engine that is not in the state since loading happens
         // asynchronously and the search engine may not be loaded yet.
         assertEquals("unrecognized_id", store.state.search.userSelectedSearchEngineId)

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/state/SearchStateTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/state/SearchStateTest.kt
@@ -1,0 +1,230 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.state
+
+import mozilla.components.browser.state.search.RegionState
+import mozilla.components.browser.state.search.SearchEngine
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SearchStateTest {
+    @Test
+    fun `selectedOrDefaultSearchEngine - selects engine by user selected search engine id`() {
+        val state = SearchState(
+            region = RegionState("US", "US"),
+            regionSearchEngines = listOf(
+                SearchEngine("engine-a", "Engine A", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-b", "Engine B", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-c", "Engine C", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            customSearchEngines = listOf(
+                SearchEngine("engine-d", "Engine D", mock(), type = SearchEngine.Type.CUSTOM),
+                SearchEngine("engine-e", "Engine E", mock(), type = SearchEngine.Type.CUSTOM)
+            ),
+            additionalSearchEngines = listOf(
+                SearchEngine("engine-f", "Engine F", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            additionalAvailableSearchEngines = listOf(
+                SearchEngine("engine-g", "Engine G", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL),
+                SearchEngine("engine-h", "Engine H", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            hiddenSearchEngines = listOf(
+                SearchEngine("engine-i", "Engine I", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            regionDefaultSearchEngineId = "engine-b",
+            userSelectedSearchEngineId = "engine-e",
+            userSelectedSearchEngineName = "Engine H" // Purposefully using name of other engine here
+        )
+
+        val searchEngine = state.selectedOrDefaultSearchEngine
+        assertNotNull(searchEngine!!)
+        assertEquals("engine-e", searchEngine.id)
+        assertEquals("Engine E", searchEngine.name)
+    }
+
+    @Test
+    fun `selectedOrDefaultSearchEngine - selects engine by user selected search engine name`() {
+        val state = SearchState(
+            region = RegionState("US", "US"),
+            regionSearchEngines = listOf(
+                SearchEngine("engine-a", "Engine A", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-b", "Engine B", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-c", "Engine C", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            customSearchEngines = listOf(
+                SearchEngine("engine-d", "Engine D", mock(), type = SearchEngine.Type.CUSTOM),
+                SearchEngine("engine-e", "Engine E", mock(), type = SearchEngine.Type.CUSTOM)
+            ),
+            additionalSearchEngines = listOf(
+                SearchEngine("engine-f", "Engine F", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            additionalAvailableSearchEngines = listOf(
+                SearchEngine("engine-g", "Engine G", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL),
+                SearchEngine("engine-h", "Engine H", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            hiddenSearchEngines = listOf(
+                SearchEngine("engine-i", "Engine I", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            regionDefaultSearchEngineId = "engine-b",
+            userSelectedSearchEngineId = "engine-x",
+            userSelectedSearchEngineName = "Engine D"
+        )
+
+        val searchEngine = state.selectedOrDefaultSearchEngine
+        assertNotNull(searchEngine!!)
+        assertEquals("engine-d", searchEngine.id)
+        assertEquals("Engine D", searchEngine.name)
+    }
+
+    @Test
+    fun `selectedOrDefaultSearchEngine - uses region default if user has made no choice`() {
+        val state = SearchState(
+            region = RegionState("US", "US"),
+            regionSearchEngines = listOf(
+                SearchEngine("engine-a", "Engine A", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-b", "Engine B", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-c", "Engine C", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            customSearchEngines = listOf(
+                SearchEngine("engine-d", "Engine D", mock(), type = SearchEngine.Type.CUSTOM),
+                SearchEngine("engine-e", "Engine E", mock(), type = SearchEngine.Type.CUSTOM)
+            ),
+            additionalSearchEngines = listOf(
+                SearchEngine("engine-f", "Engine F", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            additionalAvailableSearchEngines = listOf(
+                SearchEngine("engine-g", "Engine G", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL),
+                SearchEngine("engine-h", "Engine H", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            hiddenSearchEngines = listOf(
+                SearchEngine("engine-i", "Engine I", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            regionDefaultSearchEngineId = "engine-b",
+            userSelectedSearchEngineId = null,
+            userSelectedSearchEngineName = null
+        )
+
+        val searchEngine = state.selectedOrDefaultSearchEngine
+        assertNotNull(searchEngine!!)
+        assertEquals("engine-b", searchEngine.id)
+        assertEquals("Engine B", searchEngine.name)
+    }
+
+    @Test
+    fun `selectedOrDefaultSearchEngine - fallback - use first region engine`() {
+        val state = SearchState(
+            region = RegionState("US", "US"),
+            regionSearchEngines = listOf(
+                SearchEngine("engine-a", "Engine A", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-b", "Engine B", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-c", "Engine C", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            customSearchEngines = listOf(
+                SearchEngine("engine-d", "Engine D", mock(), type = SearchEngine.Type.CUSTOM),
+                SearchEngine("engine-e", "Engine E", mock(), type = SearchEngine.Type.CUSTOM)
+            ),
+            additionalSearchEngines = listOf(
+                SearchEngine("engine-f", "Engine F", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            additionalAvailableSearchEngines = listOf(
+                SearchEngine("engine-g", "Engine G", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL),
+                SearchEngine("engine-h", "Engine H", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            hiddenSearchEngines = listOf(
+                SearchEngine("engine-i", "Engine I", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            regionDefaultSearchEngineId = null,
+            userSelectedSearchEngineId = null,
+            userSelectedSearchEngineName = null
+        )
+
+        val searchEngine = state.selectedOrDefaultSearchEngine
+        assertNotNull(searchEngine!!)
+        assertEquals("engine-a", searchEngine.id)
+        assertEquals("Engine A", searchEngine.name)
+    }
+
+    @Test
+    fun `selectedOrDefaultSearchEngine - is null by default`() {
+        val state = SearchState()
+        assertNull(state.selectedOrDefaultSearchEngine)
+    }
+
+    @Test
+    fun `searchEngines - combines lists`() {
+        val state = SearchState(
+            region = RegionState("US", "US"),
+            regionSearchEngines = listOf(
+                SearchEngine("engine-a", "Engine A", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-b", "Engine B", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-c", "Engine C", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            customSearchEngines = listOf(
+                SearchEngine("engine-d", "Engine D", mock(), type = SearchEngine.Type.CUSTOM),
+                SearchEngine("engine-e", "Engine E", mock(), type = SearchEngine.Type.CUSTOM)
+            ),
+            additionalSearchEngines = listOf(
+                SearchEngine("engine-f", "Engine F", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            additionalAvailableSearchEngines = listOf(
+                SearchEngine("engine-g", "Engine G", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL),
+                SearchEngine("engine-h", "Engine H", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            hiddenSearchEngines = listOf(
+                SearchEngine("engine-i", "Engine I", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            regionDefaultSearchEngineId = null,
+            userSelectedSearchEngineId = null,
+            userSelectedSearchEngineName = null
+        )
+
+        val searchEngines = state.searchEngines
+        assertEquals(6, searchEngines.size)
+        assertEquals("engine-a", searchEngines[0].id)
+        assertEquals("engine-b", searchEngines[1].id)
+        assertEquals("engine-c", searchEngines[2].id)
+        assertEquals("engine-f", searchEngines[3].id)
+        assertEquals("engine-d", searchEngines[4].id)
+        assertEquals("engine-e", searchEngines[5].id)
+    }
+
+    @Test
+    fun `availableSearchEngines - combines lists`() {
+        val state = SearchState(
+            region = RegionState("US", "US"),
+            regionSearchEngines = listOf(
+                SearchEngine("engine-a", "Engine A", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-b", "Engine B", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-c", "Engine C", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            customSearchEngines = listOf(
+                SearchEngine("engine-d", "Engine D", mock(), type = SearchEngine.Type.CUSTOM),
+                SearchEngine("engine-e", "Engine E", mock(), type = SearchEngine.Type.CUSTOM)
+            ),
+            additionalSearchEngines = listOf(
+                SearchEngine("engine-f", "Engine F", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            additionalAvailableSearchEngines = listOf(
+                SearchEngine("engine-g", "Engine G", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL),
+                SearchEngine("engine-h", "Engine H", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            hiddenSearchEngines = listOf(
+                SearchEngine("engine-i", "Engine I", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            regionDefaultSearchEngineId = null,
+            userSelectedSearchEngineId = null,
+            userSelectedSearchEngineName = null
+        )
+
+        val available = state.availableSearchEngines
+        assertEquals(3, available.size)
+        assertEquals("engine-i", available[0].id)
+        assertEquals("engine-g", available[1].id)
+        assertEquals("engine-h", available[2].id)
+    }
+}

--- a/components/feature/search/src/main/java/mozilla/components/feature/search/storage/SearchMetadataStorage.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/storage/SearchMetadataStorage.kt
@@ -11,7 +11,8 @@ import mozilla.components.feature.search.middleware.SearchMiddleware
 
 private const val PREFERENCE_FILE = "mozac_feature_search_metadata"
 
-private const val PREFERENCE_KEY_USER_SELECTED_SEARCH_ENGINE_ID = "user_selected_search_engine"
+private const val PREFERENCE_KEY_USER_SELECTED_SEARCH_ENGINE_ID = "user_selected_search_engine_id"
+private const val PREFERENCE_KEY_USER_SELECTED_SEARCH_ENGINE_NAME = "user_selected_search_engine_name"
 private const val PREFERENCE_KEY_HIDDEN_SEARCH_ENGINES = "hidden_search_engines"
 private const val PREFERENCE_KEY_ADDITIONAL_SEARCH_ENGINES = "additional_search_engines"
 
@@ -28,19 +29,26 @@ internal class SearchMetadataStorage(
     }
 ) : SearchMiddleware.MetadataStorage {
     /**
-     * Gets the ID of the default search engine the user has picked. Returns `null` if the user
-     * has not made a choice.
+     * Gets the ID (and optinally name) of the default search engine the user has picked. Returns
+     * `null` if the user has not made a choice.
      */
-    override suspend fun getUserSelectedSearchEngineId(): String? {
-        return preferences.value.getString(PREFERENCE_KEY_USER_SELECTED_SEARCH_ENGINE_ID, null)
+    override suspend fun getUserSelectedSearchEngine(): SearchMiddleware.MetadataStorage.UserChoice? {
+        val id = preferences.value.getString(PREFERENCE_KEY_USER_SELECTED_SEARCH_ENGINE_ID, null)
+            ?: return null
+
+        return SearchMiddleware.MetadataStorage.UserChoice(
+            id,
+            preferences.value.getString(PREFERENCE_KEY_USER_SELECTED_SEARCH_ENGINE_NAME, null)
+        )
     }
 
     /**
-     * Sets the ID of the default search engine the user has picked.
+     * Sets the ID (and optionally name) of the default search engine the user has picked.
      */
-    override suspend fun setUserSelectedSearchEngineId(id: String) {
+    override suspend fun setUserSelectedSearchEngine(id: String, name: String?) {
         preferences.value.edit()
             .putString(PREFERENCE_KEY_USER_SELECTED_SEARCH_ENGINE_ID, id)
+            .putString(PREFERENCE_KEY_USER_SELECTED_SEARCH_ENGINE_NAME, name)
             .apply()
     }
 

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/ext/BrowserStoreKtTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/ext/BrowserStoreKtTest.kt
@@ -71,6 +71,7 @@ class BrowserStoreKtTest {
                 )
             ),
             userSelectedSearchEngineId = null,
+            userSelectedSearchEngineName = null,
             regionDefaultSearchEngineId = "google",
             customSearchEngines = emptyList(),
             hiddenSearchEngines = emptyList(),
@@ -95,6 +96,7 @@ class BrowserStoreKtTest {
         store.dispatch(SearchAction.SetSearchEnginesAction(
             regionSearchEngines = listOf(),
             userSelectedSearchEngineId = null,
+            userSelectedSearchEngineName = null,
             regionDefaultSearchEngineId = "default",
             customSearchEngines = emptyList(),
             hiddenSearchEngines = emptyList(),


### PR DESCRIPTION
There are two reasons why we need the name in addition to the ID:
* When the user switches to a new "home" region then the previously selected search engine ID may no longer be in the
  list. However there may be a different version of that search engine with a different ID for this region. In this
  case we want to select that search engine - since for the user there's no visible difference. A famous example of
  that is "Google", which may have different IDs / search plugins depending on region.
* Fenix saves the search engine name and we need to import that.

Fenix (as well as Fennec) already used the name, so it should be safe to pick the selected search engine based on
the name of the search engine.