### PR TITLE
Closes #7247: Deprecate Session[Manager] observable methods

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/LegacySessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/LegacySessionManager.kt
@@ -2,12 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+@file:Suppress("DEPRECATION")
+
 package mozilla.components.browser.session
 
 import androidx.annotation.GuardedBy
 import mozilla.components.concept.engine.Engine
-import mozilla.components.support.base.observer.Observable
-import mozilla.components.support.base.observer.ObserverRegistry
+import mozilla.components.support.base.observer.DeprecatedObservable
+import mozilla.components.support.base.observer.DeprecatedObserverRegistry
 import kotlin.math.max
 import kotlin.math.min
 
@@ -17,8 +19,8 @@ import kotlin.math.min
 @Suppress("TooManyFunctions", "LargeClass")
 class LegacySessionManager(
     val engine: Engine,
-    delegate: Observable<SessionManager.Observer> = ObserverRegistry()
-) : Observable<SessionManager.Observer> by delegate {
+    delegate: DeprecatedObserverRegistry<SessionManager.Observer> = DeprecatedObserverRegistry()
+) : DeprecatedObservable<SessionManager.Observer> by delegate {
     // It's important that any access to `values` is synchronized;
     @GuardedBy("values")
     private val values = mutableListOf<Session>()

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SelectionAwareSessionObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SelectionAwareSessionObserver.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.session
 
 import androidx.annotation.CallSuper
+import mozilla.components.support.base.observer.OBSERVER_DEPRECATION_MESSAGE
 
 /**
  * This class is a combination of [Session.Observer] and
@@ -16,7 +17,8 @@ import androidx.annotation.CallSuper
  * @property activeSession the currently observed session
  * @property sessionManager the application's session manager
  */
-@Deprecated("Use browser store for observing session state changes instead")
+@Deprecated(OBSERVER_DEPRECATION_MESSAGE)
+@Suppress("DEPRECATION") // SessionManager observable is deprecated
 abstract class SelectionAwareSessionObserver(
     private val sessionManager: SessionManager
 ) : SessionManager.Observer, Session.Observer {

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+@file:Suppress("DEPRECATION")
+
 package mozilla.components.browser.session
 
 import android.content.Intent
@@ -28,8 +30,8 @@ import mozilla.components.concept.engine.content.blocking.Tracker
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.engine.media.RecordingDevice
 import mozilla.components.concept.engine.permission.PermissionRequest
-import mozilla.components.support.base.observer.Observable
-import mozilla.components.support.base.observer.ObserverRegistry
+import mozilla.components.support.base.observer.DeprecatedObservable
+import mozilla.components.support.base.observer.DeprecatedObserverRegistry
 import java.util.UUID
 import kotlin.properties.Delegates
 
@@ -43,8 +45,8 @@ class Session(
     val source: SessionState.Source = SessionState.Source.NONE,
     val id: String = UUID.randomUUID().toString(),
     val contextId: String? = null,
-    delegate: Observable<Observer> = ObserverRegistry()
-) : Observable<Session.Observer> by delegate {
+    delegate: DeprecatedObserverRegistry<Observer> = DeprecatedObserverRegistry()
+) : DeprecatedObservable<Session.Observer> by delegate {
     // For migration purposes every `Session` has a reference to the `BrowserStore` (if used) in order to dispatch
     // actions to it when the `Session` changes.
     internal var store: BrowserStore? = null

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+@file:Suppress("DEPRECATION")
+
 package mozilla.components.browser.session
 
 import mozilla.components.browser.session.ext.syncDispatch
@@ -20,7 +22,7 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
-import mozilla.components.support.base.observer.Observable
+import mozilla.components.support.base.observer.DeprecatedObservable
 
 /**
  * This class provides access to a centralized registry of all active sessions.
@@ -30,7 +32,7 @@ class SessionManager(
     val engine: Engine,
     private val store: BrowserStore? = null,
     private val delegate: LegacySessionManager = LegacySessionManager(engine)
-) : Observable<SessionManager.Observer> by delegate {
+) : DeprecatedObservable<SessionManager.Observer> by delegate {
     /**
      * Returns the number of session including CustomTab sessions.
      */

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -103,6 +103,7 @@ internal class EngineObserver(
         return newUri.isInScope(listOf(scopeUri))
     }
 
+    @Suppress("DEPRECATION") // Session observable is deprecated
     override fun onLoadRequest(
         url: String,
         triggeredByRedirect: Boolean,

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/utils/AllSessionsObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/utils/AllSessionsObserver.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.session.utils
 
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.support.base.observer.OBSERVER_DEPRECATION_MESSAGE
 
 /**
  * This class is a combination of [Session.Observer] and [SessionManager.Observer]. It observers all [Session] instances
@@ -13,6 +14,8 @@ import mozilla.components.browser.session.SessionManager
  *
  * @property sessionManager the application's session manager
  */
+@Deprecated(OBSERVER_DEPRECATION_MESSAGE)
+@Suppress("DEPRECATION") // SessionManager and Session observable are deprecated
 class AllSessionsObserver(
     private val sessionManager: SessionManager,
     private val sessionObserver: Observer
@@ -60,6 +63,7 @@ class AllSessionsObserver(
     }
 }
 
+@Suppress("DEPRECATION") // SessionManager observable is deprecated
 private class Observer(
     val parent: AllSessionsObserver
 ) : SessionManager.Observer {

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -28,6 +28,7 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 
+@Suppress("DEPRECATION") // SessionManager observable is deprecated
 class SessionManagerTest {
     @Test
     fun `session can be added`() {

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -39,6 +39,7 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 
+@Suppress("DEPRECATION") // Session observable is deprecated
 class SessionTest {
     @Test
     fun `registered observers get notified`() {

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -1118,6 +1118,7 @@ class EngineObserverTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Session observable is deprecated
     fun `onLoadRequest notifies session observers`() {
         val url = "https://www.mozilla.org"
         val sessionObserver: Session.Observer = mock()

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/utils/AllSessionsObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/utils/AllSessionsObserverTest.kt
@@ -15,6 +15,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
+@Suppress("DEPRECATION") // AllSessionsObserver is deprecated
 class AllSessionsObserverTest {
     @Test
     fun `Observer will be registered on all already existing Sessions`() {

--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksFeature.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksFeature.kt
@@ -47,7 +47,8 @@ class AppLinksFeature(
     private val loadUrlUseCase: SessionUseCases.DefaultLoadUrlUseCase? = null
 ) : LifecycleAwareFeature {
 
-    @Suppress("DEPRECATION") // https://github.com/mozilla-mobile/android-components/issues/8913
+    @Suppress("DEPRECATION")
+    // TODO migrate to browser-state: https://github.com/mozilla-mobile/android-components/issues/8913
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal val observer = object : mozilla.components.browser.session.SelectionAwareSessionObserver(sessionManager) {
             override fun onLaunchIntentRequest(

--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksFeatureTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksFeatureTest.kt
@@ -100,6 +100,8 @@ class AppLinksFeatureTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
+    // TODO Migrate to browser-state: https://github.com/mozilla-mobile/android-components/issues/8913
     fun `when valid sessionId is provided, observe its session`() {
         feature = AppLinksFeature(
             mockContext,
@@ -116,6 +118,8 @@ class AppLinksFeatureTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
+    // TODO Migrate to browser-state: https://github.com/mozilla-mobile/android-components/issues/8913
     fun `when sessionId is NOT provided, observe selected session`() {
         feature = AppLinksFeature(
             mockContext,
@@ -129,12 +133,16 @@ class AppLinksFeatureTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
+    // TODO Migrate to browser-state: https://github.com/mozilla-mobile/android-components/issues/8913
     fun `when start is called must register SessionManager observers`() {
         feature.start()
         verify(mockSessionManager).register(feature.observer)
     }
 
     @Test
+    @Suppress("DEPRECATION")
+    // TODO Migrate to browser-state: https://github.com/mozilla-mobile/android-components/issues/8913
     fun `when stop is called must unregister SessionManager observers `() {
         feature.stop()
         verify(mockSessionManager).unregister(feature.observer)

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
@@ -42,7 +42,9 @@ import mozilla.components.support.utils.ColorUtils.getReadableTextColor
  * @param shareListener Invoked when the share button is pressed.
  * @param closeListener Invoked when the close button is pressed.
  */
-@Suppress("LargeClass")
+@Suppress("LargeClass", "Deprecation")
+// SessionManager observable is deprecated. This feature needs to be migrated to browser-state:
+// https://github.com/mozilla-mobile/android-components/issues/4257
 class CustomTabsToolbarFeature(
     private val sessionManager: SessionManager,
     private val toolbar: BrowserToolbar,

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
@@ -81,6 +81,8 @@ class CustomTabsToolbarFeatureTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
+    // TODO migrate to browser-state: https://github.com/mozilla-mobile/android-components/issues/4257
     fun `stop calls unregister`() {
         val sessionManager: SessionManager = mock()
         val session: Session = mock()
@@ -592,6 +594,8 @@ class CustomTabsToolbarFeatureTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
+    // TODO migrate to browser-state: https://github.com/mozilla-mobile/android-components/issues/4257
     fun `show title only if not empty`() {
         val sessionManager: SessionManager = mock()
         val toolbar = BrowserToolbar(testContext)

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/CustomTabSessionTitleObserverTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/CustomTabSessionTitleObserverTest.kt
@@ -35,6 +35,8 @@ class CustomTabSessionTitleObserverTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
+    // TODO migrate to browser-state: https://github.com/mozilla-mobile/android-components/issues/4257
     fun `Will use URL as title if title was shown once and is now empty`() {
         val toolbar = MockToolbar()
         val session = Session("https://mozilla.org")

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/CoordinateScrollingFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/CoordinateScrollingFeatureTest.kt
@@ -41,6 +41,8 @@ class CoordinateScrollingFeatureTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
+    // TODO Migrate to browser-state: https://github.com/mozilla-mobile/android-components/issues/7482
     fun `when session loading StateChanged and engine canScrollVertically is false must remove scrollFlags`() {
 
         val session = getSelectedSession()
@@ -55,6 +57,8 @@ class CoordinateScrollingFeatureTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
+    // TODO Migrate to browser-state: https://github.com/mozilla-mobile/android-components/issues/7482
     fun `when session loading StateChanged and engine canScrollVertically is true must add DEFAULT_SCROLL_FLAGS `() {
 
         val session = getSelectedSession()
@@ -71,6 +75,8 @@ class CoordinateScrollingFeatureTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
+    // TODO Migrate to browser-state: https://github.com/mozilla-mobile/android-components/issues/7482
     fun `when session loading StateChanged and engine canScrollVertically is true must add custom scrollFlags`() {
 
         val session = getSelectedSession()

--- a/components/support/base/src/main/java/mozilla/components/support/base/observer/Observable.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/observer/Observable.kt
@@ -107,3 +107,50 @@ interface Observable<T> {
      */
     fun isObserved(): Boolean
 }
+
+/**
+ * A deprecated version of [Observable] to migrate and deprecate existing
+ * components individually. All components implement [Observable] by delegate
+ * so this makes it easy to deprecate without having to override all methods
+ * in each component separately.
+ */
+@Deprecated(OBSERVER_DEPRECATION_MESSAGE)
+@Suppress("TooManyFunctions")
+interface DeprecatedObservable<T> : Observable<T> {
+
+    @Deprecated(OBSERVER_DEPRECATION_MESSAGE)
+    override fun register(observer: T)
+
+    @Deprecated(OBSERVER_DEPRECATION_MESSAGE)
+    override fun register(observer: T, owner: LifecycleOwner, autoPause: Boolean)
+
+    @Deprecated(OBSERVER_DEPRECATION_MESSAGE)
+    override fun register(observer: T, view: View)
+
+    @Deprecated(OBSERVER_DEPRECATION_MESSAGE)
+    override fun unregister(observer: T)
+
+    @Deprecated(OBSERVER_DEPRECATION_MESSAGE)
+    override fun unregisterObservers()
+
+    @Deprecated(OBSERVER_DEPRECATION_MESSAGE)
+    override fun notifyObservers(block: T.() -> Unit)
+
+    @Deprecated(OBSERVER_DEPRECATION_MESSAGE)
+    override fun notifyAtLeastOneObserver(block: T.() -> Unit)
+
+    @Deprecated(OBSERVER_DEPRECATION_MESSAGE)
+    override fun pauseObserver(observer: T)
+
+    @Deprecated(OBSERVER_DEPRECATION_MESSAGE)
+    override fun resumeObserver(observer: T)
+
+    @Deprecated(OBSERVER_DEPRECATION_MESSAGE)
+    override fun <R> wrapConsumers(block: T.(R) -> Boolean): List<(R) -> Boolean>
+
+    @Deprecated(OBSERVER_DEPRECATION_MESSAGE)
+    override fun isObserved(): Boolean
+}
+
+const val OBSERVER_DEPRECATION_MESSAGE =
+    "Use browser store (browser-state component) for observing state changes instead"

--- a/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
@@ -233,3 +233,13 @@ open class ObserverRegistry<T> : Observable<T> {
         }
     }
 }
+
+/**
+ * A deprecated version of [ObserverRegistry] to migrate and deprecate existing
+ * components individually. All components implement [ObserverRegistry] by
+ * delegate so this makes it easy to deprecate without having to override
+ * all methods in each component separately.
+ */
+@Deprecated(OBSERVER_DEPRECATION_MESSAGE)
+@Suppress("Deprecation")
+class DeprecatedObserverRegistry<T> : ObserverRegistry<T>(), DeprecatedObservable<T>


### PR DESCRIPTION
We want to deprecate observable methods in `SessionManager` and `Session`, but not in other components (for now). That's why we introduce deprecated subtypes here which allow us to migrate components individually. Also, since our components implement `Observable` by delegate this allows us to simply drop in the deprecated version as needed, without having to override all methods in every component separately.

Good news is that there wasn't much left in A-C. I've linked to existing tickets where deprecation had to be suppressed for now. 🎉 

