### PR TITLE
For #8893 - Add a new partial bind method to TabViewHolder

### DIFF
--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsAdapter.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsAdapter.kt
@@ -49,7 +49,28 @@ open class TabsAdapter(
     override fun onBindViewHolder(holder: TabViewHolder, position: Int) {
         val tabs = tabs ?: return
 
-        holder.bind(tabs.list[position], position == tabs.selectedIndex, styling, this)
+        holder.bind(tabs.list[position], isTabSelected(tabs, position), styling, this)
+    }
+
+    override fun onBindViewHolder(
+        holder: TabViewHolder,
+        position: Int,
+        payloads: List<Any>
+    ) {
+        tabs?.let { tabs ->
+            if (tabs.list.isEmpty()) return
+
+            if (payloads.isEmpty()) {
+                onBindViewHolder(holder, position)
+                return
+            }
+
+            if (payloads.contains(PAYLOAD_HIGHLIGHT_SELECTED_ITEM) && position == tabs.selectedIndex) {
+                holder.updateSelectedTabIndicator(true)
+            } else if (payloads.contains(PAYLOAD_DONT_HIGHLIGHT_SELECTED_ITEM) && position == tabs.selectedIndex) {
+                holder.updateSelectedTabIndicator(false)
+            }
+        }
     }
 
     override fun updateTabs(tabs: Tabs) {
@@ -65,4 +86,22 @@ open class TabsAdapter(
     override fun onTabsMoved(fromPosition: Int, toPosition: Int) = notifyItemMoved(fromPosition, toPosition)
 
     override fun onTabsChanged(position: Int, count: Int) = notifyItemRangeChanged(position, count)
+
+    override fun isTabSelected(tabs: Tabs, position: Int) = tabs.selectedIndex == position
+
+    companion object {
+        /**
+         * Payload used in onBindViewHolder for a partial update of the current view.
+         *
+         * Signals that the currently selected tab should be highlighted. This is the default behavior.
+         */
+        val PAYLOAD_HIGHLIGHT_SELECTED_ITEM: Int = R.id.payload_highlight_selected_item
+
+        /**
+         * Payload used in onBindViewHolder for a partial update of the current view.
+         *
+         * Signals that the currently selected tab should NOT be highlighted. No tabs would appear as highlighted.
+         */
+        val PAYLOAD_DONT_HIGHLIGHT_SELECTED_ITEM: Int = R.id.payload_dont_highlight_selected_item
+    }
 }

--- a/components/browser/tabstray/src/main/res/values/ids.xml
+++ b/components/browser/tabstray/src/main/res/values/ids.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <item name="payload_highlight_selected_item" type="id"/>
+    <item name="payload_dont_highlight_selected_item" type="id"/>
+</resources>

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/DefaultTabViewHolderTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/DefaultTabViewHolderTest.kt
@@ -4,27 +4,32 @@
 
 package mozilla.components.browser.tabstray
 
+import android.content.res.ColorStateList
 import android.graphics.Bitmap
+import android.graphics.drawable.ColorDrawable
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.concept.base.images.ImageLoadRequest
+import mozilla.components.concept.base.images.ImageLoader
 import mozilla.components.concept.tabstray.Tab
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.support.base.observer.ObserverRegistry
-import mozilla.components.concept.base.images.ImageLoadRequest
-import mozilla.components.concept.base.images.ImageLoader
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.nullable
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
@@ -181,5 +186,78 @@ class DefaultTabViewHolderTest {
         viewHolder.bind(tab, false, mock(), mock())
 
         assertEquals(drawable, thumbnailView.drawable)
+    }
+
+    @Test
+    fun `bind sets the values for this instance's Tab and TabsTrayStyling properties`() {
+        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
+        val viewHolder = DefaultTabViewHolder(view)
+        val tab = Tab("123", "https://example.com")
+        val styling: TabsTrayStyling = mock()
+
+        assertNull(viewHolder.tab)
+        assertNull(viewHolder.styling)
+
+        viewHolder.bind(tab, false, styling, mock())
+
+        assertSame(tab, viewHolder.tab)
+        assertSame(styling, viewHolder.styling)
+    }
+
+    @Test
+    fun `bind shows an item as selected or not`() {
+        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
+        val tab = Tab("123", "https://example.com")
+        val viewHolder = spy(DefaultTabViewHolder(view))
+
+        viewHolder.bind(tab, false, mock(), mock())
+        verify(viewHolder).updateSelectedTabIndicator(false)
+
+        viewHolder.bind(tab, true, mock(), mock())
+        verify(viewHolder).updateSelectedTabIndicator(true)
+    }
+
+    @Test
+    fun `updateSelectedTabIndicator should further delegate to the appropriate method`() {
+        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
+        val viewHolder = spy(DefaultTabViewHolder(view))
+
+        viewHolder.updateSelectedTabIndicator(showAsSelected = true)
+        verify(viewHolder).showItemAsSelected()
+
+        viewHolder.updateSelectedTabIndicator(showAsSelected = false)
+        verify(viewHolder).showItemAsNotSelected()
+    }
+
+    @Test
+    fun `showItemAsSelected should use TabsTrayStyling for indicating that an item is currently selected`() {
+        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
+        val viewHolder = spy(DefaultTabViewHolder(view))
+        val tab = Tab("123", "https://example.com")
+        val styling = TabsTrayStyling()
+
+        // Need to be called first to set the styling for this holder
+        viewHolder.bind(tab, false, TabsTrayStyling(), mock())
+        viewHolder.updateSelectedTabIndicator(true)
+
+        assertEquals(styling.selectedItemTextColor, viewHolder.titleView.textColors.defaultColor)
+        assertEquals(styling.selectedItemBackgroundColor, (viewHolder.itemView.background as ColorDrawable).color)
+        assertEquals(ColorStateList.valueOf(styling.selectedItemTextColor), viewHolder.closeView.imageTintList)
+    }
+
+    @Test
+    fun `showItemAsSelected should use TabsTrayStyling for indicating that an item is not currently selected`() {
+        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
+        val viewHolder = spy(DefaultTabViewHolder(view))
+        val tab = Tab("123", "https://example.com")
+        val styling = TabsTrayStyling()
+
+        // Need to be called first to set the styling for this holder
+        viewHolder.bind(tab, true, TabsTrayStyling(), mock())
+        viewHolder.updateSelectedTabIndicator(false)
+
+        assertEquals(styling.itemTextColor, viewHolder.titleView.textColors.defaultColor)
+        assertEquals(styling.itemBackgroundColor, (viewHolder.itemView.background as ColorDrawable).color)
+        assertEquals(ColorStateList.valueOf(styling.itemTextColor), viewHolder.closeView.imageTintList)
     }
 }

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabViewHolderTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabViewHolderTest.kt
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.tabstray
+
+import android.view.View
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import junit.framework.TestCase
+import mozilla.components.concept.tabstray.Tab
+import mozilla.components.concept.tabstray.TabsTray
+import mozilla.components.support.base.observer.Observable
+import mozilla.components.support.test.expectException
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TabViewHolderTest : TestCase() {
+
+    @Test
+    fun `updateSelectedTabIndicator needs to have a provided implementation`() {
+        val simpleTabViewHolder = object : TabViewHolder(View(testContext)) {
+            override var tab: Tab? = null
+            override fun bind(
+                tab: Tab,
+                isSelected: Boolean,
+                styling: TabsTrayStyling,
+                observable: Observable<TabsTray.Observer>
+            ) { /* noop */ }
+        }
+
+        expectException(UnsupportedOperationException::class) {
+            simpleTabViewHolder.updateSelectedTabIndicator(true)
+        }
+    }
+
+    @Test
+    fun `updateSelectedTabIndicator with a provided implementation just works`() {
+        val tabViewHolder = object : TabViewHolder(View(testContext)) {
+            override var tab: Tab? = null
+            override fun bind(
+                tab: Tab,
+                isSelected: Boolean,
+                styling: TabsTrayStyling,
+                observable: Observable<TabsTray.Observer>
+            ) { /* noop */ }
+            override fun updateSelectedTabIndicator(showAsSelected: Boolean) { /* noop */ }
+        }
+
+        // Simply test that this would not fail the test like it would happen above.
+        tabViewHolder.updateSelectedTabIndicator(true)
+    }
+}

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabsAdapterTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabsAdapterTest.kt
@@ -7,6 +7,8 @@ package mozilla.components.browser.tabstray
 import android.view.View
 import android.widget.FrameLayout
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.tabstray.TabsAdapter.Companion.PAYLOAD_DONT_HIGHLIGHT_SELECTED_ITEM
+import mozilla.components.browser.tabstray.TabsAdapter.Companion.PAYLOAD_HIGHLIGHT_SELECTED_ITEM
 import mozilla.components.concept.tabstray.Tab
 import mozilla.components.concept.tabstray.Tabs
 import mozilla.components.concept.tabstray.TabsTray
@@ -17,6 +19,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
@@ -28,6 +32,8 @@ private class TestTabViewHolder(view: View) : TabViewHolder(view) {
         styling: TabsTrayStyling,
         observable: Observable<TabsTray.Observer>
     ) { /* noop */ }
+
+    override fun updateSelectedTabIndicator(showAsSelected: Boolean) { /* noop */ }
 }
 
 @RunWith(AndroidJUnit4::class)
@@ -134,5 +140,63 @@ class TabsAdapterTest {
         )
 
         verify(observer).onTabsUpdated()
+    }
+
+    @Test
+    fun `onBindViewHolder will use payloads to indicate if this item is selected`() {
+        val adapter = TabsAdapter()
+        val holder = spy(TestTabViewHolder(View(testContext)))
+        adapter.updateTabs(Tabs(listOf(mock(), mock()), selectedIndex = 1))
+
+        adapter.onBindViewHolder(holder, 0, listOf(PAYLOAD_HIGHLIGHT_SELECTED_ITEM))
+        verify(holder, never()).updateSelectedTabIndicator(ArgumentMatchers.anyBoolean())
+
+        adapter.onBindViewHolder(holder, 1, listOf(PAYLOAD_HIGHLIGHT_SELECTED_ITEM))
+        verify(holder).updateSelectedTabIndicator(true)
+    }
+
+    @Test
+    fun `onBindViewHolder will use payloads to indicate if this item is not selected`() {
+        val adapter = TabsAdapter()
+        val holder = spy(TestTabViewHolder(View(testContext)))
+        adapter.updateTabs(Tabs(listOf(mock(), mock()), selectedIndex = 1))
+
+        adapter.onBindViewHolder(holder, 0, listOf(PAYLOAD_DONT_HIGHLIGHT_SELECTED_ITEM))
+        verify(holder, never()).updateSelectedTabIndicator(ArgumentMatchers.anyBoolean())
+
+        adapter.onBindViewHolder(holder, 1, listOf(PAYLOAD_DONT_HIGHLIGHT_SELECTED_ITEM))
+        verify(holder).updateSelectedTabIndicator(false)
+    }
+
+    @Test
+    fun `onBindViewHolder with payloads will return early if there are currently no open tabs`() {
+        val adapter = TabsAdapter()
+        val holder = TestTabViewHolder(View(testContext))
+        val payloads = spy(arrayListOf(PAYLOAD_DONT_HIGHLIGHT_SELECTED_ITEM))
+
+        adapter.onBindViewHolder(holder, 0, payloads)
+        // verify that calls we expect further down are not happening after the null check
+        verify(payloads, never()).isEmpty()
+        verify(payloads, never()).contains(ArgumentMatchers.anyInt())
+
+        adapter.updateTabs(Tabs(emptyList(), selectedIndex = 0))
+        adapter.onBindViewHolder(holder, 0, payloads)
+        // verify that calls we expect further down are not happening after the null check
+        verify(payloads, never()).isEmpty()
+        verify(payloads, never()).contains(ArgumentMatchers.anyInt())
+    }
+
+    @Test
+    fun `onBindViewHolder with empty payloads will call onBindViewHolder and return early for a full bind`() {
+        val adapter = TabsAdapter()
+        val holder = TestTabViewHolder(View(testContext))
+        val emptyPayloads = spy(arrayListOf<String>())
+        adapter.updateTabs(Tabs(listOf(mock()), selectedIndex = 0))
+
+        adapter.onBindViewHolder(holder, 0, emptyPayloads)
+
+        verify(emptyPayloads).isEmpty()
+        // verify that calls we expect further down are not happening after the isEmpty check
+        verify(emptyPayloads, never()).contains(ArgumentMatchers.anyString())
     }
 }

--- a/components/concept/tabstray/src/main/java/mozilla/components/concept/tabstray/TabsTray.kt
+++ b/components/concept/tabstray/src/main/java/mozilla/components/concept/tabstray/TabsTray.kt
@@ -64,6 +64,11 @@ interface TabsTray : Observable<TabsTray.Observer> {
     fun onTabsChanged(position: Int, count: Int)
 
     /**
+     * Called when binding a new item to get if it should be shown as selected or not.
+     */
+    fun isTabSelected(tabs: Tabs, position: Int): Boolean
+
+    /**
      * Convenience method to cast the implementation of this interface to an Android View object.
      */
     fun asView(): View = this as View

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
@@ -478,4 +478,6 @@ private class MockedTabsTray : TabsTray {
     override fun pauseObserver(observer: TabsTray.Observer) {}
 
     override fun resumeObserver(observer: TabsTray.Observer) {}
+
+    override fun isTabSelected(tabs: Tabs, position: Int): Boolean = false
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,12 @@ permalink: /changelog/
 * **browser-thumbnail**
   * Catch `IOException` that may be thrown when deleting thumbnails.
 
+* **browser-tabstray**
+  * ⚠️ **This is a breaking change**: Support temporary hiding if a tab is selected. For this you should use partial bindings with PAYLOAD_(DONT_)HIGHLIGHT_SELECTED_ITEM; override TabsAdapter#isTabSelected for new item bindings; override TabViewHolder#updateSelectedTabIndicator.
+
+* **concept-tabstray**:
+  * ⚠️ **This is a breaking change**: A new method - `isTabSelected` was added that exposes to clients an easy way to change what a "selected" tab means.
+
 # 68.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v67.0.0...v68.0.0)


### PR DESCRIPTION
This new method allows temporarily suppressing the 'selected tab' decoration
and then re-enable the default behavior.

The result of using this on Fenix:
![selectAndCheck](https://user-images.githubusercontent.com/11428869/99394529-b38f4700-28e7-11eb-8784-8d2da2e6df98.gif)
[video](https://drive.google.com/file/d/1HAAG-Bn1qpbOlp0vHzH2QjZvnLzN2g4n/view?usp=sharing)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR does not include any a11y user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
