### PR TITLE
Closes #8868: Prevent white flash for reader pages with dark theme

### DIFF
--- a/components/feature/readerview/src/main/assets/extensions/readerview/readerview-background.js
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/readerview-background.js
@@ -10,8 +10,11 @@ let serializedDocs = new Map();
 browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
   switch (message.action) {
      case 'show':
-       browser.tabs.update({url: `/readerview.html?url=${encodeURIComponent(message.url)}&id=${sender.contextId}`}).catch((e) => {
-         console.error("Failed to open reader view", e, e.stack);
+       let id = sender.contextId;
+       let url = encodeURIComponent(message.url);
+       let colorScheme = message.options.colorScheme;
+       browser.tabs.update({url: `/readerview.html?url=${url}&colorScheme=${colorScheme}&id=${id}`}).catch((e) => {
+           console.error("Failed to open reader view", e, e.stack);
        });
        break;
      case 'addSerializedDoc':

--- a/components/feature/readerview/src/main/assets/extensions/readerview/readerview.html
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/readerview.html
@@ -10,6 +10,4 @@
       <script src="readability/readability-0.2.0.js"></script>
       <script src="readerview.js"></script>
   </head>
-  <body>
-  </body>
 </html>

--- a/components/feature/readerview/src/main/assets/extensions/readerview/readerview.js
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/readerview.js
@@ -91,11 +91,11 @@ class ReaderView {
     let bodyClasses = document.body.classList;
 
     if (this.fontType) {
-      bodyClasses.remove(this.fontType)
+      bodyClasses.remove(this.fontType);
     }
 
-    this.fontType = fontType
-    bodyClasses.add(this.fontType)
+    this.fontType = fontType;
+    bodyClasses.add(this.fontType);
   }
 
   /**
@@ -113,11 +113,11 @@ class ReaderView {
     let bodyClasses = document.body.classList;
 
     if (this.colorScheme) {
-      bodyClasses.remove(this.colorScheme)
+      bodyClasses.remove(this.colorScheme);
     }
 
-    this.colorScheme = colorScheme
-    bodyClasses.add(this.colorScheme)
+    this.colorScheme = colorScheme;
+    bodyClasses.add(this.colorScheme);
   }
 
   /**
@@ -338,6 +338,7 @@ function getPreparedDocument(id, url) {
 
 let readerView = new ReaderView();
 connectNativePort();
+prepareBody();
 
 function connectNativePort() {
   let url = new URL(window.location.href);
@@ -390,4 +391,17 @@ function connectNativePort() {
         console.error(`Received invalid action ${message.action}`);
     }
   });
+}
+
+/**
+ * Applies the configured color scheme to the HTML body while reader view is loading. This is to
+ * prevent "flashes" caused by having to change the color later.
+ */
+function prepareBody() {
+  let url = new URL(window.location.href);
+  let colorScheme = decodeURIComponent(url.searchParams.get("colorScheme"));
+  let body = document.createElement("body");
+  body.classList.add("mozac-readerview-body");
+  body.classList.add(colorScheme);
+  document.body = body;
 }

--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
@@ -216,8 +216,17 @@ class ReaderViewFeature(
 
     private fun ensureExtensionInstalled() {
         val feature = WeakReference(this)
+        val store = WeakReference(store)
         extensionController.install(engine, onSuccess = {
+            // In case the extension was installed while an extension page was
+            // displayed (if on startup we opened directly into a
+            // restored reader view page), we have to reload the extension page,
+            // as we may have missed to connect the port.
             feature.get()?.connectReaderViewContentScript()
+            val selectedTab = store.get()?.state?.selectedTab
+            if (selectedTab?.readerState?.active == true) {
+                selectedTab.engineState.engineSession?.reload()
+            }
         })
     }
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -34,6 +34,7 @@ import mozilla.components.browser.thumbnails.storage.ThumbnailStorage
 import mozilla.components.concept.base.crash.Breadcrumb
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.addons.AddonManager
 import mozilla.components.feature.addons.amo.AddonCollectionProvider
@@ -103,6 +104,7 @@ open class DefaultComponents(private val applicationContext: Context) {
             requestInterceptor = SampleRequestInterceptor(applicationContext)
             remoteDebuggingEnabled = true
             supportMultipleWindows = true
+            preferredColorScheme = PreferredColorScheme.Dark
         }
     }
 


### PR DESCRIPTION
Basically just making sure we set the configure background color on the otherwise empty body right away to prevent the white flash.

I've also resurrected a workaround for initial load I seem to have dropped by mistake in a previous change.