### PR TITLE
Dismiss the login select prompt when navigating away

### DIFF
--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -128,7 +128,8 @@ class PromptFeature private constructor(
     // These three scopes have identical lifetimes. We do not yet have a way of combining scopes
     private var handlePromptScope: CoroutineScope? = null
     private var dismissPromptScope: CoroutineScope? = null
-    private var activePromptRequest: PromptRequest? = null
+    @VisibleForTesting
+    var activePromptRequest: PromptRequest? = null
 
     internal val promptAbuserDetector = PromptAbuserDetector()
     private val logger = Logger("PromptFeature")
@@ -283,12 +284,13 @@ class PromptFeature private constructor(
         }
     }
 
-    /**
-     * Stops observing the selected session for incoming prompt requests.
-     */
     override fun stop() {
+        // Stops observing the selected session for incoming prompt requests.
         handlePromptScope?.cancel()
         dismissPromptScope?.cancel()
+
+        // Dismisses the logins prompt so that it can appear on another tab
+        dismissLoginSelectPrompt()
     }
 
     /**
@@ -671,6 +673,16 @@ class PromptFeature private constructor(
             is SelectLoginPrompt,
             is Share -> true
             is Alert, is TextPrompt, is Confirm, is Repost -> promptAbuserDetector.shouldShowMoreDialogs
+        }
+    }
+
+    /**
+     * Dismisses the select login prompt if it is active.
+     */
+    @VisibleForTesting
+    fun dismissLoginSelectPrompt() {
+        (activePromptRequest as? SelectLoginPrompt)?.let {
+            loginPicker?.dismissCurrentLoginSelect(it)
         }
     }
 }

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -248,9 +248,7 @@ class PromptFeature private constructor(
                         } else if (!it.loading) {
                             promptAbuserDetector.resetJSAlertAbuseState()
                         } else if (it.loading) {
-                            if (activePromptRequest is SelectLoginPrompt) {
-                                loginPicker?.dismissCurrentLoginSelect(activePromptRequest as SelectLoginPrompt)
-                            }
+                            dismissLoginSelectPrompt()
                         }
                         activePromptRequest = it.promptRequest
                     }
@@ -265,9 +263,8 @@ class PromptFeature private constructor(
                     state.findTabOrCustomTabOrSelectedTab(customTabId)?.content?.url
                 )
             }.collect {
-                if (activePromptRequest is SelectLoginPrompt) {
-                    loginPicker?.dismissCurrentLoginSelect(activePromptRequest as SelectLoginPrompt)
-                }
+                dismissLoginSelectPrompt()
+
                 val prompt = activePrompt?.get()
                 if (prompt?.shouldDismissOnLoad() == true) {
                     prompt.dismiss()

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
@@ -254,6 +254,43 @@ class PromptFeatureTest {
     }
 
     @Test
+    fun `Calling onStop will attempt to dismiss the login prompt`() {
+        val feature = spy(
+            PromptFeature(
+                mock<Activity>(),
+                store,
+                fragmentManager = fragmentManager
+            ) { }
+        )
+
+        feature.stop()
+
+        verify(feature).dismissLoginSelectPrompt()
+    }
+
+    @Test
+    fun `Calling dismissLoginSelectPrompt should dismiss the login picker if the login prompt is active`() {
+        val feature = spy(
+            PromptFeature(
+                mock<Activity>(),
+                store,
+                fragmentManager = fragmentManager
+            ) { }
+        )
+        val selectLoginPrompt = mock<PromptRequest.SelectLoginPrompt>()
+
+        feature.loginPicker = loginPicker
+        feature.activePromptRequest = mock()
+        feature.dismissLoginSelectPrompt()
+        verify(feature.loginPicker!!, never()).dismissCurrentLoginSelect(any())
+
+        feature.loginPicker = loginPicker
+        feature.activePromptRequest = selectLoginPrompt
+        feature.dismissLoginSelectPrompt()
+        verify(feature.loginPicker!!).dismissCurrentLoginSelect(selectLoginPrompt)
+    }
+
+    @Test
     fun `Calling onCancel will consume promptRequest`() {
         val feature =
             PromptFeature(activity = mock(), store = store, fragmentManager = fragmentManager) { }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **feature-prompts**:
+  * 🚒 Bug fixed [issue #9229](https://github.com/mozilla-mobile/android-components/issues/9229) - Dismiss SelectLoginPrompt from the current tab when opening a new one ensuring the new one can show it's own. When returning to the previous tab users should focus a login field to see the SelectLoginPrompt again.
+
 # 70.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v69.0.0...v70.0.0)


### PR DESCRIPTION
This allow for this prompt to be shown in any new other tab.
When returning to the initial tab users should focus any login fields to get the prompt again.

Before and after on Fenix:
<img src="https://user-images.githubusercontent.com/11428869/102240001-12a0a580-3f00-11eb-9410-e8916c0d9dd9.gif" width="33%" />
[video](https://drive.google.com/file/d/19UiwiwcGFIzPWBSK1iEBYrMHmu0sVHgc/view?usp=sharing)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR does not include any a11y user facing features.

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
