### PR TITLE
Issue #8879: feature-containers: Replace InitializeContainerState with generic init action.

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -1009,11 +1009,6 @@ sealed class ContainerAction : BrowserAction() {
     data class AddContainersAction(val containers: List<ContainerState>) : ContainerAction()
 
     /**
-     * Initializes the [BrowserState.containers] state.
-     */
-    object InitializeContainerState : ContainerAction()
-
-    /**
      * Removes all state of the removed container from [BrowserState.containers].
      */
     data class RemoveContainerAction(val contextId: String) : ContainerAction()

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContainerReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContainerReducer.kt
@@ -26,7 +26,6 @@ internal object ContainerReducer {
                         .toMap())
                 )
             }
-            is ContainerAction.InitializeContainerState -> state
             is ContainerAction.RemoveContainerAction -> {
                 state.copy(
                     containers = state.containers - action.contextId

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContainerActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContainerActionTest.kt
@@ -4,7 +4,6 @@
 
 package mozilla.components.browser.state.action
 
-import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.ContainerState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.test.ext.joinBlocking
@@ -79,28 +78,6 @@ class ContainerActionTest {
         assertEquals(container1, store.state.containers.values.first())
         assertEquals(container2, store.state.containers.values.elementAt(1))
         assertEquals(container3, store.state.containers.values.last())
-    }
-
-    @Test
-    fun `InitializeContainerState - Initializes the BrowserState containers state`() {
-        val container = ContainerState(
-            contextId = "contextId",
-            name = "Personal",
-            color = ContainerState.Color.GREEN,
-            icon = ContainerState.Icon.CART
-        )
-        val store = BrowserStore(
-            initialState = BrowserState(
-                containers = mapOf(container.contextId to container)
-            )
-        )
-
-        assertFalse(store.state.containers.isEmpty())
-        assertEquals(container, store.state.containers.values.first())
-
-        val state = store.state
-        store.dispatch(ContainerAction.InitializeContainerState).joinBlocking()
-        assertSame(state, store.state)
     }
 
     @Test

--- a/components/feature/containers/build.gradle
+++ b/components/feature/containers/build.gradle
@@ -73,6 +73,7 @@ dependencies {
     androidTestImplementation Dependencies.testing_coroutines
 
     testImplementation project(':support-test')
+    testImplementation project(':support-test-libstate')
 
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_coroutines

--- a/components/feature/containers/src/main/java/mozilla/components/feature/containers/ContainerMiddleware.kt
+++ b/components/feature/containers/src/main/java/mozilla/components/feature/containers/ContainerMiddleware.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.ContainerAction
+import mozilla.components.browser.state.action.InitAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.Container
 import mozilla.components.browser.state.state.ContainerState
@@ -39,7 +40,7 @@ class ContainerMiddleware(
         action: BrowserAction
     ) {
         when (action) {
-            is ContainerAction.InitializeContainerState -> initializeContainers(context.store)
+            is InitAction -> initializeContainers(context.store)
             is ContainerAction.AddContainerAction -> addContainer(action)
             is ContainerAction.RemoveContainerAction -> removeContainer(context.store, action)
         }


### PR DESCRIPTION
Like PR #9079: We introduced a generic `InitAction` a while ago and can replace `InitializeContainerState` with it.