### PR TITLE
Update to GeckoView Beta 84.0.20201206192040 on master

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -11,7 +11,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Beta Version.
      */
-    const val beta_version = "84.0.20201201213706"
+    const val beta_version = "84.0.20201206192040"
 
     /**
      * GeckoView Release Version.


### PR DESCRIPTION
This (automated) patch updates GV Beta on master to 84.0.20201206192040.