### PR TITLE
Closes #9292: Crash when deserializing sessions with source field

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -16,6 +16,7 @@ import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.state.EngineState
 import mozilla.components.browser.state.state.ReaderState
+import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.recover.RecoverableTab
 import mozilla.components.browser.state.store.BrowserStore
@@ -181,7 +182,8 @@ class SessionManager(
                     id = it.id,
                     initialUrl = it.url,
                     contextId = it.contextId,
-                    private = it.private
+                    private = it.private,
+                    source = SessionState.Source.RESTORED
                 ).apply {
                     title = it.title
                     parentId = it.parentId

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/storage/BrowserStateSerializer.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/storage/BrowserStateSerializer.kt
@@ -182,6 +182,7 @@ private fun JsonReader.tabSession(): RecoverableTab? {
             Keys.SESSION_READER_MODE_KEY -> readerStateActive = nextBooleanOrNull()
             Keys.SESSION_READER_MODE_ACTIVE_URL_KEY -> readerActiveUrl = nextStringOrNull()
             Keys.SESSION_LAST_ACCESS -> lastAccess = nextLong()
+            Keys.SESSION_SOURCE_KEY -> nextString()
             else -> throw IllegalArgumentException("Unknown session key: $name")
         }
     }

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/storage/SnapshotSerializer.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/storage/SnapshotSerializer.kt
@@ -170,6 +170,7 @@ internal object Keys {
     const val SESSION_READER_MODE_ACTIVE_URL_KEY = "readerModeArticleUrl"
     const val SESSION_TITLE = "title"
     const val SESSION_LAST_ACCESS = "lastAccess"
+    const val SESSION_SOURCE_KEY = "source"
 
     const val SESSION_KEY = "session"
     const val ENGINE_SESSION_KEY = "engineSession"

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.session
 
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.state.CustomTabConfig
+import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.state.recover.toRecoverableTab
 import mozilla.components.browser.state.store.BrowserStore
@@ -314,6 +315,10 @@ class SessionManagerTest {
         assertTrue(sessionManager.sessions[0].private)
         assertFalse(sessionManager.sessions[1].private)
         assertFalse(sessionManager.sessions[2].private)
+
+        assertEquals(SessionState.Source.RESTORED, sessionManager.sessions[0].source)
+        assertEquals(SessionState.Source.RESTORED, sessionManager.sessions[1].source)
+        assertEquals(SessionState.Source.RESTORED, sessionManager.sessions[2].source)
     }
 
     @Test

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/storage/BrowserStateSerializerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/storage/BrowserStateSerializerTest.kt
@@ -10,9 +10,11 @@ import android.util.JsonWriter
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.state.state.EngineState
 import mozilla.components.browser.state.state.ReaderState
+import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSessionState
+import mozilla.components.support.ktx.util.streamJSON
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
@@ -84,6 +86,28 @@ class BrowserStateSerializerTest {
         assertTrue(restoredTab.readerState.active)
         assertEquals("https://www.example.org", restoredTab.readerState.activeUrl)
     }
+
+    @Test
+    fun `Read tab with session source`() {
+        // We don't write tabs with session source anymore but need to be tolerant to
+        // session source being in the JSON to remain backward compatible.
+        val engineState = createFakeEngineState()
+        val engine = createFakeEngine(engineState)
+        val tab = createTab(url = "https://www.mozilla.org", title = "Mozilla")
+        val file = AtomicFile(
+            File.createTempFile(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        )
+        writeTabWithSource(tab, file)
+
+        // When reading we don't care about the source either as we will just set
+        // it to RESTORED. So we just need to make sure we de-serialized successfully.
+        val serializer = BrowserStateSerializer()
+        val restoredTab = serializer.readTab(engine, file)
+        assertNotNull(restoredTab!!)
+
+        assertEquals("https://www.mozilla.org", restoredTab.url)
+        assertEquals("Mozilla", restoredTab.title)
+    }
 }
 
 private fun createFakeEngineState(): EngineSessionState {
@@ -105,4 +129,33 @@ private fun createFakeEngine(engineState: EngineSessionState): Engine {
         engineState
     }
     return engine
+}
+
+private fun writeTabWithSource(tab: TabSessionState, file: AtomicFile) {
+    file.streamJSON { tabWithSource(tab) }
+}
+
+private fun JsonWriter.tabWithSource(
+    tab: TabSessionState
+) {
+    beginObject()
+
+    name(Keys.SESSION_KEY)
+    beginObject().apply {
+        name(Keys.SESSION_URL_KEY)
+        value(tab.content.url)
+
+        name(Keys.SESSION_UUID_KEY)
+        value(tab.id)
+
+        name(Keys.SESSION_TITLE)
+        value(tab.content.title)
+
+        name(Keys.SESSION_SOURCE_KEY)
+        value(tab.source.name)
+
+        endObject()
+    }
+
+    endObject()
 }


### PR DESCRIPTION
In https://github.com/mozilla-mobile/android-components/issues/6651 we stopped serializing and persisting the session source and just set it to `RESTORED` when deserializing.

Our new `BrowserStateSerializer` now crashes when it sees fields it doesn't support and we recently started using it for `feature-collections`: https://github.com/mozilla-mobile/android-components/issues/6651

So we need to make `BrowserStateSerializer` tolerant to `source` being in the tab JSON, and also make sure we set the session to `RESTORED` as before.
