### PR TITLE
Close #9269: Catch IOException when deleting icon caches

### DIFF
--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/utils/IconDiskCache.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/utils/IconDiskCache.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.icons.utils
 
 import android.content.Context
 import android.graphics.Bitmap
+import androidx.annotation.VisibleForTesting
 import com.jakewharton.disklrucache.DiskLruCache
 import mozilla.components.browser.icons.Icon
 import mozilla.components.browser.icons.IconRequest
@@ -36,8 +37,10 @@ class IconDiskCache :
     DiskIconLoader.LoaderDiskCache, DiskIconPreparer.PreparerDiskCache,
     DiskIconProcessor.ProcessorDiskCache {
     private val logger = Logger("Icons/IconDiskCache")
-    private var iconResourcesCache: DiskLruCache? = null
-    private var iconDataCache: DiskLruCache? = null
+    @VisibleForTesting
+    internal var iconResourcesCache: DiskLruCache? = null
+    @VisibleForTesting
+    internal var iconDataCache: DiskLruCache? = null
     private val iconResourcesCacheWriteLock = Any()
     private val iconDataCacheWriteLock = Any()
 
@@ -118,8 +121,17 @@ class IconDiskCache :
     }
 
     internal fun clear(context: Context) {
-        getIconResourcesCache(context).delete()
-        getIconDataCache(context).delete()
+        try {
+            getIconResourcesCache(context).delete()
+        } catch (e: IOException) {
+            logger.warn("Icon resource cache could not be cleared. Perhaps there is none?")
+        }
+
+        try {
+            getIconDataCache(context).delete()
+        } catch (e: IOException) {
+            logger.warn("Icon data cache could not be cleared. Perhaps there is none?")
+        }
 
         iconResourcesCache = null
         iconDataCache = null

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/utils/IconDiskCacheTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/utils/IconDiskCacheTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.icons.utils
 
 import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.jakewharton.disklrucache.DiskLruCache
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.concept.engine.manifest.Size
 import mozilla.components.support.test.any
@@ -13,10 +14,12 @@ import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mockito.`when`
+import java.io.IOException
 import java.io.OutputStream
 
 @RunWith(AndroidJUnit4::class)
@@ -80,5 +83,22 @@ class IconDiskCacheTest {
         val data = cache.getIconData(testContext, resource)
         assertNotNull(data!!)
         assertEquals("Hello World", String(data))
+    }
+
+    @Test
+    fun `Clearing cache directories catches IOException`() {
+        val cache = IconDiskCache()
+        val dataCache: DiskLruCache = mock()
+        val resCache: DiskLruCache = mock()
+        cache.iconDataCache = dataCache
+        cache.iconResourcesCache = resCache
+
+        `when`(dataCache.delete()).thenThrow(IOException("test"))
+        `when`(resCache.delete()).thenThrow(IOException("test"))
+
+        cache.clear(testContext)
+
+        assertNull(cache.iconDataCache)
+        assertNull(cache.iconResourcesCache)
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,9 @@ permalink: /changelog/
 * **feature-accounts-push**
   * Rolling back to previous behaviour of renewing push registration token when the `subscriptionExpired` flag is observed.
 
+* **browser-icons**
+  * Catch `IOException` that may be thrown when deleting icon caches.
+
 # 70.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v69.0.0...v70.0.0)


### PR DESCRIPTION
Similar to https://github.com/mozilla-mobile/fenix/issues/13209, we're catching the IOException if we try to delete a directory that was just deleted.

Closes #9269 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
