### PR TITLE
Closes #9131: Add site permission indicators in the toolbar

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -18,6 +18,7 @@ import mozilla.components.browser.state.state.EngineState
 import mozilla.components.browser.state.state.LoadRequestState
 import mozilla.components.browser.state.state.MediaSessionState
 import mozilla.components.browser.state.state.MediaState
+import mozilla.components.browser.state.state.content.PermissionHighlightsState
 import mozilla.components.browser.state.state.ReaderState
 import mozilla.components.browser.state.state.SecurityInfoState
 import mozilla.components.browser.state.state.SessionState
@@ -276,6 +277,14 @@ sealed class ContentAction : BrowserAction() {
      * Updates the progress of the [ContentState] with the given [sessionId].
      */
     data class UpdateProgressAction(val sessionId: String, val progress: Int) : ContentAction()
+
+    /**
+     * Updates permissions highlights of the [ContentState] with the given [sessionId].
+     */
+    data class UpdatePermissionHighlightsStateAction(
+        val sessionId: String,
+        val highlights: PermissionHighlightsState
+    ) : ContentAction()
 
     /**
      * Updates the title of the [ContentState] with the given [sessionId].

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
@@ -201,6 +201,9 @@ internal object ContentStateReducer {
             is ContentAction.UpdateDesktopModeAction -> updateContentState(state, action.sessionId) {
                 it.copy(desktopMode = action.enabled)
             }
+            is ContentAction.UpdatePermissionHighlightsStateAction -> updateContentState(state, action.sessionId) {
+                it.copy(permissionHighlights = action.highlights)
+            }
         }
     }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
@@ -8,6 +8,7 @@ import android.graphics.Bitmap
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.state.content.FindResultState
 import mozilla.components.browser.state.state.content.HistoryState
+import mozilla.components.browser.state.state.content.PermissionHighlightsState
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.engine.media.RecordingDevice
@@ -45,7 +46,9 @@ import mozilla.components.concept.engine.window.WindowRequest
  * @property firstContentfulPaint whether or not the first contentful paint has happened.
  * @property pictureInPictureEnabled True if the session is being displayed in PIP mode.
  * @property loadRequest last [LoadRequestState] if this session.
- * @property permissionRequestsList Holds unprocessed content requests.
+ * @property permissionIndicator Holds the state of any site permission that was granted/denied
+ * that should be brought to the user's attention, for example when media content is not able to
+ * play because the autoplay settings.
  * @property appPermissionRequestsList Holds unprocessed app requests.
  * @property refreshCanceled Indicates if an intent of refreshing was canceled.
  * True if a page refresh was cancelled by the user, defaults to false. Note that this is not about
@@ -78,6 +81,7 @@ data class ContentState(
     val webAppManifest: WebAppManifest? = null,
     val firstContentfulPaint: Boolean = false,
     val history: HistoryState = HistoryState(),
+    val permissionHighlights: PermissionHighlightsState = PermissionHighlightsState(),
     val permissionRequestsList: List<PermissionRequest> = emptyList(),
     val appPermissionRequestsList: List<PermissionRequest> = emptyList(),
     val pictureInPictureEnabled: Boolean = false,

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/PermissionHighlightsState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/PermissionHighlightsState.kt
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.state.content
+
+/**
+ * Value type that represents any information about permissions that should
+ * be brought to user's attention.
+ *
+ * @property isAutoPlayBlocking indicates if the autoplay setting
+ * disabled some web content from playing.
+ */
+data class PermissionHighlightsState(
+    val isAutoPlayBlocking: Boolean = false
+)

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
@@ -14,6 +14,7 @@ import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.state.content.FindResultState
 import mozilla.components.browser.state.state.content.HistoryState
+import mozilla.components.browser.state.state.content.PermissionHighlightsState
 import mozilla.components.browser.state.state.createCustomTab
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
@@ -684,5 +685,17 @@ class ContentActionTest {
 
         assertFalse(tab.content.desktopMode)
         assertFalse(otherTab.content.desktopMode)
+    }
+
+    @Test
+    fun `UpdatePermissionHighlightsStateAction updates permissionHighlights state`() {
+
+        assertFalse(tab.content.permissionHighlights.isAutoPlayBlocking)
+
+        store.dispatch(
+                ContentAction.UpdatePermissionHighlightsStateAction(tab.id, PermissionHighlightsState(true))
+        ).joinBlocking()
+
+        assertTrue(tab.content.permissionHighlights.isAutoPlayBlocking)
     }
 }

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -25,6 +25,7 @@ import mozilla.components.browser.toolbar.edit.EditToolbar
 import mozilla.components.concept.toolbar.AutocompleteDelegate
 import mozilla.components.concept.toolbar.AutocompleteResult
 import mozilla.components.concept.toolbar.Toolbar
+import mozilla.components.concept.toolbar.Toolbar.PermissionHighlights
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.ui.autocomplete.AutocompleteView
@@ -110,6 +111,14 @@ class BrowserToolbar @JvmOverloads constructor(
     override var siteSecure: Toolbar.SiteSecurity
         get() = display.siteSecurity
         set(value) { display.siteSecurity = value }
+
+    override var permissionHighlights: PermissionHighlights = PermissionHighlights.NONE
+        set(value) {
+            if (field != value) {
+                display.setPermissionIndicator(value)
+                field = value
+            }
+        }
 
     override var siteTrackingProtection: Toolbar.SiteTrackingProtection =
         Toolbar.SiteTrackingProtection.OFF_GLOBALLY

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/PermissionHighlightsIconView.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/PermissionHighlightsIconView.kt
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.toolbar.display
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.util.AttributeSet
+import androidx.annotation.VisibleForTesting
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.core.view.isVisible
+import mozilla.components.browser.toolbar.R
+import mozilla.components.concept.toolbar.Toolbar.PermissionHighlights
+import mozilla.components.concept.toolbar.Toolbar.PermissionHighlights.AUTOPLAY_BLOCKED
+import mozilla.components.concept.toolbar.Toolbar.PermissionHighlights.NONE
+
+/**
+ * Internal widget to display the different icons of site permission.
+ */
+internal class PermissionHighlightsIconView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : AppCompatImageView(context, attrs, defStyleAttr) {
+
+    init {
+        visibility = GONE
+    }
+
+    var permissionHighlights: PermissionHighlights = NONE
+        set(value) {
+            if (value != field) {
+                field = value
+                updateIcon()
+            }
+        }
+
+    @VisibleForTesting
+    internal var permissionTint: Int? = null
+
+    private var iconAutoplayBlocked: Drawable =
+        requireNotNull(AppCompatResources.getDrawable(context, DEFAULT_ICON_AUTOPLAY_BLOCKED))
+
+    fun setTint(tint: Int) {
+        permissionTint = tint
+        setColorFilter(tint)
+    }
+
+    fun setIcons(icons: DisplayToolbar.Icons.PermissionHighlights) {
+        this.iconAutoplayBlocked = icons.autoPlayBlocked
+
+        updateIcon()
+    }
+
+    @Synchronized
+    @VisibleForTesting
+    internal fun updateIcon() {
+        val update = permissionHighlights.toUpdate()
+
+        isVisible = update.visible
+
+        contentDescription = if (update.contentDescription != null) {
+            context.getString(update.contentDescription)
+        } else {
+            null
+        }
+
+        permissionTint?.let { setColorFilter(it) }
+        setImageDrawable(update.drawable)
+    }
+
+    companion object {
+        val DEFAULT_ICON_AUTOPLAY_BLOCKED =
+            R.drawable.mozac_ic_autoplay_blocked
+    }
+
+    private fun PermissionHighlights.toUpdate(): Update = when (this) {
+        AUTOPLAY_BLOCKED -> Update(
+            iconAutoplayBlocked,
+            R.string.mozac_browser_toolbar_content_description_autoplay_blocked,
+            true)
+
+        NONE -> Update(
+            null,
+            null,
+            false
+        )
+    }
+}

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/TrackingProtectionIconView.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/TrackingProtectionIconView.kt
@@ -126,7 +126,7 @@ internal class TrackingProtectionIconView @JvmOverloads constructor(
     }
 }
 
-private class Update(
+internal class Update(
     val drawable: Drawable?,
     @StringRes val contentDescription: Int?,
     val visible: Boolean

--- a/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_displaytoolbar.xml
+++ b/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_displaytoolbar.xml
@@ -83,6 +83,18 @@
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/mozac_ic_site_security" />
 
+    <mozilla.components.browser.toolbar.display.PermissionHighlightsIconView
+        android:id="@+id/mozac_browser_toolbar_permission_indicator"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginTop="8dp"
+        android:importantForAccessibility="no"
+        android:scaleType="center"
+        android:visibility="gone"
+        app:layout_constraintStart_toEndOf="@+id/mozac_browser_toolbar_security_indicator"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/mozac_ic_autoplay_blocked" />
+
     <!-- URL & Title -->
 
     <mozilla.components.browser.toolbar.display.OriginView
@@ -91,7 +103,7 @@
         android:layout_height="40dp"
         android:layout_marginTop="8dp"
         app:layout_constraintEnd_toStartOf="@+id/mozac_browser_toolbar_page_actions"
-        app:layout_constraintStart_toEndOf="@+id/mozac_browser_toolbar_security_indicator"
+        app:layout_constraintStart_toEndOf="@+id/mozac_browser_toolbar_permission_indicator"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_goneMarginStart="8dp"
         app:layout_goneMarginTop="8dp" />

--- a/components/browser/toolbar/src/main/res/values/strings.xml
+++ b/components/browser/toolbar/src/main/res/values/strings.xml
@@ -16,4 +16,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Site information</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Loading</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Some content has been blocked by the autoplay setting</string>
 </resources>

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -16,6 +16,7 @@ import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.browser.toolbar.R
 import mozilla.components.concept.menu.MenuButton
+import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.concept.toolbar.Toolbar.SiteSecurity
 import mozilla.components.concept.toolbar.Toolbar.SiteTrackingProtection
 import mozilla.components.support.base.Component
@@ -96,6 +97,18 @@ class DisplayToolbarTest {
     }
 
     @Test
+    fun `permissionViewColor will change the color of the permissionIconView`() {
+        val (_, displayToolbar) = createDisplayToolbar()
+
+        assertNull(displayToolbar.views.permissionIndicator.colorFilter)
+
+        displayToolbar.colors = displayToolbar.colors.copy(permissionHighlights = Color.BLUE)
+
+        assertNotNull(displayToolbar.views.permissionIndicator.colorFilter)
+        assertNotNull(displayToolbar.views.permissionIndicator.permissionTint)
+    }
+
+    @Test
     fun `tracking protection and separator views become visible when states ON OR ACTIVE are set to siteTrackingProtection`() {
         val (_, displayToolbar) = createDisplayToolbar()
 
@@ -165,6 +178,33 @@ class DisplayToolbarTest {
         assertEquals(
             drawable1,
             displayToolbar.views.trackingProtectionIndicator.drawable
+        )
+    }
+
+    @Test
+    fun `setPermissionIcons will forward to PermissionHighlightsIconView`() {
+        val (_, displayToolbar) = createDisplayToolbar()
+
+        val oldPermissionIcon = displayToolbar.views.permissionIndicator.drawable
+        assertNotNull(oldPermissionIcon)
+
+        val drawable1 = testContext.getDrawable(PermissionHighlightsIconView.DEFAULT_ICON_AUTOPLAY_BLOCKED)!!
+
+        displayToolbar.indicators = listOf(DisplayToolbar.Indicators.PERMISSION_HIGHLIGHTS)
+        displayToolbar.icons = displayToolbar.icons.copy(
+            permissionHighlights = DisplayToolbar.Icons.PermissionHighlights(drawable1)
+        )
+
+        assertNotEquals(
+            oldPermissionIcon,
+            displayToolbar.views.permissionIndicator.drawable
+        )
+
+        displayToolbar.setPermissionIndicator(Toolbar.PermissionHighlights.AUTOPLAY_BLOCKED)
+
+        assertNotEquals(
+            oldPermissionIcon,
+            displayToolbar.views.permissionIndicator.drawable
         )
     }
 
@@ -662,6 +702,39 @@ class DisplayToolbarTest {
         displayToolbar.setOnSiteSecurityClickedListener(null)
 
         assertNull(displayToolbar.views.securityIndicator.background)
+    }
+
+    @Test
+    fun `clicking on permission indicator invokes listener`() {
+        var listenerInvoked = false
+
+        val (_, displayToolbar) = createDisplayToolbar()
+
+        assertNull(displayToolbar.views.permissionIndicator.background)
+
+        displayToolbar.setOnPermissionIndicatorClickedListener {
+            listenerInvoked = true
+        }
+
+        assertNotNull(displayToolbar.views.permissionIndicator.background)
+
+        displayToolbar.views.permissionIndicator.performClick()
+
+        assertTrue(listenerInvoked)
+
+        listenerInvoked = false
+
+        displayToolbar.setOnPermissionIndicatorClickedListener { }
+
+        assertNotNull(displayToolbar.views.permissionIndicator.background)
+
+        displayToolbar.views.permissionIndicator.performClick()
+
+        assertFalse(listenerInvoked)
+
+        displayToolbar.setOnPermissionIndicatorClickedListener(null)
+
+        assertNull(displayToolbar.views.permissionIndicator.background)
     }
 
     @Test

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/PermissionHighlightsIconViewTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/PermissionHighlightsIconViewTest.kt
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.toolbar.display
+
+import androidx.core.view.isVisible
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.toolbar.R
+import mozilla.components.concept.toolbar.Toolbar.PermissionHighlights.NONE
+import mozilla.components.concept.toolbar.Toolbar.PermissionHighlights.AUTOPLAY_BLOCKED
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class PermissionHighlightsIconViewTest {
+
+    @Test
+    fun `after setting tint, can get trackingProtectionTint`() {
+        val view = PermissionHighlightsIconView(testContext)
+        view.setTint(android.R.color.black)
+        assertEquals(android.R.color.black, view.permissionTint)
+    }
+
+    @Test
+    fun `setting permissionHighlights status will trigger an icon updated`() {
+        val view = PermissionHighlightsIconView(testContext)
+
+        view.permissionHighlights = AUTOPLAY_BLOCKED
+
+        assertEquals(AUTOPLAY_BLOCKED, view.permissionHighlights)
+        assertTrue(view.isVisible)
+        assertNotNull(view.drawable)
+        assertEquals(
+            view.contentDescription,
+            testContext.getString(R.string.mozac_browser_toolbar_content_description_autoplay_blocked)
+        )
+
+        view.permissionHighlights = NONE
+
+        assertEquals(NONE, view.permissionHighlights)
+        assertNull(view.drawable)
+        assertFalse(view.isVisible)
+        assertNull(view.contentDescription)
+    }
+
+    @Test
+    fun `setIcons will trigger an icon updated`() {
+        val view = spy(PermissionHighlightsIconView(testContext))
+
+        view.setIcons(DisplayToolbar.Icons.PermissionHighlights(
+                testContext.getDrawable(
+                        TrackingProtectionIconView.DEFAULT_ICON_ON_NO_TRACKERS_BLOCKED
+                )!!))
+
+        verify(view).updateIcon()
+    }
+}

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -48,6 +48,11 @@ interface Toolbar {
     var siteSecure: SiteSecurity
 
     /**
+     * Sets/Gets the site site permission indicator to be displayed on the toolbar.
+     */
+    var permissionHighlights: PermissionHighlights
+
+    /**
      * Sets/Gets the site tracking protection state to be displayed on the toolbar.
      */
     var siteTrackingProtection: SiteTrackingProtection
@@ -407,5 +412,19 @@ interface Toolbar {
          * Tracking protection has been disabled for all sites.
          */
         OFF_GLOBALLY,
+    }
+
+    /**
+     * Indicates which site permission indicator a site should show.
+     */
+    enum class PermissionHighlights {
+        /**
+         * The site has autoplay blocked.
+         */
+        AUTOPLAY_BLOCKED,
+        /**
+         * The site does not have any permission indicator to show.
+         */
+        NONE
     }
 }

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/CustomTabSessionTitleObserverTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/CustomTabSessionTitleObserverTest.kt
@@ -63,7 +63,7 @@ class CustomTabSessionTitleObserverTest {
 
     private class MockToolbar : Toolbar {
         override var title: String = ""
-
+        override var permissionHighlights: Toolbar.PermissionHighlights = Toolbar.PermissionHighlights.NONE
         override var url: CharSequence by ThrowProperty()
         override var private: Boolean by ThrowProperty()
         override var siteSecure: Toolbar.SiteSecurity by ThrowProperty()

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarPresenter.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarPresenter.kt
@@ -11,8 +11,10 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collect
 import mozilla.components.browser.state.selector.findCustomTabOrSelectedTab
 import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.toolbar.Toolbar
+import mozilla.components.concept.toolbar.Toolbar.PermissionHighlights
 import mozilla.components.concept.toolbar.Toolbar.SiteTrackingProtection
 import mozilla.components.feature.toolbar.internal.URLRenderer
 import mozilla.components.lib.state.ext.flowScoped
@@ -78,8 +80,17 @@ class ToolbarPresenter(
 
                 else -> SiteTrackingProtection.OFF_GLOBALLY
             }
+
+            updatePermissionIndicator(tab)
         } else {
             clear()
+        }
+    }
+
+    private fun updatePermissionIndicator(tab: SessionState) {
+        toolbar.permissionHighlights = when {
+            tab.content.permissionHighlights.isAutoPlayBlocking -> PermissionHighlights.AUTOPLAY_BLOCKED
+            else -> PermissionHighlights.NONE
         }
     }
 
@@ -93,5 +104,6 @@ class ToolbarPresenter(
         toolbar.siteSecure = Toolbar.SiteSecurity.INSECURE
 
         toolbar.siteTrackingProtection = SiteTrackingProtection.OFF_GLOBALLY
+        toolbar.permissionHighlights = PermissionHighlights.NONE
     }
 }

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
@@ -35,6 +35,7 @@ import org.mockito.Mockito.verify
 class ToolbarAutocompleteFeatureTest {
 
     class TestToolbar : Toolbar {
+        override var permissionHighlights: Toolbar.PermissionHighlights = Toolbar.PermissionHighlights.NONE
         override var siteTrackingProtection: Toolbar.SiteTrackingProtection =
             Toolbar.SiteTrackingProtection.OFF_GLOBALLY
         override var title: String = ""

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
@@ -19,6 +19,7 @@ import org.mockito.Mockito.spy
 class ToolbarInteractorTest {
 
     class TestToolbar : Toolbar {
+        override var permissionHighlights: Toolbar.PermissionHighlights = Toolbar.PermissionHighlights.NONE
         override var url: CharSequence = ""
         override var siteSecure: Toolbar.SiteSecurity = Toolbar.SiteSecurity.INSECURE
         override var private: Boolean = false

--- a/components/ui/icons/src/main/res/drawable/mozac_ic_autoplay_blocked.xml
+++ b/components/ui/icons/src/main/res/drawable/mozac_ic_autoplay_blocked.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/mozac_ui_icons_fill"
+        android:pathData="M19.168,8.458A7.985,7.985 0,0 1,8.462 19.164L6.987,20.639A9.986,9.986 0,0 0,20.643 6.984Z" />
+    <path
+        android:fillColor="@color/mozac_ui_icons_fill"
+        android:pathData="M21.707,2.293a1,1 0,0 0,-1.414 0l-1.97,1.97a9.915,9.915 0,0 0,-2.991 -1.694,1 1,0 1,0 -0.666,1.885 7.88,7.88 0,0 1,2.227 1.239L13.311,9.275 10.5,7.643A1,1 0,0 0,9 8.508v5.078l-3.3,3.3A7.922,7.922 0,0 1,4 12,8 8,0 0,1 7,5.773V9.5a0.5,0.5 0,0 0,1 0v-6A0.5,0.5 0,0 0,7.5 3h-5a0.5,0.5 0,0 0,0 1H6.024A9.939,9.939 0,0 0,4.273 18.313l-1.98,1.98a1,1 0,1 0,1.414 1.414l18,-18A1,1 0,0 0,21.707 2.293Z" />
+    <path
+        android:fillColor="@color/mozac_ui_icons_fill"
+        android:pathData="M16.5,11.128l-4.166,4.165 4.179,-2.428a1,1 0,0 0,0 -1.73Z" />
+</vector>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,8 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **browser-toolbar**
+  * 🌟 Added API to show site permission indicators for more information see [#9131](https://github.com/mozilla-mobile/android-components/issues/9131).
 
 # 69.0.0
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
@@ -15,6 +15,7 @@ import kotlinx.android.synthetic.main.fragment_browser.view.*
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.mapNotNull
 import mozilla.components.browser.state.selector.findCustomTabOrSelectedTab
+import mozilla.components.browser.toolbar.display.DisplayToolbar
 import mozilla.components.feature.downloads.DownloadsFeature
 import mozilla.components.feature.downloads.manager.FetchDownloadManager
 import mozilla.components.feature.privatemode.feature.SecureWindowFeature
@@ -24,6 +25,7 @@ import mozilla.components.feature.session.SessionFeature
 import mozilla.components.feature.session.SwipeRefreshFeature
 import mozilla.components.feature.sitepermissions.SitePermissionsFeature
 import mozilla.components.feature.sitepermissions.SitePermissionsRules
+import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action.ALLOWED
 import mozilla.components.feature.toolbar.ToolbarFeature
 import mozilla.components.lib.state.ext.consumeFlow
 import mozilla.components.support.base.feature.PermissionsFeature
@@ -83,6 +85,20 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
                 sessionId),
             owner = this,
             view = layout)
+
+        layout.toolbar.display.setOnPermissionIndicatorClickedListener {
+            sitePermissionsFeature.withFeature { feature ->
+                feature.sitePermissionsRules = feature.sitePermissionsRules?.copy(
+                    autoplayAudible = ALLOWED,
+                    autoplayInaudible = ALLOWED
+                )
+                components.sessionUseCases.reload()
+            }
+        }
+
+        layout.toolbar.display.indicators += listOf(
+            DisplayToolbar.Indicators.TRACKING_PROTECTION
+        )
 
         swipeRefreshFeature.set(
             feature = SwipeRefreshFeature(
@@ -148,8 +164,8 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
                 storage = components.permissionStorage,
                 fragmentManager = parentFragmentManager,
                 sitePermissionsRules = SitePermissionsRules(
-                    autoplayAudible = SitePermissionsRules.AutoplayAction.ALLOWED,
-                    autoplayInaudible = SitePermissionsRules.AutoplayAction.ALLOWED,
+                    autoplayAudible = SitePermissionsRules.AutoplayAction.BLOCKED,
+                    autoplayInaudible = SitePermissionsRules.AutoplayAction.BLOCKED,
                     camera = SitePermissionsRules.Action.ASK_TO_ALLOW,
                     location = SitePermissionsRules.Action.ASK_TO_ALLOW,
                     notification = SitePermissionsRules.Action.ASK_TO_ALLOW,


### PR DESCRIPTION
We want to add an icon in the toolbar to make users aware of some site permissions that are allowed/denied on a site. 
For the moment, we want to start with autoplay to mimic the same behaviour as we have in desktop see https://github.com/mozilla-mobile/android-components/issues/9131#issuecomment-738350815, later we could add an site permission indicator when sites are granted location access (same as desktop). 

This is [an example ](https://drive.google.com/file/d/174LY4_sPcrv4-9SoJ26Z6Udtxd0LVvKG/view)of how the icon will work after we finish working on https://github.com/mozilla-mobile/android-components/issues/9156, for now we want to introduce the api.

Fenix pr https://github.com/mozilla-mobile/fenix/pull/16947

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
