### PR TITLE
Closes #9073 remove unwanted dots in the file name

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -44,6 +44,7 @@ import mozilla.components.support.ktx.kotlin.isEmail
 import mozilla.components.support.ktx.kotlin.isExtensionUrl
 import mozilla.components.support.ktx.kotlin.isGeoLocation
 import mozilla.components.support.ktx.kotlin.isPhone
+import mozilla.components.support.ktx.kotlin.sanitizeFileName
 import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
 import mozilla.components.support.utils.DownloadUtils
 import org.json.JSONObject
@@ -811,7 +812,7 @@ class GeckoEngineSession(
                             url = url,
                             contentLength = contentLength,
                             contentType = contentType,
-                            fileName = fileName,
+                            fileName = fileName.sanitizeFileName(),
                             response = response,
                             isPrivate = privateMode
                     )

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -44,6 +44,7 @@ import mozilla.components.support.ktx.kotlin.isEmail
 import mozilla.components.support.ktx.kotlin.isExtensionUrl
 import mozilla.components.support.ktx.kotlin.isGeoLocation
 import mozilla.components.support.ktx.kotlin.isPhone
+import mozilla.components.support.ktx.kotlin.sanitizeFileName
 import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
 import mozilla.components.support.utils.DownloadUtils
 import org.json.JSONObject
@@ -811,7 +812,7 @@ class GeckoEngineSession(
                             url = url,
                             contentLength = contentLength,
                             contentType = contentType,
-                            fileName = fileName,
+                            fileName = fileName.sanitizeFileName(),
                             response = response,
                             isPrivate = privateMode
                     )

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -44,6 +44,7 @@ import mozilla.components.support.ktx.kotlin.isEmail
 import mozilla.components.support.ktx.kotlin.isExtensionUrl
 import mozilla.components.support.ktx.kotlin.isGeoLocation
 import mozilla.components.support.ktx.kotlin.isPhone
+import mozilla.components.support.ktx.kotlin.sanitizeFileName
 import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
 import mozilla.components.support.utils.DownloadUtils
 import org.json.JSONObject
@@ -804,7 +805,7 @@ class GeckoEngineSession(
                             url = url,
                             contentLength = contentLength,
                             contentType = contentType,
-                            fileName = fileName,
+                            fileName = fileName.sanitizeFileName(),
                             response = response,
                             isPrivate = privateMode
                     )

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/ext/DownloadState.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/ext/DownloadState.kt
@@ -10,6 +10,7 @@ import mozilla.components.concept.fetch.Headers
 import mozilla.components.concept.fetch.Headers.Names.CONTENT_DISPOSITION
 import mozilla.components.concept.fetch.Headers.Names.CONTENT_LENGTH
 import mozilla.components.concept.fetch.Headers.Names.CONTENT_TYPE
+import mozilla.components.support.ktx.kotlin.sanitizeFileName
 import mozilla.components.support.utils.DownloadUtils
 import java.io.InputStream
 import java.net.URLConnection
@@ -35,12 +36,13 @@ internal fun DownloadState.withResponse(headers: Headers, stream: InputStream?):
         contentType = headers[CONTENT_TYPE]
     }
 
+    val newFileName = if (fileName.isNullOrBlank()) {
+        DownloadUtils.guessFileName(contentDisposition, destinationDirectory, url, contentType)
+    } else {
+        fileName
+    }
     return copy(
-        fileName = if (fileName.isNullOrBlank()) {
-            DownloadUtils.guessFileName(contentDisposition, destinationDirectory, url, contentType)
-        } else {
-            fileName
-        },
+        fileName = newFileName?.sanitizeFileName(),
         contentType = contentType,
         contentLength = contentLength ?: headers[CONTENT_LENGTH]?.toLongOrNull()
     )

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
@@ -146,7 +146,13 @@ fun String.sanitizeURL(): String {
  * For example for an input of "/../../../../../../directory/file.txt" you will get "file.txt"
  */
 fun String.sanitizeFileName(): String {
-    return this.substringAfterLast(File.separatorChar)
+    val file = File(this.substringAfterLast(File.separatorChar))
+    // Remove unwanted subsequent dots in the file name.
+    return if (file.extension.trim().isNotEmpty() && file.nameWithoutExtension.isNotEmpty()) {
+        file.name.replace("\\.\\.+".toRegex(), ".")
+    } else {
+        file.name.replace(".", "")
+    }
 }
 
 /**

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
@@ -172,7 +172,7 @@ class StringTest {
 
     @Test
     fun sanitizeFileName() {
-        var file = "/../../../../../../../../../../directory/file.txt"
+        var file = "/../../../../../../../../../../directory/file.......txt"
         val fileName = "file.txt"
 
         assertEquals(fileName, file.sanitizeFileName())
@@ -180,5 +180,15 @@ class StringTest {
         file = "/root/directory/file.txt"
 
         assertEquals(fileName, file.sanitizeFileName())
+
+        assertEquals("file", "file".sanitizeFileName())
+
+        assertEquals("file", "file..".sanitizeFileName())
+
+        assertEquals("file", "file.".sanitizeFileName())
+
+        assertEquals("file", ".file".sanitizeFileName())
+
+        assertEquals("test.2020.12.01.txt", "test.2020.12.01.txt".sanitizeFileName())
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@ permalink: /changelog/
 
 * **feature-downloads**
   * 🚒 Bug fixed [issue #9033](https://github.com/mozilla-mobile/android-components/issues/9033) - Fix resuming downloads in slow networks more details see the [Fenix issue](https://github.com/mozilla-mobile/fenix/issues/9354#issuecomment-731267368).
+  * 🚒 Bug fixed [issue #9073](https://github.com/mozilla-mobile/android-components/issues/9073) - Fix crash downloading a file with multiple dots on it, for more details see the [Fenix issue](https://github.com/mozilla-mobile/fenix/issues/16443).
 
 * **feature-app-links**
     * Added handling of PackageItemInfo.packageName NullPointerException on some Xiaomi and TCL devices


### PR DESCRIPTION
In Android 10, we are getting a crash when we try to add a download with a file name that contains multiple dots like (file..txt) to the download System Database, let's sanitize the file name and avoid this issue, for more info see the related Fenix issue https://github.com/mozilla-mobile/fenix/issues/16443

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
