### PR TITLE
Closes #9022: Memory leak in BrowserThumbnails.requestScreenshot

### DIFF
--- a/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/BrowserThumbnails.kt
+++ b/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/BrowserThumbnails.kt
@@ -58,6 +58,11 @@ class BrowserThumbnails(
      */
     fun requestScreenshot() {
         if (!isLowOnMemory()) {
+            // Create a local reference to prevent capturing "this" in the lambda
+            // which would leak the context if the view is destroyed before the
+            // callback is invoked. This is a workaround for:
+            // https://bugzilla.mozilla.org/show_bug.cgi?id=1678364
+            val store = this.store
             engineView.captureThumbnail {
                 val bitmap = it ?: return@captureThumbnail
                 val tabId = store.state.selectedTabId ?: return@captureThumbnail

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineView.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineView.kt
@@ -96,7 +96,10 @@ interface EngineView {
 
     /**
      * Request a screenshot of the visible portion of the web page currently being rendered.
-     * @param onFinish A callback to inform that process of capturing a thumbnail has finished.
+     * @param onFinish A callback to inform that process of capturing a
+     * thumbnail has finished. Important for engine-gecko: Make sure not to reference the
+     * context or view in this callback to prevent memory leaks:
+     * https://bugzilla.mozilla.org/show_bug.cgi?id=1678364
      */
     fun captureThumbnail(onFinish: (Bitmap?) -> Unit)
 


### PR DESCRIPTION
GV ticket filed, see #9022 for details, but let's work around the leak for now until we have a generic solution.