### PR TITLE
Update Taskcluster and Mergify badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Android components
 
-[![Task Status](https://github.taskcluster.net/v1/repository/mozilla-mobile/android-components/master/badge.svg)](https://github.taskcluster.net/v1/repository/mozilla-mobile/android-components/master/latest)
+[![Task Status](https://firefox-ci-tc.services.mozilla.com/api/github/v1/repository/mozilla-mobile/android-components/master/badge.svg)](https://firefox-ci-tc.services.mozilla.com/api/github/v1/repository/mozilla-mobile/android-components/master/latest)
 [![codecov](https://codecov.io/gh/mozilla-mobile/android-components/branch/master/graph/badge.svg)](https://codecov.io/gh/mozilla-mobile/android-components)
-[![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/19637)
+[![Mergify Status](https://img.shields.io/endpoint.svg?url=https://gh.mergify.io/badges/mozilla-mobile/android-components&style=flat)](https://mergify.io)
 [![chat.mozilla.org](https://img.shields.io/badge/chat-on%20matrix-51bb9c)](https://chat.mozilla.org/#/room/#android-components:mozilla.org)
 
 _A collection of Android libraries to build browsers or browser-like applications._


### PR DESCRIPTION
With the badge now [rendering correctly](https://github.com/taskcluster/taskcluster/issues/3358) we can update the badge in our README based on [the docs][0] where the SVG can be found. That said, there is still something broken because it shows 'no info yet'. 😄 

Will file another issue for that with the TC team.

[0]: https://firefox-ci-tc.services.mozilla.com/docs/reference/integrations/github#adding-status-badges-to-your-projects-readme

Replaced bors (rip) badge for the Mergify one as well based on [these docs](https://docs.mergify.io/badge.html).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
