### PR TITLE
Add issue template for ui-tests failures/intermittent tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/---ui-test.md
+++ b/.github/ISSUE_TEMPLATE/---ui-test.md
@@ -1,0 +1,13 @@
+---
+name: "\U0001F494 Intermittent UI Test Issue"
+about: Create an issue to help log a UI test failure
+labels: "eng:ui-test, intermittent-test"
+title: "Intermittent UI test failure - <Classname.testName>"
+assignees: ''
+
+---
+
+### Firebase Test Run:
+Provide a Firebase test run report link here showcasing the problem
+### Stacktrace:
+### Build: 

--- a/.github/ISSUE_TEMPLATE/ui-test.md
+++ b/.github/ISSUE_TEMPLATE/ui-test.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F494 Intermittent UI Test Issue"
+name: "💔 Intermittent UI Test Issue"
 about: Create an issue to help log a UI test failure
 labels: "eng:ui-test, intermittent-test"
 title: "Intermittent UI test failure - <Classname.testName>"


### PR DESCRIPTION

This PR just adds a template to create issues for ui tests failures or intermittent issues with the tests