### PR TITLE
Issue #7247: Deprecate SelectionAwareSessionObserver

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SelectionAwareSessionObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SelectionAwareSessionObserver.kt
@@ -16,6 +16,7 @@ import androidx.annotation.CallSuper
  * @property activeSession the currently observed session
  * @property sessionManager the application's session manager
  */
+@Deprecated("Use browser store for observing session state changes instead")
 abstract class SelectionAwareSessionObserver(
     private val sessionManager: SessionManager
 ) : SessionManager.Observer, Session.Observer {

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SelectionAwareSessionObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SelectionAwareSessionObserverTest.kt
@@ -11,6 +11,7 @@ import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 
+@Suppress("DEPRECATION")
 class SelectionAwareSessionObserverTest {
     private lateinit var sessionManager: SessionManager
     private lateinit var session1: Session

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/CoordinateScrollingFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/CoordinateScrollingFeature.kt
@@ -10,7 +10,6 @@ import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_
 import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_EXIT_UNTIL_COLLAPSED
 import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
 import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_SNAP
-import mozilla.components.browser.session.SelectionAwareSessionObserver
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineView
@@ -22,12 +21,13 @@ import mozilla.components.support.base.feature.LifecycleAwareFeature
  *
  * A use case could be collapsing a toolbar every time that the user scrolls.
  */
+@Suppress("DEPRECATION") // https://github.com/mozilla-mobile/android-components/issues/7482
 class CoordinateScrollingFeature(
     sessionManager: SessionManager,
     private val engineView: EngineView,
     private val view: View,
     private val scrollFlags: Int = DEFAULT_SCROLL_FLAGS
-) : SelectionAwareSessionObserver(sessionManager), LifecycleAwareFeature {
+) : mozilla.components.browser.session.SelectionAwareSessionObserver(sessionManager), LifecycleAwareFeature {
 
     /**
      * Start feature: Starts adding scrolling behavior for the indicated view.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,9 @@ permalink: /changelog/
 * **feature-search**
  * * ⚠️ **This is a breaking change**: `SearchUseCases` no longer requires a `Context` parameter in the constructor. 
 
+* **browser-session**
+  * `SelectionAwareSessionObserver` is now deprecated. All session state changes can be observed using the browser store (`browser-state` module).    
+
 # 65.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v64.0.0...v65.0.0)

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -65,6 +65,12 @@ tasks.register("updateTestExtensionVersion", Copy) { task ->
     updateExtensionVersion(task, 'src/main/assets/extensions/test')
 }
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach() {
+    kotlinOptions.freeCompilerArgs += [
+            "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi"
+    ]
+}
+
 dependencies {
     implementation project(':concept-awesomebar')
     implementation project(':concept-fetch')

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -361,33 +361,52 @@ open class DefaultComponents(private val applicationContext: Context) {
     }
 
     private val menuToolbar by lazy {
-        val forward = BrowserMenuItemToolbar.Button(
-            mozilla.components.ui.icons.R.drawable.mozac_ic_forward,
-            iconTintColorResource = R.color.photonBlue90,
-            contentDescription = "Forward",
-            isEnabled = { sessionManager.selectedSession?.canGoForward == true }
+        val back = BrowserMenuItemToolbar.TwoStateButton(
+            primaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_back,
+            primaryImageTintResource = R.color.photonBlue90,
+            primaryContentDescription = "Back",
+            isInPrimaryState = {
+                sessionManager.selectedSession?.canGoBack ?: true
+            },
+            disableInSecondaryState = true,
+            secondaryImageTintResource = R.color.photonGrey40
+        ) {
+            sessionUseCases.goBack()
+        }
+
+        val forward = BrowserMenuItemToolbar.TwoStateButton(
+            primaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_forward,
+            primaryContentDescription = "Forward",
+            primaryImageTintResource = R.color.photonBlue90,
+            isInPrimaryState = {
+                sessionManager.selectedSession?.canGoForward ?: true
+            },
+            disableInSecondaryState = true,
+            secondaryImageTintResource = R.color.photonGrey40
         ) {
             sessionUseCases.goForward()
         }
 
-        val refresh = BrowserMenuItemToolbar.Button(
-            mozilla.components.ui.icons.R.drawable.mozac_ic_refresh,
-            iconTintColorResource = R.color.photonBlue90,
-            contentDescription = "Refresh",
-            isEnabled = { sessionManager.selectedSession?.loading != true }
+        val refresh = BrowserMenuItemToolbar.TwoStateButton(
+            primaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_refresh,
+            primaryContentDescription = "Refresh",
+            primaryImageTintResource = R.color.photonBlue90,
+            isInPrimaryState = {
+                sessionManager.selectedSession?.loading == false
+            },
+            secondaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_stop,
+            secondaryContentDescription = "Stop",
+            secondaryImageTintResource = R.color.photonBlue90,
+            disableInSecondaryState = false
         ) {
-            sessionUseCases.reload()
+            if (sessionManager.selectedSession?.loading == true) {
+                sessionUseCases.stopLoading()
+            } else {
+                sessionUseCases.reload()
+            }
         }
 
-        val stop = BrowserMenuItemToolbar.Button(
-            mozilla.components.ui.icons.R.drawable.mozac_ic_stop,
-            iconTintColorResource = R.color.photonBlue90,
-            contentDescription = "Stop"
-        ) {
-            sessionUseCases.stopLoading()
-        }
-
-        BrowserMenuItemToolbar(listOf(forward, refresh, stop))
+        BrowserMenuItemToolbar(listOf(back, forward, refresh))
     }
 
     val shippedDomainsProvider by lazy {


### PR DESCRIPTION
With recent refactorings, we don't use it in Fenix anymore. Follow-up tickets are filed for remaining features and linked in source.