### PR TITLE
Closes #9176  Add support for site specific autoplay permissions

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/PermissionHighlightsState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/PermissionHighlightsState.kt
@@ -4,6 +4,9 @@
 
 package mozilla.components.browser.state.state.content
 
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
 /**
  * Value type that represents any information about permissions that should
  * be brought to user's attention.
@@ -11,6 +14,7 @@ package mozilla.components.browser.state.state.content
  * @property isAutoPlayBlocking indicates if the autoplay setting
  * disabled some web content from playing.
  */
+@Parcelize
 data class PermissionHighlightsState(
     val isAutoPlayBlocking: Boolean = false
-)
+) : Parcelable

--- a/components/feature/sitepermissions/schemas/mozilla.components.feature.sitepermissions.db.SitePermissionsDatabase/5.json
+++ b/components/feature/sitepermissions/schemas/mozilla.components.feature.sitepermissions.db.SitePermissionsDatabase/5.json
@@ -1,0 +1,94 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "f5379c8eb4f1519eb5994e508626ca10",
+    "entities": [
+      {
+        "tableName": "site_permissions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`origin` TEXT NOT NULL, `location` INTEGER NOT NULL, `notification` INTEGER NOT NULL, `microphone` INTEGER NOT NULL, `camera` INTEGER NOT NULL, `bluetooth` INTEGER NOT NULL, `local_storage` INTEGER NOT NULL, `autoplay_audible` INTEGER NOT NULL, `autoplay_inaudible` INTEGER NOT NULL, `media_key_system_access` INTEGER NOT NULL, `saved_at` INTEGER NOT NULL, PRIMARY KEY(`origin`))",
+        "fields": [
+          {
+            "fieldPath": "origin",
+            "columnName": "origin",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notification",
+            "columnName": "notification",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "microphone",
+            "columnName": "microphone",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "camera",
+            "columnName": "camera",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bluetooth",
+            "columnName": "bluetooth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localStorage",
+            "columnName": "local_storage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoplayAudible",
+            "columnName": "autoplay_audible",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoplayInaudible",
+            "columnName": "autoplay_inaudible",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaKeySystemAccess",
+            "columnName": "media_key_system_access",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "saved_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "origin"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f5379c8eb4f1519eb5994e508626ca10')"
+    ]
+  }
+}

--- a/components/feature/sitepermissions/src/androidTest/java/mozilla/components/feature/sitepermissions/db/SitePermissionsDaoTest.kt
+++ b/components/feature/sitepermissions/src/androidTest/java/mozilla/components/feature/sitepermissions/db/SitePermissionsDaoTest.kt
@@ -9,6 +9,7 @@ import androidx.core.net.toUri
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import mozilla.components.feature.sitepermissions.SitePermissions
+import mozilla.components.feature.sitepermissions.SitePermissions.AutoplayStatus
 import mozilla.components.feature.sitepermissions.SitePermissions.Status.ALLOWED
 import mozilla.components.feature.sitepermissions.SitePermissions.Status.BLOCKED
 import org.junit.After
@@ -45,6 +46,8 @@ class SitePermissionsDaoTest {
 
         assertEquals(origin, siteFromDb.origin)
         assertEquals(BLOCKED, siteFromDb.camera)
+        assertEquals(AutoplayStatus.BLOCKED, siteFromDb.autoplayAudible)
+        assertEquals(AutoplayStatus.ALLOWED, siteFromDb.autoplayInaudible)
     }
 
     @Test
@@ -70,12 +73,20 @@ class SitePermissionsDaoTest {
         var siteFromDb = dao.getSitePermissionsBy(origin)!!.toSitePermission()
 
         assertEquals(BLOCKED, siteFromDb.camera)
+        assertEquals(AutoplayStatus.BLOCKED, siteFromDb.autoplayAudible)
+        assertEquals(AutoplayStatus.ALLOWED, siteFromDb.autoplayInaudible)
 
-        dao.update(siteFromDb.copy(camera = ALLOWED).toSitePermissionsEntity())
+        dao.update(siteFromDb.copy(
+            camera = ALLOWED,
+            autoplayInaudible = AutoplayStatus.ALLOWED,
+            autoplayAudible = AutoplayStatus.ALLOWED
+        ).toSitePermissionsEntity())
 
         siteFromDb = dao.getSitePermissionsBy(origin)!!.toSitePermission()
 
         assertEquals(ALLOWED, siteFromDb.camera)
+        assertEquals(AutoplayStatus.ALLOWED, siteFromDb.autoplayAudible)
+        assertEquals(AutoplayStatus.ALLOWED, siteFromDb.autoplayInaudible)
 
         dao.deleteSitePermissions(siteFromDb.toSitePermissionsEntity())
 

--- a/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissions.kt
+++ b/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissions.kt
@@ -21,8 +21,8 @@ data class SitePermissions(
     val camera: Status = NO_DECISION,
     val bluetooth: Status = NO_DECISION,
     val localStorage: Status = NO_DECISION,
-    val autoplayAudible: Status = NO_DECISION,
-    val autoplayInaudible: Status = NO_DECISION,
+    val autoplayAudible: AutoplayStatus = AutoplayStatus.BLOCKED,
+    val autoplayInaudible: AutoplayStatus = AutoplayStatus.ALLOWED,
     val mediaKeySystemAccess: Status = NO_DECISION,
     val savedAt: Long
 ) : Parcelable {
@@ -39,6 +39,37 @@ data class SitePermissions(
             BLOCKED, NO_DECISION -> ALLOWED
             ALLOWED -> BLOCKED
         }
+
+        /**
+         * Converts from [SitePermissions.Status] to [AutoplayStatus].
+         */
+        fun toAutoplayStatus(): AutoplayStatus {
+            return when (this) {
+                NO_DECISION, BLOCKED -> AutoplayStatus.BLOCKED
+                ALLOWED -> AutoplayStatus.ALLOWED
+            }
+        }
+    }
+
+    /**
+     * An enum that represents the status that autoplay can have.
+     */
+    enum class AutoplayStatus(internal val id: Int) {
+        BLOCKED(Status.BLOCKED.id), ALLOWED(Status.ALLOWED.id);
+        /**
+         * Indicates if the status is allowed.
+         */
+        fun isAllowed() = this == ALLOWED
+
+        /**
+         * Convert from a AutoplayStatus to Status.
+         */
+        fun toStatus(): Status {
+            return when (this) {
+                BLOCKED -> Status.BLOCKED
+                ALLOWED -> Status.ALLOWED
+            }
+        }
     }
 
     /**
@@ -52,8 +83,8 @@ data class SitePermissions(
             Permission.LOCAL_STORAGE -> localStorage
             Permission.NOTIFICATION -> notification
             Permission.LOCATION -> location
-            Permission.AUTOPLAY_AUDIBLE -> autoplayAudible
-            Permission.AUTOPLAY_INAUDIBLE -> autoplayInaudible
+            Permission.AUTOPLAY_AUDIBLE -> autoplayAudible.toStatus()
+            Permission.AUTOPLAY_INAUDIBLE -> autoplayInaudible.toStatus()
             Permission.MEDIA_KEY_SYSTEM_ACCESS -> mediaKeySystemAccess
         }
     }

--- a/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsRules.kt
+++ b/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsRules.kt
@@ -6,42 +6,24 @@ package mozilla.components.feature.sitepermissions
 
 import mozilla.components.concept.engine.permission.Permission
 import mozilla.components.concept.engine.permission.PermissionRequest
+import mozilla.components.feature.sitepermissions.SitePermissions.AutoplayStatus
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action.ASK_TO_ALLOW
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action.BLOCKED
+import mozilla.components.feature.sitepermissions.SitePermissionsRules.AutoplayAction
 
 /**
  * Indicate how site permissions must behave by permission category.
  */
-data class SitePermissionsRules internal constructor(
+data class SitePermissionsRules constructor(
     val camera: Action,
     val location: Action,
     val notification: Action,
     val microphone: Action,
-    val autoplayAudible: Action,
-    val autoplayInaudible: Action,
+    val autoplayAudible: AutoplayAction,
+    val autoplayInaudible: AutoplayAction,
     val persistentStorage: Action,
     val mediaKeySystemAccess: Action
 ) {
-
-    constructor(
-        camera: Action,
-        location: Action,
-        notification: Action,
-        microphone: Action,
-        autoplayAudible: AutoplayAction,
-        autoplayInaudible: AutoplayAction,
-        persistentStorage: Action,
-        mediaKeySystemAccess: Action
-    ) : this(
-        camera = camera,
-        location = location,
-        notification = notification,
-        microphone = microphone,
-        autoplayAudible = autoplayAudible.toAction(),
-        autoplayInaudible = autoplayInaudible.toAction(),
-        persistentStorage = persistentStorage,
-        mediaKeySystemAccess = mediaKeySystemAccess
-    )
 
     enum class Action {
         ALLOWED, BLOCKED, ASK_TO_ALLOW;
@@ -62,6 +44,13 @@ data class SitePermissionsRules internal constructor(
         internal fun toAction(): Action = when (this) {
             ALLOWED -> Action.ALLOWED
             BLOCKED -> Action.BLOCKED
+        }
+        /**
+         * Convert from an AutoplayAction to an AutoplayStatus.
+         */
+        fun toAutoplayStatus(): AutoplayStatus = when (this) {
+            ALLOWED -> AutoplayStatus.ALLOWED
+            BLOCKED -> AutoplayStatus.BLOCKED
         }
     }
 
@@ -91,10 +80,10 @@ data class SitePermissionsRules internal constructor(
                 camera
             }
             is Permission.ContentAutoPlayAudible -> {
-                autoplayAudible
+                autoplayAudible.toAction()
             }
             is Permission.ContentAutoPlayInaudible -> {
-                autoplayInaudible
+                autoplayInaudible.toAction()
             }
             is Permission.ContentMediaKeySystemAccess -> {
                 mediaKeySystemAccess
@@ -121,8 +110,8 @@ data class SitePermissionsRules internal constructor(
                 notification = notification.toStatus(),
                 microphone = microphone.toStatus(),
                 camera = camera.toStatus(),
-                autoplayAudible = autoplayAudible.toStatus(),
-                autoplayInaudible = autoplayInaudible.toStatus(),
+                autoplayAudible = autoplayAudible.toAutoplayStatus(),
+                autoplayInaudible = autoplayInaudible.toAutoplayStatus(),
                 localStorage = persistentStorage.toStatus(),
                 mediaKeySystemAccess = mediaKeySystemAccess.toStatus(),
                 savedAt = savedAt

--- a/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsStorage.kt
+++ b/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsStorage.kt
@@ -115,8 +115,8 @@ class SitePermissionsStorage(
                 map.putIfAllowed(LOCAL_STORAGE, localStorage, permission)
                 map.putIfAllowed(NOTIFICATION, notification, permission)
                 map.putIfAllowed(LOCATION, location, permission)
-                map.putIfAllowed(AUTOPLAY_AUDIBLE, autoplayAudible, permission)
-                map.putIfAllowed(AUTOPLAY_INAUDIBLE, autoplayInaudible, permission)
+                map.putIfAllowed(AUTOPLAY_AUDIBLE, autoplayAudible.toStatus(), permission)
+                map.putIfAllowed(AUTOPLAY_INAUDIBLE, autoplayInaudible.toStatus(), permission)
                 map.putIfAllowed(MEDIA_KEY_SYSTEM_ACCESS, mediaKeySystemAccess, permission)
             }
         }

--- a/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/db/SitePermissionsEntity.kt
+++ b/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/db/SitePermissionsEntity.kt
@@ -38,10 +38,10 @@ internal data class SitePermissionsEntity(
     var localStorage: SitePermissions.Status,
 
     @ColumnInfo(name = "autoplay_audible")
-    var autoplayAudible: SitePermissions.Status,
+    var autoplayAudible: SitePermissions.AutoplayStatus,
 
     @ColumnInfo(name = "autoplay_inaudible")
-    var autoplayInaudible: SitePermissions.Status,
+    var autoplayInaudible: SitePermissions.AutoplayStatus,
 
     @ColumnInfo(name = "media_key_system_access")
     var mediaKeySystemAccess: SitePermissions.Status,

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsRulesTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsRulesTest.kt
@@ -14,9 +14,11 @@ import mozilla.components.concept.engine.permission.Permission.ContentNotificati
 import mozilla.components.concept.engine.permission.Permission.ContentVideoCapture
 import mozilla.components.concept.engine.permission.Permission.Generic
 import mozilla.components.concept.engine.permission.PermissionRequest
+import mozilla.components.feature.sitepermissions.SitePermissions.AutoplayStatus
 import mozilla.components.feature.sitepermissions.SitePermissions.Status
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action.ASK_TO_ALLOW
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action.BLOCKED
+import mozilla.components.feature.sitepermissions.SitePermissionsRules.AutoplayAction
 import mozilla.components.support.base.feature.OnNeedToRequestPermissions
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
@@ -57,8 +59,8 @@ class SitePermissionsRulesTest {
             location = BLOCKED,
             notification = ASK_TO_ALLOW,
             microphone = BLOCKED,
-            autoplayAudible = ASK_TO_ALLOW,
-            autoplayInaudible = BLOCKED,
+            autoplayAudible = AutoplayAction.BLOCKED,
+            autoplayInaudible = AutoplayAction.ALLOWED,
             persistentStorage = BLOCKED,
             mediaKeySystemAccess = ASK_TO_ALLOW
         )
@@ -83,11 +85,11 @@ class SitePermissionsRulesTest {
 
         doReturn(listOf(Permission.ContentAutoPlayAudible())).`when`(mockRequest).permissions
         action = rules.getActionFrom(mockRequest)
-        assertEquals(action, rules.autoplayAudible)
+        assertEquals(action, rules.autoplayAudible.toAction())
 
         doReturn(listOf(Permission.ContentAutoPlayInaudible())).`when`(mockRequest).permissions
         action = rules.getActionFrom(mockRequest)
-        assertEquals(action, rules.autoplayInaudible)
+        assertEquals(action, rules.autoplayInaudible.toAction())
 
         doReturn(listOf(Generic("", ""))).`when`(mockRequest).permissions
         action = rules.getActionFrom(mockRequest)
@@ -110,8 +112,8 @@ class SitePermissionsRulesTest {
             persistentStorage = BLOCKED,
             notification = ASK_TO_ALLOW,
             microphone = BLOCKED,
-            autoplayInaudible = ASK_TO_ALLOW,
-            autoplayAudible = ASK_TO_ALLOW,
+            autoplayInaudible = AutoplayAction.ALLOWED,
+            autoplayAudible = AutoplayAction.BLOCKED,
             mediaKeySystemAccess = ASK_TO_ALLOW
         )
 
@@ -126,8 +128,8 @@ class SitePermissionsRulesTest {
             location = BLOCKED,
             notification = ASK_TO_ALLOW,
             microphone = ASK_TO_ALLOW,
-            autoplayInaudible = BLOCKED,
-            autoplayAudible = BLOCKED,
+            autoplayInaudible = AutoplayAction.ALLOWED,
+            autoplayAudible = AutoplayAction.BLOCKED,
             persistentStorage = BLOCKED,
             mediaKeySystemAccess = ASK_TO_ALLOW
         )
@@ -145,8 +147,8 @@ class SitePermissionsRulesTest {
                 localStorage = Status.BLOCKED,
                 notification = Status.NO_DECISION,
                 microphone = Status.BLOCKED,
-                autoplayInaudible = Status.NO_DECISION,
-                autoplayAudible = Status.NO_DECISION,
+                autoplayInaudible = AutoplayStatus.ALLOWED,
+                autoplayAudible = AutoplayStatus.BLOCKED,
                 mediaKeySystemAccess = Status.BLOCKED,
                 savedAt = 1L
         )
@@ -156,8 +158,8 @@ class SitePermissionsRulesTest {
                 location = BLOCKED,
                 notification = ASK_TO_ALLOW,
                 microphone = BLOCKED,
-                autoplayInaudible = ASK_TO_ALLOW,
-                autoplayAudible = ASK_TO_ALLOW,
+                autoplayInaudible = AutoplayAction.ALLOWED,
+                autoplayAudible = AutoplayAction.BLOCKED,
                 persistentStorage = BLOCKED,
                 mediaKeySystemAccess = BLOCKED
         )
@@ -174,5 +176,11 @@ class SitePermissionsRulesTest {
         assertEquals(expectedSitePermission.localStorage, convertedSitePermissions.localStorage)
         assertEquals(expectedSitePermission.mediaKeySystemAccess, convertedSitePermissions.mediaKeySystemAccess)
         assertEquals(expectedSitePermission.savedAt, convertedSitePermissions.savedAt)
+    }
+
+    @Test
+    fun `AutoplayAction - toAutoplayStatus`() {
+        assertEquals(AutoplayStatus.ALLOWED, AutoplayAction.ALLOWED.toAutoplayStatus())
+        assertEquals(AutoplayStatus.BLOCKED, AutoplayAction.BLOCKED.toAutoplayStatus())
     }
 }

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsStorageTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsStorageTest.kt
@@ -12,6 +12,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.engine.DataCleanable
 import mozilla.components.concept.engine.Engine.BrowsingData
+import mozilla.components.feature.sitepermissions.SitePermissions.AutoplayStatus
 import mozilla.components.feature.sitepermissions.SitePermissions.Status.ALLOWED
 import mozilla.components.feature.sitepermissions.SitePermissions.Status.BLOCKED
 import mozilla.components.feature.sitepermissions.SitePermissions.Status.NO_DECISION
@@ -160,8 +161,8 @@ class SitePermissionsStorageTest {
                 microphone = ALLOWED,
                 camera = BLOCKED,
                 bluetooth = ALLOWED,
-                autoplayAudible = BLOCKED,
-                autoplayInaudible = NO_DECISION,
+                autoplayAudible = AutoplayStatus.BLOCKED,
+                autoplayInaudible = AutoplayStatus.BLOCKED,
                 mediaKeySystemAccess = NO_DECISION,
                 savedAt = 0
             ),
@@ -173,8 +174,8 @@ class SitePermissionsStorageTest {
                 microphone = ALLOWED,
                 camera = BLOCKED,
                 bluetooth = ALLOWED,
-                autoplayAudible = BLOCKED,
-                autoplayInaudible = NO_DECISION,
+                autoplayAudible = AutoplayStatus.BLOCKED,
+                autoplayInaudible = AutoplayStatus.BLOCKED,
                 mediaKeySystemAccess = NO_DECISION,
                 savedAt = 0
             )

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsTest.kt
@@ -5,9 +5,12 @@
 package mozilla.components.feature.sitepermissions
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.feature.sitepermissions.SitePermissions.AutoplayStatus
 import mozilla.components.feature.sitepermissions.SitePermissions.Status.NO_DECISION
 import mozilla.components.feature.sitepermissions.SitePermissions.Status.ALLOWED
 import mozilla.components.feature.sitepermissions.SitePermissions.Status.BLOCKED
+import mozilla.components.feature.sitepermissions.SitePermissionsStorage.Permission.AUTOPLAY_AUDIBLE
+import mozilla.components.feature.sitepermissions.SitePermissionsStorage.Permission.AUTOPLAY_INAUDIBLE
 import mozilla.components.feature.sitepermissions.SitePermissionsStorage.Permission.NOTIFICATION
 import mozilla.components.feature.sitepermissions.SitePermissionsStorage.Permission.LOCAL_STORAGE
 import mozilla.components.feature.sitepermissions.SitePermissionsStorage.Permission.LOCATION
@@ -30,11 +33,15 @@ class SitePermissionsTest {
         assertEquals(NO_DECISION, sitePermissions[MICROPHONE])
         assertEquals(NO_DECISION, sitePermissions[BLUETOOTH])
         assertEquals(NO_DECISION, sitePermissions[CAMERA])
+        assertEquals(BLOCKED, sitePermissions[AUTOPLAY_AUDIBLE])
+        assertEquals(ALLOWED, sitePermissions[AUTOPLAY_INAUDIBLE])
 
         sitePermissions = sitePermissions.copy(
             location = ALLOWED,
             notification = BLOCKED,
-            microphone = NO_DECISION
+            microphone = NO_DECISION,
+            autoplayAudible = AutoplayStatus.ALLOWED,
+            autoplayInaudible = AutoplayStatus.BLOCKED
         )
 
         assertEquals(BLOCKED, sitePermissions[NOTIFICATION])
@@ -43,5 +50,41 @@ class SitePermissionsTest {
         assertEquals(NO_DECISION, sitePermissions[BLUETOOTH])
         assertEquals(NO_DECISION, sitePermissions[CAMERA])
         assertEquals(NO_DECISION, sitePermissions[LOCAL_STORAGE])
+        assertEquals(ALLOWED, sitePermissions[AUTOPLAY_AUDIBLE])
+        assertEquals(BLOCKED, sitePermissions[AUTOPLAY_INAUDIBLE])
+    }
+
+    @Test
+    fun `AutoplayStatus - toStatus`() {
+        var sitePermissions = SitePermissions(
+            origin = "mozilla.dev",
+            autoplayInaudible = AutoplayStatus.BLOCKED,
+            autoplayAudible = AutoplayStatus.BLOCKED,
+            savedAt = 0
+        )
+
+        assertEquals(BLOCKED, sitePermissions.autoplayAudible.toStatus())
+        assertEquals(BLOCKED, sitePermissions.autoplayInaudible.toStatus())
+
+        sitePermissions = sitePermissions.copy(
+            autoplayAudible = AutoplayStatus.ALLOWED,
+            autoplayInaudible = AutoplayStatus.ALLOWED
+        )
+
+        assertEquals(ALLOWED, sitePermissions.autoplayAudible.toStatus())
+        assertEquals(ALLOWED, sitePermissions.autoplayInaudible.toStatus())
+    }
+
+    @Test
+    fun `Status to AutoplayStatus`() {
+        assertEquals(AutoplayStatus.BLOCKED, BLOCKED.toAutoplayStatus())
+        assertEquals(AutoplayStatus.ALLOWED, ALLOWED.toAutoplayStatus())
+        assertEquals(AutoplayStatus.BLOCKED, NO_DECISION.toAutoplayStatus())
+    }
+
+    @Test
+    fun `AutoplayStatus ids are aligned with Status`() {
+        assertEquals(AutoplayStatus.BLOCKED.id, AutoplayStatus.BLOCKED.id)
+        assertEquals(AutoplayStatus.ALLOWED, AutoplayStatus.ALLOWED)
     }
 }

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/db/SitePermissionEntityTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/db/SitePermissionEntityTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.feature.sitepermissions.db
 
 import mozilla.components.feature.sitepermissions.SitePermissions
+import mozilla.components.feature.sitepermissions.SitePermissions.AutoplayStatus
 import mozilla.components.feature.sitepermissions.SitePermissions.Status.ALLOWED
 import mozilla.components.feature.sitepermissions.SitePermissions.Status.BLOCKED
 import mozilla.components.feature.sitepermissions.SitePermissions.Status.NO_DECISION
@@ -23,8 +24,8 @@ class SitePermissionEntityTest {
             microphone = NO_DECISION,
             camera = NO_DECISION,
             bluetooth = ALLOWED,
-            autoplayInaudible = BLOCKED,
-            autoplayAudible = NO_DECISION,
+            autoplayInaudible = AutoplayStatus.ALLOWED,
+            autoplayAudible = AutoplayStatus.BLOCKED,
             mediaKeySystemAccess = NO_DECISION,
             savedAt = 0
         )
@@ -56,8 +57,8 @@ class SitePermissionEntityTest {
             microphone = NO_DECISION,
             camera = NO_DECISION,
             bluetooth = ALLOWED,
-            autoplayInaudible = BLOCKED,
-            autoplayAudible = NO_DECISION,
+            autoplayInaudible = AutoplayStatus.ALLOWED,
+            autoplayAudible = AutoplayStatus.BLOCKED,
             mediaKeySystemAccess = NO_DECISION,
             savedAt = 0
         )

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/db/StatusConverterTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/db/StatusConverterTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.sitepermissions.db
 
+import mozilla.components.feature.sitepermissions.SitePermissions.AutoplayStatus
 import mozilla.components.feature.sitepermissions.SitePermissions.Status.BLOCKED
 import mozilla.components.feature.sitepermissions.SitePermissions.Status.NO_DECISION
 import mozilla.components.feature.sitepermissions.SitePermissions.Status.ALLOWED
@@ -42,5 +43,30 @@ class StatusConverterTest {
 
         index = converter.toInt(NO_DECISION)
         assertEquals(index, NO_DECISION.id)
+    }
+
+    @Test
+    fun `convert from int to autoplay status`() {
+        val converter = StatusConverter()
+
+        var status = converter.toAutoplayStatus(AutoplayStatus.BLOCKED.id)
+        assertEquals(status, AutoplayStatus.BLOCKED)
+
+        status = converter.toAutoplayStatus(AutoplayStatus.ALLOWED.id)
+        assertEquals(status, AutoplayStatus.ALLOWED)
+
+        status = converter.toAutoplayStatus(Int.MAX_VALUE)
+        assertEquals(AutoplayStatus.BLOCKED, status)
+    }
+
+    @Test
+    fun `convert from autoplay status to int`() {
+        val converter = StatusConverter()
+
+        var index = converter.toInt(AutoplayStatus.ALLOWED)
+        assertEquals(index, AutoplayStatus.ALLOWED.id)
+
+        index = converter.toInt(AutoplayStatus.BLOCKED)
+        assertEquals(index, AutoplayStatus.BLOCKED.id)
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,6 +33,9 @@ permalink: /changelog/
 * **feature-qr**
   * QR Scanner can now scan inverted QR codes, by decoding inverted source when the decoding the original source fails.
 
+* **feature-sitepermissions**
+  * ⚠️ **This is a breaking change**: The `SitePermissions` constructor, now parameter types for `autoplayAudible` and `autoplayInaudible` have changed to `AutoplayStatus` as autoplay permissions only support two status `ALLOWED` and `BLOCKED`.
+
 * **feature-app-links**
   * ⚠️ **This is a breaking change**: Migrated this component to use `browser-state` instead of `browser-session`. It is now required to pass a `BrowserStore` instance (instead of `SessionManager`) to `AppLinksFeature`.
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
@@ -26,7 +26,7 @@ import mozilla.components.feature.session.SessionFeature
 import mozilla.components.feature.session.SwipeRefreshFeature
 import mozilla.components.feature.sitepermissions.SitePermissionsFeature
 import mozilla.components.feature.sitepermissions.SitePermissionsRules
-import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action.ALLOWED
+import mozilla.components.feature.sitepermissions.SitePermissionsRules.AutoplayAction
 import mozilla.components.feature.toolbar.ToolbarFeature
 import mozilla.components.lib.state.ext.consumeFlow
 import mozilla.components.support.base.feature.PermissionsFeature
@@ -91,8 +91,8 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
         layout.toolbar.display.setOnPermissionIndicatorClickedListener {
             sitePermissionsFeature.withFeature { feature ->
                 feature.sitePermissionsRules = feature.sitePermissionsRules?.copy(
-                    autoplayAudible = ALLOWED,
-                    autoplayInaudible = ALLOWED
+                    autoplayAudible = AutoplayAction.ALLOWED,
+                    autoplayInaudible = AutoplayAction.ALLOWED
                 )
                 components.sessionUseCases.reload()
             }
@@ -179,8 +179,8 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
                 storage = components.permissionStorage,
                 fragmentManager = parentFragmentManager,
                 sitePermissionsRules = SitePermissionsRules(
-                    autoplayAudible = SitePermissionsRules.AutoplayAction.BLOCKED,
-                    autoplayInaudible = SitePermissionsRules.AutoplayAction.BLOCKED,
+                    autoplayAudible = AutoplayAction.BLOCKED,
+                    autoplayInaudible = AutoplayAction.BLOCKED,
                     camera = SitePermissionsRules.Action.ASK_TO_ALLOW,
                     location = SitePermissionsRules.Action.ASK_TO_ALLOW,
                     notification = SitePermissionsRules.Action.ASK_TO_ALLOW,


### PR DESCRIPTION
This pr introduce `AutoplayStatus` as the autoplay permission works a bit different from other permissions, it doesn't show a prompt for users to allow or deny, it uses the default values (Allowed autoplay inaudible and Denied autoplay audible) and shows an indicator in the toolbar when the permissions is denied. For this reason we changed 
`autoplayAudible` and `autoplayInaudible` from `Status` **(NO_DECISION,BLOCKED,ALLOWED)** to `AutoplayStatus` **(BLOCKED,ALLOWED)** and we are triggering a db migration to any `NO_DECISION (0)` value to migrated one of the valid options for autoplay `BLOCKED(1) ALLOWED(0)`.

There is not rush on this pr, I did some extensive manual testing to avoid any unexpected behaviour but as we are to do a db migration I preferred to just review and wait until after the holidays break to land, a [Fenix pr](https://github.com/mozilla-mobile/fenix/pull/17101/files). 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
