### PR TITLE
Bump a-s dependency to 67.1.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -30,7 +30,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "2.4"
 
-    const val mozilla_appservices = "67.0.0"
+    const val mozilla_appservices = "67.1.0"
 
     const val mozilla_glean = "33.0.4"
 


### PR DESCRIPTION
Changes: https://github.com/mozilla/application-services/releases/tag/v67.1.0