### PR TITLE
GeckoView (Nightly) 85.0.20201204094005

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -6,7 +6,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Nightly Version.
      */
-    const val nightly_version = "85.0.20201203094726"
+    const val nightly_version = "85.0.20201204094005"
 
     /**
      * GeckoView Beta Version.


### PR DESCRIPTION
This (automated) patch updates GV Nightly on master to 85.0.20201204094005.