### PR TITLE
Closes #4571: Introduce API to purge (back/forward) history of tabs.

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -415,6 +415,13 @@ class GeckoEngineSession(
     }
 
     /**
+     * Purges the history for the session (back and forward history).
+     */
+    override fun purgeHistory() {
+        geckoSession.purgeHistory()
+    }
+
+    /**
      * See [EngineSession.close].
      */
     override fun close() {

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -415,6 +415,13 @@ class GeckoEngineSession(
     }
 
     /**
+     * Purges the history for the session (back and forward history).
+     */
+    override fun purgeHistory() {
+        geckoSession.purgeHistory()
+    }
+
+    /**
      * See [EngineSession.close].
      */
     override fun close() {

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -408,6 +408,13 @@ class GeckoEngineSession(
     }
 
     /**
+     * Purges the history for the session (back and forward history).
+     */
+    override fun purgeHistory() {
+        geckoSession.purgeHistory()
+    }
+
+    /**
      * See [EngineSession.close].
      */
     override fun close() {

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -233,6 +233,13 @@ class SystemEngineSession(
     }
 
     /**
+     * Clears the internal back/forward list.
+     */
+    override fun purgeHistory() {
+        webView.clearHistory()
+    }
+
+    /**
      * See [EngineSession.settings]
      */
     override val settings: Settings

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -958,6 +958,17 @@ class SystemEngineSessionTest {
     }
 
     @Test
+    fun `purgeHistory delegates to clearHistory`() {
+        val engineSession = SystemEngineSession(testContext)
+
+        val webView: WebView = mock()
+        engineSession.webView = webView
+
+        engineSession.purgeHistory()
+        verify(webView).clearHistory()
+    }
+
+    @Test
     fun `GIVEN webView_canGoBack() true WHEN goBack() is called THEN verify EngineObserver onNavigateBack() is triggered`() {
         var observedOnNavigateBack = false
 

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -77,7 +77,7 @@ class EngineObserverTest {
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
             override fun exitFullScreenMode() {}
-
+            override fun purgeHistory() {}
             override fun loadData(data: String, mimeType: String, encoding: String) {
                 notifyObservers { onLocationChange(data) }
                 notifyObservers { onProgress(100) }
@@ -127,6 +127,7 @@ class EngineObserverTest {
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
             override fun exitFullScreenMode() {}
+            override fun purgeHistory() {}
             override fun loadData(data: String, mimeType: String, encoding: String) {}
             override fun loadUrl(
                 url: String,
@@ -169,7 +170,6 @@ class EngineObserverTest {
             override fun disableTrackingProtection() {
                 notifyObservers { onTrackerBlockingEnabledChange(false) }
             }
-
             override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {}
             override fun loadUrl(
                 url: String,
@@ -182,6 +182,7 @@ class EngineObserverTest {
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
             override fun exitFullScreenMode() {}
+            override fun purgeHistory() {}
         }
         val observer = EngineObserver(session, mock())
         engineSession.register(observer)
@@ -1173,6 +1174,8 @@ class EngineObserverTest {
 
         val observer = EngineObserver(session, store)
         observer.onNavigateBack()
+        store.waitUntilIdle()
+
         store.waitUntilIdle()
 
         middleware.assertFirstAction(ContentAction.UpdateSearchTermsAction::class) { action ->

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -761,6 +761,11 @@ sealed class EngineAction : BrowserAction() {
         val sessionId: String,
         val engineSessionObserver: EngineSession.Observer
     ) : EngineAction()
+
+    /**
+     * Purges the back/forward history of all tabs and custom tabs.
+     */
+    object PurgeHistoryAction : EngineAction()
 }
 
 /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/selector/Selectors.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/selector/Selectors.kt
@@ -108,3 +108,6 @@ val BrowserState.privateTabs: List<TabSessionState>
  */
 val BrowserState.normalTabs: List<TabSessionState>
     get() = getNormalOrPrivateTabs(private = false)
+
+val BrowserState.allTabs: List<SessionState>
+    get() = tabs + customTabs

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -660,6 +660,11 @@ abstract class EngineSession(
     open fun markActiveForWebExtensions(active: Boolean) = Unit
 
     /**
+     * Purges the history for the session (back and forward history).
+     */
+    abstract fun purgeHistory()
+
+    /**
      * Close the session. This may free underlying objects. Call this when you are finished using
      * this session.
      */

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -985,6 +985,8 @@ open class DummyEngineSession : EngineSession() {
 
     override fun exitFullScreenMode() {}
 
+    override fun purgeHistory() {}
+
     // Helper method to access the protected method from test cases.
     fun notifyInternalObservers(block: Observer.() -> Unit) {
         notifyObservers(block)

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
@@ -352,6 +352,20 @@ class SessionUseCases(
         }
     }
 
+    /**
+     * UseCase for purging the (back and forward) history of all tabs and custom tabs.
+     */
+    class PurgeHistoryUseCase internal constructor(
+        private val store: BrowserStore
+    ) {
+        /**
+         * Purges the (back and forward) history of all tabs and custom tabs.
+         */
+        operator fun invoke() {
+            store.dispatch(EngineAction.PurgeHistoryAction)
+        }
+    }
+
     val loadUrl: DefaultLoadUrlUseCase by lazy { DefaultLoadUrlUseCase(store, sessionManager, onNoSession) }
     val loadData: LoadDataUseCase by lazy { LoadDataUseCase(store, sessionManager, onNoSession) }
     val reload: ReloadUrlUseCase by lazy { ReloadUrlUseCase(store, sessionManager) }
@@ -363,4 +377,5 @@ class SessionUseCases(
     val exitFullscreen: ExitFullScreenUseCase by lazy { ExitFullScreenUseCase(store, sessionManager) }
     val clearData: ClearDataUseCase by lazy { ClearDataUseCase(store, sessionManager) }
     val crashRecovery: CrashRecoveryUseCase by lazy { CrashRecoveryUseCase(store) }
+    val purgeHistory: PurgeHistoryUseCase by lazy { PurgeHistoryUseCase(store) }
 }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.session
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.CrashAction
 import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.state.BrowserState
@@ -18,6 +19,8 @@ import mozilla.components.concept.engine.Engine.BrowsingData
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
+import mozilla.components.support.test.middleware.CaptureActionsMiddleware
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
@@ -283,5 +286,17 @@ class SessionUseCasesTest {
         useCases.crashRecovery.invoke()
         verify(store).dispatch(CrashAction.RestoreCrashedSessionAction("tab1"))
         verify(store).dispatch(CrashAction.RestoreCrashedSessionAction("customTab1"))
+    }
+
+    @Test
+    fun `PurgeHistoryUseCase dispatches PurgeHistory action`() {
+        val captureMiddleware = CaptureActionsMiddleware<BrowserState, BrowserAction>()
+        val store = BrowserStore(middleware = listOf(captureMiddleware))
+        val useCases = SessionUseCases(store, sessionManager)
+
+        useCases.purgeHistory()
+
+        store.waitUntilIdle()
+        captureMiddleware.assertFirstAction(EngineAction.PurgeHistoryAction::class)
     }
 }

--- a/components/support/test-libstate/src/main/java/mozilla/components/support/test/middleware/CaptureActionsMiddleware.kt
+++ b/components/support/test-libstate/src/main/java/mozilla/components/support/test/middleware/CaptureActionsMiddleware.kt
@@ -45,10 +45,11 @@ class CaptureActionsMiddleware<S : State, A : Action> : Middleware<S, A> {
     }
 
     /**
-     * Executes the given [block] with the first action of type [clazz] that was dispatched on the
-     * store. Throws [AssertionError] if no such action was dispatched.
+     * Asserts that an action of type [clazz] was dispatched and optionally executes a given [block]
+     * with the first action of type [clazz] that was dispatched on the store. Throws [AssertionError]
+     * if no such action was dispatched.
      */
-    fun <X : A> assertFirstAction(clazz: KClass<X>, block: (X) -> Unit) {
+    fun <X : A> assertFirstAction(clazz: KClass<X>, block: (X) -> Unit = {}) {
         val action = findFirstAction(clazz)
         block(action)
     }


### PR DESCRIPTION
* For `PurgeHistoryUseCase` I decided to not introduce a "tab ID" parameter and instead have
  it purge the history of all tabs. It seems like this is what we need and individual tab
  history removal is not needed for now.
* Some tabs may not have an `EngineSession` assigned. Creating one just to call purgeHistory()
  seems excessive. Instead I am dropping an attached `EngineSessionState` which will cause
  those tabs to just reload the URL with not back/forward history when they get restored.