### PR TITLE
Close #8904 Use the gecko fetch client when resuming a download

### DIFF
--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
@@ -614,7 +614,13 @@ abstract class AbstractFetchDownloadService : Service() {
         }
 
         val request = Request(download.url.sanitizeURL(), headers = headers, cookiePolicy = cookiePolicy)
-        val response = download.response ?: httpClient.fetch(request)
+        // When resuming a download we need to use the httpClient as
+        // download.response doesn't support adding headers.
+        val response = if (isResumingDownload) {
+            httpClient.fetch(request)
+        } else {
+            download.response ?: httpClient.fetch(request)
+        }
         logger.debug("Fetching download for ${currentDownloadJobState.state.id} ")
 
         // If we are resuming a download and the response does not contain a CONTENT_RANGE

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
@@ -1116,6 +1116,22 @@ class AbstractFetchDownloadServiceTest {
     }
 
     @Test
+    fun `performDownload - use the client response when resuming a download`() {
+        val responseFromDownloadState = mock<Response>()
+        val responseFromClient = mock<Response>()
+        val download = spy(DownloadState("https://example.com/file.txt", "file.txt", response = responseFromDownloadState))
+        val downloadJob = DownloadJobState(currentBytesCopied = 100, state = download, status = DOWNLOADING)
+
+        doReturn(404).`when`(responseFromClient).status
+        doReturn(responseFromClient).`when`(client).fetch(any())
+
+        service.performDownload(downloadJob)
+
+        verify(responseFromClient, atLeastOnce()).status
+        verifyZeroInteractions(responseFromDownloadState)
+    }
+
+    @Test
     fun `onDestroy cancels all running jobs`() = runBlocking {
         val download = DownloadState("https://example.com/file.txt", "file.txt")
         val response = Response(

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,7 +14,10 @@ permalink: /changelog/
 * **accounts-push**
   * 🚒 Bug fixed [issue #8745](https://github.com/mozilla-mobile/android-components/issues/8745) - Remove OneTimeFxaPushReset from FxaPushSupportFeature
     * ⚠️ **This is a breaking change** because the public API changes with the removal of the class.
-    
+
+* **feature-downloads**
+  * 🚒 Bug fixed [issue #8904](https://github.com/mozilla-mobile/android-components/issues/8904) Fix resuming downloads in nightly/beta more details see the [Fenix issue](https://github.com/mozilla-mobile/fenix/issues/9354).
+
 * **feature-search**
  * * ⚠️ **This is a breaking change**: `SearchUseCases` no longer requires a `Context` parameter in the constructor. 
 


### PR DESCRIPTION
Before adding the [new gecko view download API](https://github.com/mozilla-mobile/android-components/commit/449abd4010c159fa90dddac00d4db7cfa002aecd#diff-51a4f62b18b097b25a5482b31e10be7850f9a23d1c097fecaa7fb2d4f6674bc1). We used to use  the gecko fetch client that has the corresponding [header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range) for performing the resuming download. Now that we are always [using the new API when available](https://github.com/mozilla-mobile/android-components/blob/8d02e5944fe0f0b5edc49308515b3954474be192/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt#L617), resuming downloads are failing, as the new gv download API doesn't allow to pass headers we have to use the gecko fetch client when performing a resuming a download. Related issue https://github.com/mozilla-mobile/fenix/issues/9354


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
