### PR TITLE
Add an autofill test to demonstrate how to load and use the API.

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -268,6 +268,10 @@ projects:
     path: components/ui/tabcounter
     description: 'A tab counter for browsers.'
     publish: true
+  service-autofill:
+    path: components/service/autofill
+    description: 'A library for autofilling addresses and credit cards.'
+    publish: true
   service-firefox-accounts:
     path: components/service/firefox-accounts
     description: 'A library for integrating with Firefox Accounts.'

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -142,6 +142,7 @@ object Dependencies {
     const val mozilla_sync_logins = "org.mozilla.appservices:logins:${Versions.mozilla_appservices}"
     const val mozilla_places = "org.mozilla.appservices:places:${Versions.mozilla_appservices}"
     const val mozilla_sync_manager = "org.mozilla.appservices:syncmanager:${Versions.mozilla_appservices}"
+    const val mozilla_autofill = "org.mozilla.appservices:autofill:${Versions.mozilla_appservices}"
 
     const val mozilla_push = "org.mozilla.appservices:push:${Versions.mozilla_appservices}"
 

--- a/components/service/autofill/build.gradle
+++ b/components/service/autofill/build.gradle
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion config.minSdkVersion
+    }
+
+    lintOptions {
+        warningsAsErrors true
+        abortOnError true
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'proguard-rules-consumer.pro'
+        }
+    }
+}
+
+dependencies {
+    api Dependencies.mozilla_autofill
+
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
+
+    implementation Dependencies.androidx_work_runtime
+
+    testImplementation project(':support-test')
+    testImplementation Dependencies.androidx_test_core
+    testImplementation Dependencies.androidx_test_junit
+    testImplementation Dependencies.androidx_work_testing
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_coroutines
+
+    testImplementation Dependencies.mozilla_full_megazord_forUnitTests
+    testImplementation Dependencies.kotlin_reflect
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/components/service/autofill/proguard-rules-consumer.pro
+++ b/components/service/autofill/proguard-rules-consumer.pro
@@ -1,0 +1,4 @@
+# ProGuard rules for consumers of this library.
+
+# Experiments specific protections
+-keep class mozilla.components.service.nimbus.** { *; }

--- a/components/service/autofill/proguard-rules.pro
+++ b/components/service/autofill/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/service/autofill/src/main/AndroidManifest.xml
+++ b/components/service/autofill/src/main/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest package="mozilla.components.service.autofill"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+</manifest>

--- a/components/service/autofill/src/test/java/mozilla/components/service/autofill/TestAutofill.kt
+++ b/components/service/autofill/src/test/java/mozilla/components/service/autofill/TestAutofill.kt
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.autofill
+
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.core.app.ApplicationProvider
+import android.content.Context
+import org.junit.Assert.assertEquals
+import org.junit.runner.RunWith
+import org.junit.Test
+import org.mozilla.appservices.autofill.Store
+import org.mozilla.appservices.autofill.NewCreditCardFields
+import java.io.File
+import mozilla.appservices.Megazord
+
+@RunWith(AndroidJUnit4::class)
+class AutofillTest {
+    @Test
+    fun `check we can create and use the low level component`() {
+        // Set the name of the native library so that we use
+        // the appservices megazord for compiled code.
+        Megazord.init()
+        System.setProperty(
+            "uniffi.component.autofill.libraryOverride",
+            System.getProperty("mozilla.appservices.megazord.library", "megazord")
+        )
+
+        val context: Context = ApplicationProvider.getApplicationContext()
+        val dataDir = File(context.applicationInfo.dataDir, "autofill")
+        val store = Store(dataDir.path)
+
+        // Add a credit-card.
+        val cc = NewCreditCardFields(
+            ccName = "My name",
+            ccNumber = "1234-5678-9012-3456",
+            ccExpMonth = 12,
+            ccExpYear = 2020,
+            ccType = "fake"
+        )
+        val added = store.addCreditCard(cc)
+        val fetched = store.getCreditCard(added.guid)
+        assertEquals(added, fetched)
+        assertEquals(fetched.ccType, "fake")
+    }
+}
+


### PR DESCRIPTION
Test via `./gradlew :service-autofill:test`

This is unlikely to ever evolve into a real PR, it's more of an example to help @grigoryk get started.

Creates a `mozilla.components.service.autofill` package - this might also be a good time to discuss the naming of this component - grepping for `autofill` in a-c has lots of hits. @lougeniaC64 were discussing this but failed to some up with a good name. Maybe `adcc`? Not self-describing, but maybe better than `addresses_and_creditcards` :)
