### PR TITLE
For fenix#15279: proof of concept using LazyComponent

### DIFF
--- a/components/browser/search/src/main/java/mozilla/components/browser/search/ext/SearchEngineManager.kt
+++ b/components/browser/search/src/main/java/mozilla/components/browser/search/ext/SearchEngineManager.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import mozilla.components.browser.search.DefaultSearchEngineProvider
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.search.SearchEngineManager
+import mozilla.components.support.base.utils.LazyComponent
 
 /**
  * Converts a [SearchEngineManager] to follow the [DefaultSearchEngineProvider] interface.
@@ -18,14 +19,14 @@ import mozilla.components.browser.search.SearchEngineManager
  *
  * https://github.com/mozilla-mobile/android-components/issues/8686
  */
-fun SearchEngineManager.toDefaultSearchEngineProvider(
+fun LazyComponent<SearchEngineManager>.toDefaultSearchEngineProvider(
     context: Context
 ) = object : DefaultSearchEngineProvider {
     override fun getDefaultSearchEngine(): SearchEngine? {
-        return getDefaultSearchEngine(context)
+        return get().getDefaultSearchEngine(context)
     }
 
     override suspend fun retrieveDefaultSearchEngine(): SearchEngine? {
-        return getDefaultSearchEngineAsync(context)
+        return get().getDefaultSearchEngineAsync(context)
     }
 }

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/suggestions/SearchSuggestionClientTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/suggestions/SearchSuggestionClientTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.search.SearchEngineParser
 import mozilla.components.browser.search.ext.toDefaultSearchEngineProvider
+import mozilla.components.support.base.utils.LazyComponent
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
@@ -104,9 +105,10 @@ class SearchSuggestionClientTest {
                 "google", "searchplugins/google-b-m.xml")
 
         val searchEngineManager: SearchEngineManager = mock()
+        val lazyManager = LazyComponent { searchEngineManager }
         val client = SearchSuggestionClient(
             testContext,
-            searchEngineManager.toDefaultSearchEngineProvider(testContext),
+            lazyManager.toDefaultSearchEngineProvider(testContext),
             GOOGLE_MOCK_RESPONSE
         )
 

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppUseCases.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppUseCases.kt
@@ -9,6 +9,7 @@ import androidx.core.content.pm.ShortcutManagerCompat
 import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.pwa.ext.installableManifest
+import mozilla.components.support.base.utils.LazyComponent
 
 /**
  * These use cases allow for adding a web app or web site to the homescreen.
@@ -16,7 +17,7 @@ import mozilla.components.feature.pwa.ext.installableManifest
 class WebAppUseCases(
     private val applicationContext: Context,
     private val store: BrowserStore,
-    private val shortcutManager: WebAppShortcutManager
+    private val shortcutManager: LazyComponent<WebAppShortcutManager>
 ) {
     /**
      * Checks if the launcher supports adding shortcuts.
@@ -28,7 +29,7 @@ class WebAppUseCases(
      * Checks to see if the current session can be installed as a Progressive Web App.
      */
     fun isInstallable() =
-        store.state.selectedTab?.installableManifest() != null && shortcutManager.supportWebApps
+        store.state.selectedTab?.installableManifest() != null && shortcutManager.get().supportWebApps
 
     /**
      * Let the user add the selected session to the homescreen.
@@ -42,7 +43,7 @@ class WebAppUseCases(
     class AddToHomescreenUseCase internal constructor(
         private val applicationContext: Context,
         private val store: BrowserStore,
-        private val shortcutManager: WebAppShortcutManager
+        private val shortcutManager: LazyComponent<WebAppShortcutManager>
     ) {
 
         /**
@@ -51,7 +52,7 @@ class WebAppUseCases(
          */
         suspend operator fun invoke(overrideBasicShortcutName: String? = null) {
             val session = store.state.selectedTab ?: return
-            shortcutManager.requestPinShortcut(applicationContext, session, overrideBasicShortcutName)
+            shortcutManager.get().requestPinShortcut(applicationContext, session, overrideBasicShortcutName)
         }
     }
 
@@ -69,7 +70,7 @@ class WebAppUseCases(
      */
     class GetInstallStateUseCase internal constructor(
         private val store: BrowserStore,
-        private val shortcutManager: WebAppShortcutManager
+        private val shortcutManager: LazyComponent<WebAppShortcutManager>
     ) {
         /**
          * @param currentTimeMs the current time against which manifest usage timeouts will be validated
@@ -78,7 +79,7 @@ class WebAppUseCases(
             currentTimeMs: Long = System.currentTimeMillis()
         ): WebAppShortcutManager.WebAppInstallState? {
             val session = store.state.selectedTab ?: return null
-            return shortcutManager.getWebAppInstallState(session.content.url, currentTimeMs)
+            return shortcutManager.get().getWebAppInstallState(session.content.url, currentTimeMs)
         }
     }
 

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/feature/ManifestUpdateFeature.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/feature/ManifestUpdateFeature.kt
@@ -22,6 +22,7 @@ import mozilla.components.feature.pwa.ManifestStorage
 import mozilla.components.feature.pwa.WebAppShortcutManager
 import mozilla.components.lib.state.ext.flow
 import mozilla.components.support.base.feature.LifecycleAwareFeature
+import mozilla.components.support.base.utils.LazyComponent
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 
 /**
@@ -37,7 +38,7 @@ import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 class ManifestUpdateFeature(
     private val applicationContext: Context,
     private val store: BrowserStore,
-    private val shortcutManager: WebAppShortcutManager,
+    private val shortcutManager: LazyComponent<WebAppShortcutManager>,
     private val storage: ManifestStorage,
     private val sessionId: String,
     private var initialManifest: WebAppManifest
@@ -57,7 +58,7 @@ class ManifestUpdateFeature(
     @VisibleForTesting
     internal suspend fun updateStoredManifest(manifest: WebAppManifest) {
         storage.updateManifest(manifest)
-        shortcutManager.updateShortcuts(applicationContext, listOf(manifest))
+        shortcutManager.get().updateShortcuts(applicationContext, listOf(manifest))
         initialManifest = manifest
     }
 

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppUseCasesTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppUseCasesTest.kt
@@ -15,6 +15,7 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.manifest.Size
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.fetch.Client
+import mozilla.components.support.base.utils.LazyComponent
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertFalse
@@ -39,7 +40,7 @@ class WebAppUseCasesTest {
             selectedTabId = session.id
         ))
 
-        val webAppUseCases = WebAppUseCases(testContext, store, mock<WebAppShortcutManager>())
+        val webAppUseCases = WebAppUseCases(testContext, store, LazyComponent { mock() })
         assertFalse(webAppUseCases.isInstallable())
     }
 
@@ -65,7 +66,7 @@ class WebAppUseCasesTest {
         val shortcutManager: WebAppShortcutManager = mock()
         `when`(shortcutManager.supportWebApps).thenReturn(true)
 
-        val webAppUseCases = WebAppUseCases(testContext, store, shortcutManager)
+        val webAppUseCases = WebAppUseCases(testContext, store, LazyComponent { shortcutManager })
         assertTrue(webAppUseCases.isInstallable())
     }
 
@@ -95,7 +96,7 @@ class WebAppUseCasesTest {
         val shortcutManager: WebAppShortcutManager = mock()
         `when`(shortcutManager.supportWebApps).thenReturn(false)
 
-        assertFalse(WebAppUseCases(testContext, store, shortcutManager).isInstallable())
+        assertFalse(WebAppUseCases(testContext, store, LazyComponent { shortcutManager }).isInstallable())
     }
 
     @Test
@@ -113,7 +114,7 @@ class WebAppUseCasesTest {
 
         `when`(storage.hasRecentManifest("https://www.mozilla.org", currentTime)).thenReturn(true)
 
-        assertEquals(WebAppShortcutManager.WebAppInstallState.Installed, WebAppUseCases(testContext, store, shortcutManager).getInstallState(currentTime))
+        assertEquals(WebAppShortcutManager.WebAppInstallState.Installed, WebAppUseCases(testContext, store, LazyComponent { shortcutManager }).getInstallState(currentTime))
     }
 }
 

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/feature/ManifestUpdateFeatureTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/feature/ManifestUpdateFeatureTest.kt
@@ -19,6 +19,7 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.feature.pwa.ManifestStorage
 import mozilla.components.feature.pwa.WebAppShortcutManager
+import mozilla.components.support.base.utils.LazyComponent
 import mozilla.components.support.test.any
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
@@ -35,7 +36,7 @@ import org.mockito.Mockito.verify
 @RunWith(AndroidJUnit4::class)
 class ManifestUpdateFeatureTest {
 
-    private lateinit var shortcutManager: WebAppShortcutManager
+    private lateinit var shortcutManager: LazyComponent<WebAppShortcutManager>
     private lateinit var storage: ManifestStorage
     private lateinit var store: BrowserStore
     private lateinit var dispatcher: TestCoroutineDispatcher
@@ -50,7 +51,7 @@ class ManifestUpdateFeatureTest {
     @Before
     fun setUp() {
         storage = mock()
-        shortcutManager = mock()
+        shortcutManager = LazyComponent { mock() }
 
         dispatcher = TestCoroutineDispatcher()
         Dispatchers.setMain(dispatcher)
@@ -252,7 +253,7 @@ class ManifestUpdateFeatureTest {
         feature.updateStoredManifest(manifest)
 
         verify(storage).updateManifest(manifest)
-        verify(shortcutManager).updateShortcuts(testContext, listOf(manifest))
+        verify(shortcutManager.get()).updateShortcuts(testContext, listOf(manifest))
     }
 
     @Test

--- a/components/feature/search/build.gradle
+++ b/components/feature/search/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation project(':browser-state')
     implementation project(':concept-engine')
     implementation project(':service-location')
+    implementation project(':support-base')
     implementation project(':support-utils')
     implementation project(':support-ktx')
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -139,6 +139,13 @@ permalink: /changelog/
 * **service-nimbus**
   * Added new Nimbus rapid experiment library component. This is a Rust based component that is delivered to A-C through the appservices megazord. See the [nimbus-sdk repo](https://github.com/mozilla/nimbus-sdk) for more info.
 
+* **browser-search**
+  * ⚠️ **This is a breaking change**: `SearchEngineManager.toDefaultSearchEngineProvider` has become `LazyComponent<SearchEngineManager>.toDefaultSearchEngineProvider`.
+
+* **feature-pwa**
+  * ⚠️ **This is a breaking change**: `WebAppUseCases`'s initializer argument, `WebAppShortcutManager`, is wrapped in a `LazyComponent`. The same applies to the classes defined inside `WebAppUseCases`.
+  * ⚠️ **This is a breaking change**: `ManifestUpdateFeature`'s initializer argument, `WebAppShortcutManager`, is wrapped in a `LazyComponent`.
+
 # 65.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v64.0.0...v65.0.0)

--- a/docs/tmp-changelog.md
+++ b/docs/tmp-changelog.md
@@ -1,6 +1,9 @@
 Adding our changes here instead of directly to the changelog so that if we need to rebase, we don't
 have to stop on every commit for a merge conflict. This file will be removed at the end of this PR.
 
+* **browser-search**
+  * ⚠️ **This is a breaking change**: `SearchEngineManager.toDefaultSearchEngineProvider` has become `LazyComponent<SearchEngineManager>.toDefaultSearchEngineProvider`.
+
 * **feature-pwa**
   * ⚠️ **This is a breaking change**: `WebAppUseCases`'s initializer argument, `WebAppShortcutManager`, is wrapped in a `LazyComponent`. The same applies to the classes defined inside `WebAppUseCases`.
   * ⚠️ **This is a breaking change**: `ManifestUpdateFeature`'s initializer argument, `WebAppShortcutManager`, is wrapped in a `LazyComponent`.

--- a/docs/tmp-changelog.md
+++ b/docs/tmp-changelog.md
@@ -3,3 +3,4 @@ have to stop on every commit for a merge conflict. This file will be removed at 
 
 * **feature-pwa**
   * ⚠️ **This is a breaking change**: `WebAppUseCases`'s initializer argument, `WebAppShortcutManager`, is wrapped in a `LazyComponent`. The same applies to the classes defined inside `WebAppUseCases`.
+  * ⚠️ **This is a breaking change**: `ManifestUpdateFeature`'s initializer argument, `WebAppShortcutManager`, is wrapped in a `LazyComponent`.

--- a/docs/tmp-changelog.md
+++ b/docs/tmp-changelog.md
@@ -1,9 +1,0 @@
-Adding our changes here instead of directly to the changelog so that if we need to rebase, we don't
-have to stop on every commit for a merge conflict. This file will be removed at the end of this PR.
-
-* **browser-search**
-  * ⚠️ **This is a breaking change**: `SearchEngineManager.toDefaultSearchEngineProvider` has become `LazyComponent<SearchEngineManager>.toDefaultSearchEngineProvider`.
-
-* **feature-pwa**
-  * ⚠️ **This is a breaking change**: `WebAppUseCases`'s initializer argument, `WebAppShortcutManager`, is wrapped in a `LazyComponent`. The same applies to the classes defined inside `WebAppUseCases`.
-  * ⚠️ **This is a breaking change**: `ManifestUpdateFeature`'s initializer argument, `WebAppShortcutManager`, is wrapped in a `LazyComponent`.

--- a/docs/tmp-changelog.md
+++ b/docs/tmp-changelog.md
@@ -1,0 +1,5 @@
+Adding our changes here instead of directly to the changelog so that if we need to rebase, we don't
+have to stop on every commit for a merge conflict. This file will be removed at the end of this PR.
+
+* **feature-pwa**
+  * ⚠️ **This is a breaking change**: `WebAppUseCases`'s initializer argument, `WebAppShortcutManager`, is wrapped in a `LazyComponent`. The same applies to the classes defined inside `WebAppUseCases`.


### PR DESCRIPTION
This PR is expected to be paired with fenix PR https://github.com/mozilla-mobile/fenix/pull/16410.

This is a proof-of-concept using `LazyComponent`. The corresponding PR in fenix moved two components to be `LazyComponent`. One of the changes reduced the number of components initialized by one during MAIN startup and removed one runBlocking call during MAIN startup.

I'm not sure what our gains will look like from these changes though I will note that it's a lot of work to convert components, especially between two repositories. @csadilek Do you think it's worth continuing to work on this? I suppose I should measure the difference...

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
  - No new tests needed as just converting to lazy component
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
