### PR TITLE
For #9042 - Dismiss pull to refresh if beforeunload prompt is cancelled

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -427,6 +427,7 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         val onDeny: () -> Unit = {
             if (!geckoPrompt.isComplete) {
                 geckoResult.complete(geckoPrompt.confirm(AllowOrDeny.DENY))
+                geckoEngineSession.notifyObservers { onBeforeUnloadPromptDenied() }
             }
         }
 

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -1048,6 +1048,30 @@ class GeckoPromptDelegateTest {
     }
 
     @Test
+    fun `onBeforeUnloadPrompt will inform listeners when if navigation is cancelled`() {
+        val mockSession = GeckoEngineSession(runtime)
+        var onBeforeUnloadPromptCancelledCalled = false
+        var request: PromptRequest.BeforeUnload = mock()
+
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                request = promptRequest as PromptRequest.BeforeUnload
+            }
+
+            override fun onBeforeUnloadPromptDenied() {
+                onBeforeUnloadPromptCancelledCalled = true
+            }
+        })
+        val prompt = mock<GeckoBeforeUnloadPrompt>()
+        doReturn(false).`when`(prompt).isComplete
+
+        GeckoPromptDelegate(mockSession).onBeforeUnloadPrompt(mock(), prompt)
+        request.onStay()
+
+        assertTrue(onBeforeUnloadPromptCancelledCalled)
+    }
+
+    @Test
     fun `onSharePrompt must provide a Share PromptRequest`() {
         val mockSession = GeckoEngineSession(runtime)
         var request: PromptRequest.Share? = null

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -426,6 +426,7 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         val onDeny: () -> Unit = {
             if (!geckoPrompt.isComplete) {
                 geckoResult.complete(geckoPrompt.confirm(AllowOrDeny.DENY))
+                geckoEngineSession.notifyObservers { onBeforeUnloadPromptDenied() }
             }
         }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -1053,6 +1053,30 @@ class GeckoPromptDelegateTest {
     }
 
     @Test
+    fun `onBeforeUnloadPrompt will inform listeners when if navigation is cancelled`() {
+        val mockSession = GeckoEngineSession(runtime)
+        var onBeforeUnloadPromptCancelledCalled = false
+        var request: PromptRequest.BeforeUnload = mock()
+
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                request = promptRequest as PromptRequest.BeforeUnload
+            }
+
+            override fun onBeforeUnloadPromptDenied() {
+                onBeforeUnloadPromptCancelledCalled = true
+            }
+        })
+        val prompt = mock<GeckoBeforeUnloadPrompt>()
+        doReturn(false).`when`(prompt).isComplete
+
+        GeckoPromptDelegate(mockSession).onBeforeUnloadPrompt(mock(), prompt)
+        request.onStay()
+
+        assertTrue(onBeforeUnloadPromptCancelledCalled)
+    }
+
+    @Test
     fun `onSharePrompt must provide a Share PromptRequest`() {
         val mockSession = GeckoEngineSession(runtime)
         var request: PromptRequest.Share? = null

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -427,6 +427,7 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         val onDeny: () -> Unit = {
             if (!geckoPrompt.isComplete) {
                 geckoResult.complete(geckoPrompt.confirm(AllowOrDeny.DENY))
+                geckoEngineSession.notifyObservers { onBeforeUnloadPromptDenied() }
             }
         }
 

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -1051,6 +1051,30 @@ class GeckoPromptDelegateTest {
     }
 
     @Test
+    fun `onBeforeUnloadPrompt will inform listeners when if navigation is cancelled`() {
+        val mockSession = GeckoEngineSession(runtime)
+        var onBeforeUnloadPromptCancelledCalled = false
+        var request: PromptRequest.BeforeUnload = mock()
+
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                request = promptRequest as PromptRequest.BeforeUnload
+            }
+
+            override fun onBeforeUnloadPromptDenied() {
+                onBeforeUnloadPromptCancelledCalled = true
+            }
+        })
+        val prompt = mock<GeckoBeforeUnloadPrompt>()
+        doReturn(false).`when`(prompt).isComplete
+
+        GeckoPromptDelegate(mockSession).onBeforeUnloadPrompt(mock(), prompt)
+        request.onStay()
+
+        assertTrue(onBeforeUnloadPromptCancelledCalled)
+    }
+
+    @Test
     fun `onSharePrompt must provide a Share PromptRequest`() {
         val mockSession = GeckoEngineSession(runtime)
         var request: PromptRequest.Share? = null

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -289,6 +289,10 @@ internal class EngineObserver(
         store?.dispatch(ContentAction.UpdateRefreshCanceledStateAction(session.id, true))
     }
 
+    override fun onBeforeUnloadPromptDenied() {
+        store?.dispatch(ContentAction.UpdateRefreshCanceledStateAction(session.id, true))
+    }
+
     override fun onWindowRequest(windowRequest: WindowRequest) {
         store?.dispatch(
             ContentAction.UpdateWindowRequestAction(

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -459,6 +459,16 @@ class EngineObserverTest {
     }
 
     @Test
+    fun engineObserverHandlesOnBeforeUnloadDenied() {
+        val session = Session("")
+        val store: BrowserStore = mock()
+        val observer = EngineObserver(session, store)
+
+        observer.onBeforeUnloadPromptDenied()
+        verify(store).dispatch(ContentAction.UpdateRefreshCanceledStateAction(session.id, true))
+    }
+
+    @Test
     fun engineObserverNotifiesFullscreenMode() {
         val session = Session("https://www.mozilla.org", id = "test-id")
         val store: BrowserStore = mock()

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -82,6 +82,11 @@ abstract class EngineSession(
         fun onRepostPromptCancelled() = Unit
 
         /**
+         * User cancelled a beforeunload prompt. Navigating to another page is cancelled.
+         */
+        fun onBeforeUnloadPromptDenied() = Unit
+
+        /**
          * The engine received a request to open or close a window.
          *
          * @param windowRequest the request to describing the required window action.


### PR DESCRIPTION

![PullToRefreshIsDismissedAfterOnB](https://user-images.githubusercontent.com/11428869/99950803-ca211c80-2d85-11eb-84ce-6eb3ad277503.gif)
[video](https://drive.google.com/file/d/15y5RKMerBPHjIY9gd_XA4vBtOualVc7o/view?usp=sharing)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR or does not need a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR follows does not include any a11y user facing features.

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
