### PR TITLE
 Closes #9261: Remove extra space when the permission_indicator is gone 

### DIFF
--- a/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_displaytoolbar.xml
+++ b/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_displaytoolbar.xml
@@ -85,7 +85,7 @@
 
     <mozilla.components.browser.toolbar.display.PermissionHighlightsIconView
         android:id="@+id/mozac_browser_toolbar_permission_indicator"
-        android:layout_width="40dp"
+        android:layout_width="30dp"
         android:layout_height="40dp"
         android:layout_marginTop="8dp"
         android:importantForAccessibility="no"
@@ -93,6 +93,8 @@
         android:visibility="gone"
         app:layout_constraintStart_toEndOf="@+id/mozac_browser_toolbar_security_indicator"
         app:layout_constraintTop_toTopOf="parent"
+        android:paddingStart="0dp"
+        android:paddingEnd="8dp"
         app:layout_goneMarginStart="8dp"
         app:srcCompat="@drawable/mozac_ic_autoplay_blocked" />
 

--- a/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_displaytoolbar.xml
+++ b/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_displaytoolbar.xml
@@ -93,6 +93,7 @@
         android:visibility="gone"
         app:layout_constraintStart_toEndOf="@+id/mozac_browser_toolbar_security_indicator"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_goneMarginStart="8dp"
         app:srcCompat="@drawable/mozac_ic_autoplay_blocked" />
 
     <!-- URL & Title -->
@@ -105,7 +106,6 @@
         app:layout_constraintEnd_toStartOf="@+id/mozac_browser_toolbar_page_actions"
         app:layout_constraintStart_toEndOf="@+id/mozac_browser_toolbar_permission_indicator"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_goneMarginStart="8dp"
         app:layout_goneMarginTop="8dp" />
 
     <!-- Page actions -->


### PR DESCRIPTION
As we added the permission indicator, I didn't notice that the `OriginView` had a [layout_goneMarginStart](https://github.com/mozilla-mobile/android-components/blob/3320a792e13cce9dedb9f150cacd930b5f4ebea7/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_displaytoolbar.xml#L108), intended to add some space between the `OriginView` and the security indicator when it's gone, as now the permission indicator it's in the position where the `OriginView` was we have to move the `goneMargin` to the permission indicator for when the security indicator is gone.

**With the fix**.
![image](https://user-images.githubusercontent.com/773158/102539346-8c10d300-407b-11eb-91ca-2f97725ea31e.png)
![image](https://user-images.githubusercontent.com/773158/102539526-cb3f2400-407b-11eb-947a-2abd5e9e5180.png)

**Without the fix**.

![image](https://user-images.githubusercontent.com/773158/102539424-ac409200-407b-11eb-82a8-7aef7d62cd0f.png)

![image](https://user-images.githubusercontent.com/773158/102539473-be223500-407b-11eb-892b-b8fd208ba8ae.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
