### PR TITLE
Closes #7888: Crash fetching icon with invalid URI scheme

### DIFF
--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/loader/HttpIconLoader.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/loader/HttpIconLoader.kt
@@ -18,6 +18,7 @@ import mozilla.components.concept.fetch.isSuccess
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.net.isHttpOrHttps
 import java.io.IOException
+import java.lang.IllegalArgumentException
 import java.util.concurrent.TimeUnit
 
 private const val CONNECT_TIMEOUT = 2L // Seconds
@@ -63,7 +64,16 @@ class HttpIconLoader(
             }
         } catch (e: IOException) {
             logger.debug("IOException while trying to download icon resource", e)
-            return IconLoader.Result.NoResult
+            IconLoader.Result.NoResult
+        } catch (e: IllegalArgumentException) {
+            // Despite checking that the icon URL scheme is http or https we're
+            // still seeing GeckoView rejecting requests due to unsupported URI
+            // schemes. We believe this could be caused by GeckoView converting
+            // the String toLowerCase, but can't find a reproducible case.
+            // Instead of crashing let's log the details so we can get to bottom
+            // of it once we can reproduce.
+            logger.debug("Invalid request to fetch icon: $downloadRequest", e)
+            IconLoader.Result.NoResult
         }
     }
 

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/loader/HttpIconLoaderTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/loader/HttpIconLoaderTest.kt
@@ -31,6 +31,7 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 import java.io.InputStream
 import java.io.IOException
+import java.lang.IllegalArgumentException
 
 @RunWith(AndroidJUnit4::class)
 class HttpIconLoaderTest {
@@ -219,6 +220,21 @@ class HttpIconLoaderTest {
 
         val resource = IconRequest.Resource(
             url = "https://www.example.org",
+            type = IconRequest.Resource.Type.APPLE_TOUCH_ICON
+        )
+
+        assertEquals(IconLoader.Result.NoResult, loader.load(mock(), mock(), resource))
+    }
+
+    @Test
+    fun `Loader will return NoResult for IllegalArgumentExceptions`() {
+        val client: Client = mock()
+
+        val loader = HttpIconLoader(client)
+        doThrow(IllegalArgumentException("test")).`when`(client).fetch(any())
+
+        val resource = IconRequest.Resource(
+            url = "http://www.example.org",
             type = IconRequest.Resource.Type.APPLE_TOUCH_ICON
         )
 


### PR DESCRIPTION
Since this has been crashing for a while (https://sentry.prod.mozaws.net/operations/firefox/issues/8893487/) let's catch, handle and log it instead. We can't log to Sentry (because we need the url) but once we have a reproducible case we'll know what exactly is going on.