### PR TITLE
Do not run the GV Update Action on forks

### DIFF
--- a/.github/workflows/update-geckoview.yml
+++ b/.github/workflows/update-geckoview.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: "Update GV (Beta)"
         uses: mozilla-mobile/relbot@master
-        if: github.repository == ‘mozilla-mobile/android-components’
+        if: github.repository == "mozilla-mobile/android-components"
         with:
           project: android-components
           command: update-geckoview-beta

--- a/.github/workflows/update-geckoview.yml
+++ b/.github/workflows/update-geckoview.yml
@@ -30,6 +30,7 @@ jobs:
     steps:
       - name: "Update GV (Beta)"
         uses: mozilla-mobile/relbot@master
+        if: github.repository == ‘mozilla-mobile/android-components’
         with:
           project: android-components
           command: update-geckoview-beta


### PR DESCRIPTION
This patch adds a check to the action to make sure it only runs on the `mozilla-mobile/android-components` repository and not on forks. This removes some surprises for forks.