### PR TITLE
For Fenix#16832: Separate facts for addon install and addon enabled

### DIFF
--- a/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
+++ b/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
@@ -301,7 +301,6 @@ object WebExtensionSupport {
         runtime.listInstalledWebExtensions(
             onSuccess = {
                 extensions -> extensions.forEach { registerInstalledExtension(store, it) }
-//                emitWebExtensionsInitializedFact(extensions)
                 closeUnsupportedTabs(store, extensions)
                 initializationResult.complete(Unit)
                 onExtensionsLoaded?.invoke(extensions.filter { !it.isBuiltIn() })

--- a/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/facts/WebExtensionFacts.kt
+++ b/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/facts/WebExtensionFacts.kt
@@ -18,7 +18,8 @@ class WebExtensionFacts {
      * Items that specify which portion of the web extension events were invoked.
      */
     object Items {
-        const val WEB_EXTENSIONS_INITIALIZED = "web_extensions_initialized"
+        const val WEB_EXTENSION_ENABLED = "web_extension_enabled"
+        const val WEB_EXTENSION_INSTALLED = "web_extension_installed"
     }
 }
 
@@ -37,15 +38,22 @@ private fun emitWebExtensionFact(
     ).collect()
 }
 
-internal fun emitWebExtensionsInitializedFact(extensions: List<WebExtension>) {
-    val installedAddons = extensions.filter { !it.isBuiltIn() }
-    val enabledAddons = installedAddons.filter { it.isEnabled() }
+internal fun emitWebExtensionEnabledFact(extension: WebExtension) {
     emitWebExtensionFact(
         Action.INTERACTION,
-        WebExtensionFacts.Items.WEB_EXTENSIONS_INITIALIZED,
+        WebExtensionFacts.Items.WEB_EXTENSION_ENABLED,
         metadata = mapOf(
-            "installed" to installedAddons.map { it.id },
-            "enabled" to enabledAddons.map { it.id }
+            "enabled" to extension.id
+        )
+    )
+}
+
+internal fun emitWebExtensionInstalledFact(extension: WebExtension) {
+    emitWebExtensionFact(
+        Action.INTERACTION,
+        WebExtensionFacts.Items.WEB_EXTENSION_INSTALLED,
+        metadata = mapOf(
+            "installed" to extension.id
         )
     )
 }

--- a/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
+++ b/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
@@ -39,7 +39,7 @@ import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
 import mozilla.components.support.webextensions.WebExtensionSupport.toState
-import mozilla.components.support.webextensions.facts.WebExtensionFacts.Items.WEB_EXTENSIONS_INITIALIZED
+import mozilla.components.support.webextensions.facts.WebExtensionFacts.Items.WEB_EXTENSION_INSTALLED
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -114,12 +114,9 @@ class WebExtensionSupportTest {
             val interactionFact = facts[0]
             assertEquals(FactsAction.INTERACTION, interactionFact.action)
             assertEquals(Component.SUPPORT_WEBEXTENSIONS, interactionFact.component)
-            assertEquals(WEB_EXTENSIONS_INITIALIZED, interactionFact.item)
-            assertEquals(2, interactionFact.metadata?.size)
+            assertEquals(WEB_EXTENSION_INSTALLED, interactionFact.item)
+            assertEquals(1, interactionFact.metadata?.size)
             assertTrue(interactionFact.metadata?.containsKey("installed")!!)
-            assertTrue(interactionFact.metadata?.containsKey("enabled")!!)
-            assertEquals(listOf(ext1.id, ext2.id), interactionFact.metadata?.get("installed"))
-            assertEquals(listOf(ext1.id), interactionFact.metadata?.get("enabled"))
         }
         assertEquals(ext1, WebExtensionSupport.installedExtensions[ext1.id])
         assertEquals(ext2, WebExtensionSupport.installedExtensions[ext2.id])


### PR DESCRIPTION
For [Fenix #16832](https://github.com/mozilla-mobile/fenix/issues/16832) 
Fenix PR: https://github.com/mozilla-mobile/fenix/pull/17445

This PR separates the Facts for Addons into two separate facts - one for addon installation, and another for addon enabled - instead of one fact that could be either an install or enable event. This makes it easier for Fenix to handle these facts for our metrics pings.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
