### PR TITLE
Uplift: Bug 1600916 - Add version field to task payload for beetmover (taskcluster)

### DIFF
--- a/taskcluster/ac_taskgraph/build_config.py
+++ b/taskcluster/ac_taskgraph/build_config.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 import os
 import yaml
 
+from six import ensure_text
+
 from taskgraph.util.memoize import memoize
 
 
@@ -27,7 +29,7 @@ def get_components():
 
 
 def get_version():
-    return _read_build_config()["componentsVersion"]
+    return ensure_text(_read_build_config()["componentsVersion"])
 
 
 def get_path(component):

--- a/taskcluster/ac_taskgraph/transforms/beetmover.py
+++ b/taskcluster/ac_taskgraph/transforms/beetmover.py
@@ -58,3 +58,17 @@ def set_artifact_map(config, tasks):
         } for dep in deps]
 
         yield task
+
+
+@transforms.add
+def add_version(config, tasks):
+    version = get_version()
+    nightly_version = get_nightly_version(config, version)
+
+    for task in tasks:
+        task["worker"]["version"] = craft_path_version(
+            version,
+            task["attributes"]["build-type"],
+            nightly_version
+        )
+        yield task

--- a/taskcluster/ac_taskgraph/worker_types.py
+++ b/taskcluster/ac_taskgraph/worker_types.py
@@ -65,6 +65,7 @@ def build_scriptworker_signing_payload(config, task, task_def):
     "scriptworker-beetmover",
     schema={
         Required("action"): text_type,
+        Required("version"): text_type,
         Required("artifact-map"): [{
             Required("paths"): {
                 Any(text_type): {
@@ -82,7 +83,7 @@ def build_scriptworker_signing_payload(config, task, task_def):
         }],
     },
 )
-def build_scriptworker_signing_payload(config, task, task_def):
+def build_scriptworker_beetmover_payload(config, task, task_def):
     worker = task["worker"]
 
     task_def["tags"]["worker-implementation"] = "scriptworker"
@@ -97,6 +98,7 @@ def build_scriptworker_signing_payload(config, task, task_def):
         "artifactMap": worker["artifact-map"],
         "releaseProperties": {"appName": worker.pop("beetmover-application-name")},
         "upstreamArtifacts": worker["upstream-artifacts"],
+        "version": worker["version"]
     }
 
     scope_prefix = config.graph_config["scriptworker"]["scope-prefix"]


### PR DESCRIPTION
Uplift of Bug 1600916 - Add version field to task payload for beetmover (taskcluster)

Same uplift happened on `releases/60.0`.
