### PR TITLE
Revert "Closes #8660: Crash when launching PWA with open tab"

### DIFF
--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessor.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessor.kt
@@ -5,7 +5,7 @@
 package mozilla.components.feature.pwa.intent
 
 import android.content.Intent
-import android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP
+import android.content.Intent.FLAG_ACTIVITY_NEW_DOCUMENT
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.state.state.SessionState.Source
@@ -56,7 +56,7 @@ class WebAppIntentProcessor(
                 loadUrlUseCase(targetUrl, session, EngineSession.LoadUrlFlags.external())
             }
 
-            intent.flags = FLAG_ACTIVITY_CLEAR_TOP
+            intent.flags = FLAG_ACTIVITY_NEW_DOCUMENT
             intent.putSessionId(session.id)
             intent.putWebAppManifest(webAppManifest)
 

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessorTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessorTest.kt
@@ -6,7 +6,6 @@ package mozilla.components.feature.pwa.intent
 
 import android.content.Intent
 import android.content.Intent.ACTION_VIEW
-import android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP
 import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -69,7 +68,6 @@ class WebAppIntentProcessorTest {
         val intent = Intent(ACTION_VIEW_PWA, "https://mozilla.com".toUri())
         assertTrue(processor.process(intent))
         assertNotNull(intent.getSessionId())
-        assertEquals(FLAG_ACTIVITY_CLEAR_TOP, intent.flags)
         assertEquals(manifest, intent.getWebAppManifest())
     }
 


### PR DESCRIPTION
Reverts mozilla-mobile/android-components#8845, because surprisingly it doesn't work in Nightly although we verified in debug builds, plus it makes other existing problems worse.

If the last `ExternalAppBrowserActivity` is destroyed it's possible to navigate back in the PWA and land on the `HomeActivity` which allows selecting tabs 🔥 . This was also reproducible before (with don't keep activities enabled) but reproduces easily now.

Let's back it out and try again.