### PR TITLE
Issue #8491: Change default top sites for different regions

### DIFF
--- a/components/feature/top-sites/build.gradle
+++ b/components/feature/top-sites/build.gradle
@@ -50,9 +50,11 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 }
 
 dependencies {
+    implementation project(':browser-state')
     implementation project(':browser-storage-sync')
     implementation project(':support-ktx')
     implementation project(':support-base')
+    implementation project(':support-locale')
     implementation project(':support-utils')
 
     implementation Dependencies.kotlin_stdlib

--- a/components/feature/top-sites/schemas/mozilla.components.feature.top.sites.db.TopSiteDatabase/4.json
+++ b/components/feature/top-sites/schemas/mozilla.components.feature.top.sites.db.TopSiteDatabase/4.json
@@ -1,0 +1,102 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "33dd80d6f91426fe0778ee42d01f8ca1",
+    "entities": [
+      {
+        "tableName": "top_sites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `title` TEXT NOT NULL, `url` TEXT NOT NULL, `is_default` INTEGER NOT NULL, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "is_default",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "default_top_sites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `region` TEXT NOT NULL, `language` TEXT NOT NULL, `title` TEXT NOT NULL, `url` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "region",
+            "columnName": "region",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '33dd80d6f91426fe0778ee42d01f8ca1')"
+    ]
+  }
+}

--- a/components/feature/top-sites/src/androidTest/java/mozilla/components/feature/top/sites/OnDevicePinnedSitesStorageTest.kt
+++ b/components/feature/top-sites/src/androidTest/java/mozilla/components/feature/top/sites/OnDevicePinnedSitesStorageTest.kt
@@ -12,8 +12,19 @@ import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.runBlocking
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.BAIDU_URL
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.CN_REGION
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.EN_LANGUAGE
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.GOOGLE_URL
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.JD_URL
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.POCKET_TRENDING_URL
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.RU_REGION
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.WIKIPEDIA_URL
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.XX_LANGUAGE
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.XX_REGION
 import mozilla.components.feature.top.sites.TopSite.Type.DEFAULT
 import mozilla.components.feature.top.sites.TopSite.Type.PINNED
+import mozilla.components.feature.top.sites.db.DefaultSite
 import mozilla.components.feature.top.sites.db.Migrations
 import mozilla.components.feature.top.sites.db.TopSiteDatabase
 import org.junit.After
@@ -60,7 +71,7 @@ class OnDevicePinnedSitesStorageTest {
     }
 
     @Test
-    fun testAddingAllDefaultSites() = runBlocking {
+    fun testAddingAllPinnedSitesAsDefault() = runBlocking {
         val defaultTopSites = listOf(
             Pair("Mozilla", "https://www.mozilla.org"),
             Pair("Firefox", "https://www.firefox.com"),
@@ -177,6 +188,136 @@ class OnDevicePinnedSitesStorageTest {
         assertEquals(1, storage.getPinnedSitesCount())
         assertEquals("https://www.firefox.com", pinnedSites[0].url)
         assertEquals("Mozilla Firefox", pinnedSites[0].title)
+    }
+
+    @Test
+    fun testGettingDefaultSites() = runBlocking {
+        val defaultTopSites = listOf(
+            DefaultSite(
+                CN_REGION,
+                XX_LANGUAGE,
+                context.getString(R.string.default_top_site_baidu),
+                BAIDU_URL
+            ),
+            DefaultSite(
+                CN_REGION,
+                XX_LANGUAGE,
+                context.getString(R.string.default_top_site_jd),
+                JD_URL
+            ),
+            DefaultSite(
+                RU_REGION,
+                EN_LANGUAGE,
+                context.getString(R.string.pocket_pinned_top_articles),
+                POCKET_TRENDING_URL
+            ),
+            DefaultSite(
+                RU_REGION,
+                XX_LANGUAGE,
+                context.getString(R.string.default_top_site_wikipedia),
+                WIKIPEDIA_URL
+            ),
+            DefaultSite(
+                XX_REGION,
+                XX_LANGUAGE,
+                context.getString(R.string.default_top_site_google),
+                GOOGLE_URL
+            ),
+            DefaultSite(
+                XX_REGION,
+                EN_LANGUAGE,
+                context.getString(R.string.pocket_pinned_top_articles),
+                POCKET_TRENDING_URL
+            ),
+            DefaultSite(
+                XX_REGION,
+                XX_LANGUAGE,
+                context.getString(R.string.default_top_site_wikipedia),
+                WIKIPEDIA_URL
+            )
+        )
+
+        storage.addAllDefaultSites(defaultTopSites)
+
+        var defaultSites = storage.getDefaultSites(CN_REGION, XX_LANGUAGE)
+
+        assertEquals(2, defaultSites.size)
+        with(defaultSites[0]) {
+            assertEquals(context.getString(R.string.default_top_site_baidu), title)
+            assertEquals(BAIDU_URL, url)
+            assertEquals(CN_REGION, region)
+            assertEquals(XX_LANGUAGE, language)
+        }
+        with(defaultSites[1]) {
+            assertEquals(context.getString(R.string.default_top_site_jd), title)
+            assertEquals(JD_URL, url)
+            assertEquals(CN_REGION, region)
+            assertEquals(XX_LANGUAGE, language)
+        }
+
+        defaultSites = storage.getDefaultSites(RU_REGION, EN_LANGUAGE)
+
+        assertEquals(2, defaultSites.size)
+        with(defaultSites[0]) {
+            assertEquals(context.getString(R.string.pocket_pinned_top_articles), title)
+            assertEquals(POCKET_TRENDING_URL, url)
+            assertEquals(RU_REGION, region)
+            assertEquals(EN_LANGUAGE, language)
+        }
+        with(defaultSites[1]) {
+            assertEquals(context.getString(R.string.default_top_site_wikipedia), title)
+            assertEquals(WIKIPEDIA_URL, url)
+            assertEquals(RU_REGION, region)
+            assertEquals(XX_LANGUAGE, language)
+        }
+
+        defaultSites = storage.getDefaultSites(RU_REGION, XX_LANGUAGE)
+
+        assertEquals(1, defaultSites.size)
+        with(defaultSites[0]) {
+            assertEquals(context.getString(R.string.default_top_site_wikipedia), title)
+            assertEquals(WIKIPEDIA_URL, url)
+            assertEquals(RU_REGION, region)
+            assertEquals(XX_LANGUAGE, language)
+        }
+
+        defaultSites = storage.getDefaultSites(XX_REGION, EN_LANGUAGE)
+
+        assertEquals(3, defaultSites.size)
+        with(defaultSites[0]) {
+            assertEquals(context.getString(R.string.default_top_site_google), title)
+            assertEquals(GOOGLE_URL, url)
+            assertEquals(XX_REGION, region)
+            assertEquals(XX_LANGUAGE, language)
+        }
+        with(defaultSites[1]) {
+            assertEquals(context.getString(R.string.pocket_pinned_top_articles), title)
+            assertEquals(POCKET_TRENDING_URL, url)
+            assertEquals(XX_REGION, region)
+            assertEquals(EN_LANGUAGE, language)
+        }
+        with(defaultSites[2]) {
+            assertEquals(context.getString(R.string.default_top_site_wikipedia), title)
+            assertEquals(WIKIPEDIA_URL, url)
+            assertEquals(XX_REGION, region)
+            assertEquals(XX_LANGUAGE, language)
+        }
+
+        defaultSites = storage.getDefaultSites(XX_REGION, XX_LANGUAGE)
+
+        assertEquals(2, defaultSites.size)
+        with(defaultSites[0]) {
+            assertEquals(context.getString(R.string.default_top_site_google), title)
+            assertEquals(GOOGLE_URL, url)
+            assertEquals(XX_REGION, region)
+            assertEquals(XX_LANGUAGE, language)
+        }
+        with(defaultSites[1]) {
+            assertEquals(context.getString(R.string.default_top_site_wikipedia), title)
+            assertEquals(WIKIPEDIA_URL, url)
+            assertEquals(XX_REGION, region)
+            assertEquals(XX_LANGUAGE, language)
+        }
     }
 
     @Test
@@ -303,6 +444,96 @@ class OnDevicePinnedSitesStorageTest {
             )
             assertEquals(1, cursor.getInt(cursor.getColumnIndexOrThrow("is_default")))
             assertEquals(4, cursor.getInt(cursor.getColumnIndexOrThrow("created_at")))
+        }
+    }
+
+    @Test
+    fun migrate3to4() = runBlocking {
+        val dbVersion3 = helper.createDatabase(MIGRATION_TEST_DB, 3).apply {
+            execSQL(
+                "INSERT INTO " +
+                    "top_sites " +
+                    "(title, url, is_default, created_at) " +
+                    "VALUES " +
+                    "('Google','https://www.google.com/',1,1)," +
+                    "('Top Articles','https://getpocket.com/fenix-top-articles',1,2)," +
+                    "('Wikipedia','https://www.wikipedia.org/',1,3)"
+            )
+        }
+
+        dbVersion3.query("SELECT * FROM top_sites").use { cursor ->
+            assertEquals(5, cursor.columnCount)
+        }
+
+        val dbVersion4 = helper.runMigrationsAndValidate(
+            MIGRATION_TEST_DB, 4, true, Migrations.migration_3_4
+        ).apply {
+            // Insert test data into the new default_top_sites table.
+            execSQL(
+                "INSERT INTO " +
+                    "default_top_sites " +
+                    "(region, language, title, url) " +
+                    "VALUES " +
+                    "('XX','XX','Firefox','https://www.firefox.com')," +
+                    "('US','en','Monitor','https://monitor.firefox.com/')"
+            )
+        }
+
+        // Inspect that no changes occurred to the top_sites table.
+        dbVersion4.query("SELECT * FROM top_sites").use { cursor ->
+            assertEquals(5, cursor.columnCount)
+            assertEquals(3, cursor.count)
+
+            cursor.moveToFirst()
+            assertEquals("Google", cursor.getString(cursor.getColumnIndexOrThrow("title")))
+            assertEquals(
+                "https://www.google.com/",
+                cursor.getString(cursor.getColumnIndexOrThrow("url"))
+            )
+            assertEquals(1, cursor.getInt(cursor.getColumnIndexOrThrow("is_default")))
+            assertEquals(1, cursor.getInt(cursor.getColumnIndexOrThrow("created_at")))
+
+            cursor.moveToNext()
+            assertEquals("Top Articles", cursor.getString(cursor.getColumnIndexOrThrow("title")))
+            assertEquals(
+                "https://getpocket.com/fenix-top-articles",
+                cursor.getString(cursor.getColumnIndexOrThrow("url"))
+            )
+            assertEquals(1, cursor.getInt(cursor.getColumnIndexOrThrow("is_default")))
+            assertEquals(2, cursor.getInt(cursor.getColumnIndexOrThrow("created_at")))
+
+            cursor.moveToNext()
+            assertEquals("Wikipedia", cursor.getString(cursor.getColumnIndexOrThrow("title")))
+            assertEquals(
+                "https://www.wikipedia.org/",
+                cursor.getString(cursor.getColumnIndexOrThrow("url"))
+            )
+            assertEquals(1, cursor.getInt(cursor.getColumnIndexOrThrow("is_default")))
+            assertEquals(3, cursor.getInt(cursor.getColumnIndexOrThrow("created_at")))
+        }
+
+        // Query that new records were able to be inserted into the new default_top_sites table.
+        dbVersion4.query("SELECT * FROM default_top_sites").use { cursor ->
+            assertEquals(5, cursor.columnCount)
+            assertEquals(2, cursor.count)
+
+            cursor.moveToFirst()
+            assertEquals("XX", cursor.getString(cursor.getColumnIndexOrThrow("region")))
+            assertEquals("XX", cursor.getString(cursor.getColumnIndexOrThrow("language")))
+            assertEquals("Firefox", cursor.getString(cursor.getColumnIndexOrThrow("title")))
+            assertEquals(
+                "https://www.firefox.com",
+                cursor.getString(cursor.getColumnIndexOrThrow("url"))
+            )
+
+            cursor.moveToNext()
+            assertEquals("US", cursor.getString(cursor.getColumnIndexOrThrow("region")))
+            assertEquals("en", cursor.getString(cursor.getColumnIndexOrThrow("language")))
+            assertEquals("Monitor", cursor.getString(cursor.getColumnIndexOrThrow("title")))
+            assertEquals(
+                "https://monitor.firefox.com/",
+                cursor.getString(cursor.getColumnIndexOrThrow("url"))
+            )
         }
     }
 }

--- a/components/feature/top-sites/src/androidTest/java/mozilla/components/feature/top/sites/db/DefaultSiteDaoTest.kt
+++ b/components/feature/top-sites/src/androidTest/java/mozilla/components/feature/top/sites/db/DefaultSiteDaoTest.kt
@@ -1,0 +1,167 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.top.sites.db
+
+import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+class DefaultSiteDaoTest {
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private lateinit var database: TopSiteDatabase
+    private lateinit var defaultSiteDao: DefaultSiteDao
+    private lateinit var executor: ExecutorService
+
+    @get:Rule
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @Before
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder(context, TopSiteDatabase::class.java).build()
+        defaultSiteDao = database.defaultSiteDao()
+        executor = Executors.newSingleThreadExecutor()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+        executor.shutdown()
+    }
+
+    @Test
+    fun insertDefaultSite() {
+        val defaultSite = DefaultSiteEntity(
+            region = "XX",
+            language = "XX",
+            title = "Mozilla",
+            url = "https://www.mozilla.org"
+        ).also {
+            it.id = defaultSiteDao.insertDefaultSite(it)
+        }
+
+        val defaultSites = defaultSiteDao.getDefaultSites("XX", "XX")
+
+        assertEquals(1, defaultSites.size)
+        with(defaultSites[0]) {
+            assertEquals(defaultSite, this)
+            assertEquals(defaultSite.id, id)
+            assertEquals(defaultSite.region, region)
+            assertEquals(defaultSite.language, language)
+            assertEquals(defaultSite.title, title)
+            assertEquals(defaultSite.url, url)
+        }
+    }
+
+    @Test
+    fun insertAllDefaultSites() {
+        val defaultSite1 = DefaultSiteEntity(
+            region = "XX",
+            language = "XX",
+            title = "Mozilla",
+            url = "https://www.mozilla.org"
+        )
+        val defaultSite2 = DefaultSiteEntity(
+            region = "XX",
+            language = "XX",
+            title = "Wikipedia",
+            url = "https://www.wikipedia.org"
+        )
+
+        defaultSiteDao.insertAllDefaultSites(listOf(
+            defaultSite1,
+            defaultSite2
+        ))
+
+        val defaultSites = defaultSiteDao.getDefaultSites("XX", "XX")
+
+        assertEquals(2, defaultSites.size)
+        with(defaultSites[0]) {
+            assertEquals(defaultSite1, this)
+            assertEquals(defaultSite1.id, id)
+            assertEquals(defaultSite1.region, region)
+            assertEquals(defaultSite1.language, language)
+            assertEquals(defaultSite1.title, title)
+            assertEquals(defaultSite1.url, url)
+        }
+        with(defaultSites[1]) {
+            assertEquals(defaultSite2, this)
+            assertEquals(defaultSite2.id, id)
+            assertEquals(defaultSite2.region, region)
+            assertEquals(defaultSite2.language, language)
+            assertEquals(defaultSite2.title, title)
+            assertEquals(defaultSite2.url, url)
+        }
+    }
+
+    @Test
+    fun getDefaultSites() {
+        var defaultSite = DefaultSiteEntity(
+            region = "US",
+            language = "en",
+            title = "Mozilla",
+            url = "https://www.mozilla.org"
+        ).also {
+            it.id = defaultSiteDao.insertDefaultSite(it)
+        }
+
+        var defaultSites = defaultSiteDao.getDefaultSites("US", "en")
+
+        assertEquals(1, defaultSites.size)
+        assertEquals(defaultSite, defaultSites[0])
+
+        val defaultSite2 = DefaultSiteEntity(
+            region = "US",
+            language = "en",
+            title = "Wikipedia",
+            url = "https://www.wikipedia.org"
+        ).also {
+            it.id = defaultSiteDao.insertDefaultSite(it)
+        }
+
+        defaultSites = defaultSiteDao.getDefaultSites("US", "en")
+
+        assertEquals(2, defaultSites.size)
+        assertEquals(defaultSite, defaultSites[0])
+        assertEquals(defaultSite2, defaultSites[1])
+
+        defaultSite = DefaultSiteEntity(
+            region = "US",
+            language = "XX",
+            title = "Mozilla",
+            url = "https://www.mozilla.org"
+        ).also {
+            it.id = defaultSiteDao.insertDefaultSite(it)
+        }
+
+        defaultSites = defaultSiteDao.getDefaultSites("US", "XX")
+
+        assertEquals(1, defaultSites.size)
+        assertEquals(defaultSite, defaultSites[0])
+
+        defaultSite = DefaultSiteEntity(
+            region = "XX",
+            language = "en",
+            title = "Mozilla",
+            url = "https://www.mozilla.org"
+        ).also {
+            it.id = defaultSiteDao.insertDefaultSite(it)
+        }
+
+        defaultSites = defaultSiteDao.getDefaultSites("XX", "en")
+
+        assertEquals(1, defaultSites.size)
+        assertEquals(defaultSite, defaultSites[0])
+    }
+}

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/DefaultTopSitesStorage.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/DefaultTopSitesStorage.kt
@@ -4,17 +4,24 @@
 
 package mozilla.components.feature.top.sites
 
+import android.content.Context
+import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import mozilla.components.browser.state.search.RegionState
 import mozilla.components.browser.storage.sync.PlacesHistoryStorage
 import mozilla.components.concept.storage.FrecencyThresholdOption
+import mozilla.components.feature.top.sites.TopSite.Type.DEFAULT
 import mozilla.components.feature.top.sites.TopSite.Type.FRECENT
+import mozilla.components.feature.top.sites.db.DefaultSite
 import mozilla.components.feature.top.sites.ext.hasUrl
 import mozilla.components.feature.top.sites.ext.toTopSite
 import mozilla.components.feature.top.sites.facts.emitTopSitesCountFact
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
+import mozilla.components.support.locale.LocaleManager
+import java.util.Locale
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -23,27 +30,160 @@ import kotlin.coroutines.CoroutineContext
  * @param pinnedSitesStorage An instance of [PinnedSiteStorage], used for storing pinned sites.
  * @param historyStorage An instance of [PlacesHistoryStorage], used for retrieving top frecent
  * sites from history.
- * @param defaultTopSites A list containing a title to url pair of default top sites to be added
- * to the [PinnedSiteStorage].
+ * @param region The region of the user.
+ * @param isDefaultSiteAdded Whether or not the default sites were already added from Fenix.
  */
+@Suppress("LongParameterList")
 class DefaultTopSitesStorage(
+    context: Context,
     private val pinnedSitesStorage: PinnedSiteStorage,
     private val historyStorage: PlacesHistoryStorage,
-    private val defaultTopSites: List<Pair<String, String>> = listOf(),
+    private val region: RegionState?,
+    private val isDefaultSiteAdded: Boolean,
     coroutineContext: CoroutineContext = Dispatchers.IO
 ) : TopSitesStorage, Observable<TopSitesStorage.Observer> by ObserverRegistry() {
 
+    private val sharedPref = context.getSharedPreferences(PREFERENCE_NAME, Context.MODE_PRIVATE)
     private var scope = CoroutineScope(coroutineContext)
 
     // Cache of the last retrieved top sites
     var cachedTopSites = listOf<TopSite>()
 
     init {
-        if (defaultTopSites.isNotEmpty()) {
+        if (sharedPref.getInt(MOZAC_LOCAL_DEFAULT_TOP_SITES_VERSION, 0) !=
+            sharedPref.getInt(MOZAC_DEFAULT_TOP_SITES_VERSION, 1)
+        ) {
             scope.launch {
-                pinnedSitesStorage.addAllPinnedSites(defaultTopSites, isDefault = true)
+                initializeDefaultTopSites(context)
+
+                if (!isDefaultSiteAdded) {
+                    // Add default top sites for new installs into the pinned sites database table
+                    // based on the user's region and language.
+
+                    // If the current region is not CN, RU, TR, KZ or BY, default to a generic XX
+                    // region.
+                    val countryCode =
+                        if (region?.current != null && listOf(
+                                CN_REGION,
+                                RU_REGION,
+                                TR_REGION,
+                                KZ_REGION,
+                                BY_REGION
+                            ).contains(region.current)
+                        ) region.current else XX_REGION
+
+                    val locale = LocaleManager.getCurrentLocale(context)
+                        ?: LocaleManager.getSystemDefault()
+                    val language =
+                        if (locale.language == Locale("en").language) EN_LANGUAGE else XX_LANGUAGE
+
+                    val defaultTopSites =
+                        pinnedSitesStorage.getDefaultSites(countryCode, language)
+                            .map { entity -> Pair(entity.title, entity.url) }
+                    pinnedSitesStorage.addAllPinnedSites(defaultTopSites, isDefault = true)
+                } else if (listOf(CN_REGION, RU_REGION, TR_REGION, KZ_REGION, BY_REGION).contains(
+                        region?.current
+                    )
+                ) {
+                    // Remove existing Google default top sites for CN, RU, TR, KZ, BY regions.
+                    pinnedSitesStorage.getPinnedSites()
+                        .find { it.type == DEFAULT && it.url == GOOGLE_URL }?.let {
+                            removeTopSite(it)
+                        }
+                }
             }
+
+            sharedPref.edit().putInt(MOZAC_LOCAL_DEFAULT_TOP_SITES_VERSION, 1).apply()
         }
+    }
+
+    /**
+     * Adds all the default top sites into the default top sites database table.
+     */
+    @Suppress("LongMethod")
+    private suspend fun initializeDefaultTopSites(context: Context) {
+        pinnedSitesStorage.addAllDefaultSites(
+            listOf(
+                DefaultSite(
+                    CN_REGION,
+                    XX_LANGUAGE,
+                    context.getString(R.string.default_top_site_baidu),
+                    BAIDU_URL
+                ),
+                DefaultSite(
+                    CN_REGION,
+                    XX_LANGUAGE,
+                    context.getString(R.string.default_top_site_jd),
+                    JD_URL
+                ),
+                DefaultSite(
+                    RU_REGION,
+                    EN_LANGUAGE,
+                    context.getString(R.string.pocket_pinned_top_articles),
+                    POCKET_TRENDING_URL
+                ),
+                DefaultSite(
+                    RU_REGION,
+                    XX_LANGUAGE,
+                    context.getString(R.string.default_top_site_wikipedia),
+                    WIKIPEDIA_URL
+                ),
+                DefaultSite(
+                    TR_REGION,
+                    EN_LANGUAGE,
+                    context.getString(R.string.pocket_pinned_top_articles),
+                    POCKET_TRENDING_URL
+                ),
+                DefaultSite(
+                    TR_REGION,
+                    XX_LANGUAGE,
+                    context.getString(R.string.default_top_site_wikipedia),
+                    WIKIPEDIA_URL
+                ),
+                DefaultSite(
+                    KZ_REGION,
+                    EN_LANGUAGE,
+                    context.getString(R.string.pocket_pinned_top_articles),
+                    POCKET_TRENDING_URL
+                ),
+                DefaultSite(
+                    KZ_REGION,
+                    XX_LANGUAGE,
+                    context.getString(R.string.default_top_site_wikipedia),
+                    WIKIPEDIA_URL
+                ),
+                DefaultSite(
+                    BY_REGION,
+                    EN_LANGUAGE,
+                    context.getString(R.string.pocket_pinned_top_articles),
+                    POCKET_TRENDING_URL
+                ),
+                DefaultSite(
+                    BY_REGION,
+                    XX_LANGUAGE,
+                    context.getString(R.string.default_top_site_wikipedia),
+                    WIKIPEDIA_URL
+                ),
+                DefaultSite(
+                    XX_REGION,
+                    XX_LANGUAGE,
+                    context.getString(R.string.default_top_site_google),
+                    GOOGLE_URL
+                ),
+                DefaultSite(
+                    XX_REGION,
+                    EN_LANGUAGE,
+                    context.getString(R.string.pocket_pinned_top_articles),
+                    POCKET_TRENDING_URL
+                ),
+                DefaultSite(
+                    XX_REGION,
+                    XX_LANGUAGE,
+                    context.getString(R.string.default_top_site_wikipedia),
+                    WIKIPEDIA_URL
+                )
+            )
+        )
     }
 
     override fun addTopSite(title: String, url: String, isDefault: Boolean) {
@@ -102,5 +242,38 @@ class DefaultTopSitesStorage(
         cachedTopSites = topSites
 
         return topSites
+    }
+
+    companion object {
+        internal const val PREFERENCE_NAME = "mozac_feature_top_sites"
+
+        // The user's local default top sites version.
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        internal const val MOZAC_LOCAL_DEFAULT_TOP_SITES_VERSION =
+            "MOZAC_LOCAL_DEFAULT_TOP_SITES_VERSION"
+        // This is a MOZAC managed versioning number to upgrade default top sites in the future.
+        private const val MOZAC_DEFAULT_TOP_SITES_VERSION =
+            "MOZAC_DEFAULT_TOP_SITES_VERSION"
+
+        internal const val CN_REGION = "CN"
+        internal const val RU_REGION = "RU"
+        internal const val TR_REGION = "TR"
+        internal const val KZ_REGION = "KZ"
+        internal const val BY_REGION = "BY"
+        // Catch all for other regions that does not fall into CN, RU, TR, KZ, or BY.
+        internal const val XX_REGION = "XX"
+
+        internal const val EN_LANGUAGE = "en"
+        // Catch all for other languages that does not fall into "en".
+        internal const val XX_LANGUAGE = "XX"
+
+        internal const val POCKET_TRENDING_URL = "https://getpocket.com/fenix-top-articles"
+        internal const val WIKIPEDIA_URL = "https://www.wikipedia.org/"
+        internal const val GOOGLE_URL = "https://www.google.com/"
+        internal const val BAIDU_URL = "https://m.baidu.com/?from=1000969a"
+        internal const val JD_URL = "https://union-click.jd.com/jdc" +
+            "?e=&p=AyIGZRprFDJWWA1FBCVbV0IUWVALHFRBEwQAQB1AWQkFVUVXfFkAF14lRFRbJXstVWR3WQ1rJ08AZnhS" +
+            "HDJBYh4LZR9eEAMUBlccWCUBEQZRGFoXCxc3ZRteJUl8BmUZWhQ" +
+            "AEwdRGF0cMhIAVB5ZFAETBVAaXRwyFQdcKydLSUpaCEtYFAIXN2UrWCUyIgdVK1slXVZaCCtZFAMWDg%3D%3D"
     }
 }

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/db/DefaultSiteDao.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/db/DefaultSiteDao.kt
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.top.sites.db
+
+import androidx.annotation.WorkerThread
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Transaction
+
+/**
+ * Internal DAO for accessing [DefaultSiteEntity] instances.
+ */
+@Dao
+internal interface DefaultSiteDao {
+    @WorkerThread
+    @Insert
+    fun insertDefaultSite(site: DefaultSiteEntity): Long
+
+    @WorkerThread
+    @Transaction
+    fun insertAllDefaultSites(sites: List<DefaultSiteEntity>): List<Long> {
+        return sites.map { entity ->
+            val id = insertDefaultSite(entity)
+            entity.id = id
+            id
+        }
+    }
+
+    @WorkerThread
+    @Query("""
+        SELECT * FROM default_top_sites
+        WHERE (region = :countryCode
+        AND (language = :language OR language = 'XX'))
+    """)
+    fun getDefaultSites(countryCode: String, language: String): List<DefaultSiteEntity>
+}

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/db/DefaultSiteEntity.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/db/DefaultSiteEntity.kt
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.top.sites.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Internal entity representing a default site.
+ */
+@Entity(tableName = "default_top_sites")
+internal data class DefaultSiteEntity(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "id")
+    var id: Long? = null,
+
+    @ColumnInfo(name = "region")
+    var region: String,
+
+    @ColumnInfo(name = "language")
+    var language: String,
+
+    @ColumnInfo(name = "title")
+    var title: String,
+
+    @ColumnInfo(name = "url")
+    var url: String
+) {
+    internal fun toDefaultSite(): DefaultSite {
+        return DefaultSite(
+            region,
+            language,
+            title,
+            url
+        )
+    }
+}
+
+/**
+ * Represents a default site.
+ *
+ * @property region The country region to add this default site for.
+ * (Example: US, CN, XX - catch all for all regions)
+ * @property language The language to add this default site for.
+ * (Example: en, XX - catch all for all languages)
+ * @property title The title of the default site.
+ * @property url The url of the default site.
+ **/
+data class DefaultSite(
+    val region: String,
+    val language: String,
+    val title: String,
+    val url: String
+)

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/db/TopSiteDatabase.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/db/TopSiteDatabase.kt
@@ -14,9 +14,10 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 /**
  * Internal database for storing top sites.
  */
-@Database(entities = [PinnedSiteEntity::class], version = 3)
+@Database(entities = [PinnedSiteEntity::class, DefaultSiteEntity::class], version = 4)
 internal abstract class TopSiteDatabase : RoomDatabase() {
     abstract fun pinnedSiteDao(): PinnedSiteDao
+    abstract fun defaultSiteDao(): DefaultSiteDao
 
     companion object {
         @Volatile
@@ -34,6 +35,8 @@ internal abstract class TopSiteDatabase : RoomDatabase() {
                 Migrations.migration_1_2
             ).addMigrations(
                 Migrations.migration_2_3
+            ).addMigrations(
+                Migrations.migration_3_4
             ).build().also {
                 instance = it
             }
@@ -101,6 +104,21 @@ internal object Migrations {
                     "('https://getpocket.com/fenix-top-articles', " +
                     "'https://www.wikipedia.org/', " +
                     "'https://www.youtube.com/')"
+            )
+        }
+    }
+
+    @Suppress("MagicNumber")
+    val migration_3_4 = object : Migration(3, 4) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            // Creates a new default_top_sites table.
+            database.execSQL(
+                "CREATE TABLE IF NOT EXISTS `default_top_sites` (" +
+                    "`id` INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                    "`region` TEXT NOT NULL, " +
+                    "`language` TEXT NOT NULL, " +
+                    "`title` TEXT NOT NULL, " +
+                    "`url` TEXT NOT NULL)"
             )
         }
     }

--- a/components/feature/top-sites/src/main/res/values/mozac_feature_top_sites_strings.xml
+++ b/components/feature/top-sites/src/main/res/values/mozac_feature_top_sites_strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <!-- Default title for pinned Baidu top site that links to Baidu home page  -->
+    <string name="default_top_site_baidu" translatable="false">百度</string>
+    <!-- Default title for pinned JD top site that links to JD home page  -->
+    <string name="default_top_site_jd" translatable="false">京东</string>
+    <!-- Default title for pinned Pocket top site that links to trending Pocket site -->
+    <string name="pocket_pinned_top_articles" translatable="false">Top Articles</string>
+    <!-- Default title for pinned Wikipedia top site that links to Wikipedia home page -->
+    <string name="default_top_site_wikipedia" translatable="false">Wikipedia</string>
+    <!-- Default title for pinned Google top site that links to Google home page  -->
+    <string name="default_top_site_google" translatable="false">Google</string>
+</resources>

--- a/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/DefaultTopSitesStorageTest.kt
+++ b/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/DefaultTopSitesStorageTest.kt
@@ -4,20 +4,44 @@
 
 package mozilla.components.feature.top.sites
 
+import android.content.Context
+import android.content.SharedPreferences
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
+import mozilla.components.browser.state.search.RegionState
 import mozilla.components.browser.storage.sync.PlacesHistoryStorage
 import mozilla.components.concept.storage.FrecencyThresholdOption
 import mozilla.components.concept.storage.TopFrecentSiteInfo
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.BAIDU_URL
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.BY_REGION
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.CN_REGION
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.EN_LANGUAGE
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.GOOGLE_URL
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.JD_URL
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.KZ_REGION
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.MOZAC_LOCAL_DEFAULT_TOP_SITES_VERSION
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.POCKET_TRENDING_URL
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.PREFERENCE_NAME
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.RU_REGION
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.TR_REGION
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.WIKIPEDIA_URL
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.XX_LANGUAGE
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage.Companion.XX_REGION
+import mozilla.components.feature.top.sites.db.DefaultSite
 import mozilla.components.feature.top.sites.ext.toTopSite
+import mozilla.components.support.locale.LocaleManager
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.whenever
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
@@ -28,30 +52,488 @@ class DefaultTopSitesStorageTest {
 
     private val pinnedSitesStorage: PinnedSiteStorage = mock()
     private val historyStorage: PlacesHistoryStorage = mock()
+    private val region: RegionState = mock()
+
+    @Before
+    fun setup() {
+        // Set the local default top sites version to the latest to avoid the
+        // DefaultTopSitesStorage.init(). Tests should specify the correct local default
+        // top sites version to test DefaultTopSitesStorage.init().
+        preference(testContext).edit().putInt(MOZAC_LOCAL_DEFAULT_TOP_SITES_VERSION, 1).apply()
+    }
+
+    @After
+    fun shutdown() {
+        preference(testContext).edit().remove(MOZAC_LOCAL_DEFAULT_TOP_SITES_VERSION).apply()
+    }
 
     @Test
     fun `default top sites are added to pinned site storage on init`() = runBlockingTest {
-        val defaultTopSites = listOf(
-            Pair("Mozilla", "https://mozilla.com"),
-            Pair("Firefox", "https://firefox.com")
+        preference(testContext).edit().putInt(MOZAC_LOCAL_DEFAULT_TOP_SITES_VERSION, 0).apply()
+
+        // This is same list called in `initializeDefaultTopSites` in [DefaultTopSitesStorage].
+        val defaultSites = listOf(
+            DefaultSite(
+                CN_REGION,
+                XX_LANGUAGE,
+                testContext.getString(R.string.default_top_site_baidu),
+                BAIDU_URL
+            ),
+            DefaultSite(
+                CN_REGION,
+                XX_LANGUAGE,
+                testContext.getString(R.string.default_top_site_jd),
+                JD_URL
+            ),
+            DefaultSite(
+                RU_REGION,
+                EN_LANGUAGE,
+                testContext.getString(R.string.pocket_pinned_top_articles),
+                POCKET_TRENDING_URL
+            ),
+            DefaultSite(
+                RU_REGION,
+                XX_LANGUAGE,
+                testContext.getString(R.string.default_top_site_wikipedia),
+                WIKIPEDIA_URL
+            ),
+            DefaultSite(
+                TR_REGION,
+                EN_LANGUAGE,
+                testContext.getString(R.string.pocket_pinned_top_articles),
+                POCKET_TRENDING_URL
+            ),
+            DefaultSite(
+                TR_REGION,
+                XX_LANGUAGE,
+                testContext.getString(R.string.default_top_site_wikipedia),
+                WIKIPEDIA_URL
+            ),
+            DefaultSite(
+                KZ_REGION,
+                EN_LANGUAGE,
+                testContext.getString(R.string.pocket_pinned_top_articles),
+                POCKET_TRENDING_URL
+            ),
+            DefaultSite(
+                KZ_REGION,
+                XX_LANGUAGE,
+                testContext.getString(R.string.default_top_site_wikipedia),
+                WIKIPEDIA_URL
+            ),
+            DefaultSite(
+                BY_REGION,
+                EN_LANGUAGE,
+                testContext.getString(R.string.pocket_pinned_top_articles),
+                POCKET_TRENDING_URL
+            ),
+            DefaultSite(
+                BY_REGION,
+                XX_LANGUAGE,
+                testContext.getString(R.string.default_top_site_wikipedia),
+                WIKIPEDIA_URL
+            ),
+            DefaultSite(
+                XX_REGION,
+                XX_LANGUAGE,
+                testContext.getString(R.string.default_top_site_google),
+                DefaultTopSitesStorage.GOOGLE_URL
+            ),
+            DefaultSite(
+                XX_REGION,
+                EN_LANGUAGE,
+                testContext.getString(R.string.pocket_pinned_top_articles),
+                POCKET_TRENDING_URL
+            ),
+            DefaultSite(
+                XX_REGION,
+                XX_LANGUAGE,
+                testContext.getString(R.string.default_top_site_wikipedia),
+                WIKIPEDIA_URL
+            )
+        )
+        val defaultTopSites = defaultSites.map { entity -> Pair(entity.title, entity.url) }
+
+        whenever(pinnedSitesStorage.getDefaultSites(anyString(), anyString())).thenReturn(
+            defaultSites
         )
 
         DefaultTopSitesStorage(
+            testContext,
             pinnedSitesStorage,
             historyStorage,
-            defaultTopSites,
+            region = region,
+            isDefaultSiteAdded = false,
             coroutineContext
         )
 
+        verify(pinnedSitesStorage).addAllDefaultSites(defaultSites)
         verify(pinnedSitesStorage).addAllPinnedSites(defaultTopSites, isDefault = true)
+    }
+
+    @Test
+    fun `default sites added to pinned sites storage for CN region`() = runBlockingTest {
+        preference(testContext).edit().putInt(MOZAC_LOCAL_DEFAULT_TOP_SITES_VERSION, 0).apply()
+
+        val defaultSites = listOf(
+            DefaultSite(
+                CN_REGION,
+                XX_LANGUAGE,
+                testContext.getString(R.string.default_top_site_baidu),
+                BAIDU_URL
+            ),
+            DefaultSite(
+                CN_REGION,
+                XX_LANGUAGE,
+                testContext.getString(R.string.default_top_site_jd),
+                JD_URL
+            )
+        )
+        val defaultTopSites = defaultSites.map { entity -> Pair(entity.title, entity.url) }
+
+        whenever(pinnedSitesStorage.getDefaultSites(anyString(), anyString())).thenReturn(
+            defaultSites
+        )
+
+        DefaultTopSitesStorage(
+            testContext,
+            pinnedSitesStorage,
+            historyStorage,
+            region = RegionState(CN_REGION, CN_REGION),
+            isDefaultSiteAdded = false,
+            coroutineContext
+        )
+
+        verify(pinnedSitesStorage).getDefaultSites(CN_REGION, EN_LANGUAGE)
+        verify(pinnedSitesStorage).addAllPinnedSites(defaultTopSites, isDefault = true)
+    }
+
+    @Test
+    fun `default sites added to pinned sites storage for RU region`() = runBlockingTest {
+        preference(testContext).edit().putInt(MOZAC_LOCAL_DEFAULT_TOP_SITES_VERSION, 0).apply()
+
+        val defaultSites = listOf(
+            DefaultSite(
+                RU_REGION,
+                EN_LANGUAGE,
+                testContext.getString(R.string.pocket_pinned_top_articles),
+                POCKET_TRENDING_URL
+            ),
+            DefaultSite(
+                RU_REGION,
+                XX_LANGUAGE,
+                testContext.getString(R.string.default_top_site_wikipedia),
+                WIKIPEDIA_URL
+            )
+        )
+        val defaultTopSites = defaultSites.map { entity -> Pair(entity.title, entity.url) }
+
+        whenever(pinnedSitesStorage.getDefaultSites(anyString(), anyString())).thenReturn(
+            defaultSites
+        )
+
+        DefaultTopSitesStorage(
+            testContext,
+            pinnedSitesStorage,
+            historyStorage,
+            region = RegionState(RU_REGION, RU_REGION),
+            isDefaultSiteAdded = false,
+            coroutineContext
+        )
+
+        verify(pinnedSitesStorage).getDefaultSites(RU_REGION, EN_LANGUAGE)
+        verify(pinnedSitesStorage).addAllPinnedSites(defaultTopSites, isDefault = true)
+    }
+
+    @Test
+    fun `default sites added to pinned sites storage for RU region and XX language`() = runBlockingTest {
+        preference(testContext).edit().putInt(MOZAC_LOCAL_DEFAULT_TOP_SITES_VERSION, 0).apply()
+
+        val defaultSites = listOf(
+            DefaultSite(
+                RU_REGION,
+                EN_LANGUAGE,
+                testContext.getString(R.string.pocket_pinned_top_articles),
+                POCKET_TRENDING_URL
+            ),
+            DefaultSite(
+                RU_REGION,
+                XX_LANGUAGE,
+                testContext.getString(R.string.default_top_site_wikipedia),
+                WIKIPEDIA_URL
+            )
+        )
+        val defaultTopSites = defaultSites.map { entity -> Pair(entity.title, entity.url) }
+
+        whenever(pinnedSitesStorage.getDefaultSites(anyString(), anyString())).thenReturn(
+            defaultSites
+        )
+
+        LocaleManager.setNewLocale(testContext, "es")
+
+        DefaultTopSitesStorage(
+            testContext,
+            pinnedSitesStorage,
+            historyStorage,
+            region = RegionState(RU_REGION, RU_REGION),
+            isDefaultSiteAdded = false,
+            coroutineContext
+        )
+
+        verify(pinnedSitesStorage).getDefaultSites(RU_REGION, XX_LANGUAGE)
+        verify(pinnedSitesStorage).addAllPinnedSites(defaultTopSites, isDefault = true)
+
+        LocaleManager.resetToSystemDefault(testContext)
+    }
+
+    @Test
+    fun `default sites added to pinned sites storage for TR region`() = runBlockingTest {
+        preference(testContext).edit().putInt(MOZAC_LOCAL_DEFAULT_TOP_SITES_VERSION, 0).apply()
+
+        val defaultSites = listOf(
+            DefaultSite(
+                TR_REGION,
+                EN_LANGUAGE,
+                testContext.getString(R.string.pocket_pinned_top_articles),
+                POCKET_TRENDING_URL
+            ),
+            DefaultSite(
+                TR_REGION,
+                XX_LANGUAGE,
+                testContext.getString(R.string.default_top_site_wikipedia),
+                WIKIPEDIA_URL
+            )
+        )
+        val defaultTopSites = defaultSites.map { entity -> Pair(entity.title, entity.url) }
+
+        whenever(pinnedSitesStorage.getDefaultSites(anyString(), anyString())).thenReturn(
+            defaultSites
+        )
+
+        DefaultTopSitesStorage(
+            testContext,
+            pinnedSitesStorage,
+            historyStorage,
+            region = RegionState(TR_REGION, TR_REGION),
+            isDefaultSiteAdded = false,
+            coroutineContext
+        )
+
+        verify(pinnedSitesStorage).getDefaultSites(TR_REGION, EN_LANGUAGE)
+        verify(pinnedSitesStorage).addAllPinnedSites(defaultTopSites, isDefault = true)
+    }
+
+    @Test
+    fun `default sites added to pinned sites storage for KZ region`() = runBlockingTest {
+        preference(testContext).edit().putInt(MOZAC_LOCAL_DEFAULT_TOP_SITES_VERSION, 0).apply()
+
+        val defaultSites = listOf(
+            DefaultSite(
+                KZ_REGION,
+                EN_LANGUAGE,
+                testContext.getString(R.string.pocket_pinned_top_articles),
+                POCKET_TRENDING_URL
+            ),
+            DefaultSite(
+                KZ_REGION,
+                XX_LANGUAGE,
+                testContext.getString(R.string.default_top_site_wikipedia),
+                WIKIPEDIA_URL
+            )
+        )
+        val defaultTopSites = defaultSites.map { entity -> Pair(entity.title, entity.url) }
+
+        whenever(pinnedSitesStorage.getDefaultSites(anyString(), anyString())).thenReturn(
+            defaultSites
+        )
+
+        DefaultTopSitesStorage(
+            testContext,
+            pinnedSitesStorage,
+            historyStorage,
+            region = RegionState(KZ_REGION, KZ_REGION),
+            isDefaultSiteAdded = false,
+            coroutineContext
+        )
+
+        verify(pinnedSitesStorage).getDefaultSites(KZ_REGION, EN_LANGUAGE)
+        verify(pinnedSitesStorage).addAllPinnedSites(defaultTopSites, isDefault = true)
+    }
+
+    @Test
+    fun `default sites added to pinned sites storage for BY region`() = runBlockingTest {
+        preference(testContext).edit().putInt(MOZAC_LOCAL_DEFAULT_TOP_SITES_VERSION, 0).apply()
+
+        val defaultSites = listOf(
+            DefaultSite(
+                BY_REGION,
+                EN_LANGUAGE,
+                testContext.getString(R.string.pocket_pinned_top_articles),
+                POCKET_TRENDING_URL
+            ),
+            DefaultSite(
+                BY_REGION,
+                XX_LANGUAGE,
+                testContext.getString(R.string.default_top_site_wikipedia),
+                WIKIPEDIA_URL
+            )
+        )
+        val defaultTopSites = defaultSites.map { entity -> Pair(entity.title, entity.url) }
+
+        whenever(pinnedSitesStorage.getDefaultSites(anyString(), anyString())).thenReturn(
+            defaultSites
+        )
+
+        DefaultTopSitesStorage(
+            testContext,
+            pinnedSitesStorage,
+            historyStorage,
+            region = RegionState(BY_REGION, BY_REGION),
+            isDefaultSiteAdded = false,
+            coroutineContext
+        )
+
+        verify(pinnedSitesStorage).getDefaultSites(BY_REGION, EN_LANGUAGE)
+        verify(pinnedSitesStorage).addAllPinnedSites(defaultTopSites, isDefault = true)
+    }
+
+    @Test
+    fun `default sites added to pinned sites storage for US region`() = runBlockingTest {
+        preference(testContext).edit().putInt(MOZAC_LOCAL_DEFAULT_TOP_SITES_VERSION, 0).apply()
+
+        val defaultSites = listOf(
+            DefaultSite(
+                XX_REGION,
+                XX_LANGUAGE,
+                testContext.getString(R.string.default_top_site_google),
+                GOOGLE_URL
+            ),
+            DefaultSite(
+                XX_REGION,
+                EN_LANGUAGE,
+                testContext.getString(R.string.pocket_pinned_top_articles),
+                POCKET_TRENDING_URL
+            ),
+            DefaultSite(
+                XX_REGION,
+                XX_LANGUAGE,
+                testContext.getString(R.string.default_top_site_wikipedia),
+                WIKIPEDIA_URL
+            )
+        )
+        val defaultTopSites = defaultSites.map { entity -> Pair(entity.title, entity.url) }
+
+        whenever(pinnedSitesStorage.getDefaultSites(anyString(), anyString())).thenReturn(
+            defaultSites
+        )
+
+        DefaultTopSitesStorage(
+            testContext,
+            pinnedSitesStorage,
+            historyStorage,
+            region = RegionState("US", "US"),
+            isDefaultSiteAdded = false,
+            coroutineContext
+        )
+
+        verify(pinnedSitesStorage).getDefaultSites(XX_REGION, EN_LANGUAGE)
+        verify(pinnedSitesStorage).addAllPinnedSites(defaultTopSites, isDefault = true)
+    }
+
+    @Test
+    fun `update existing Google default top sites according to region CN, RU, TR, KZ, BY`() = runBlockingTest {
+        preference(testContext).edit().putInt(MOZAC_LOCAL_DEFAULT_TOP_SITES_VERSION, 0).apply()
+
+        val defaultSiteGoogle = TopSite(
+            id = 1,
+            title = "Google",
+            url = GOOGLE_URL,
+            createdAt = 1,
+            type = TopSite.Type.DEFAULT
+        )
+        val pinnedSite = TopSite(
+            id = 2,
+            title = "Wikipedia",
+            url = "https://wikipedia.com",
+            createdAt = 2,
+            type = TopSite.Type.PINNED
+        )
+        whenever(pinnedSitesStorage.getPinnedSites()).thenReturn(
+            listOf(
+                defaultSiteGoogle,
+                pinnedSite
+            )
+        )
+
+        DefaultTopSitesStorage(
+            testContext,
+            pinnedSitesStorage,
+            historyStorage,
+            region = RegionState(CN_REGION, CN_REGION),
+            isDefaultSiteAdded = true,
+            coroutineContext
+        )
+
+        verify(historyStorage).deleteVisitsFor(defaultSiteGoogle.url)
+        verify(pinnedSitesStorage).removePinnedSite(defaultSiteGoogle)
+
+        DefaultTopSitesStorage(
+            testContext,
+            pinnedSitesStorage,
+            historyStorage,
+            region = RegionState(RU_REGION, RU_REGION),
+            isDefaultSiteAdded = true,
+            coroutineContext
+        )
+
+        verify(historyStorage).deleteVisitsFor(defaultSiteGoogle.url)
+        verify(pinnedSitesStorage).removePinnedSite(defaultSiteGoogle)
+
+        DefaultTopSitesStorage(
+            testContext,
+            pinnedSitesStorage,
+            historyStorage,
+            region = RegionState(TR_REGION, TR_REGION),
+            isDefaultSiteAdded = true,
+            coroutineContext
+        )
+
+        verify(historyStorage).deleteVisitsFor(defaultSiteGoogle.url)
+        verify(pinnedSitesStorage).removePinnedSite(defaultSiteGoogle)
+
+        DefaultTopSitesStorage(
+            testContext,
+            pinnedSitesStorage,
+            historyStorage,
+            region = RegionState(KZ_REGION, KZ_REGION),
+            isDefaultSiteAdded = true,
+            coroutineContext
+        )
+
+        verify(historyStorage).deleteVisitsFor(defaultSiteGoogle.url)
+        verify(pinnedSitesStorage).removePinnedSite(defaultSiteGoogle)
+
+        DefaultTopSitesStorage(
+            testContext,
+            pinnedSitesStorage,
+            historyStorage,
+            region = RegionState(BY_REGION, BY_REGION),
+            isDefaultSiteAdded = true,
+            coroutineContext
+        )
+
+        verify(historyStorage).deleteVisitsFor(defaultSiteGoogle.url)
+        verify(pinnedSitesStorage).removePinnedSite(defaultSiteGoogle)
     }
 
     @Test
     fun `addPinnedSite`() = runBlockingTest {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
+            testContext,
             pinnedSitesStorage,
             historyStorage,
-            listOf(),
+            region = region,
+            isDefaultSiteAdded = true,
             coroutineContext
         )
         defaultTopSitesStorage.addTopSite("Mozilla", "https://mozilla.com", isDefault = false)
@@ -66,9 +548,11 @@ class DefaultTopSitesStorageTest {
     @Test
     fun `removeTopSite`() = runBlockingTest {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
+            testContext,
             pinnedSitesStorage,
             historyStorage,
-            listOf(),
+            region = region,
+            isDefaultSiteAdded = true,
             coroutineContext
         )
 
@@ -111,9 +595,11 @@ class DefaultTopSitesStorageTest {
     @Test
     fun `updateTopSite`() = runBlockingTest {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
+            testContext,
             pinnedSitesStorage,
             historyStorage,
-            listOf(),
+            region = region,
+            isDefaultSiteAdded = true,
             coroutineContext
         )
 
@@ -154,9 +640,11 @@ class DefaultTopSitesStorageTest {
     @Test
     fun `getTopSites returns only default and pinned sites when frecencyConfig is null`() = runBlockingTest {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
+            testContext,
             pinnedSitesStorage,
             historyStorage,
-            listOf(),
+            region = region,
+            isDefaultSiteAdded = true,
             coroutineContext
         )
 
@@ -207,9 +695,11 @@ class DefaultTopSitesStorageTest {
     @Test
     fun `getTopSites returns pinned and frecent sites when frecencyConfig is specified`() = runBlockingTest {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
+            testContext,
             pinnedSitesStorage,
             historyStorage,
-            listOf(),
+            region = region,
+            isDefaultSiteAdded = true,
             coroutineContext
         )
 
@@ -301,9 +791,11 @@ class DefaultTopSitesStorageTest {
     @Test
     fun `getTopSites filters out frecent sites that already exist in pinned sites`() = runBlockingTest {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
+            testContext,
             pinnedSitesStorage,
             historyStorage,
-            listOf(),
+            region = region,
+            isDefaultSiteAdded = true,
             coroutineContext
         )
 
@@ -362,5 +854,11 @@ class DefaultTopSitesStorageTest {
         assertEquals(frecentSite1.toTopSite(), topSites[4])
         assertEquals("mozilla.com", frecentSiteWithNoTitle.toTopSite().title)
         assertEquals(defaultTopSitesStorage.cachedTopSites, topSites)
+    }
+
+    companion object {
+        private fun preference(context: Context): SharedPreferences {
+            return context.getSharedPreferences(PREFERENCE_NAME, Context.MODE_PRIVATE)
+        }
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,8 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **feature-top-sites**
+  * ⚠️ **This is a breaking change**: `DefaultTopSitesStorage` will maintain a database table of the list of default top sites to add to the `PinnedSiteStorage` based on the user's region and language. `DefaultTopSitesStorage` requires the application context, `RegionState` and `isDefaultSiteAdded` boolean. See [#8491](https://github.com/mozilla-mobile/android-components/issues/8491).
 
 # 74.0.0
 


### PR DESCRIPTION
Fixes #8491. This focuses on moving the logic of adding default top sites from Fenix to AC https://github.com/mozilla-mobile/fenix/blob/1b6cebf4d43ac977cfae9e101c4e4b5d1ec24ef9/app/src/main/java/org/mozilla/fenix/components/Core.kt#L325-L364. In particular, we want to focus on how Mozilla Online adds their own separate set of defaults. Certain sites like Pocket are only added when the device language is English, Google is not added for a set of regions and should be removed from existing devices in those regions.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
