### PR TITLE
Closes #9186: Use services.addons.mozilla.org as collection endpoint

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
@@ -32,7 +32,7 @@ import java.util.Date
 import java.util.Locale
 
 internal const val API_VERSION = "api/v4"
-internal const val DEFAULT_SERVER_URL = "https://addons.mozilla.org"
+internal const val DEFAULT_SERVER_URL = "https://services.addons.mozilla.org"
 internal const val DEFAULT_COLLECTION_USER = "mozilla"
 internal const val DEFAULT_COLLECTION_NAME = "7e8d6dc651b54ab385fb8791bf9dac"
 internal const val COLLECTION_FILE_NAME_PREFIX = "mozilla_components_addon_collection"
@@ -123,7 +123,8 @@ class AddonCollectionProvider(
     private fun fetchAvailableAddons(readTimeoutInSeconds: Long?): List<Addon> {
         client.fetch(
             Request(
-                url = "$serverURL/$API_VERSION/accounts/account/$collectionUser/collections/$collectionName/addons" +
+                // NB: The trailing slash after addons is important to prevent a redirect and additional request
+                url = "$serverURL/$API_VERSION/accounts/account/$collectionUser/collections/$collectionName/addons/" +
                     "?page_size=$PAGE_SIZE" +
                     "&sort=${sortOption.value}",
                 readTimeout = Pair(readTimeoutInSeconds ?: DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/amo/AddonCollectionProviderTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/amo/AddonCollectionProviderTest.kt
@@ -123,8 +123,8 @@ class AddonCollectionProviderTest {
         // Authors
         assertTrue(addon.authors.isEmpty())
         verify(client).fetch(Request(
-            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
-                "7e8d6dc651b54ab385fb8791bf9dac/addons?page_size=$PAGE_SIZE&sort=${SortOption.POPULARITY_DESC.value}",
+            url = "https://services.addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
+                "7e8d6dc651b54ab385fb8791bf9dac/addons/?page_size=$PAGE_SIZE&sort=${SortOption.POPULARITY_DESC.value}",
             readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
         ))
 
@@ -139,8 +139,8 @@ class AddonCollectionProviderTest {
         val provider = spy(AddonCollectionProvider(testContext, client = mockedClient))
         provider.getAvailableAddons(readTimeoutInSeconds = 5)
         verify(mockedClient).fetch(Request(
-            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
-                "7e8d6dc651b54ab385fb8791bf9dac/addons?page_size=$PAGE_SIZE&sort=${SortOption.POPULARITY_DESC.value}",
+            url = "https://services.addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
+                "7e8d6dc651b54ab385fb8791bf9dac/addons/?page_size=$PAGE_SIZE&sort=${SortOption.POPULARITY_DESC.value}",
             readTimeout = Pair(5, TimeUnit.SECONDS)
         ))
         Unit
@@ -338,8 +338,8 @@ class AddonCollectionProviderTest {
 
         provider.getAvailableAddons()
         verify(mockedClient).fetch(Request(
-            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
-                "$collectionName/addons?page_size=$PAGE_SIZE&sort=${SortOption.POPULARITY_DESC.value}",
+            url = "https://services.addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
+                "$collectionName/addons/?page_size=$PAGE_SIZE&sort=${SortOption.POPULARITY_DESC.value}",
             readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
         ))
 
@@ -361,8 +361,8 @@ class AddonCollectionProviderTest {
         }
 
         verify(mockedClient).fetch(Request(
-            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
-                "$collectionName/addons?page_size=$PAGE_SIZE&sort=${SortOption.POPULARITY.value}",
+            url = "https://services.addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
+                "$collectionName/addons/?page_size=$PAGE_SIZE&sort=${SortOption.POPULARITY.value}",
             readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
         ))
 
@@ -376,8 +376,8 @@ class AddonCollectionProviderTest {
         }
 
         verify(mockedClient).fetch(Request(
-            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
-                "$collectionName/addons?page_size=$PAGE_SIZE&sort=${SortOption.POPULARITY_DESC.value}",
+            url = "https://services.addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
+                "$collectionName/addons/?page_size=$PAGE_SIZE&sort=${SortOption.POPULARITY_DESC.value}",
             readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
         ))
 
@@ -391,8 +391,8 @@ class AddonCollectionProviderTest {
         }
 
         verify(mockedClient).fetch(Request(
-            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
-                "$collectionName/addons?page_size=$PAGE_SIZE&sort=${SortOption.NAME.value}",
+            url = "https://services.addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
+                "$collectionName/addons/?page_size=$PAGE_SIZE&sort=${SortOption.NAME.value}",
             readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
         ))
 
@@ -406,8 +406,8 @@ class AddonCollectionProviderTest {
         }
 
         verify(mockedClient).fetch(Request(
-            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
-                "$collectionName/addons?page_size=$PAGE_SIZE&sort=${SortOption.NAME_DESC.value}",
+            url = "https://services.addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
+                "$collectionName/addons/?page_size=$PAGE_SIZE&sort=${SortOption.NAME_DESC.value}",
             readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
         ))
 
@@ -421,8 +421,8 @@ class AddonCollectionProviderTest {
         }
 
         verify(mockedClient).fetch(Request(
-            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
-                "$collectionName/addons?page_size=$PAGE_SIZE&sort=${SortOption.DATE_ADDED.value}",
+            url = "https://services.addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
+                "$collectionName/addons/?page_size=$PAGE_SIZE&sort=${SortOption.DATE_ADDED.value}",
             readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
         ))
 
@@ -436,8 +436,8 @@ class AddonCollectionProviderTest {
         }
 
         verify(mockedClient).fetch(Request(
-            url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
-                "$collectionName/addons?page_size=$PAGE_SIZE&sort=${SortOption.DATE_ADDED_DESC.value}",
+            url = "https://services.addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
+                "$collectionName/addons/?page_size=$PAGE_SIZE&sort=${SortOption.DATE_ADDED_DESC.value}",
             readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
         ))
 
@@ -457,8 +457,8 @@ class AddonCollectionProviderTest {
 
         provider.getAvailableAddons()
         verify(mockedClient).fetch(Request(
-            url = "https://addons.mozilla.org/api/v4/accounts/account/" +
-                "$collectionUser/collections/$collectionName/addons" +
+            url = "https://services.addons.mozilla.org/api/v4/accounts/account/" +
+                "$collectionUser/collections/$collectionName/addons/" +
                 "?page_size=$PAGE_SIZE" +
                 "&sort=${SortOption.POPULARITY_DESC.value}",
             readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
@@ -481,8 +481,8 @@ class AddonCollectionProviderTest {
 
         provider.getAvailableAddons()
         verify(mockedClient).fetch(Request(
-            url = "https://addons.mozilla.org/api/v4/accounts/account/" +
-                "$DEFAULT_COLLECTION_USER/collections/$DEFAULT_COLLECTION_NAME/addons" +
+            url = "https://services.addons.mozilla.org/api/v4/accounts/account/" +
+                "$DEFAULT_COLLECTION_USER/collections/$DEFAULT_COLLECTION_NAME/addons/" +
                 "?page_size=$PAGE_SIZE" +
                 "&sort=${SortOption.POPULARITY_DESC.value}",
             readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)


### PR DESCRIPTION
See #9186.

(We could clean up the test a bit too to re-use the string, but let's do that separately. I want this change to be small to cherry-pick and back out as needed.)