### PR TITLE
Version 63.0.6 with GV Beta 83.0.20201105203649.

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -1,4 +1,4 @@
-componentsVersion: 63.0.5
+componentsVersion: 63.0.6
 projects:
   concept-awesomebar:
     path: components/concept/awesomebar

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -11,7 +11,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Beta Version.
      */
-    const val beta_version = "83.0.20201103183834"
+    const val beta_version = "83.0.20201105203649"
 
     /**
      * GeckoView Release Version.


### PR DESCRIPTION
This (automated) patch updates GV Beta to 83.0.20201105203649.