### PR TITLE
Closes #9243: Shutdown correctly when Media Session Service is killed

### DIFF
--- a/components/feature/media/src/main/java/mozilla/components/feature/media/MediaSessionFeature.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/MediaSessionFeature.kt
@@ -40,7 +40,7 @@ class MediaSessionFeature(
             }.map { tab ->
                 tab.none {
                     it.mediaSessionState != null &&
-                        it.mediaSessionState!!.playbackState != MediaSession.PlaybackState.UNKNOWN
+                        it.mediaSessionState!!.playbackState == MediaSession.PlaybackState.PLAYING
                 }
             }.ifChanged().collect { isEmpty ->
                 process(isEmpty)

--- a/components/feature/media/src/main/java/mozilla/components/feature/media/service/MediaSessionServiceDelegate.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/service/MediaSessionServiceDelegate.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.media.AudioManager
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaSessionCompat
+import androidx.annotation.VisibleForTesting
 import androidx.core.app.NotificationManagerCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
@@ -65,8 +66,7 @@ internal class MediaSessionServiceDelegate(
     }
 
     fun onDestroy() {
-        scope?.cancel()
-
+        destroy()
         logger.debug("Service destroyed")
     }
 
@@ -163,8 +163,14 @@ internal class MediaSessionServiceDelegate(
         }
     }
 
-    private fun shutdown() {
+    @VisibleForTesting
+    internal fun destroy() {
+        scope?.cancel()
         audioFocus.abandon()
+    }
+
+    @VisibleForTesting
+    internal fun shutdown() {
         mediaSession.release()
         service.stopSelf()
     }

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/MediaSessionFeatureTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/MediaSessionFeatureTest.kt
@@ -108,7 +108,7 @@ class MediaSessionFeatureTest {
     }
 
     @Test
-    fun `feature only starts foreground service when there were no previous media session`() {
+    fun `feature only starts foreground service when there were no previous playing media session`() {
         val mockApplicationContext: Context = mock()
         val initialState = BrowserState(
             tabs = listOf(createTab(
@@ -152,6 +152,12 @@ class MediaSessionFeatureTest {
         verify(mockApplicationContext, times(1)).startForegroundService(any())
 
         store.dispatch(MediaSessionAction.ActivatedMediaSessionAction(store.state.tabs[0].id, mock()))
+        store.waitUntilIdle()
+        dispatcher.advanceUntilIdle()
+        verify(mockApplicationContext, times(1)).startForegroundService(any())
+
+        store.dispatch(MediaSessionAction.UpdateMediaPlaybackStateAction(store.state.tabs[0].id,
+            MediaSession.PlaybackState.PAUSED))
         store.waitUntilIdle()
         dispatcher.advanceUntilIdle()
         verify(mockApplicationContext, times(1)).startForegroundService(any())


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
