### PR TITLE
For #9098: Allow rotation of edit suggestion arrow button.

### DIFF
--- a/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/BrowserAwesomeBar.kt
+++ b/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/BrowserAwesomeBar.kt
@@ -50,6 +50,7 @@ class BrowserAwesomeBar @JvmOverloads constructor(
     internal var listener: (() -> Unit)? = null
     internal var editSuggestionListener: ((String) -> Unit)? = null
     internal val styling: BrowserAwesomeBarStyling
+    var customizeForBottomToolbar: Boolean = false
 
     /**
      * The [SuggestionLayout] implementation controls layout inflation and view binding for suggestions.

--- a/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/SuggestionsAdapter.kt
+++ b/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/SuggestionsAdapter.kt
@@ -127,7 +127,7 @@ internal class SuggestionsAdapter(
         position: Int
     ) = synchronized(suggestions) {
         val suggestion = suggestions[position]
-        holder.actual.bind(suggestion) { awesomeBar.listener?.invoke() }
+        holder.actual.bind(suggestion, awesomeBar.customizeForBottomToolbar) { awesomeBar.listener?.invoke() }
     }
 
     override fun onViewRecycled(holder: ViewHolderWrapper) {

--- a/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/layout/DefaultSuggestionViewHolder.kt
+++ b/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/layout/DefaultSuggestionViewHolder.kt
@@ -15,6 +15,7 @@ import androidx.core.widget.ImageViewCompat
 import androidx.annotation.VisibleForTesting
 import mozilla.components.browser.awesomebar.BrowserAwesomeBar
 import mozilla.components.browser.awesomebar.R
+import mozilla.components.browser.awesomebar.layout.DefaultSuggestionViewHolder.Chips.Companion.EDIT_ARROW_ROTATION
 import mozilla.components.browser.awesomebar.widget.FlowLayout
 import mozilla.components.concept.awesomebar.AwesomeBar
 
@@ -47,7 +48,11 @@ internal sealed class DefaultSuggestionViewHolder {
             ImageViewCompat.setImageTintList(this, ColorStateList.valueOf(awesomeBar.styling.descriptionTextColor))
         }
 
-        override fun bind(suggestion: AwesomeBar.Suggestion, selectionListener: () -> Unit) {
+        override fun bind(
+            suggestion: AwesomeBar.Suggestion,
+            customizeForBottomToolbar: Boolean,
+            selectionListener: () -> Unit
+        ) {
             val title = if (suggestion.title.isNullOrEmpty()) suggestion.description else suggestion.title
 
             iconView.setImageBitmap(suggestion.icon)
@@ -79,6 +84,11 @@ internal sealed class DefaultSuggestionViewHolder {
                 editView.visibility = View.GONE
             } else {
                 editView.visibility = View.VISIBLE
+
+                if (customizeForBottomToolbar) {
+                    editView.rotation = EDIT_ARROW_ROTATION
+                }
+
                 editView.setOnClickListener {
                     awesomeBar.editSuggestionListener?.invoke(suggestion.editSuggestion!!)
                 }
@@ -103,7 +113,11 @@ internal sealed class DefaultSuggestionViewHolder {
         private val inflater = LayoutInflater.from(view.context)
         private val iconView = view.findViewById<ImageView>(R.id.mozac_browser_awesomebar_icon)
 
-        override fun bind(suggestion: AwesomeBar.Suggestion, selectionListener: () -> Unit) {
+        override fun bind(
+            suggestion: AwesomeBar.Suggestion,
+            customizeForBottomToolbar: Boolean,
+            selectionListener: () -> Unit
+        ) {
             chipsView.removeAllViews()
 
             iconView.setImageBitmap(suggestion.icon)
@@ -131,6 +145,7 @@ internal sealed class DefaultSuggestionViewHolder {
 
         companion object {
             val LAYOUT_ID = R.layout.mozac_browser_awesomebar_item_chips
+            const val EDIT_ARROW_ROTATION = 270f
         }
     }
 }

--- a/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/layout/SuggestionViewHolder.kt
+++ b/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/layout/SuggestionViewHolder.kt
@@ -19,8 +19,14 @@ abstract class SuggestionViewHolder(
      * Contract: When a suggestion was selected/clicked the view will invoke the appropriate callback of the suggestion
      * ([AwesomeBar.Suggestion.onSuggestionClicked] or [AwesomeBar.Suggestion.onChipClicked]) as well as the provided
      * [selectionListener] function.
+     * Using [customizeForBottomToolbar] a client app can chose to modify suggestions UI
+     * in order to improve the integration with a bottom toolbar.
      */
-    abstract fun bind(suggestion: AwesomeBar.Suggestion, selectionListener: () -> Unit)
+    abstract fun bind(
+        suggestion: AwesomeBar.Suggestion,
+        customizeForBottomToolbar: Boolean = false,
+        selectionListener: () -> Unit
+    )
 
     /**
      * Notifies this [SuggestionViewHolder] that it has been recycled. If this holder (or its views) keep references to

--- a/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/SuggestionsAdapterTest.kt
+++ b/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/SuggestionsAdapterTest.kt
@@ -20,6 +20,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doReturn
@@ -207,7 +208,7 @@ class SuggestionsAdapterTest {
 
         adapter.onBindViewHolder(wrapper, 0)
 
-        verify(viewHolder).bind(eq(suggestion), any())
+        verify(viewHolder).bind(eq(suggestion), anyBoolean(), any())
     }
 
     @Test
@@ -232,7 +233,7 @@ class SuggestionsAdapterTest {
         val suggestion: AwesomeBar.Suggestion = mock()
 
         val holder = spy(object : SuggestionViewHolder(View(testContext)) {
-            override fun bind(suggestion: AwesomeBar.Suggestion, selectionListener: () -> Unit) = Unit
+            override fun bind(suggestion: AwesomeBar.Suggestion, customizeForBottomToolbar: Boolean, selectionListener: () -> Unit) = Unit
         })
 
         val layout: SuggestionLayout = mock()

--- a/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/layout/DefaultSuggestionViewHolderTest.kt
+++ b/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/layout/DefaultSuggestionViewHolderTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.awesomebar.layout
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageButton
 import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.awesomebar.BrowserAwesomeBar
@@ -54,6 +55,56 @@ class DefaultSuggestionViewHolderTest {
         val descriptionView = view.findViewById<TextView>(R.id.mozac_browser_awesomebar_description)
         assertEquals("https://www.mozilla.org", descriptionView.text)
         assertEquals(View.VISIBLE, descriptionView.visibility)
+    }
+
+    @Test
+    fun `DefaultViewHolder has a rotated image for edit button if set as such in awesomebar`() {
+        val view = LayoutInflater.from(testContext).inflate(
+            R.layout.mozac_browser_awesomebar_item_generic, null, false)
+
+        val awesomeBar = BrowserAwesomeBar(testContext)
+        awesomeBar.customizeForBottomToolbar = true
+        val viewHolder = DefaultSuggestionViewHolder.Default(awesomeBar, view)
+
+        val suggestion = AwesomeBar.Suggestion(
+            mock(),
+            title = "Hello World",
+            description = "https://www.mozilla.org",
+            editSuggestion = "https://www.mozilla.org"
+        )
+
+        viewHolder.bind(suggestion, awesomeBar.customizeForBottomToolbar) {
+            // Do nothing
+        }
+
+        val editArrowButton = view.findViewById<ImageButton>(R.id.mozac_browser_awesomebar_edit_suggestion)
+        assertEquals(View.VISIBLE, editArrowButton.visibility)
+        assertEquals(270f, editArrowButton.rotation)
+    }
+
+    @Test
+    fun `DefaultViewHolder does not have a rotated image for edit button if set as such in awesomebar`() {
+        val view = LayoutInflater.from(testContext).inflate(
+            R.layout.mozac_browser_awesomebar_item_generic, null, false)
+
+        val awesomeBar = BrowserAwesomeBar(testContext)
+        awesomeBar.customizeForBottomToolbar = false
+        val viewHolder = DefaultSuggestionViewHolder.Default(awesomeBar, view)
+
+        val suggestion = AwesomeBar.Suggestion(
+            mock(),
+            title = "Hello World",
+            description = "https://www.mozilla.org",
+            editSuggestion = "https://www.mozilla.org"
+        )
+
+        viewHolder.bind(suggestion, awesomeBar.customizeForBottomToolbar) {
+            // Do nothing
+        }
+
+        val editArrowButton = view.findViewById<ImageButton>(R.id.mozac_browser_awesomebar_edit_suggestion)
+        assertEquals(View.VISIBLE, editArrowButton.visibility)
+        assertEquals(0f, editArrowButton.rotation)
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **browser-toolbar**
   * 🌟 Added API to show site permission indicators for more information see [#9131](https://github.com/mozilla-mobile/android-components/issues/9131).
 
+* **browser-awesomebar**:
+    * Awesomebar can now be customized for bottom toolbar using the [customizeForBottomToolbar] property
+    
 # 69.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v68.0.0...v69.0.0)


### PR DESCRIPTION
Fenix PR for rotating arrow: https://github.com/mozilla-mobile/fenix/pull/16815

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
