### PR TITLE
Close #9145: Catch IOException where clearing thumbnails

### DIFF
--- a/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/utils/ThumbnailDiskCache.kt
+++ b/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/utils/ThumbnailDiskCache.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.thumbnails.utils
 
 import android.content.Context
 import android.graphics.Bitmap
+import androidx.annotation.VisibleForTesting
 import com.jakewharton.disklrucache.DiskLruCache
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.concept.base.images.ImageLoadRequest
@@ -22,12 +23,17 @@ private const val WEBP_QUALITY = 90
  */
 class ThumbnailDiskCache {
     private val logger = Logger("ThumbnailDiskCache")
-    private var thumbnailCache: DiskLruCache? = null
+    @VisibleForTesting
+    internal var thumbnailCache: DiskLruCache? = null
     private val thumbnailCacheWriteLock = Any()
 
     internal fun clear(context: Context) {
         synchronized(thumbnailCacheWriteLock) {
-            getThumbnailCache(context).delete()
+            try {
+                getThumbnailCache(context).delete()
+            } catch (e: IOException) {
+                logger.warn("Thumbnail cache could not be cleared. Perhaps there are none?")
+            }
             thumbnailCache = null
         }
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,9 @@ permalink: /changelog/
   * ⚠️ **This is a breaking change**: The `SitePermissionsRules` constructor, now requires a new parameter `mediaKeySystemAccess`.
   * 🌟 Added support for EME permission prompts, see [#7121](https://github.com/mozilla-mobile/android-components/issues/7121).
 
+* **browser-thumbnail**
+  * Catch `IOException` that may be thrown when deleting thumbnails.
+
 # 68.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v67.0.0...v68.0.0)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
