### PR TITLE
Closes #8459: Disable jetifier.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,4 +49,5 @@ libLicense=MPL-2.0
 libLicenseUrl=https://www.mozilla.org/en-US/MPL/2.0/
 
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false
+


### PR DESCRIPTION
See #8459 for details. Locally it looks like it is no longer needed. So let's see what taskcluster thinks.