### PR TITLE
Issue #9120: Migrate ManifestUpdateFeature to use BrowserStore instead of SessionManager.

### DIFF
--- a/components/feature/pwa/build.gradle
+++ b/components/feature/pwa/build.gradle
@@ -42,7 +42,6 @@ android {
 dependencies {
     implementation project(':browser-icons')
     implementation project(':browser-session')
-    implementation project(':browser-state')
     implementation project(':concept-engine')
     implementation project(':concept-fetch')
     implementation project(':feature-customtabs')
@@ -64,6 +63,7 @@ dependencies {
     kapt Dependencies.androidx_room_compiler
 
     testImplementation project(':support-test')
+    testImplementation project(':support-test-libstate')
 
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.androidx_test_junit

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserFragment.kt
@@ -80,7 +80,7 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
                 ),
                 ManifestUpdateFeature(
                     requireContext(),
-                    components.sessionManager,
+                    components.store,
                     components.webAppShortcutManager,
                     components.webAppManifestStorage,
                     sessionId!!,


### PR DESCRIPTION
Together with PR #9117 this should complete the migration of `feature-pwa`.