### PR TITLE
Search use cases

### DIFF
--- a/components/feature/awesomebar/build.gradle
+++ b/components/feature/awesomebar/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     implementation project(':concept-storage')
 
     implementation project(':browser-search')
-    implementation project(':browser-session')
     implementation project(':browser-state')
     implementation project(':browser-icons')
 

--- a/components/feature/search/src/main/java/mozilla/components/feature/search/SearchUseCases.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/SearchUseCases.kt
@@ -37,7 +37,7 @@ class SearchUseCases(
         fun invoke(
             searchTerms: String,
             searchEngine: LegacySearchEngine? = null,
-            parentSession: Session? = null
+            parentSessionId: String? = null
         )
     }
 
@@ -55,7 +55,7 @@ class SearchUseCases(
         override fun invoke(
             searchTerms: String,
             searchEngine: LegacySearchEngine?,
-            parentSession: Session?
+            parentSessionId: String?
         ) {
             invoke(searchTerms, sessionManager.selectedSession, searchEngine)
         }
@@ -104,7 +104,7 @@ class SearchUseCases(
         override fun invoke(
             searchTerms: String,
             searchEngine: LegacySearchEngine?,
-            parentSession: Session?
+            parentSessionId: String?
         ) {
             invoke(
                 searchTerms,
@@ -112,7 +112,7 @@ class SearchUseCases(
                 selected = true,
                 private = isPrivate,
                 searchEngine = searchEngine,
-                parentSession = parentSession
+                parentSessionId = parentSessionId
             )
         }
 
@@ -133,7 +133,7 @@ class SearchUseCases(
             selected: Boolean = true,
             private: Boolean = false,
             searchEngine: LegacySearchEngine? = null,
-            parentSession: Session? = null
+            parentSessionId: String? = null
         ) {
             val searchUrl = searchEngine?.let {
                 searchEngine.buildSearchUrl(searchTerms)
@@ -146,6 +146,8 @@ class SearchUseCases(
 
             val session = Session(searchUrl, private, source)
             session.searchTerms = searchTerms
+
+            val parentSession = parentSessionId?.let { sessionManager.findSessionById(it) }
 
             sessionManager.add(session, selected, parent = parentSession)
 

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/SearchUseCasesTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/SearchUseCasesTest.kt
@@ -137,7 +137,9 @@ class SearchUseCasesTest {
         whenever(searchEngineManager.getDefaultSearchEngine(testContext)).thenReturn(searchEngine)
 
         val parentSession = mock<Session>()
-        useCases.newPrivateTabSearch.invoke(searchTerms, parentSession = parentSession)
+        whenever(sessionManager.findSessionById("test-parent")).thenReturn(parentSession)
+
+        useCases.newPrivateTabSearch.invoke(searchTerms, parentSessionId = "test-parent")
 
         val captor = argumentCaptor<Session>()
         verify(sessionManager).add(captor.capture(), eq(true), eq(null), eq(null), eq(parentSession))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **feature-search**
+  * ⚠️ **This is a breaking change**: Use cases in `SearchUseCases` now take the ID of s session/tab as parameter instead of a `Session` instance.
+
 # 68.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v67.0.0...v68.0.0)
@@ -33,7 +36,7 @@ permalink: /changelog/
   * Added handling of PackageItemInfo.packageName NullPointerException on some Xiaomi and TCL devices
 
 * **service-glean**
-  * 🆙  Updated Glean to version 33.1.2 ([changelog](https://github.com/mozilla/glean/releases/tag/v33.1.2))
+  * 🆙 Updated Glean to version 33.1.2 ([changelog](https://github.com/mozilla/glean/releases/tag/v33.1.2))
 
 * **feature-tab-collections**:
     * [createCollection] now returns the id of the newly created collection

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -210,7 +210,7 @@ open class DefaultComponents(private val applicationContext: Context) {
             searchUseCases.defaultSearch.invoke(
                 searchTerms = searchTerms,
                 searchEngine = null,
-                parentSession = null
+                parentSessionId = null
             )
         }
     }


### PR DESCRIPTION
Closes #9082.

This breaking change removes the requirement to pass a `Session` to `SearchUseCases` and instead uses the `id`. With that `feature-awesomebar` no longer needs to depend on `browser-session`. 