### PR TITLE
Fixes #8815 Expose global opt out for first inclusion with Fenix

### DIFF
--- a/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/Nimbus.kt
+++ b/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/Nimbus.kt
@@ -20,6 +20,7 @@ import org.mozilla.experiments.nimbus.AppContext
 import org.mozilla.experiments.nimbus.AvailableRandomizationUnits
 import org.mozilla.experiments.nimbus.EnrolledExperiment
 import org.mozilla.experiments.nimbus.NimbusClient
+import org.mozilla.experiments.nimbus.NimbusClientInterface
 import org.mozilla.experiments.nimbus.RemoteSettingsConfig
 import java.io.File
 import java.util.Locale
@@ -28,7 +29,7 @@ import java.util.concurrent.Executors
 /**
  * This is the main experiments API, which is exposed through the global [Nimbus] object.
  */
-internal interface NimbusApi {
+interface NimbusApi {
     /**
      * Get the list of currently enrolled experiments
      *
@@ -58,38 +59,33 @@ internal interface NimbusApi {
     fun optOut(experimentId: String)
 
     /**
-     * Set global opt-in/out for all experiments
-     *
-     * @param active Set `true` to enable experiment enrollment or `false` to unenroll from all
+     * Control the opt out for all experiments at once. This is likely a user action.
      */
-    fun setGlobalUserParticipation(active: Boolean)
-
-    /**
-     * Get current global opt-in/out state for all experiments
-     *
-     * @return the current state of the global participation, or null if not initialized
-     */
-    fun getGlobalUserParticipation(): Boolean?
+    var globalUserParticipation: Boolean
 }
+
+private const val LOG_TAG = "service/Nimbus"
+private const val EXPERIMENT_BUCKET_NAME = "main"
+private const val EXPERIMENT_COLLECTION_NAME = "nimbus-mobile-experiments"
+private const val NIMBUS_DATA_DIR: String = "nimbus_data"
 
 /**
  * A singleton implementation of the [NimbusApi] interface backed by the Nimbus SDK.
  */
-object Nimbus : NimbusApi {
-    private const val LOG_TAG = "service/Nimbus"
-    private const val EXPERIMENT_BUCKET_NAME = "main"
-    private const val EXPERIMENT_COLLECTION_NAME = "nimbus-mobile-experiments"
-    private const val NIMBUS_DATA_DIR: String = "nimbus_data"
-
+class Nimbus : NimbusApi {
     // Using a single threaded executor here to enforce synchronization where needed.
     private val scope: CoroutineScope =
         CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
 
-    private lateinit var nimbus: NimbusClient
+    private lateinit var nimbus: NimbusClientInterface
     private lateinit var dataDir: File
     private var onExperimentUpdated: ((List<EnrolledExperiment>) -> Unit)? = null
 
     private var isInitialized = false
+
+    override var globalUserParticipation: Boolean
+        get() = nimbus.getGlobalUserParticipation()
+        set(active) = nimbus.setGlobalUserParticipation(active)
 
     /**
      * Initialize the Nimbus SDK library.
@@ -108,7 +104,7 @@ object Nimbus : NimbusApi {
      * callback will be supplied with the list of active experiments (if any) for which the client
      * is enrolled.
      */
-    fun init(
+    fun initialize(
         context: Context,
         onExperimentUpdated: ((activeExperiments: List<EnrolledExperiment>) -> Unit)? = null
     ) {
@@ -121,28 +117,28 @@ object Nimbus : NimbusApi {
 
         this.onExperimentUpdated = onExperimentUpdated
 
+        // Build Nimbus AppContext object to pass into initialize
+        val experimentContext = buildExperimentContext(context)
+
+        // Build a File object to represent the data directory for Nimbus data
+        dataDir = File(context.applicationInfo.dataDir, NIMBUS_DATA_DIR)
+
+        // Initialize Nimbus
+        nimbus = NimbusClient(
+            experimentContext,
+            dataDir.path,
+            RemoteSettingsConfig(
+                serverUrl = context.resources.getString(R.string.nimbus_default_endpoint),
+                bucketName = EXPERIMENT_BUCKET_NAME,
+                collectionName = EXPERIMENT_COLLECTION_NAME
+            ),
+            // The "dummy" field here is required for obscure reasons when generating code on desktop,
+            // so we just automatically set it to a dummy value.
+            AvailableRandomizationUnits(clientId = null, dummy = 0)
+        )
+
         // Do initialization off of the main thread
         scope.launch {
-            // Build Nimbus AppContext object to pass into initialize
-            val experimentContext = buildExperimentContext(context)
-
-            // Build a File object to represent the data directory for Nimbus data
-            dataDir = File(context.applicationInfo.dataDir, NIMBUS_DATA_DIR)
-
-            // Initialize Nimbus
-            nimbus = NimbusClient(
-                experimentContext,
-                dataDir.path,
-                RemoteSettingsConfig(
-                    serverUrl = context.resources.getString(R.string.nimbus_default_endpoint),
-                    bucketName = EXPERIMENT_BUCKET_NAME,
-                    collectionName = EXPERIMENT_COLLECTION_NAME
-                ),
-                // The "dummy" field here is required for obscure reasons when generating code on desktop,
-                // so we just automatically set it to a dummy value.
-                AvailableRandomizationUnits(clientId = null, dummy = 0)
-            )
-
             // Get experiments
             val activeExperiments = nimbus.getActiveExperiments()
 
@@ -172,16 +168,6 @@ object Nimbus : NimbusApi {
     override fun optOut(experimentId: String) {
         if (!isInitialized) return
         nimbus.optOut(experimentId)
-    }
-
-    override fun setGlobalUserParticipation(active: Boolean) {
-        if (!isInitialized) return
-        nimbus.setGlobalUserParticipation(active)
-    }
-
-    override fun getGlobalUserParticipation(): Boolean? {
-        if (!isInitialized) return null
-        return nimbus.getGlobalUserParticipation()
     }
 
     // This function shouldn't be exposed to the public API, but is meant for testing purposes to

--- a/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/NimbusTest.kt
+++ b/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/NimbusTest.kt
@@ -53,7 +53,8 @@ class NimbusTest {
             userFacingDescription = "A test experiment for testing experiments",
             userFacingName = "Test Experiment"))
 
-        Nimbus.recordExperimentTelemetry(experiments = enrolledExperiments)
+        val nimbus = Nimbus()
+        nimbus.recordExperimentTelemetry(experiments = enrolledExperiments)
         assertTrue(Glean.testIsExperimentActive("test-experiment"))
         val experimentData = Glean.testGetExperimentData("test-experiment")
         assertEquals("test-branch", experimentData.branch)

--- a/samples/glean/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
+++ b/samples/glean/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
@@ -22,6 +22,12 @@ import org.mozilla.samples.glean.GleanMetrics.Pings
 
 class GleanApplication : Application() {
 
+    companion object {
+        val nimbus: Nimbus by lazy {
+            Nimbus()
+        }
+    }
+
     override fun onCreate() {
         super.onCreate()
 
@@ -58,7 +64,7 @@ class GleanApplication : Application() {
     private fun initNimbus() {
         RustLog.enable()
         RustHttpConfig.setClient(lazy { HttpURLConnectionClient() })
-        Nimbus.init(this) {
+        nimbus.initialize(this) {
             val intent = Intent()
             intent.action = "org.mozilla.samples.glean.experiments.updated"
             sendBroadcast(intent)

--- a/samples/glean/src/main/java/org/mozilla/samples/glean/MainActivity.kt
+++ b/samples/glean/src/main/java/org/mozilla/samples/glean/MainActivity.kt
@@ -9,10 +9,9 @@ import android.graphics.Color
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import kotlinx.android.synthetic.main.activity_main.*
-import mozilla.components.service.nimbus.Nimbus
 import org.mozilla.experiments.nimbus.EnrolledExperiment
-import org.mozilla.samples.glean.GleanMetrics.Test
 import org.mozilla.samples.glean.GleanMetrics.BrowserEngagement
+import org.mozilla.samples.glean.GleanMetrics.Test
 import org.mozilla.samples.glean.library.SamplesGleanLibrary
 
 /**
@@ -97,10 +96,10 @@ open class MainActivity : AppCompatActivity(), ExperimentUpdateReceiver.Experime
         textViewExperimentStatus.setBackgroundColor(Color.WHITE)
         textViewExperimentStatus.text = getString(R.string.experiment_not_active)
 
-        activeExperiments = Nimbus.getActiveExperiments()
-
+        val nimbus = GleanApplication.nimbus
+        activeExperiments = nimbus.getActiveExperiments()
         if (activeExperiments.any { it.slug == "test-color" }) {
-            val color = when (Nimbus.getExperimentBranch("test-color")) {
+            val color = when (nimbus.getExperimentBranch("test-color")) {
                 "blue" -> Color.BLUE
                 "red" -> Color.RED
                 "control" -> Color.DKGRAY
@@ -112,7 +111,7 @@ open class MainActivity : AppCompatActivity(), ExperimentUpdateReceiver.Experime
                 textViewExperimentStatus.setBackgroundColor(color)
                 textViewExperimentStatus.text = getString(
                     R.string.experiment_active_branch,
-                    "Experiment Branch: ${Nimbus.getExperimentBranch("test-color")}")
+                    "Experiment Branch: ${nimbus.getExperimentBranch("test-color")}")
             }
         }
     }


### PR DESCRIPTION
Fixes #8815.

This PR starts the process of integrating the [Nimbus Android Component][1], specifically to expose the `globalUserParticipation` property.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

[1]: https://docs.google.com/document/d/1kchihPal0__A4VOAiPJarNuZXns5KhOHHfIeIzT6zfU/edit