### PR TITLE
No issue: Update tab counter string description for plurals

### DIFF
--- a/components/ui/tabcounter/src/main/res/values/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
 <resources>
     <!-- Message announced to the user when tab tray is selected with 1 tab -->
     <string name="mozac_tab_counter_open_tab_tray_single">1 open tab. Tap to switch tabs.</string>
-    <!-- Message announced to the user when tab tray is selected with 0 or 2+ tabs -->
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
     <string name="mozac_tab_counter_open_tab_tray_plural">%1$s open tabs. Tap to switch tabs.</string>
     <!-- Browser menu button that creates a new tab -->
     <string name="mozac_browser_menu_new_tab">New tab</string>


### PR DESCRIPTION
Incorporates @Delphine's [feedback](https://github.com/mozilla-l10n/android-l10n/pull/297/files#r539502649) that we do not support specific plurals for Android. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
