### PR TITLE
Closes #9075: Add mechanism to load URL when fails to launch third party app

### DIFF
--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksFeature.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksFeature.kt
@@ -59,12 +59,20 @@ class AppLinksFeature(
                     return
                 }
 
-                val doOpenApp = {
-                    useCases.openAppLink(appIntent, failedToLaunchAction = failedToLaunchAction)
-                }
-
                 val doNotOpenApp = {
                     loadUrlUseCase?.invoke(url, session, EngineSession.LoadUrlFlags.none())
+                }
+
+                val loadUrlAction = {
+                    loadUrlUseCase?.invoke(url, session, EngineSession.LoadUrlFlags.none())
+                }
+
+                val doOpenApp = {
+                    useCases.openAppLink(
+                        appIntent,
+                        failedToLaunchAction = failedToLaunchAction,
+                        loadUrlAction = loadUrlAction
+                    )
                 }
 
                 if (!session.private || fragmentManager == null) {

--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
@@ -191,7 +191,8 @@ class AppLinksUseCases(
         operator fun invoke(
             appIntent: Intent?,
             launchInNewTask: Boolean = true,
-            failedToLaunchAction: () -> Unit = {}
+            failedToLaunchAction: () -> Unit = {},
+            loadUrlAction: () -> Unit = {}
         ) {
             appIntent?.let {
                 try {
@@ -207,6 +208,7 @@ class AppLinksUseCases(
                 } catch (e: Exception) {
                     when (e) {
                         is ActivityNotFoundException, is SecurityException, is NullPointerException -> {
+                            loadUrlAction()
                             failedToLaunchAction()
                             Logger.error("failed to start third party app activity", e)
                         }

--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksFeatureTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksFeatureTest.kt
@@ -146,7 +146,7 @@ class AppLinksFeatureTest {
         userTapsOnSession(intentUrl, false)
 
         verifyNoMoreInteractions(mockDialog)
-        verify(mockOpenRedirect).invoke(any(), anyBoolean(), any())
+        verify(mockOpenRedirect).invoke(any(), anyBoolean(), any(), any())
     }
 
     @Test
@@ -155,7 +155,7 @@ class AppLinksFeatureTest {
         userTapsOnSession(intentUrl, true)
 
         verify(mockDialog).showNow(eq(mockFragmentManager), anyString())
-        verify(mockOpenRedirect, never()).invoke(any(), anyBoolean(), any())
+        verify(mockOpenRedirect, never()).invoke(any(), anyBoolean(), any(), any())
     }
 
     @Test

--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksInterceptorTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksInterceptorTest.kt
@@ -417,7 +417,7 @@ class AppLinksInterceptorTest {
 
         val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, null, true, false, false, false, false)
         assert(response is RequestInterceptor.InterceptionResponse.AppIntent)
-        verify(mockOpenRedirect).invoke(any(), anyBoolean(), any())
+        verify(mockOpenRedirect).invoke(any(), anyBoolean(), any(), any())
     }
 
     @Test
@@ -447,7 +447,7 @@ class AppLinksInterceptorTest {
 
         val response = appLinksInterceptor.onLoadRequest(mockEngineSession, intentUrl, null, false, true, false, false, false)
         assert(response is RequestInterceptor.InterceptionResponse.AppIntent)
-        verify(mockOpenRedirect).invoke(any(), anyBoolean(), any())
+        verify(mockOpenRedirect).invoke(any(), anyBoolean(), any(), any())
     }
 
     @Test

--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksUseCasesTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksUseCasesTest.kt
@@ -370,12 +370,16 @@ class AppLinksUseCasesTest {
         val subject = AppLinksUseCases(context, { true })
 
         var failedToLaunch = false
+        var loadUrl = false
         val failedAction = { failedToLaunch = true }
+        val loadUrlAction = { loadUrl = true }
         `when`(context.startActivity(any())).thenThrow(ActivityNotFoundException("failed"))
-        subject.openAppLink(redirect.appIntent, failedToLaunchAction = failedAction)
+        subject.openAppLink(redirect.appIntent, failedToLaunchAction = failedAction,
+            loadUrlAction = loadUrlAction)
 
         verify(context).startActivity(any())
         assert(failedToLaunch)
+        assert(loadUrl)
     }
 
     @Test

--- a/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
+++ b/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
@@ -903,7 +903,7 @@ class ContextMenuCandidateTest {
             mock(),
             HitResult.UNKNOWN("https://www.otherexample.com"))
 
-        verify(openAppLinkRedirectMock, times(2)).invoke(any(), anyBoolean(), any())
+        verify(openAppLinkRedirectMock, times(2)).invoke(any(), anyBoolean(), any(), any())
     }
 
     @Test

--- a/config/detekt-baseline.xml
+++ b/config/detekt-baseline.xml
@@ -265,7 +265,7 @@
     <ID>UndocumentedPublicFunction:AllSessionsObserver.kt$AllSessionsObserver.Observer$fun onRegisteredToSession(session: Session)</ID>
     <ID>UndocumentedPublicFunction:AllSessionsObserver.kt$AllSessionsObserver.Observer$fun onUnregisteredFromSession(session: Session)</ID>
     <ID>UndocumentedPublicFunction:AppLinksUseCases.kt$AppLinksUseCases.GetAppLinkRedirect$operator fun invoke(url: String): AppLinkRedirect</ID>
-    <ID>UndocumentedPublicFunction:AppLinksUseCases.kt$AppLinksUseCases.OpenAppLinkRedirect$operator fun invoke( appIntent: Intent?, launchInNewTask: Boolean = true, failedToLaunchAction: () -&gt; Unit = {} )</ID>
+    <ID>UndocumentedPublicFunction:AppLinksUseCases.kt$AppLinksUseCases.OpenAppLinkRedirect$operator fun invoke( appIntent: Intent?, launchInNewTask: Boolean = true, failedToLaunchAction: () -&gt; Unit = {}, loadUrlAction: () -&gt; Unit = {} )</ID>
     <ID>UndocumentedPublicFunction:AutoSave.kt$AutoSave.Storage$fun save(snapshot: SessionManager.Snapshot): Boolean</ID>
     <ID>UndocumentedPublicFunction:BrowserFragment.kt$BrowserFragment.Companion$fun create(sessionId: String? = null)</ID>
     <ID>UndocumentedPublicFunction:BrowserMenu.kt$BrowserMenu$fun dismiss()</ID>


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
