### PR TITLE
Version 67.0.5 with GV Beta 84.0.20201126155845.

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -1,4 +1,4 @@
-componentsVersion: 67.0.4
+componentsVersion: 67.0.5
 projects:
   concept-awesomebar:
     path: components/concept/awesomebar

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -11,7 +11,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Beta Version.
      */
-    const val beta_version = "84.0.20201122152513"
+    const val beta_version = "84.0.20201126155845"
 
     /**
      * GeckoView Release Version.


### PR DESCRIPTION
This (automated) patch updates GV Beta to 84.0.20201126155845.