### PR TITLE
For #9043 - Stop leaking the old MotionEvent handled state

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
@@ -81,8 +81,7 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
             }
 
             MotionEvent.ACTION_DOWN -> {
-                // A new gesture started. Reset handled status and ask GV if it can handle this.
-                inputResult = INPUT_RESULT_UNHANDLED
+                // A new gesture started. Ask GV if it can handle this.
                 updateInputResult(event)
 
                 nestedOffsetY = 0
@@ -96,7 +95,12 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
             }
 
             // We don't care about other touch events
-            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> stopNestedScroll()
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                stopNestedScroll()
+                // Reset handled status so that parents of this View would not get the old value
+                // when querying it for a newly started touch event.
+                inputResult = INPUT_RESULT_UNHANDLED
+            }
         }
 
         // Execute event handler from parent class in all cases

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
@@ -28,6 +28,7 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_HANDLED
+import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_UNHANDLED
 import org.robolectric.Robolectric.buildActivity
 
 @RunWith(AndroidJUnit4::class)
@@ -126,15 +127,19 @@ class NestedGeckoViewTest {
     @Test
     fun `verify onTouchEvent when ACTION_UP or ACTION_CANCEL`() {
         val nestedWebView = spy(NestedGeckoView(context))
+        nestedWebView.inputResult = INPUT_RESULT_HANDLED
         val mockChildHelper: NestedScrollingChildHelper = mock()
         nestedWebView.childHelper = mockChildHelper
         doReturn(true).`when`(nestedWebView).callSuperOnTouchEvent(any())
 
         nestedWebView.onTouchEvent(mockMotionEvent(ACTION_UP))
         verify(mockChildHelper).stopNestedScroll()
+        assertEquals(INPUT_RESULT_UNHANDLED, nestedWebView.inputResult)
 
+        nestedWebView.inputResult = INPUT_RESULT_HANDLED
         nestedWebView.onTouchEvent(mockMotionEvent(ACTION_CANCEL))
         verify(mockChildHelper, times(2)).stopNestedScroll()
+        assertEquals(INPUT_RESULT_UNHANDLED, nestedWebView.inputResult)
 
         // onTouchEventForResult should be called only for ACTION_DOWN
         verify(nestedWebView, times(0)).updateInputResult(any())

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
@@ -81,8 +81,7 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
             }
 
             MotionEvent.ACTION_DOWN -> {
-                // A new gesture started. Reset handled status and ask GV if it can handle this.
-                inputResult = INPUT_RESULT_UNHANDLED
+                // A new gesture started. Ask GV if it can handle this.
                 updateInputResult(event)
 
                 nestedOffsetY = 0
@@ -96,7 +95,12 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
             }
 
             // We don't care about other touch events
-            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> stopNestedScroll()
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                stopNestedScroll()
+                // Reset handled status so that parents of this View would not get the old value
+                // when querying it for a newly started touch event.
+                inputResult = INPUT_RESULT_UNHANDLED
+            }
         }
 
         // Execute event handler from parent class in all cases

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
@@ -28,6 +28,7 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_HANDLED
+import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_UNHANDLED
 import org.robolectric.Robolectric.buildActivity
 
 @RunWith(AndroidJUnit4::class)
@@ -126,15 +127,19 @@ class NestedGeckoViewTest {
     @Test
     fun `verify onTouchEvent when ACTION_UP or ACTION_CANCEL`() {
         val nestedWebView = spy(NestedGeckoView(context))
+        nestedWebView.inputResult = INPUT_RESULT_HANDLED
         val mockChildHelper: NestedScrollingChildHelper = mock()
         nestedWebView.childHelper = mockChildHelper
         doReturn(true).`when`(nestedWebView).callSuperOnTouchEvent(any())
 
         nestedWebView.onTouchEvent(mockMotionEvent(ACTION_UP))
         verify(mockChildHelper).stopNestedScroll()
+        assertEquals(INPUT_RESULT_UNHANDLED, nestedWebView.inputResult)
 
+        nestedWebView.inputResult = INPUT_RESULT_HANDLED
         nestedWebView.onTouchEvent(mockMotionEvent(ACTION_CANCEL))
         verify(mockChildHelper, times(2)).stopNestedScroll()
+        assertEquals(INPUT_RESULT_UNHANDLED, nestedWebView.inputResult)
 
         // onTouchEventForResult should be called only for ACTION_DOWN
         verify(nestedWebView, times(0)).updateInputResult(any())

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
@@ -81,8 +81,7 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
             }
 
             MotionEvent.ACTION_DOWN -> {
-                // A new gesture started. Reset handled status and ask GV if it can handle this.
-                inputResult = INPUT_RESULT_UNHANDLED
+                // A new gesture started. Ask GV if it can handle this.
                 updateInputResult(event)
 
                 nestedOffsetY = 0
@@ -96,7 +95,12 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
             }
 
             // We don't care about other touch events
-            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> stopNestedScroll()
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                stopNestedScroll()
+                // Reset handled status so that parents of this View would not get the old value
+                // when querying it for a newly started touch event.
+                inputResult = INPUT_RESULT_UNHANDLED
+            }
         }
 
         // Execute event handler from parent class in all cases

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
@@ -28,6 +28,7 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_HANDLED
+import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_UNHANDLED
 import org.robolectric.Robolectric.buildActivity
 
 @RunWith(AndroidJUnit4::class)
@@ -126,15 +127,19 @@ class NestedGeckoViewTest {
     @Test
     fun `verify onTouchEvent when ACTION_UP or ACTION_CANCEL`() {
         val nestedWebView = spy(NestedGeckoView(context))
+        nestedWebView.inputResult = INPUT_RESULT_HANDLED
         val mockChildHelper: NestedScrollingChildHelper = mock()
         nestedWebView.childHelper = mockChildHelper
         doReturn(true).`when`(nestedWebView).callSuperOnTouchEvent(any())
 
         nestedWebView.onTouchEvent(mockMotionEvent(ACTION_UP))
         verify(mockChildHelper).stopNestedScroll()
+        assertEquals(INPUT_RESULT_UNHANDLED, nestedWebView.inputResult)
 
+        nestedWebView.inputResult = INPUT_RESULT_HANDLED
         nestedWebView.onTouchEvent(mockMotionEvent(ACTION_CANCEL))
         verify(mockChildHelper, times(2)).stopNestedScroll()
+        assertEquals(INPUT_RESULT_UNHANDLED, nestedWebView.inputResult)
 
         // onTouchEventForResult should be called only for ACTION_DOWN
         verify(nestedWebView, times(0)).updateInputResult(any())


### PR DESCRIPTION
How a previous touch was handled was reset when NestedGeckoView would be called
to act for the next touch.
This means the container of NestedGeckoView would get the old status if
querying for it in onInterceptTouchEvent, before NestedGeckoView having the
chance to act upon the new touch.
Resetting the status when the touch is finished ensures any following checks
before NestedGeckoView had the chance to update the status would return the
default UNHANDLED value.

Before & after:
![BeforeAfterLeakingHandledState](https://user-images.githubusercontent.com/11428869/99952962-2b96ba80-2d89-11eb-9b5e-1c27409187e0.gif)
[video](https://drive.google.com/file/d/1KvRhFvdZ2Gpr5owdFi7v-6-XGZkZxvcb/view?usp=sharing)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR or does not need a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR follows does not include any a11y user facing features.

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
