### PR TITLE
Use proper quotes in update-geckoview.yml workflow

### DIFF
--- a/.github/workflows/update-geckoview.yml
+++ b/.github/workflows/update-geckoview.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: "Update GV (Beta)"
         uses: mozilla-mobile/relbot@master
-        if: github.repository == "mozilla-mobile/android-components"
+        if: github.repository == 'mozilla-mobile/android-components'
         with:
           project: android-components
           command: update-geckoview-beta


### PR DESCRIPTION
The previous version of this patch incorrectly used double quotes while these expressions take single quotes only.