### PR TITLE
Version 57.0.9 with GV Release 81.0.20201108175212.

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -1,4 +1,4 @@
-componentsVersion: 57.0.8
+componentsVersion: 57.0.9
 projects:
   concept-awesomebar:
     path: components/concept/awesomebar

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -16,7 +16,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Release Version.
      */
-    const val release_version = "81.0.20201012085804"
+    const val release_version = "81.0.20201108175212"
 }
 
 @Suppress("Unused", "MaxLineLength")


### PR DESCRIPTION
This (automated) patch updates GV Release to 81.0.20201108175212.