### PR TITLE
Create create-release.yml on the release branch

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,35 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+#
+# This workflow triggers if .buildconfig.yml is changed on any of the
+# release branches. It will ask the relbot action to create a release.
+#
+# Currently relbot has a hard-coded "current A-C" version; there is no
+# relationship between what relbot does and on which branch the
+# .builconfig.yml is updated. If the updated branch does not match with
+# what relbot thinks is current, then nothing happens.
+#
+
+name: "Create Release"
+
+on:
+  push:
+    branches:
+      - 'releases/**'
+    paths:
+      - '.buildconfig.yml'
+jobs:
+  main:
+    name: "Create Release"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Create Release"
+        uses: mozilla-mobile/relbot@master
+        if: github.repository == 'mozilla-mobile/android-components'
+        with:
+          project: android-components
+          command: create-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This patch uplifts the `create-release.yml` workflow to the 67 branch. Otherwise it won't be executed.