### PR TITLE
Trim memory: Suspend tabs less aggressively

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/middleware/TrimMemoryMiddleware.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/middleware/TrimMemoryMiddleware.kt
@@ -67,13 +67,13 @@ internal class TrimMemoryMiddleware : Middleware<BrowserState, BrowserAction> {
             tab.engineState.engineSession != null
         }.sortedByDescending { tab ->
             if (tab is TabSessionState) {
-                // We want to suspend the tabs that haven't been access for a while first
+                // We want to suspend the tabs that haven't been accessed for a while first
                 tab.lastAccess
             } else {
                 // We are more aggressive with custom tabs an always consider them for suspension
                 0
             }
-        }.drop(MIN_ACTIVE_TABS) // Keep the first tabs and suspend the rest
+        }.drop(MIN_ACTIVE_TABS) // Keep n [MIN_ACTIVE_TABS] most recently accessed tabs.
     }
 }
 
@@ -83,11 +83,8 @@ private fun shouldCloseEngineSessions(level: Int): Boolean {
         // process, but the system will begin killing background processes if apps do not release resources.
         ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL -> true
 
-        // Background: The system is running low on memory and our process is near the middle of the LRU list.
-        // If the system becomes further constrained for memory, there's a chance our process will be killed.
-        ComponentCallbacks2.TRIM_MEMORY_MODERATE,
-            // Background: The system is running low on memory and our process is one of the first to be killed
-            // if the system does not recover memory now.
+        // Background: The system is running low on memory and our process is one of the first to be killed
+        // if the system does not recover memory now.
         ComponentCallbacks2.TRIM_MEMORY_COMPLETE -> true
 
         else -> false

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/middleware/TrimMemoryMiddleware.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/middleware/TrimMemoryMiddleware.kt
@@ -8,10 +8,16 @@ import android.content.ComponentCallbacks2
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.SystemAction
+import mozilla.components.browser.state.selector.allTabs
 import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.SessionState
+import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.MiddlewareContext
 import mozilla.components.support.base.log.logger.Logger
+
+// The number of tabs we keep active and do not suspend (in addition to the selected tab)
+private const val MIN_ACTIVE_TABS = 3
 
 /**
  * [Middleware] responsible for suspending [EngineSession] instances on low memory.
@@ -32,24 +38,42 @@ internal class TrimMemoryMiddleware : Middleware<BrowserState, BrowserAction> {
     }
 
     private fun trimMemory(
-        store: MiddlewareContext<BrowserState, BrowserAction>,
+        context: MiddlewareContext<BrowserState, BrowserAction>,
         action: SystemAction.LowMemoryAction
     ) {
         if (!shouldCloseEngineSessions(action.level)) {
             return
         }
 
-        logger.info("Suspending tabs to trim memory")
+        val suspendTabs = determineTabsToSuspend(context.state)
+
+        logger.info("Trim memory (tabs=${context.state.allTabs.size}, suspending=${suspendTabs.size})")
 
         // This is not the most efficient way of doing this. We are looping over all tabs and then
         // dispatching a SuspendEngineSessionAction for each tab that is no longer needed.
-        (store.state.tabs + store.state.customTabs).forEach { tab ->
-            if (tab.id != store.state.selectedTabId) {
-                store.dispatch(
-                    EngineAction.SuspendEngineSessionAction(tab.id)
-                )
-            }
+        suspendTabs.forEach { tab ->
+            context.dispatch(EngineAction.SuspendEngineSessionAction(tab.id))
         }
+    }
+
+    private fun determineTabsToSuspend(
+        state: BrowserState
+    ): List<SessionState> {
+        return state.allTabs.filter { tab ->
+            // We never suspend the currently selected tab
+            tab.id != state.selectedTabId
+        }.filter { tab ->
+            // Only tabs with an engine session can get suspended
+            tab.engineState.engineSession != null
+        }.sortedByDescending { tab ->
+            if (tab is TabSessionState) {
+                // We want to suspend the tabs that haven't been access for a while first
+                tab.lastAccess
+            } else {
+                // We are more aggressive with custom tabs an always consider them for suspension
+                0
+            }
+        }.drop(MIN_ACTIVE_TABS) // Keep the first tabs and suspend the rest
     }
 }
 


### PR DESCRIPTION
This patch tries to reduce the effect we are seeing in https://github.com/mozilla-mobile/fenix/issues/12731

We are now:
* Waiting for a higher memory pressure level until we suspend tabs
* Do not suspend all tabs, but keep the last recently used ones (3 + selected tab for now)

This does not completely fix the problem though since we see Android aggressively kill the content process of Gecko. For this I will file something in Bugzilla.