### PR TITLE
Closes #8867: Correctly handle PageAction enabled state

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -180,12 +180,7 @@ class GeckoWebExtension(
                 session: GeckoSession?,
                 action: GeckoNativeWebExtensionAction
             ) {
-                // Page action API doesn't support enable/disable so we enable by default.
-                actionHandler.onPageAction(
-                    this@GeckoWebExtension,
-                    null,
-                    action.convert().copy(enabled = true)
-                )
+                actionHandler.onPageAction(this@GeckoWebExtension, null, action.convert())
             }
 
             override fun onTogglePopup(
@@ -225,12 +220,7 @@ class GeckoWebExtension(
                 geckoSession: GeckoSession?,
                 action: GeckoNativeWebExtensionAction
             ) {
-                // Page action API doesn't support enable/disable so we enable by default.
-                actionHandler.onPageAction(
-                    this@GeckoWebExtension,
-                    session,
-                    action.convert().copy(enabled = true)
-                )
+                actionHandler.onPageAction(this@GeckoWebExtension, session, action.convert())
             }
         }
 

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -180,12 +180,7 @@ class GeckoWebExtension(
                 session: GeckoSession?,
                 action: GeckoNativeWebExtensionAction
             ) {
-                // Page action API doesn't support enable/disable so we enable by default.
-                actionHandler.onPageAction(
-                    this@GeckoWebExtension,
-                    null,
-                    action.convert().copy(enabled = true)
-                )
+                actionHandler.onPageAction(this@GeckoWebExtension, null, action.convert())
             }
 
             override fun onTogglePopup(
@@ -225,12 +220,7 @@ class GeckoWebExtension(
                 geckoSession: GeckoSession?,
                 action: GeckoNativeWebExtensionAction
             ) {
-                // Page action API doesn't support enable/disable so we enable by default.
-                actionHandler.onPageAction(
-                    this@GeckoWebExtension,
-                    session,
-                    action.convert().copy(enabled = true)
-                )
+                actionHandler.onPageAction(this@GeckoWebExtension, session, action.convert())
             }
         }
 

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -179,12 +179,7 @@ class GeckoWebExtension(
                 session: GeckoSession?,
                 action: GeckoNativeWebExtensionAction
             ) {
-                // Page action API doesn't support enable/disable so we enable by default.
-                actionHandler.onPageAction(
-                    this@GeckoWebExtension,
-                    null,
-                    action.convert().copy(enabled = true)
-                )
+                actionHandler.onPageAction(this@GeckoWebExtension, null, action.convert())
             }
 
             override fun onTogglePopup(
@@ -224,12 +219,7 @@ class GeckoWebExtension(
                 geckoSession: GeckoSession?,
                 action: GeckoNativeWebExtensionAction
             ) {
-                // Page action API doesn't support enable/disable so we enable by default.
-                actionHandler.onPageAction(
-                    this@GeckoWebExtension,
-                    session,
-                    action.convert().copy(enabled = true)
-                )
+                actionHandler.onPageAction(this@GeckoWebExtension, session, action.convert())
             }
         }
 

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/WebExtensionBrowserMenu.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/WebExtensionBrowserMenu.kt
@@ -90,13 +90,19 @@ class WebExtensionBrowserMenu internal constructor(
                     }
 
                     extension.pageAction?.let { pageAction ->
-                        addOrUpdateAction(
-                            extension = extension,
-                            globalAction = pageAction,
-                            tabAction = tab?.extensionState?.get(extension.id)?.pageAction,
-                            menuItems = menuItems,
-                            isPageAction = true
-                        )
+                        val tabPageAction = tab?.extensionState?.get(extension.id)?.pageAction
+
+                        // Unlike browser actions, page actions are not displayed by default (only if enabled):
+                        // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action
+                        if (pageAction.copyWithOverride(tabPageAction).enabled == true) {
+                            addOrUpdateAction(
+                                extension = extension,
+                                globalAction = pageAction,
+                                tabAction = tabPageAction,
+                                menuItems = menuItems,
+                                isPageAction = true
+                            )
+                        }
                     }
                 }
 

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilderTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilderTest.kt
@@ -54,8 +54,8 @@ class WebExtensionBrowserMenuBuilderTest {
 
     @Test
     fun `web extension sub menu add-ons manager sub menu item invokes onAddonsManagerTapped when clicked`() {
-        val browserAction = WebExtensionBrowserAction("browser_action", false, mock(), "", 0, 0) {}
-        val pageAction = WebExtensionBrowserAction("page_action", false, mock(), "", 0, 0) {}
+        val browserAction = WebExtensionBrowserAction("browser_action", true, mock(), "", 0, 0) {}
+        val pageAction = WebExtensionBrowserAction("page_action", true, mock(), "", 0, 0) {}
 
         val extensions = mapOf(
             "id" to WebExtensionState(
@@ -100,8 +100,8 @@ class WebExtensionBrowserMenuBuilderTest {
 
     @Test
     fun `web extension submenu is added at the start when appendExtensionSubMenuAtStart is true`() {
-        val browserAction = WebExtensionBrowserAction("browser_action", false, mock(), "", 0, 0) {}
-        val pageAction = WebExtensionBrowserAction("page_action", false, mock(), "", 0, 0) {}
+        val browserAction = WebExtensionBrowserAction("browser_action", true, mock(), "", 0, 0) {}
+        val pageAction = WebExtensionBrowserAction("page_action", true, mock(), "", 0, 0) {}
 
         val extensions = mapOf(
             "id" to WebExtensionState(
@@ -152,8 +152,8 @@ class WebExtensionBrowserMenuBuilderTest {
 
     @Test
     fun `web extension submenu is added at the end when appendExtensionSubMenuAtStart is false`() {
-        val browserAction = WebExtensionBrowserAction("browser_action", false, mock(), "", 0, 0) {}
-        val pageAction = WebExtensionBrowserAction("page_action", false, mock(), "", 0, 0) {}
+        val browserAction = WebExtensionBrowserAction("browser_action", true, mock(), "", 0, 0) {}
+        val pageAction = WebExtensionBrowserAction("page_action", true, mock(), "", 0, 0) {}
 
         val extensions = mapOf(
             "id" to WebExtensionState(
@@ -208,8 +208,8 @@ class WebExtensionBrowserMenuBuilderTest {
         val promotableWebExtensionId = "promotable extension id"
         val promotableWebExtensionTitle = "promotable extension action title"
 
-        val pageAction = WebExtensionBrowserAction("page_action", false, mock(), "", 0, 0) {}
-        val pageActionPromotableWebExtension = WebExtensionBrowserAction(promotableWebExtensionTitle, false, mock(), "", 0, 0) {}
+        val pageAction = WebExtensionBrowserAction("page_action", true, mock(), "", 0, 0) {}
+        val pageActionPromotableWebExtension = WebExtensionBrowserAction(promotableWebExtensionTitle, true, mock(), "", 0, 0) {}
 
         // just 2 extensions in the extension menu
         val extensions = mapOf(

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuTest.kt
@@ -59,8 +59,8 @@ class WebExtensionBrowserMenuTest {
     @Test
     fun `actions are only updated when the menu is shown`() {
         webExtensionBrowserActions.clear()
-        val browserAction = WebExtensionBrowserAction("browser_action", false, mock(), "", 0, 0) {}
-        val pageAction = WebExtensionPageAction("browser_action", false, mock(), "", 0, 0) {}
+        val browserAction = WebExtensionBrowserAction("browser_action", true, mock(), "", 0, 0) {}
+        val pageAction = WebExtensionPageAction("browser_action", true, mock(), "", 0, 0) {}
         val extensions = mapOf(
             "browser_action" to WebExtensionState(
                 "browser_action",
@@ -94,9 +94,9 @@ class WebExtensionBrowserMenuTest {
         assertNotNull(popup)
 
         val defaultBrowserAction =
-            WebExtensionBrowserAction("default_title", false, mock(), "", 0, 0) {}
+            WebExtensionBrowserAction("default_title", true, mock(), "", 0, 0) {}
         val defaultPageAction =
-            WebExtensionPageAction("default_title", false, mock(), "", 0, 0) {}
+            WebExtensionPageAction("default_title", true, mock(), "", 0, 0) {}
         val defaultExtensions: Map<String, WebExtensionState> = mapOf(
             "id" to WebExtensionState(
                 "id",
@@ -117,9 +117,9 @@ class WebExtensionBrowserMenuTest {
 
         menu.dismiss()
         val anotherBrowserAction =
-            WebExtensionBrowserAction("another_title", false, mock(), "", 0, 0) {}
+            WebExtensionBrowserAction("another_title", true, mock(), "", 0, 0) {}
         val anotherPageAction =
-            WebExtensionBrowserAction("another_title", false, mock(), "", 0, 0) {}
+            WebExtensionBrowserAction("another_title", true, mock(), "", 0, 0) {}
         val anotherExtension: Map<String, WebExtensionState> = mapOf(
             "id2" to WebExtensionState(
                 "id2",
@@ -142,13 +142,13 @@ class WebExtensionBrowserMenuTest {
     @Test
     fun `render web extension actions from browser state`() {
         val defaultBrowserAction =
-            WebExtensionBrowserAction("default_browser_action_title", false, mock(), "", 0, 0) {}
+            WebExtensionBrowserAction("default_browser_action_title", true, mock(), "", 0, 0) {}
         val defaultPageAction =
-            WebExtensionPageAction("default_page_action_title", false, mock(), "", 0, 0) {}
+            WebExtensionPageAction("default_page_action_title", true, mock(), "", 0, 0) {}
         val overriddenBrowserAction =
-            WebExtensionBrowserAction("overridden_browser_action_title", false, mock(), "", 0, 0) {}
+            WebExtensionBrowserAction("overridden_browser_action_title", true, mock(), "", 0, 0) {}
         val overriddenPageAction =
-            WebExtensionBrowserAction("overridden_page_action_title", false, mock(), "", 0, 0) {}
+            WebExtensionBrowserAction("overridden_page_action_title", true, mock(), "", 0, 0) {}
 
         val extensions: Map<String, WebExtensionState> = mapOf(
             "id" to WebExtensionState(
@@ -203,13 +203,13 @@ class WebExtensionBrowserMenuTest {
     @Test
     fun `getOrUpdateWebExtensionMenuItems does not include actions from disabled extensions`() {
         val enabledPageAction =
-            WebExtensionBrowserAction("enabled_page_action", false, mock(), "", 0, 0) {}
+            WebExtensionBrowserAction("enabled_page_action", true, mock(), "", 0, 0) {}
         val disabledPageAction =
-            WebExtensionBrowserAction("disabled_page_action", false, mock(), "", 0, 0) {}
+            WebExtensionBrowserAction("disabled_page_action", true, mock(), "", 0, 0) {}
         val enabledBrowserAction =
-            WebExtensionBrowserAction("enabled_browser_action", false, mock(), "", 0, 0) {}
+            WebExtensionBrowserAction("enabled_browser_action", true, mock(), "", 0, 0) {}
         val disabledBrowserAction =
-            WebExtensionBrowserAction("disabled_browser_action", false, mock(), "", 0, 0) {}
+            WebExtensionBrowserAction("disabled_browser_action", true, mock(), "", 0, 0) {}
 
         val extensions = mapOf(
             "enabled" to WebExtensionState(
@@ -409,9 +409,9 @@ class WebExtensionBrowserMenuTest {
         whenever(view.context).thenReturn(mock())
 
         val browserAction =
-            WebExtensionBrowserAction("title", false, mock(), "", 0, 0) {}
+            WebExtensionBrowserAction("title", true, mock(), "", 0, 0) {}
         val pageAction =
-            WebExtensionPageAction("title", false, mock(), "", 0, 0) {}
+            WebExtensionPageAction("title", true, mock(), "", 0, 0) {}
         val extensions: Map<String, WebExtensionState> = mapOf(
             "some_example_id" to WebExtensionState(
                 "some_example_id",
@@ -482,5 +482,46 @@ class WebExtensionBrowserMenuTest {
         val actionItemsAllowedInPrivateBrowsing = getOrUpdateWebExtensionMenuItems(browserStateAllowedInPrivateBrowsing, tabSessionState)
         assertEquals(1, actionItemsAllowedInPrivateBrowsing.size)
         assertEquals(actionExt1, actionItemsAllowedInPrivateBrowsing[0].action)
+    }
+
+    @Test
+    fun `does not include menu item for disabled paged actions`() {
+        val enabledPageAction =
+            WebExtensionBrowserAction("enabled_page_action", true, mock(), "", 0, 0) {}
+        val disabledPageAction =
+            WebExtensionBrowserAction("disabled_page_action", false, mock(), "", 0, 0) {}
+
+        val extensions = mapOf(
+            "ext1" to WebExtensionState(
+                "ext1",
+                "url",
+                "name",
+                true,
+                pageAction = enabledPageAction
+            ),
+            "ext2" to WebExtensionState(
+                "ext2",
+                "url",
+                "name",
+                true,
+                pageAction = disabledPageAction
+            )
+        )
+
+        val store =
+            BrowserStore(
+                BrowserState(
+                    extensions = extensions
+                )
+            )
+
+        val browserMenuItems = getOrUpdateWebExtensionMenuItems(store.state)
+        assertEquals(1, browserMenuItems.size)
+
+        var menuAction = browserMenuItems[0]
+        assertEquals(
+            "enabled_page_action",
+            menuAction.action.title
+        )
     }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/Action.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/Action.kt
@@ -34,7 +34,7 @@ data class Action(
      * unchanged. An extension can send a tab-specific action and only include the properties
      * it wants to override for the tab.
      */
-    fun copyWithOverride(override: Action) =
+    fun copyWithOverride(override: Action?) = if (override != null) {
         Action(
             title = override.title ?: title,
             enabled = override.enabled ?: enabled,
@@ -44,6 +44,9 @@ data class Action(
             loadIcon = override.loadIcon ?: loadIcon,
             onClick = override.onClick
         )
+    } else {
+        this
+    }
 }
 
 typealias WebExtensionBrowserAction = Action

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeature.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeature.kt
@@ -117,12 +117,18 @@ class WebExtensionToolbarFeature(
             }
 
             extension.pageAction?.let { pageAction ->
-                addOrUpdateAction(
-                    extension = extension,
-                    globalAction = pageAction,
-                    tabAction = tab?.extensionState?.get(extension.id)?.pageAction,
-                    isPageAction = true
-                )
+                val tabPageAction = tab?.extensionState?.get(extension.id)?.pageAction
+
+                // Unlike browser actions, page actions are not displayed by default (only if enabled):
+                // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action
+                if (pageAction.copyWithOverride(tabPageAction).enabled == true) {
+                    addOrUpdateAction(
+                        extension = extension,
+                        globalAction = pageAction,
+                        tabAction = tabPageAction,
+                        isPageAction = true
+                    )
+                }
             }
         }
     }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -189,7 +189,7 @@ open class DefaultComponents(private val applicationContext: Context) {
         AddonCollectionProvider(
             applicationContext,
             client,
-            collectionName = "83a9cccfe6e24a34bd7b155ff9ee32",
+            collectionName = "7dfae8669acc4312a65e8ba5553036",
             maxCacheAgeInMinutes = DAY_IN_MINUTES
         )
     }


### PR DESCRIPTION
Uplift to beta branch: This fixed the behaviour of page actions which affect the newly introduced "Web Archives" add-on in Beta.

See: 
https://github.com/mozilla-mobile/android-components/pull/8895
https://github.com/mozilla-mobile/fenix/issues/15544