### PR TITLE
Issue #8879: feature-recentlyclosed: Replace InitializeRecentlyClosedState with generic init action.

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -85,11 +85,6 @@ sealed class SystemAction : BrowserAction() {
  */
 sealed class RecentlyClosedAction : BrowserAction() {
     /**
-     * Initializes the [BrowserState.closedTabs] state.
-     */
-    object InitializeRecentlyClosedState : RecentlyClosedAction()
-
-    /**
      * Adds a list of [ClosedTab] to the [BrowserState.closedTabs] list.
      *
      * @property tabs the [ClosedTab]s to add

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/RecentlyClosedReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/RecentlyClosedReducer.kt
@@ -20,7 +20,6 @@ internal object RecentlyClosedReducer {
                     .take(action.maxTabs))
             }
             is RecentlyClosedAction.ReplaceTabsAction -> state.copy(closedTabs = action.tabs)
-            is RecentlyClosedAction.InitializeRecentlyClosedState -> state
             is RecentlyClosedAction.RemoveClosedTabAction -> {
                 state.copy(
                     closedTabs = state.closedTabs - action.tab


### PR DESCRIPTION
We recently introduced a generic "InitAction` that `BrowserStore` dispatches automatically. This patch migrates `feature-recentlyclosed` to react to that generic action instead of `InitializeRecentlyClosedState`.