### PR TITLE
Closes #8967 prevent handling invalid requests in FilePicker

### DIFF
--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/file/FilePickerTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/file/FilePickerTest.kt
@@ -231,6 +231,25 @@ class FilePickerTest {
     }
 
     @Test
+    fun `onActivityResult will not process any PromptRequest that is not a File request`() {
+        var wasConfirmed = false
+        var wasDismissed = false
+        val onConfirm: (Boolean) -> Unit = { wasConfirmed = true }
+        val onDismiss = { wasDismissed = true }
+        val invalidRequest = PromptRequest.Alert("", "", false, onDismiss, onConfirm)
+        val spiedFilePicker = spy(filePicker)
+        val selected = prepareSelectedSession(invalidRequest)
+        val intent = Intent()
+
+        spiedFilePicker.onActivityResult(FILE_PICKER_ACTIVITY_REQUEST_CODE, RESULT_OK, intent)
+
+        assertFalse(wasConfirmed)
+        assertFalse(wasDismissed)
+        verify(store, never()).dispatch(ContentAction.ConsumePromptRequestAction(selected.id))
+        verify(spiedFilePicker, never()).handleFilePickerIntentResult(intent, request)
+    }
+
+    @Test
     fun `onRequestPermissionsResult with FILE_PICKER_REQUEST and PERMISSION_GRANTED will call onPermissionsGranted`() {
         stubContext()
         filePicker = spy(filePicker)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **feature-sitepermissions**
   * 🚒 Bug fixed [issue #8943](https://github.com/mozilla-mobile/android-components/issues/8943) Refactor `SwipeRefreshFeature` to not use `EngineSession.Observer`, this result in multiple site permissions bugs getting fixed see [fenix#8987](https://github.com/mozilla-mobile/fenix/issues/8987) and [fenix#16411](https://github.com/mozilla-mobile/fenix/issues/16411).
 
+* **feature-prompts**
+  * 🚒 Bug fixed [issue #8967](https://github.com/mozilla-mobile/android-components/issues/8967) Crash when trying to upload a file see [fenix#16537](https://github.com/mozilla-mobile/fenix/issues/16537), for more information.
+
 # 66.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v65.0.0...v66.0.0)


### PR DESCRIPTION
Details in https://github.com/mozilla-mobile/android-components/issues/8967 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
