### PR TITLE
Closes #8938: Add download ID to add-ons

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
@@ -17,7 +17,8 @@ import kotlinx.android.parcel.Parcelize
  * @property id The unique ID of this add-on.
  * @property authors List holding information about the add-on authors.
  * @property categories List of categories the add-on belongs to.
- * @property downloadUrl The (absolute) URL to download the add-on file (eg xpi).
+ * @property downloadId The unique ID of the latest version of the add-on (xpi) file.
+ * @property downloadUrl The (absolute) URL to download the latest version of the add-on file.
  * @property version The add-on version e.g "1.23.0".
  * @property permissions List of the add-on permissions for this File.
  * @property translatableName A map containing the different translations for the add-on name,
@@ -40,6 +41,7 @@ data class Addon(
     val id: String,
     val authors: List<Author> = emptyList(),
     val categories: List<String> = emptyList(),
+    val downloadId: String = "",
     val downloadUrl: String = "",
     val version: String = "",
     val permissions: List<String> = emptyList(),

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
@@ -265,13 +265,15 @@ internal fun JSONObject.getAddons(): List<Addon> {
 
 internal fun JSONObject.toAddons(): Addon {
     return with(getJSONObject("addon")) {
+        val download = getDownload()
         Addon(
             id = getSafeString("guid"),
             authors = getAuthors(),
             categories = getCategories(),
             createdAt = getSafeString("created"),
             updatedAt = getSafeString("last_updated"),
-            downloadUrl = getDownloadUrl(),
+            downloadId = download?.getDownloadId() ?: "",
+            downloadUrl = download?.getDownloadUrl() ?: "",
             version = getCurrentVersion(),
             permissions = getPermissions(),
             translatableName = getSafeMap("name"),
@@ -324,11 +326,18 @@ internal fun JSONObject.getCurrentVersion(): String {
     return optJSONObject("current_version")?.getSafeString("version") ?: ""
 }
 
-internal fun JSONObject.getDownloadUrl(): String {
+internal fun JSONObject.getDownload(): JSONObject? {
     return (getJSONObject("current_version")
         .optJSONArray("files")
         ?.getJSONObject(0))
-        ?.getSafeString("url") ?: ""
+}
+
+internal fun JSONObject.getDownloadId(): String {
+    return getSafeString("id")
+}
+
+internal fun JSONObject.getDownloadUrl(): String {
+    return getSafeString("url")
 }
 
 internal fun JSONObject.getAuthors(): List<Addon.Author> {

--- a/components/feature/addons/src/test/java/AddonManagerTest.kt
+++ b/components/feature/addons/src/test/java/AddonManagerTest.kt
@@ -301,6 +301,29 @@ class AddonManagerTest {
     }
 
     @Test
+    fun `getAddons - passes on allowCache parameter`() = runBlocking {
+        val store = BrowserStore()
+
+        val engine: Engine = mock()
+        val callbackCaptor = argumentCaptor<((List<WebExtension>) -> Unit)>()
+        whenever(engine.listInstalledWebExtensions(callbackCaptor.capture(), any())).thenAnswer {
+            callbackCaptor.value.invoke(emptyList())
+        }
+        WebExtensionSupport.initialize(engine, store)
+
+        val addonsProvider: AddonsProvider = mock()
+        whenever(addonsProvider.getAvailableAddons(anyBoolean(), eq(null))).thenReturn(emptyList())
+        val addonsManager = AddonManager(store, mock(), addonsProvider, mock())
+
+        addonsManager.getAddons()
+        verify(addonsProvider).getAvailableAddons(eq(true), eq(null))
+
+        addonsManager.getAddons(allowCache = false)
+        verify(addonsProvider).getAvailableAddons(eq(false), eq(null))
+        Unit
+    }
+
+    @Test
     fun `updateAddon - when a extension is updated successfully`() {
         val engine: Engine = mock()
         val engineSession: EngineSession = mock()

--- a/components/feature/addons/src/test/java/AddonManagerTest.kt
+++ b/components/feature/addons/src/test/java/AddonManagerTest.kt
@@ -427,16 +427,7 @@ class AddonManagerTest {
 
     @Test
     fun `installAddon successfully`() {
-        val addon = Addon(
-            id = "ext1",
-            authors = emptyList(),
-            categories = emptyList(),
-            downloadUrl = "",
-            version = "",
-            createdAt = "",
-            updatedAt = ""
-        )
-
+        val addon = Addon(id = "ext1")
         val engine: Engine = mock()
         val onSuccessCaptor = argumentCaptor<((WebExtension) -> Unit)>()
 
@@ -460,15 +451,7 @@ class AddonManagerTest {
 
     @Test
     fun `installAddon failure`() {
-        val addon = Addon(id = "ext1",
-            authors = emptyList(),
-            categories = emptyList(),
-            downloadUrl = "",
-            version = "",
-            createdAt = "",
-            updatedAt = ""
-        )
-
+        val addon = Addon(id = "ext1")
         val engine: Engine = mock()
         val onErrorCaptor = argumentCaptor<((String, Throwable) -> Unit)>()
 
@@ -520,12 +503,6 @@ class AddonManagerTest {
     fun `uninstallAddon successfully`() {
         val installedAddon = Addon(
             id = "ext1",
-            authors = emptyList(),
-            categories = emptyList(),
-            downloadUrl = "",
-            version = "",
-            createdAt = "",
-            updatedAt = "",
             installedState = Addon.InstalledState("ext1", "1.0", "", true)
         )
 
@@ -550,16 +527,7 @@ class AddonManagerTest {
 
     @Test
     fun `uninstallAddon failure cases`() {
-        val addon = Addon(
-            id = "ext1",
-            authors = emptyList(),
-            categories = emptyList(),
-            downloadUrl = "",
-            version = "",
-            createdAt = "",
-            updatedAt = ""
-        )
-
+        val addon = Addon(id = "ext1")
         val engine: Engine = mock()
         val onErrorCaptor = argumentCaptor<((String, Throwable) -> Unit)>()
         var throwable: Throwable? = null
@@ -598,12 +566,6 @@ class AddonManagerTest {
     fun `enableAddon successfully`() {
         val addon = Addon(
             id = "ext1",
-            authors = emptyList(),
-            categories = emptyList(),
-            downloadUrl = "",
-            version = "",
-            createdAt = "",
-            updatedAt = "",
             installedState = Addon.InstalledState("ext1", "1.0", "", true)
         )
 
@@ -629,15 +591,7 @@ class AddonManagerTest {
 
     @Test
     fun `enableAddon failure cases`() {
-        val addon = Addon(
-            id = "ext1",
-            authors = emptyList(),
-            categories = emptyList(),
-            downloadUrl = "",
-            version = "",
-            createdAt = "",
-            updatedAt = ""
-        )
+        val addon = Addon(id = "ext1")
         val engine: Engine = mock()
         val onErrorCaptor = argumentCaptor<((Throwable) -> Unit)>()
         var throwable: Throwable? = null
@@ -673,12 +627,6 @@ class AddonManagerTest {
     fun `disableAddon successfully`() {
         val addon = Addon(
             id = "ext1",
-            authors = emptyList(),
-            categories = emptyList(),
-            downloadUrl = "",
-            version = "",
-            createdAt = "",
-            updatedAt = "",
             installedState = Addon.InstalledState("ext1", "1.0", "", true)
         )
 
@@ -704,15 +652,7 @@ class AddonManagerTest {
 
     @Test
     fun `disableAddon failure cases`() {
-        val addon = Addon(
-            id = "ext1",
-            authors = emptyList(),
-            categories = emptyList(),
-            downloadUrl = "",
-            version = "",
-            createdAt = "",
-            updatedAt = ""
-        )
+        val addon = Addon(id = "ext1")
         val engine: Engine = mock()
         val onErrorCaptor = argumentCaptor<((Throwable) -> Unit)>()
         var throwable: Throwable? = null

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/amo/AddonCollectionProviderTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/amo/AddonCollectionProviderTest.kt
@@ -58,6 +58,10 @@ class AddonCollectionProviderTest {
             addon.siteUrl
         )
         assertEquals(
+            "3428595",
+            addon.downloadId
+        )
+        assertEquals(
             "https://addons.mozilla.org/firefox/downloads/file/3428595/ublock_origin-1.23.0-an+fx.xpi?src=",
             addon.downloadUrl
         )
@@ -108,6 +112,7 @@ class AddonCollectionProviderTest {
         assertEquals("", addon.iconUrl)
         assertEquals("", addon.siteUrl)
         assertEquals("", addon.version)
+        assertEquals("", addon.downloadId)
         assertEquals("", addon.downloadUrl)
         assertTrue(addon.permissions.isEmpty())
         assertTrue(addon.translatableName.isEmpty())

--- a/components/feature/addons/src/test/resources/collection_with_empty_values.json
+++ b/components/feature/addons/src/test/resources/collection_with_empty_values.json
@@ -28,7 +28,6 @@
           "edit_url": "https://addons.mozilla.org/en-US/developers/addon/ublock-origin/versions/4884220",
           "files": [
             {
-              "id": 3428595,
               "created": "2019-10-21T16:37:32Z",
               "hash": "sha256:b72c8bf1038d18e2d8badd0accd20f9d6938efe2f45303e99aaab189a66dbbc1",
               "is_restart_required": false,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,9 @@ permalink: /changelog/
 * **browser-session**
   * `SelectionAwareSessionObserver` is now deprecated. All session state changes can be observed using the browser store (`browser-state` module).    
 
+* **feature-addons**
+  * `AddonManager.getAddons()` now accepts a new (optional) `allowCache` parameter to configure whether or not a cached response may be returned. This is useful in case a UI flow needs the most up-to-date addons list, or to support "refresh" functionality. By default, cached responses are allowed.
+
 # 65.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v64.0.0...v65.0.0)


### PR DESCRIPTION
Just exposing the file (download) ID of the add-on in addition to the URL. We will use this ID to map to the corresponding add-on when supporting installation via AMO. It's fine to keep relying on the latest supported version as AMO and Fenix's recommended list will be kept in sync.

In Fenix, we will navigate to the Add-ons manager, refresh the add-ons list, find the corresponding add-on and trigger the permission dialog and installation.