### PR TITLE
Update application-services to v67.2.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -30,7 +30,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "2.4"
 
-    const val mozilla_appservices = "67.0.0"
+    const val mozilla_appservices = "67.2.0"
 
     const val mozilla_glean = "33.1.2"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC
 org.gradle.daemon=true
 
 # When configured, Gradle will run in incubating parallel mode.


### PR DESCRIPTION
In theory this should resolve a crasher and a perf issues with the Nimbus SDK, since it transitively pulls in an updated version of Nimbus.

I manually a build of Fenix using this PR with local app data from an older version, and confirmed that it does not have the "JSON Error" crash noticed by @csadilek in #9177. I also tried running it with the network disabled (actually, running in the emulator and yanking the network cable on the host machine) and it reported the failure to fetch experiments to adb logcat, but didn't seem to crash or otherwise misbehave.