### PR TITLE
Closes #9157: Move desktopMode state from Session to Store

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -77,7 +77,6 @@ class Session(
         fun onTrackerBlockingEnabledChanged(session: Session, blockingEnabled: Boolean) = Unit
         fun onTrackerBlocked(session: Session, tracker: Tracker, all: List<Tracker>) = Unit
         fun onTrackerLoaded(session: Session, tracker: Tracker, all: List<Tracker>) = Unit
-        fun onDesktopModeChanged(session: Session, enabled: Boolean) = Unit
         fun onContentPermissionRequested(session: Session, permissionRequest: PermissionRequest): Boolean = false
         fun onAppPermissionRequested(session: Session, permissionRequest: PermissionRequest): Boolean = false
         fun onRecordingDevicesChanged(session: Session, devices: List<RecordingDevice>) = Unit
@@ -249,13 +248,6 @@ class Session(
             // an action for the last item in the list.
             store?.syncDispatch(TrackingProtectionAction.TrackerLoadedAction(id, new.last()))
         }
-    }
-
-    /**
-     * Desktop Mode state, true if the desktop mode is requested, otherwise false.
-     */
-    var desktopMode: Boolean by Delegates.observable(false) { _, old, new ->
-        notifyObservers(old, new) { onDesktopModeChanged(this@Session, new) }
     }
 
     /**

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -223,7 +223,9 @@ internal class EngineObserver(
     }
 
     override fun onDesktopModeChange(enabled: Boolean) {
-        session.desktopMode = enabled
+        store?.dispatch(ContentAction.UpdateDesktopModeAction(
+            session.id, enabled
+        ))
     }
 
     override fun onFullScreenChange(enabled: Boolean) {

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SelectionAwareSessionObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SelectionAwareSessionObserverTest.kt
@@ -146,7 +146,6 @@ class SelectionAwareSessionObserverTest {
         observer.onCustomTabConfigChanged(session, null)
         observer.onTrackerBlockingEnabledChanged(session, true)
         observer.onTrackerBlocked(session, Tracker(""), emptyList())
-        observer.onDesktopModeChanged(session, true)
         observer.onSessionRemoved(session)
         observer.onAllSessionsRemoved()
     }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -512,18 +512,6 @@ class SessionTest {
     }
 
     @Test
-    fun `observer is notified when desktop mode is set`() {
-        val observer = mock(Session.Observer::class.java)
-        val session = Session("https://www.mozilla.org")
-        session.register(observer)
-        session.desktopMode = true
-        verify(observer).onDesktopModeChanged(
-                eq(session),
-                eq(true))
-        assertTrue(session.desktopMode)
-    }
-
-    @Test
     fun `session observer has default methods`() {
         val session = Session("")
         val defaultObserver = object : Session.Observer {}
@@ -542,7 +530,6 @@ class SessionTest {
         defaultObserver.onCustomTabConfigChanged(session, null)
         defaultObserver.onTrackerBlockingEnabledChanged(session, true)
         defaultObserver.onTrackerBlocked(session, mock(), emptyList())
-        defaultObserver.onDesktopModeChanged(session, true)
         defaultObserver.onContentPermissionRequested(session, contentPermissionRequest)
         defaultObserver.onAppPermissionRequested(session, appPermissionRequest)
         defaultObserver.onWebAppManifestChanged(session, mock())

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -509,6 +509,11 @@ sealed class ContentAction : BrowserAction() {
         val sessionId: String,
         val devices: List<RecordingDevice>
     ) : ContentAction()
+
+    /**
+     * Updates the [ContentState] of the given [sessionId] to indicate whether or not desktop mode is enabled.
+     */
+    data class UpdateDesktopModeAction(val sessionId: String, val enabled: Boolean) : ContentAction()
 }
 
 /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
@@ -198,6 +198,9 @@ internal object ContentStateReducer {
             is ContentAction.SetRecordingDevices -> updateContentState(state, action.sessionId) {
                 it.copy(recordingDevices = action.devices)
             }
+            is ContentAction.UpdateDesktopModeAction -> updateContentState(state, action.sessionId) {
+                it.copy(desktopMode = action.enabled)
+            }
         }
     }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
@@ -53,6 +53,7 @@ import mozilla.components.concept.engine.window.WindowRequest
  * cancel or abort before a page is refreshed.
  * @property recordingDevices List of recording devices (e.g. camera or microphone) currently in use
  * by web content.
+ * @property desktopMode true if desktop mode is enabled, otherwise false.
  */
 data class ContentState(
     val url: String,
@@ -82,5 +83,6 @@ data class ContentState(
     val pictureInPictureEnabled: Boolean = false,
     val loadRequest: LoadRequestState? = null,
     val refreshCanceled: Boolean = false,
-    val recordingDevices: List<RecordingDevice> = emptyList()
+    val recordingDevices: List<RecordingDevice> = emptyList(),
+    val desktopMode: Boolean = false
 )

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
@@ -669,4 +669,20 @@ class ContentActionTest {
         assertTrue(tab.content.loadRequest!!.triggeredByRedirect)
         assertFalse(tab.content.loadRequest!!.triggeredByUser)
     }
+
+    @Test
+    fun `UpdateDesktopModeEnabledAction updates desktopModeEnabled`() {
+        assertFalse(tab.content.desktopMode)
+        assertFalse(otherTab.content.desktopMode)
+
+        store.dispatch(ContentAction.UpdateDesktopModeAction(tab.id, true)).joinBlocking()
+
+        assertTrue(tab.content.desktopMode)
+        assertFalse(otherTab.content.desktopMode)
+
+        store.dispatch(ContentAction.UpdateDesktopModeAction(tab.id, false)).joinBlocking()
+
+        assertFalse(tab.content.desktopMode)
+        assertFalse(otherTab.content.desktopMode)
+    }
 }

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/SearchUseCasesTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/SearchUseCasesTest.kt
@@ -85,7 +85,7 @@ class SearchUseCasesTest {
 
         store.waitUntilIdle()
 
-        val loadUrlAction = middleware.findAction(EngineAction.LoadUrlAction::class)
+        val loadUrlAction = middleware.findFirstAction(EngineAction.LoadUrlAction::class)
         assertEquals(searchUrl, loadUrlAction.url)
     }
 
@@ -110,7 +110,7 @@ class SearchUseCasesTest {
             source = SessionState.Source.NEW_TAB
         )
 
-        val searchTermsAction = middleware.findAction(ContentAction.UpdateSearchTermsAction::class)
+        val searchTermsAction = middleware.findFirstAction(ContentAction.UpdateSearchTermsAction::class)
         assertEquals("2342", searchTermsAction.sessionId)
         assertEquals(searchTerms, searchTermsAction.searchTerms)
     }
@@ -136,7 +136,7 @@ class SearchUseCasesTest {
             source = SessionState.Source.NEW_TAB
         )
 
-        val searchTermsAction = middleware.findAction(ContentAction.UpdateSearchTermsAction::class)
+        val searchTermsAction = middleware.findFirstAction(ContentAction.UpdateSearchTermsAction::class)
         assertEquals("2342", searchTermsAction.sessionId)
         assertEquals(searchTerms, searchTermsAction.searchTerms)
     }
@@ -162,7 +162,7 @@ class SearchUseCasesTest {
             source = SessionState.Source.NONE
         )
 
-        val searchTermsAction = middleware.findAction(ContentAction.UpdateSearchTermsAction::class)
+        val searchTermsAction = middleware.findFirstAction(ContentAction.UpdateSearchTermsAction::class)
         assertEquals("1177", searchTermsAction.sessionId)
         assertEquals(searchTerms, searchTermsAction.searchTerms)
     }
@@ -188,7 +188,7 @@ class SearchUseCasesTest {
             source = SessionState.Source.NONE
         )
 
-        val searchTermsAction = middleware.findAction(ContentAction.UpdateSearchTermsAction::class)
+        val searchTermsAction = middleware.findFirstAction(ContentAction.UpdateSearchTermsAction::class)
         assertEquals("1177", searchTermsAction.sessionId)
         assertEquals(searchTerms, searchTermsAction.searchTerms)
     }

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/SearchUseCasesTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/SearchUseCasesTest.kt
@@ -82,7 +82,6 @@ class SearchUseCasesTest {
         whenever(searchEngineManager.getDefaultSearchEngine(testContext)).thenReturn(searchEngine)
 
         useCases.defaultSearch(searchTerms)
-
         store.waitUntilIdle()
 
         val loadUrlAction = middleware.findFirstAction(EngineAction.LoadUrlAction::class)
@@ -102,6 +101,7 @@ class SearchUseCasesTest {
         whenever(newTabUseCase(searchUrl)).thenReturn("2342")
 
         useCases.newTabSearch(searchTerms, SessionState.Source.NEW_TAB)
+        store.waitUntilIdle()
 
         verify(newTabUseCase).invoke(
             searchUrl,
@@ -128,6 +128,7 @@ class SearchUseCasesTest {
         whenever(newTabUseCase(searchUrl)).thenReturn("2342")
 
         useCases.defaultSearch(searchTerms)
+        store.waitUntilIdle()
 
         verify(newTabUseCase).invoke(
             searchUrl,
@@ -154,6 +155,7 @@ class SearchUseCasesTest {
         whenever(newTabUseCase(searchUrl, source = SessionState.Source.NONE)).thenReturn("1177")
 
         useCases.newPrivateTabSearch.invoke(searchTerms)
+        store.waitUntilIdle()
 
         verify(newTabUseCase).invoke(
             searchUrl,
@@ -180,6 +182,7 @@ class SearchUseCasesTest {
         whenever(newTabUseCase(searchUrl, source = SessionState.Source.NONE, parentId = "test-parent")).thenReturn("1177")
 
         useCases.newPrivateTabSearch.invoke(searchTerms, parentSessionId = "test-parent")
+        store.waitUntilIdle()
 
         verify(newTabUseCase).invoke(
             searchUrl,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ permalink: /changelog/
 
 * **browser-session**
   * ⚠️ **This is a breaking change**: `Session.searchTerms` has been removed. Use `ContentState.searchTerms` (`browser-state`) instead.
+  * ⚠️ **This is a breaking change**: `Session.desktopMode` has been removed. Use `ContentState.desktopMode` (`browser-state`) instead.
 
 * **feature-search**
   * ⚠️ **This is a breaking change**: Use cases in `SearchUseCases` now take the ID of s session/tab as parameter instead of a `Session` instance.

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -27,6 +27,7 @@ import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.engine.EngineMiddleware
 import mozilla.components.browser.session.storage.SessionStorage
 import mozilla.components.browser.session.undo.UndoMiddleware
+import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.storage.sync.PlacesHistoryStorage
 import mozilla.components.browser.thumbnails.ThumbnailsMiddleware
@@ -340,11 +341,11 @@ open class DefaultComponents(private val applicationContext: Context) {
         )
         items.add(
             BrowserMenuCheckbox("Request desktop site", {
-                sessionManager.selectedSessionOrThrow.desktopMode
+                store.state.selectedTab?.content?.desktopMode == true
             }) { checked ->
                 sessionUseCases.requestDesktopSite(checked)
             }.apply {
-                visible = { sessionManager.selectedSession != null }
+                visible = { store.state.selectedTab != null }
             }
         )
         items.add(


### PR DESCRIPTION
I've also cleaned up some tests here to remove mockito `reset` calls, and rely on our new `CaptureActionsMiddleware` instead. Added a `assertLastAction` for that.

The rest is mostly mechanical, and moves the boolean flag over to the store :).