### PR TITLE
Closes #9017: Memory leak in consumeFlow

### DIFF
--- a/components/lib/state/src/main/java/mozilla/components/lib/state/Store.kt
+++ b/components/lib/state/src/main/java/mozilla/components/lib/state/Store.kt
@@ -7,6 +7,7 @@ package mozilla.components.lib.state
 import android.os.Handler
 import android.os.Looper
 import androidx.annotation.CheckResult
+import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -38,7 +39,8 @@ open class Store<S : State, A : Action>(
     private val dispatcher = Executors.newSingleThreadExecutor(threadFactory).asCoroutineDispatcher()
     private val reducerChainBuilder = ReducerChainBuilder(threadFactory, reducer, middleware)
     private val scope = CoroutineScope(dispatcher)
-    private val subscriptions = Collections.newSetFromMap(ConcurrentHashMap<Subscription<S, A>, Boolean>())
+    @VisibleForTesting
+    internal val subscriptions = Collections.newSetFromMap(ConcurrentHashMap<Subscription<S, A>, Boolean>())
     private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
         // We want exceptions in the reducer to crash the app and not get silently ignored. Therefore we rethrow the
         // exception on the main thread.


### PR DESCRIPTION
Details in #9017 and in source comments below. :)

TL;DR: It's possible for the owning view/fragment to be destroyed before the flow is produced (this happens async on another coroutine). We would then create a subscription and never unsubscribe because `onDestroy` already happened, leaking the subscription and owner.

Alternatively, I've tried checking `owner.lifecycle.currentState` directly in `channelFlow` but that doesn't work reliably whereas this does. 

STR in Fenix:
Open new private tab
Switch to regular tab
Switch back to private mode