### PR TITLE
RELENG-150 - Add mark-as-shipped task in Android-Components

### DIFF
--- a/taskcluster/ac_taskgraph/target_tasks.py
+++ b/taskcluster/ac_taskgraph/target_tasks.py
@@ -18,6 +18,12 @@ def target_tasks_nightly(full_task_graph, parameters, graph_config):
 @_target_task("release")
 def target_tasks_release(full_task_graph, parameters, graph_config):
     def filter(task, parameters):
+        # Mark-as-shipped is always red on github-release and it confuses people.
+        # This task cannot be green if we kick off a release through github-releases, so
+        # let's exlude that task there.
+        if task.kind == "mark-as-shipped" and parameters["tasks_for"] == "github-release":
+            return False
+
         return task.attributes.get("build-type", "") == "release"
 
     return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]

--- a/taskcluster/ac_taskgraph/transforms/mark_as_shipped.py
+++ b/taskcluster/ac_taskgraph/transforms/mark_as_shipped.py
@@ -1,0 +1,44 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Apply some defaults and minor modifications to the jobs defined in the build
+kind.
+"""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
+
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def resolve_keys(config, tasks):
+    for task in tasks:
+        resolve_keyed_by(
+            task,
+            'scopes',
+            item_name=task["name"],
+            **{
+                'level': config.params["level"],
+            }
+        )
+        yield task
+
+
+@transforms.add
+def make_task_description(config, jobs):
+    for job in jobs:
+        product = "Android-components"  # shipit exactly uses this case
+        # {ver} is just a magic string to show "this isn't right"
+        # https://github.com/mozilla-mobile/fenix/pull/7306/files#r360248631
+        version = config.params['version'] or "{ver}"
+        job['worker']['release-name'] = '{product}-{version}-build{build_number}'.format(
+            product=product,
+            version=version,
+            build_number=config.params.get('build_number', 1)
+        )
+        yield job

--- a/taskcluster/ac_taskgraph/worker_types.py
+++ b/taskcluster/ac_taskgraph/worker_types.py
@@ -149,6 +149,22 @@ def build_github_release_payload(config, task, task_def):
 
 
 @payload_builder(
+    "scriptworker-shipit",
+    schema={
+        Required("release-name"): text_type,
+    },
+)
+def build_shipit_payload(config, task, task_def):
+    worker = task["worker"]
+
+    task_def["tags"]["worker-implementation"] = "scriptworker"
+
+    task_def['payload'] = {
+        'release_name': worker['release-name']
+    }
+
+
+@payload_builder(
     "scriptworker-tree",
     schema={
         Optional("upstream-artifacts"): [

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -33,16 +33,31 @@ workers:
             implementation: docker-worker
             os: linux
             worker-type: b-linux-large
-        images:
-            provisioner: 'mobile-{level}'
-            implementation: docker-worker
-            os: linux
-            worker-type: images
+        beetmover:
+            provisioner: scriptworker-k8s
+            implementation: scriptworker-beetmover
+            os: scriptworker
+            worker-type: 'mobile-{level}-beetmover'
         dep-signing:
             provisioner: scriptworker-k8s
             implementation: scriptworker-signing
             os: scriptworker
             worker-type: mobile-t-signing
+        github:
+            provisioner: scriptworker-k8s
+            implementation: scriptworker-github
+            os: scriptworker
+            worker-type: 'mobile-{level}-github'
+        images:
+            provisioner: 'mobile-{level}'
+            implementation: docker-worker
+            os: linux
+            worker-type: images
+        ship-it:
+            provisioner: scriptworker-k8s
+            implementation: scriptworker-shipit
+            os: scriptworker
+            worker-type: 'mobile-{level}-shipit'
         signing:
             provisioner: scriptworker-k8s
             implementation: scriptworker-signing
@@ -51,16 +66,6 @@ workers:
                 by-level:
                     "3": mobile-3-signing
                     default: mobile-t-signing
-        beetmover:
-            provisioner: scriptworker-k8s
-            implementation: scriptworker-beetmover
-            os: scriptworker
-            worker-type: 'mobile-{level}-beetmover'
-        github:
-            provisioner: scriptworker-k8s
-            implementation: scriptworker-github
-            os: scriptworker
-            worker-type: 'mobile-{level}-github'
         tree:
             provisioner: scriptworker-k8s
             implementation: scriptworker-tree

--- a/taskcluster/ci/mark-as-shipped/kind.yml
+++ b/taskcluster/ci/mark-as-shipped/kind.yml
@@ -1,0 +1,39 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: ac_taskgraph.loader.all_dep:loader
+
+transforms:
+    - ac_taskgraph.transforms.all_dep:transforms
+    - ac_taskgraph.transforms.mark_as_shipped:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - post-beetmover
+
+primary-dependency: post-beetmover
+
+group-by: build-type
+
+only-for-build-types:
+    - release
+
+job-template:
+    description: Mark Android-Components as shipped in ship-it
+    worker-type: ship-it
+    scopes:
+        by-level:
+            '3':
+                - project:releng:ship-it:action:mark-as-shipped
+                - project:releng:ship-it:server:production
+            default:
+                - project:releng:ship-it:action:mark-as-shipped
+                - project:releng:ship-it:server:staging
+    worker: {}
+
+    treeherder:
+        symbol: mark-shipped
+        platform: release/opt
+        kind: build
+        tier: 2


### PR DESCRIPTION
This backports:
 * https://github.com/mozilla-mobile/fenix/pull/7306
 * https://github.com/mozilla-mobile/fenix/pull/10021
 * https://github.com/mozilla-mobile/fenix/pull/13257

to A-C.

No rush in landing this patch. This depends on https://github.com/mozilla-mobile/android-components/pull/9077 because of `post-beetmover` tasks and changes made in the `all_dep` loader. This also depends on https://github.com/mozilla-releng/shipit/pull/547 +  https://github.com/mozilla-mobile/android-components/pull/9132, because this task does not appear on any existing taskcluster graph. It will show up once we enable Android-Components on shipit.

My first testing with taskgraph-diff is promising 👍 I'll wait for the PRs above to get this tested end-to-end.