### PR TITLE
Closes #8943 refactor SwipeRefreshFeature to not use EngineSession.Observer

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -140,6 +140,7 @@ internal class EngineObserver(
         session.loading = loading
         if (loading) {
             store?.dispatch(ContentAction.ClearFindResultsAction(session.id))
+            store?.dispatch(ContentAction.UpdateRefreshCanceledStateAction(session.id, false))
 
             session.trackersBlocked = emptyList()
             session.trackersLoaded = emptyList()
@@ -282,6 +283,10 @@ internal class EngineObserver(
             session.id,
             promptRequest
         ))
+    }
+
+    override fun onRepostPromptCancelled() {
+        store?.dispatch(ContentAction.UpdateRefreshCanceledStateAction(session.id, true))
     }
 
     override fun onWindowRequest(windowRequest: WindowRequest) {

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -432,6 +432,33 @@ class EngineObserverTest {
     }
 
     @Test
+    fun engineObserverClearsRefreshCanceledIfNewPageStartsLoading() {
+        val session = Session("https://www.mozilla.org", id = "test-id")
+        val store: BrowserStore = mock()
+        val observer = EngineObserver(session, store)
+
+        observer.onRepostPromptCancelled()
+
+        verify(store).dispatch(ContentAction.UpdateRefreshCanceledStateAction("test-id", true))
+
+        reset(store)
+
+        observer.onLoadingStateChange(true)
+
+        verify(store).dispatch(ContentAction.UpdateRefreshCanceledStateAction("test-id", false))
+    }
+
+    @Test
+    fun engineObserverHandlesOnRepostPromptCancelled() {
+        val session = Session("")
+        val store: BrowserStore = mock()
+        val observer = EngineObserver(session, store)
+
+        observer.onRepostPromptCancelled()
+        verify(store).dispatch(ContentAction.UpdateRefreshCanceledStateAction(session.id, true))
+    }
+
+    @Test
     fun engineObserverNotifiesFullscreenMode() {
         val session = Session("https://www.mozilla.org", id = "test-id")
         val store: BrowserStore = mock()

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -293,6 +293,12 @@ sealed class ContentAction : BrowserAction() {
         ContentAction()
 
     /**
+     * Updates the refreshCanceled state of the [ContentState] with the given [sessionId].
+     */
+    data class UpdateRefreshCanceledStateAction(val sessionId: String, val refreshCanceled: Boolean) :
+            ContentAction()
+
+    /**
      * Updates the search terms of the [ContentState] with the given [sessionId].
      */
     data class UpdateSearchTermsAction(val sessionId: String, val searchTerms: String) :

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
@@ -44,6 +44,9 @@ internal object ContentStateReducer {
             is ContentAction.UpdateLoadingStateAction -> updateContentState(state, action.sessionId) {
                 it.copy(loading = action.loading)
             }
+            is ContentAction.UpdateRefreshCanceledStateAction -> updateContentState(state, action.sessionId) {
+                it.copy(refreshCanceled = action.refreshCanceled)
+            }
             is ContentAction.UpdateSearchTermsAction -> updateContentState(state, action.sessionId) {
                 it.copy(searchTerms = action.searchTerms)
             }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
@@ -46,6 +46,10 @@ import mozilla.components.concept.engine.window.WindowRequest
  * @property loadRequest last [LoadRequestState] if this session.
  * @property permissionRequestsList Holds unprocessed content requests.
  * @property appPermissionRequestsList Holds unprocessed app requests.
+ * @property refreshCanceled Indicates if an intent of refreshing was canceled.
+ * True if a page refresh was cancelled by the user, defaults to false. Note that this is not about
+ * stopping an ongoing page load but useful in cases like swipe-to-refresh which allow users to
+ * cancel or abort before a page is refreshed.
  */
 data class ContentState(
     val url: String,
@@ -73,5 +77,6 @@ data class ContentState(
     val permissionRequestsList: List<PermissionRequest> = emptyList(),
     val appPermissionRequestsList: List<PermissionRequest> = emptyList(),
     val pictureInPictureEnabled: Boolean = false,
-    val loadRequest: LoadRequestState? = null
+    val loadRequest: LoadRequestState? = null,
+    val refreshCanceled: Boolean = false
 )

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
@@ -148,6 +148,28 @@ class ContentActionTest {
     }
 
     @Test
+    fun `UpdateRefreshCanceledStateAction updates refreshCanceled state`() {
+        assertFalse(tab.content.refreshCanceled)
+        assertFalse(otherTab.content.refreshCanceled)
+
+        store.dispatch(ContentAction.UpdateRefreshCanceledStateAction(tab.id, true)).joinBlocking()
+
+        assertTrue(tab.content.refreshCanceled)
+        assertFalse(otherTab.content.refreshCanceled)
+
+        store.dispatch(ContentAction.UpdateRefreshCanceledStateAction(tab.id, false)).joinBlocking()
+
+        assertFalse(tab.content.refreshCanceled)
+        assertFalse(otherTab.content.refreshCanceled)
+
+        store.dispatch(ContentAction.UpdateRefreshCanceledStateAction(tab.id, true)).joinBlocking()
+        store.dispatch(ContentAction.UpdateRefreshCanceledStateAction(otherTab.id, true)).joinBlocking()
+
+        assertTrue(tab.content.refreshCanceled)
+        assertTrue(otherTab.content.refreshCanceled)
+    }
+
+    @Test
     fun `UpdateTitleAction updates title`() {
         val newTitle = "This is a title"
 

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SwipeRefreshFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SwipeRefreshFeature.kt
@@ -5,20 +5,18 @@
 package mozilla.components.feature.session
 
 import android.view.View
-import androidx.annotation.VisibleForTesting
-import androidx.annotation.VisibleForTesting.PRIVATE
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
+import mozilla.components.browser.state.action.ContentAction.UpdateRefreshCanceledStateAction
 import mozilla.components.browser.state.selector.findTabOrCustomTabOrSelectedTab
 import mozilla.components.browser.state.store.BrowserStore
-import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.support.base.feature.LifecycleAwareFeature
-import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
 
 /**
  * Feature implementation to add pull to refresh functionality to browsers.
@@ -32,10 +30,7 @@ class SwipeRefreshFeature(
     private val tabId: String? = null
 ) : LifecycleAwareFeature,
     SwipeRefreshLayout.OnChildScrollUpCallback,
-    SwipeRefreshLayout.OnRefreshListener,
-    EngineSession.Observer {
-
-    private var currentSession: EngineSession? = null
+    SwipeRefreshLayout.OnRefreshListener {
     private var scope: CoroutineScope? = null
 
     init {
@@ -47,21 +42,28 @@ class SwipeRefreshFeature(
      * Start feature: Starts adding pull to refresh behavior for the active session.
      */
     override fun start() {
-        currentSession = store.state.findTabOrCustomTabOrSelectedTab(tabId)?.engineState?.engineSession?.also {
-            it.register(this)
-        }
         scope = store.flowScoped { flow ->
             flow.map { state -> state.findTabOrCustomTabOrSelectedTab(tabId) }
-                .map { tab -> tab?.content?.loading ?: false }
-                .ifChanged()
-                .collect { loading ->
-                    onLoadingStateChanged(loading)
+                .ifAnyChanged {
+                    arrayOf(it?.content?.loading, it?.content?.refreshCanceled)
+                }
+                .collect { tab ->
+                    tab?.let {
+                        if (!tab.content.loading || tab.content.refreshCanceled) {
+                            swipeRefreshLayout.isRefreshing = false
+                            if (tab.content.refreshCanceled) {
+                                // In case the user tries to refresh again
+                                // we need to reset refreshCanceled, to be able to
+                                // get a subsequent event.
+                                store.dispatch(UpdateRefreshCanceledStateAction(tab.id, false))
+                            }
+                        }
+                    }
                 }
         }
     }
 
     override fun stop() {
-        currentSession?.unregister(this)
         scope?.cancel()
     }
 
@@ -84,21 +86,6 @@ class SwipeRefreshFeature(
     override fun onRefresh() {
         store.state.findTabOrCustomTabOrSelectedTab(tabId)?.let { tab ->
             reloadUrlUseCase(tab.id)
-        }
-    }
-
-    override fun onRepostPromptCancelled() {
-        swipeRefreshLayout.isRefreshing = false
-    }
-
-    /**
-     * Called when the current session starts or stops refreshing.
-     */
-    @VisibleForTesting(otherwise = PRIVATE)
-    internal fun onLoadingStateChanged(loading: Boolean) {
-        // Don't activate the indicator unless triggered by a gesture.
-        if (!loading) {
-            swipeRefreshLayout.isRefreshing = loading
         }
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,8 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **feature-sitepermissions**
+  * 🚒 Bug fixed [issue #8943](https://github.com/mozilla-mobile/android-components/issues/8943) Refactor `SwipeRefreshFeature` to not use `EngineSession.Observer`, this result in multiple site permissions bugs getting fixed see [fenix#8987](https://github.com/mozilla-mobile/fenix/issues/8987) and [fenix#16411](https://github.com/mozilla-mobile/fenix/issues/16411).
 
 # 66.0.0
 


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
