### PR TITLE
Close #8846: Re-subscribe FxA push subscription on subscriptionExpired 

### DIFF
--- a/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/ConstellationObserverTest.kt
+++ b/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/ConstellationObserverTest.kt
@@ -7,10 +7,24 @@
 package mozilla.components.feature.accounts.push
 
 import android.content.Context
-import mozilla.components.concept.push.PushProcessor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.setMain
+import mozilla.components.concept.base.crash.CrashReporting
 import mozilla.components.concept.sync.ConstellationState
 import mozilla.components.concept.sync.Device
+import mozilla.components.concept.sync.DeviceConstellation
+import mozilla.components.concept.sync.DevicePushSubscription
+import mozilla.components.concept.sync.OAuthAccount
+import mozilla.components.feature.push.AutoPushFeature
+import mozilla.components.feature.push.AutoPushSubscription
+import mozilla.components.support.test.any
+import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.verify
@@ -18,15 +32,26 @@ import org.mockito.Mockito.verifyZeroInteractions
 
 class ConstellationObserverTest {
 
-    private val push: PushProcessor = mock()
+    private val push: AutoPushFeature = mock()
     private val verifier: VerificationDelegate = mock()
     private val state: ConstellationState = mock()
     private val device: Device = mock()
     private val context: Context = mock()
+    private val account: OAuthAccount = mock()
+    private val crashReporter: CrashReporting = mock()
+    private val testDispatcher = TestCoroutineDispatcher()
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule(testDispatcher)
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
 
     @Test
     fun `do nothing if subscription has not expired`() {
-        val observer = ConstellationObserver(push, verifier)
+        val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
 
         observer.onDevicesUpdate(state)
 
@@ -42,7 +67,7 @@ class ConstellationObserverTest {
 
     @Test
     fun `do nothing if verifier is false`() {
-        val observer = ConstellationObserver(push, verifier)
+        val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
 
         observer.onDevicesUpdate(state)
 
@@ -62,8 +87,9 @@ class ConstellationObserverTest {
     }
 
     @Test
+    @Ignore("Disabling the test until we revert the changes from #8846 and fix #7143")
     fun `invoke registration renewal`() {
-        val observer = ConstellationObserver(push, verifier)
+        val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
 
         `when`(state.currentDevice).thenReturn(device)
         `when`(device.subscriptionExpired).thenReturn(true)
@@ -74,4 +100,50 @@ class ConstellationObserverTest {
         verify(push).renewRegistration()
         verify(verifier).increment()
     }
+
+    /**
+     * Remove this test in the future. See [invoke registration renewal] test.
+     */
+    @Test
+    fun `re-subscribe for push in onDevicesUpdate`() {
+        val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
+
+        `when`(state.currentDevice).thenReturn(device)
+        `when`(device.subscriptionExpired).thenReturn(true)
+        `when`(verifier.allowedToRenew()).thenReturn(true)
+
+        observer.onDevicesUpdate(state)
+
+        verify(push).subscribe(eq("testScope"), any(), any(), any())
+        verify(verifier).increment()
+    }
+
+    @Test
+    fun `notify crash reporter if old and new subscription matches`() {
+        val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
+        val constellation: DeviceConstellation = mock()
+        val state: ConstellationState = mock()
+        val device: Device = mock()
+        val subscription: DevicePushSubscription = mock()
+
+        `when`(account.deviceConstellation()).thenReturn(constellation)
+        `when`(state.currentDevice).thenReturn(device)
+        `when`(device.subscription).thenReturn(subscription)
+        `when`(subscription.endpoint).thenReturn("https://example.com")
+
+        observer.onSubscribe(state, testSubscription())
+
+        verify(crashReporter).submitCaughtException(any())
+    }
+
+    @Test
+    fun `notify crash reporter if re-subscribe error occurs`() {
+        val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
+
+        observer.onSubscribeError(mock())
+
+        verify(crashReporter).recordCrashBreadcrumb(any())
+    }
+
+    private fun testSubscription() = AutoPushSubscription(scope = "testScope", endpoint = "https://example.com", publicKey = "", authKey = "", appServerKey = null)
 }

--- a/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
@@ -184,18 +184,18 @@ class AutoPushFeature(
      *
      * @param scope The subscription identifier which usually represents the website's URI.
      * @param appServerKey An optional key provided by the application server.
-     * @param onSubscribeError The callback invoked if the call does not successfully complete.
+     * @param onSubscribeError The callback invoked with an [Exception] if the call does not successfully complete.
      * @param onSubscribe The callback invoked when a subscription for the [scope] is created.
      */
     fun subscribe(
         scope: String,
         appServerKey: String? = null,
-        onSubscribeError: () -> Unit = {},
+        onSubscribeError: (Exception) -> Unit = {},
         onSubscribe: ((AutoPushSubscription) -> Unit) = {}
     ) {
         connection.ifInitialized {
-            coroutineScope.launchAndTry(errorBlock = {
-                onSubscribeError()
+            coroutineScope.launchAndTry(errorBlock = { exception ->
+                onSubscribeError(exception)
             }, block = {
                 val sub = subscribe(scope, appServerKey)
                 onSubscribe(sub)
@@ -207,24 +207,24 @@ class AutoPushFeature(
      * Un-subscribes from a valid subscription and invokes the [onUnsubscribe] callback with the result.
      *
      * @param scope The subscription identifier which usually represents the website's URI.
-     * @param onUnsubscribeError The callback invoked if the call does not successfully complete.
+     * @param onUnsubscribeError The callback invoked with an [Exception] if the call does not successfully complete.
      * @param onUnsubscribe The callback invoked when a subscription for the [scope] is removed.
      */
     fun unsubscribe(
         scope: String,
-        onUnsubscribeError: () -> Unit = {},
+        onUnsubscribeError: (Exception) -> Unit = {},
         onUnsubscribe: (Boolean) -> Unit = {}
     ) {
         connection.ifInitialized {
-            coroutineScope.launchAndTry(errorBlock = {
-                onUnsubscribeError()
+            coroutineScope.launchAndTry(errorBlock = { exception ->
+                onUnsubscribeError(exception)
             }, block = {
                 val result = unsubscribe(scope)
 
                 if (result) {
                     onUnsubscribe(result)
                 } else {
-                    onUnsubscribeError()
+                    onUnsubscribeError(IllegalStateException("Un-subscribing with the native client failed."))
                 }
             })
         }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,10 @@ permalink: /changelog/
   * 🚒 Bug fixed [issue #8967](https://github.com/mozilla-mobile/android-components/issues/8967) Crash when trying to upload a file see [fenix#16537](https://github.com/mozilla-mobile/fenix/issues/16537), for more information.
   * 🚒 Bug fixed [issue #8953](https://github.com/mozilla-mobile/android-components/issues/8953) - Scroll to selected prompt choice if one exists.
 
+* **feature-accounts-push**
+  * ⚠️ `FxaPushSupportFeature` now re-subscribes to push instead of triggering the registration renewal process - this is a temporary workaround and will be removed in the future, see [#7143](https://github.com/mozilla-mobile/android-components/issues/7143).
+  * `FxaPushSupportFeature` now takes an optional crash reporter in the constructor.
+
 # 66.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v65.0.0...v66.0.0)


### PR DESCRIPTION
This is a workaround fix to re-enable Send Tab when we are notified
about the subscriptionExpired flag. Until #7143 is fixed, we need to
avoid calling `registrationRenewal` to avoid going into an unfixable
state.

In the context of the FxaPushSupportFeature, we know that our end goal
is to call `push.subscribe(fxaPushScope)`, so we can by pass the
`verifyConnection` call **assuming** that our native push client is
always has the latest push token and knows how to invalidate the
endpoint with the Autopush server.

Closes #8846

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
