### PR TITLE
Post-release: Set version to 70.0.0.

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -1,4 +1,4 @@
-componentsVersion: 69.0.0
+componentsVersion: 70.0.0
 projects:
   concept-awesomebar:
     path: components/concept/awesomebar

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,15 @@ title: Changelog
 permalink: /changelog/
 ---
 
+# 70.0.0-SNAPSHOT (In Development)
+
+* [Commits](https://github.com/mozilla-mobile/android-components/compare/v69.0.0...master)
+* [Milestone](https://github.com/mozilla-mobile/android-components/milestone/130?closed=1)
+* [Dependencies](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Dependencies.kt)
+* [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
+* [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
+
+
 # 69.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v68.0.0...v69.0.0)


### PR DESCRIPTION
Will land after https://github.com/mozilla-mobile/android-components/pull/9172 is merged.