### PR TITLE
Uplift: For fenix#16232 - Make sure we cancel any in-progress auth

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -389,6 +389,12 @@ open class FxaAccountManager(
      * @return An authentication url which is to be presented to the user.
      */
     suspend fun beginAuthentication(pairingUrl: String? = null): String? {
+        // It's possible that at this point authentication is considered to be "in-progress".
+        // For example, if user started authentication flow, but cancelled it (closing a custom tab)
+        // without finishing.
+        // In a clean scenario (no prior auth attempts), this event will be ignored by the state machine.
+        processQueue(Event.Progress.CancelAuth)
+
         val event = if (pairingUrl != null) {
             Event.Account.BeginPairingFlow(pairingUrl)
         } else {

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/State.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/State.kt
@@ -59,6 +59,8 @@ internal sealed class Event {
         object FailedToCompleteAuthRestore : Progress()
         object FailedToCompleteAuth : Progress()
 
+        object CancelAuth : Progress()
+
         object FailedToRecoverFromAuthenticationProblem : Progress()
         object RecoveredFromAuthenticationProblem : Progress()
 
@@ -110,6 +112,7 @@ internal fun State.next(event: Event): State? = when (this) {
         ProgressState.BeginningAuthentication -> when (event) {
             is Event.Progress.AuthData -> State.Active(ProgressState.CompletingAuthentication)
             Event.Progress.FailedToBeginAuth -> State.Idle(AccountState.NotAuthenticated)
+            Event.Progress.CancelAuth -> State.Idle(AccountState.NotAuthenticated)
             else -> null
         }
         ProgressState.CompletingAuthentication -> when (event) {

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/manager/StateKtTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/manager/StateKtTest.kt
@@ -44,6 +44,7 @@ class StateKtTest {
                 }
                 ProgressState.BeginningAuthentication -> when (event) {
                     Event.Progress.FailedToBeginAuth -> State.Idle(AccountState.NotAuthenticated)
+                    Event.Progress.CancelAuth -> State.Idle(AccountState.NotAuthenticated)
                     is Event.Progress.AuthData -> State.Active(ProgressState.CompletingAuthentication)
                     else -> null
                 }
@@ -79,6 +80,7 @@ class StateKtTest {
             "Start" -> Event.Account.Start
             "BeginPairingFlow" -> Event.Account.BeginPairingFlow("http://some.pairing.url.com")
             "BeginEmailFlow" -> Event.Account.BeginEmailFlow
+            "CancelAuth" -> Event.Progress.CancelAuth
             "AuthenticationError" -> Event.Account.AuthenticationError("fxa op")
             "MigrateFromAccount" -> Event.Account.MigrateFromAccount(mock(), true)
             "RetryMigration" -> Event.Account.RetryMigration


### PR DESCRIPTION
> Uplift: For fenix#16232 - Make sure we cancel any in-progress auth

Prior to https://github.com/mozilla-mobile/android-components/pull/7856 we only had a NotAuthenticated
state, which user would remain in until the very end of the authentication process (receiving a 'finished...' api call).

After the refactor, we introduced an in-progress states - specifically, BeginningAuthentication. If the user
cancels the auth flow (e.g. closes a custom tab), they will remain in this state. Subsequent login attempts
would then fail.

This patch fixes this by introducing a Cancel event which we trigger whenever handling 'beginAuthentication' calls.
In normal scenarios, this event is ignored. Otherwise, it "resets" the state machine into NotAuthenticated
state before emitting any Begin* events.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
