### PR TITLE
Mergify: Automatically approve uplift PRs bumping Gecko and release version

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -29,6 +29,19 @@ pull_request_rules:
       merge:
         method: rebase
         strict: smart
+  - name: Release automation
+    conditions:
+      - base~=releases/.*
+      - author=st3fan
+      - status-success=complete-pr
+      - files~=(.buildconfig.yml|Gecko.kt)
+    actions:
+      review:
+        type: APPROVE
+        message: 🚢
+      merge:
+        method: rebase
+        strict: smart
   - name: Needs landing - Rebase
     conditions:
       - status-success=complete-pr


### PR DESCRIPTION
This automatically approves PRs from @st3fan's scripts that bump the GeckoView and/or release version on our release branches.