### PR TITLE
Issue #8744: Add additional search use cases.

### DIFF
--- a/components/feature/intent/src/test/java/mozilla/components/feature/intent/processing/TabIntentProcessorTest.kt
+++ b/components/feature/intent/src/test/java/mozilla/components/feature/intent/processing/TabIntentProcessorTest.kt
@@ -50,7 +50,6 @@ class TabIntentProcessorTest {
     private val sessionUseCases = SessionUseCases(store, sessionManager)
     private val searchEngineManager = mock<SearchEngineManager>()
     private val searchUseCases = SearchUseCases(
-        testContext,
         store,
         searchEngineManager.toDefaultSearchEngineProvider(testContext),
         sessionManager
@@ -262,7 +261,6 @@ class TabIntentProcessorTest {
         val sessionManager = spy(SessionManager(engine))
 
         val searchUseCases = SearchUseCases(
-            testContext,
             store,
             searchEngineManager.toDefaultSearchEngineProvider(testContext),
             sessionManager
@@ -338,7 +336,6 @@ class TabIntentProcessorTest {
         val sessionManager = spy(SessionManager(engine))
 
         val searchUseCases = SearchUseCases(
-            testContext,
             store,
             searchEngineManager.toDefaultSearchEngineProvider(testContext),
             sessionManager
@@ -402,7 +399,6 @@ class TabIntentProcessorTest {
         val sessionManager = spy(SessionManager(engine))
 
         val searchUseCases = SearchUseCases(
-            testContext,
             store,
             searchEngineManager.toDefaultSearchEngineProvider(testContext),
             sessionManager

--- a/components/feature/search/src/main/java/mozilla/components/feature/search/ext/SearchEngine.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/ext/SearchEngine.kt
@@ -4,8 +4,11 @@
 
 package mozilla.components.feature.search.ext
 
+import android.graphics.Bitmap
 import android.net.Uri
 import mozilla.components.browser.state.search.SearchEngine
+import java.lang.IllegalArgumentException
+import java.util.UUID
 
 /**
  * Converts a [SearchEngine] (from `browser-state`) to the legacy `SearchEngine` type from
@@ -24,3 +27,24 @@ fun SearchEngine.legacy() = mozilla.components.browser.search.SearchEngine(
     resultsUris = resultUrls.map { Uri.parse(it) },
     suggestUri = suggestUrl?.let { Uri.parse(it) }
 )
+
+/**
+ * Creates a custom [SearchEngine].
+ */
+fun createSearchEngine(
+    name: String,
+    url: String,
+    icon: Bitmap
+): SearchEngine {
+    if (!url.contains("{searchTerms}")) {
+        throw IllegalArgumentException("URL does not contain search terms placeholder")
+    }
+
+    return SearchEngine(
+        id = UUID.randomUUID().toString(),
+        name = name,
+        icon = icon,
+        type = SearchEngine.Type.CUSTOM,
+        resultUrls = listOf(url)
+    )
+}

--- a/components/feature/search/src/main/java/mozilla/components/feature/search/storage/SearchEngineWriter.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/storage/SearchEngineWriter.kt
@@ -81,8 +81,7 @@ internal class SearchEngineWriter {
         searchEngine.resultUrls.forEach { url ->
             val urlElement = xmlDocument.createElement("Url")
             urlElement.setAttribute("type", URL_TYPE_SEARCH_HTML)
-            val templateSearchString = url.replace("%s", "{searchTerms}")
-            urlElement.setAttribute("template", templateSearchString)
+            urlElement.setAttribute("template", url)
             rootElement.appendChild(urlElement)
         }
 

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/SearchUseCasesTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/SearchUseCasesTest.kt
@@ -5,7 +5,7 @@
 package mozilla.components.feature.search
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.browser.search.SearchEngine
+import mozilla.components.browser.search.SearchEngine as LegacySearchEngine
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
@@ -13,13 +13,22 @@ import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.search.ext.toDefaultSearchEngineProvider
+import mozilla.components.browser.state.search.RegionState
+import mozilla.components.browser.state.search.SearchEngine
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.SearchState
+import mozilla.components.browser.state.state.availableSearchEngines
+import mozilla.components.browser.state.state.searchEngines
+import mozilla.components.feature.search.ext.createSearchEngine
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.eq
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -29,7 +38,7 @@ import org.mockito.Mockito.verify
 @RunWith(AndroidJUnit4::class)
 class SearchUseCasesTest {
 
-    private lateinit var searchEngine: SearchEngine
+    private lateinit var searchEngine: LegacySearchEngine
     private lateinit var searchEngineManager: SearchEngineManager
     private lateinit var sessionManager: SessionManager
     private lateinit var store: BrowserStore
@@ -42,7 +51,6 @@ class SearchUseCasesTest {
         sessionManager = mock()
         store = mock()
         useCases = SearchUseCases(
-            testContext,
             store,
             searchEngineManager.toDefaultSearchEngineProvider(testContext),
             sessionManager
@@ -89,7 +97,6 @@ class SearchUseCasesTest {
         var sessionCreatedForUrl: String? = null
 
         val searchUseCases = SearchUseCases(
-            testContext,
             store,
             searchEngineManager.toDefaultSearchEngineProvider(testContext),
             sessionManager
@@ -140,4 +147,364 @@ class SearchUseCasesTest {
         verify(store).dispatch(actionCaptor.capture())
         assertEquals(searchUrl, actionCaptor.value.url)
     }
+
+    @Test
+    fun `Selecting search engine`() {
+        val store = BrowserStore(BrowserState(search = SearchState(
+            region = RegionState("US", "US"),
+            regionSearchEngines = listOf(
+                SearchEngine("engine-a", "Engine A", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-b", "Engine B", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-c", "Engine C", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            customSearchEngines = listOf(
+                SearchEngine("engine-d", "Engine D", mock(), type = SearchEngine.Type.CUSTOM),
+                SearchEngine("engine-e", "Engine E", mock(), type = SearchEngine.Type.CUSTOM)
+            ),
+            additionalSearchEngines = listOf(
+                SearchEngine("engine-f", "Engine F", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            additionalAvailableSearchEngines = listOf(
+                SearchEngine("engine-g", "Engine G", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL),
+                SearchEngine("engine-h", "Engine H", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            hiddenSearchEngines = listOf(
+                SearchEngine("engine-i", "Engine I", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            regionDefaultSearchEngineId = "engine-b",
+            userSelectedSearchEngineId = null,
+            userSelectedSearchEngineName = null
+        )))
+
+        val useCases = SearchUseCases(store, mock(), mock())
+
+        useCases.selectSearchEngine.invoke(
+            store.findSearchEngineById("engine-d")
+        )
+
+        store.waitUntilIdle()
+
+        assertEquals("engine-d", store.state.search.userSelectedSearchEngineId)
+        assertNull(store.state.search.userSelectedSearchEngineName)
+
+        useCases.selectSearchEngine.invoke(
+            store.findSearchEngineById("engine-b")
+        )
+
+        store.waitUntilIdle()
+
+        assertEquals("engine-b", store.state.search.userSelectedSearchEngineId)
+        assertEquals("Engine B", store.state.search.userSelectedSearchEngineName)
+
+        useCases.selectSearchEngine.invoke(
+            store.findSearchEngineById("engine-f")
+        )
+
+        store.waitUntilIdle()
+
+        assertEquals("engine-f", store.state.search.userSelectedSearchEngineId)
+        assertNull(store.state.search.userSelectedSearchEngineName)
+    }
+
+    @Test
+    fun `addSearchEngine - add bundled engine`() {
+        val store = BrowserStore(BrowserState(search = SearchState(
+            region = RegionState("US", "US"),
+            regionSearchEngines = listOf(
+                SearchEngine("engine-a", "Engine A", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-b", "Engine B", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-c", "Engine C", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            customSearchEngines = listOf(
+                SearchEngine("engine-d", "Engine D", mock(), type = SearchEngine.Type.CUSTOM),
+                SearchEngine("engine-e", "Engine E", mock(), type = SearchEngine.Type.CUSTOM)
+            ),
+            additionalSearchEngines = listOf(
+                SearchEngine("engine-f", "Engine F", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            additionalAvailableSearchEngines = listOf(
+                SearchEngine("engine-g", "Engine G", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL),
+                SearchEngine("engine-h", "Engine H", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            hiddenSearchEngines = listOf(
+                SearchEngine("engine-i", "Engine I", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            regionDefaultSearchEngineId = "engine-b",
+            userSelectedSearchEngineId = null,
+            userSelectedSearchEngineName = null
+        )))
+
+        val useCases = SearchUseCases(store, mock(), mock())
+
+        assertEquals(6, store.state.search.searchEngines.size)
+        assertEquals(3, store.state.search.availableSearchEngines.size)
+
+        useCases.addSearchEngine.invoke(
+            store.findSearchEngineById("engine-i")
+        )
+
+        store.waitUntilIdle()
+
+        assertEquals(7, store.state.search.searchEngines.size)
+        assertEquals(2, store.state.search.availableSearchEngines.size)
+
+        assertEquals(4, store.state.search.regionSearchEngines.size)
+        assertEquals(0, store.state.search.hiddenSearchEngines.size)
+
+        assertEquals("engine-i", store.state.search.regionSearchEngines[3].id)
+        assertEquals("Engine I", store.state.search.regionSearchEngines[3].name)
+    }
+
+    @Test
+    fun `addSearchEngine - add additional bundled engine`() {
+        val store = BrowserStore(BrowserState(search = SearchState(
+            region = RegionState("US", "US"),
+            regionSearchEngines = listOf(
+                SearchEngine("engine-a", "Engine A", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-b", "Engine B", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-c", "Engine C", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            customSearchEngines = listOf(
+                SearchEngine("engine-d", "Engine D", mock(), type = SearchEngine.Type.CUSTOM),
+                SearchEngine("engine-e", "Engine E", mock(), type = SearchEngine.Type.CUSTOM)
+            ),
+            additionalSearchEngines = listOf(
+                SearchEngine("engine-f", "Engine F", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            additionalAvailableSearchEngines = listOf(
+                SearchEngine("engine-g", "Engine G", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL),
+                SearchEngine("engine-h", "Engine H", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            hiddenSearchEngines = listOf(
+                SearchEngine("engine-i", "Engine I", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            regionDefaultSearchEngineId = "engine-b",
+            userSelectedSearchEngineId = null,
+            userSelectedSearchEngineName = null
+        )))
+
+        val useCases = SearchUseCases(store, mock(), mock())
+
+        assertEquals(6, store.state.search.searchEngines.size)
+        assertEquals(3, store.state.search.availableSearchEngines.size)
+
+        useCases.addSearchEngine.invoke(
+            store.findSearchEngineById("engine-h")
+        )
+
+        store.waitUntilIdle()
+
+        assertEquals(7, store.state.search.searchEngines.size)
+        assertEquals(2, store.state.search.availableSearchEngines.size)
+
+        assertEquals(1, store.state.search.additionalAvailableSearchEngines.size)
+        assertEquals(2, store.state.search.additionalSearchEngines.size)
+
+        assertEquals("engine-h", store.state.search.additionalSearchEngines[1].id)
+        assertEquals("Engine H", store.state.search.additionalSearchEngines[1].name)
+    }
+
+    @Test
+    fun `addSearchEngine - add custom engine`() {
+        val store = BrowserStore(BrowserState(search = SearchState(
+            region = RegionState("US", "US"),
+            regionSearchEngines = listOf(
+                SearchEngine("engine-a", "Engine A", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-b", "Engine B", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-c", "Engine C", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            customSearchEngines = listOf(
+                SearchEngine("engine-d", "Engine D", mock(), type = SearchEngine.Type.CUSTOM),
+                SearchEngine("engine-e", "Engine E", mock(), type = SearchEngine.Type.CUSTOM)
+            ),
+            additionalSearchEngines = listOf(
+                SearchEngine("engine-f", "Engine F", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            additionalAvailableSearchEngines = listOf(
+                SearchEngine("engine-g", "Engine G", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL),
+                SearchEngine("engine-h", "Engine H", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            hiddenSearchEngines = listOf(
+                SearchEngine("engine-i", "Engine I", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            regionDefaultSearchEngineId = "engine-b",
+            userSelectedSearchEngineId = null,
+            userSelectedSearchEngineName = null
+        )))
+
+        val useCases = SearchUseCases(store, mock(), mock())
+
+        assertEquals(6, store.state.search.searchEngines.size)
+        assertEquals(3, store.state.search.availableSearchEngines.size)
+
+        useCases.addSearchEngine.invoke(
+            createSearchEngine(
+                name = "Engine X",
+                url = "https://www.example.org/?q={searchTerms}",
+                icon = mock()
+            )
+        )
+
+        store.waitUntilIdle()
+
+        assertEquals(7, store.state.search.searchEngines.size)
+        assertEquals(3, store.state.search.availableSearchEngines.size)
+
+        assertEquals(3, store.state.search.customSearchEngines.size)
+        assertEquals("Engine X", store.state.search.customSearchEngines[2].name)
+        assertEquals(
+            "https://www.example.org/?q={searchTerms}",
+            store.state.search.customSearchEngines[2].resultUrls[0]
+        )
+    }
+
+    @Test
+    fun `removeSearchEngine - remove bundled engine`() {
+        val store = BrowserStore(BrowserState(search = SearchState(
+            region = RegionState("US", "US"),
+            regionSearchEngines = listOf(
+                SearchEngine("engine-a", "Engine A", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-b", "Engine B", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-c", "Engine C", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            customSearchEngines = listOf(
+                SearchEngine("engine-d", "Engine D", mock(), type = SearchEngine.Type.CUSTOM),
+                SearchEngine("engine-e", "Engine E", mock(), type = SearchEngine.Type.CUSTOM)
+            ),
+            additionalSearchEngines = listOf(
+                SearchEngine("engine-f", "Engine F", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            additionalAvailableSearchEngines = listOf(
+                SearchEngine("engine-g", "Engine G", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL),
+                SearchEngine("engine-h", "Engine H", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            hiddenSearchEngines = listOf(
+                SearchEngine("engine-i", "Engine I", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            regionDefaultSearchEngineId = "engine-b",
+            userSelectedSearchEngineId = null,
+            userSelectedSearchEngineName = null
+        )))
+
+        val useCases = SearchUseCases(store, mock(), mock())
+
+        assertEquals(6, store.state.search.searchEngines.size)
+        assertEquals(3, store.state.search.availableSearchEngines.size)
+
+        useCases.removeSearchEngine.invoke(
+            store.findSearchEngineById("engine-b")
+        )
+
+        store.waitUntilIdle()
+
+        assertEquals(5, store.state.search.searchEngines.size)
+        assertEquals(4, store.state.search.availableSearchEngines.size)
+
+        assertEquals(2, store.state.search.regionSearchEngines.size)
+        assertEquals(2, store.state.search.hiddenSearchEngines.size)
+
+        assertEquals("engine-b", store.state.search.hiddenSearchEngines[1].id)
+        assertEquals("Engine B", store.state.search.hiddenSearchEngines[1].name)
+    }
+
+    @Test
+    fun `removeSearchEngine - remove additional bundled engine`() {
+        val store = BrowserStore(BrowserState(search = SearchState(
+            region = RegionState("US", "US"),
+            regionSearchEngines = listOf(
+                SearchEngine("engine-a", "Engine A", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-b", "Engine B", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-c", "Engine C", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            customSearchEngines = listOf(
+                SearchEngine("engine-d", "Engine D", mock(), type = SearchEngine.Type.CUSTOM),
+                SearchEngine("engine-e", "Engine E", mock(), type = SearchEngine.Type.CUSTOM)
+            ),
+            additionalSearchEngines = listOf(
+                SearchEngine("engine-f", "Engine F", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            additionalAvailableSearchEngines = listOf(
+                SearchEngine("engine-g", "Engine G", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL),
+                SearchEngine("engine-h", "Engine H", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            hiddenSearchEngines = listOf(
+                SearchEngine("engine-i", "Engine I", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            regionDefaultSearchEngineId = "engine-b",
+            userSelectedSearchEngineId = null,
+            userSelectedSearchEngineName = null
+        )))
+
+        val useCases = SearchUseCases(store, mock(), mock())
+
+        assertEquals(6, store.state.search.searchEngines.size)
+        assertEquals(3, store.state.search.availableSearchEngines.size)
+
+        useCases.removeSearchEngine.invoke(
+            store.findSearchEngineById("engine-f")
+        )
+
+        store.waitUntilIdle()
+
+        assertEquals(5, store.state.search.searchEngines.size)
+        assertEquals(4, store.state.search.availableSearchEngines.size)
+
+        assertEquals(0, store.state.search.additionalSearchEngines.size)
+        assertEquals(3, store.state.search.additionalAvailableSearchEngines.size)
+
+        assertEquals("engine-f", store.state.search.additionalAvailableSearchEngines[2].id)
+        assertEquals("Engine F", store.state.search.additionalAvailableSearchEngines[2].name)
+    }
+
+    @Test
+    fun `removeSearchEngine - remove custom engine`() {
+        val store = BrowserStore(BrowserState(search = SearchState(
+            region = RegionState("US", "US"),
+            regionSearchEngines = listOf(
+                SearchEngine("engine-a", "Engine A", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-b", "Engine B", mock(), type = SearchEngine.Type.BUNDLED),
+                SearchEngine("engine-c", "Engine C", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            customSearchEngines = listOf(
+                SearchEngine("engine-d", "Engine D", mock(), type = SearchEngine.Type.CUSTOM),
+                SearchEngine("engine-e", "Engine E", mock(), type = SearchEngine.Type.CUSTOM)
+            ),
+            additionalSearchEngines = listOf(
+                SearchEngine("engine-f", "Engine F", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            additionalAvailableSearchEngines = listOf(
+                SearchEngine("engine-g", "Engine G", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL),
+                SearchEngine("engine-h", "Engine H", mock(), type = SearchEngine.Type.BUNDLED_ADDITIONAL)
+            ),
+            hiddenSearchEngines = listOf(
+                SearchEngine("engine-i", "Engine I", mock(), type = SearchEngine.Type.BUNDLED)
+            ),
+            regionDefaultSearchEngineId = "engine-b",
+            userSelectedSearchEngineId = null,
+            userSelectedSearchEngineName = null
+        )))
+
+        val useCases = SearchUseCases(store, mock(), mock())
+
+        assertEquals(6, store.state.search.searchEngines.size)
+        assertEquals(3, store.state.search.availableSearchEngines.size)
+
+        useCases.removeSearchEngine.invoke(
+            store.findSearchEngineById("engine-d")
+        )
+
+        store.waitUntilIdle()
+
+        assertEquals(5, store.state.search.searchEngines.size)
+        assertEquals(3, store.state.search.availableSearchEngines.size)
+
+        assertEquals(1, store.state.search.customSearchEngines.size)
+    }
+}
+
+private fun BrowserStore.findSearchEngineById(id: String): SearchEngine {
+    val searchEngine = (state.search.searchEngines + state.search.availableSearchEngines).find {
+        it.id == id
+    }
+    return requireNotNull(searchEngine)
 }

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/ext/SearchEngineKtTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/ext/SearchEngineKtTest.kt
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.search.ext
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.state.search.SearchEngine
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.UUID
+
+@RunWith(AndroidJUnit4::class)
+class SearchEngineKtTest {
+    @Test
+    fun `Create search URL for startpage`() {
+        val searchEngine = SearchEngine(
+            id = UUID.randomUUID().toString(),
+            name = "Escosia",
+            icon = mock(),
+            type = SearchEngine.Type.CUSTOM,
+            resultUrls = listOf(
+                "https://www.startpage.com/sp/search?q={searchTerms}"
+            )
+        )
+
+        assertEquals(
+            "https://www.startpage.com/sp/search?q=Hello%20World",
+            searchEngine.legacy().buildSearchUrl("Hello World")
+        )
+    }
+
+    @Test
+    fun `Create search URL for ecosia`() {
+        val searchEngine = createSearchEngine(
+            name = "Ecosia",
+            icon = mock(),
+            url = "https://www.ecosia.org/search?q={searchTerms}"
+        )
+
+        assertEquals(
+            "https://www.ecosia.org/search?q=Hello%20World",
+            searchEngine.legacy().buildSearchUrl("Hello World")
+        )
+    }
+}

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/storage/SearchEngineWriterTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/storage/SearchEngineWriterTest.kt
@@ -40,7 +40,7 @@ class SearchEngineWriterTest {
             name = "example",
             icon = mock(),
             type = SearchEngine.Type.CUSTOM,
-            resultUrls = listOf("https://www.example.com/search?q=%s'")
+            resultUrls = listOf("https://www.example.com/search?q={searchTerms}'")
         )
 
         val document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,9 @@ permalink: /changelog/
 * **accounts-push**
   * 🚒 Bug fixed [issue #8745](https://github.com/mozilla-mobile/android-components/issues/8745) - Remove OneTimeFxaPushReset from FxaPushSupportFeature
     * ⚠️ **This is a breaking change** because the public API changes with the removal of the class.
+    
+* **feature-search**
+ * * ⚠️ **This is a breaking change**: `SearchUseCases` no longer requires a `Context` parameter in the constructor. 
 
 # 65.0.0
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -201,7 +201,7 @@ open class DefaultComponents(private val applicationContext: Context) {
     }
 
     val searchUseCases by lazy {
-        SearchUseCases(applicationContext, store, store.toDefaultSearchEngineProvider(), sessionManager)
+        SearchUseCases(store, store.toDefaultSearchEngineProvider(), sessionManager)
     }
 
     val defaultSearchUseCase by lazy {


### PR DESCRIPTION
Those use cases make the integration code in Fenix nicer and avoids Fenix code having to decide which
actions to dispatch.

Additionally I remove the special handling of `%s` here. Using `%s` for custom search engines is an implementation detail of Fenix. Internally we only use `{searchTerms}` from the "Open Search" standard. There was a problem here where a loaded search engine got `%s` replaced and an in-memory one didn't. Now we only accept `{searchTerms}` and replacements for editing purposes happen at the app level.