### PR TITLE
GeckoView (Release) 84.0.20201211215739

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -16,7 +16,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Release Version.
      */
-    const val release_version = "84.0.20201207203640"
+    const val release_version = "84.0.20201211215739"
 }
 
 @Suppress("Unused", "MaxLineLength")


### PR DESCRIPTION
This (automated) patch updates GV Release on master to 84.0.20201211215739.