### PR TITLE
For #9299: Get download notification accent color from fenix to match theme

### DIFF
--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadNotification.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadNotification.kt
@@ -47,7 +47,8 @@ internal object DownloadNotification {
     @VisibleForTesting
     internal fun createDownloadGroupNotification(
         context: Context,
-        notifications: List<DownloadJobState>
+        notifications: List<DownloadJobState>,
+        notificationAccentColor: Int
     ): Notification {
         val allDownloadsHaveFinished = notifications.all { it.status != DOWNLOADING }
         val icon = if (allDownloadsHaveFinished) {
@@ -61,7 +62,7 @@ internal object DownloadNotification {
 
         return NotificationCompat.Builder(context, ensureChannelExists(context))
             .setSmallIcon(icon)
-            .setColor(ContextCompat.getColor(context, R.color.mozac_feature_downloads_notification))
+            .setColor(ContextCompat.getColor(context, notificationAccentColor))
             .setContentTitle(context.getString(R.string.mozac_feature_downloads_notification_channel))
             .setContentText(summaryList.joinToString("\n"))
             .setStyle(NotificationCompat.InboxStyle().addLine(summaryLine1).addLine(summaryLine2))
@@ -76,7 +77,8 @@ internal object DownloadNotification {
      */
     fun createOngoingDownloadNotification(
         context: Context,
-        downloadJobState: DownloadJobState
+        downloadJobState: DownloadJobState,
+        notificationAccentColor: Int
     ): Notification {
         val downloadState = downloadJobState.state
         val bytesCopied = downloadJobState.currentBytesCopied
@@ -87,7 +89,7 @@ internal object DownloadNotification {
             .setSmallIcon(R.drawable.mozac_feature_download_ic_ongoing_download)
             .setContentTitle(downloadState.fileName)
             .setContentText(downloadJobState.getProgress())
-            .setColor(ContextCompat.getColor(context, R.color.mozac_feature_downloads_notification))
+            .setColor(ContextCompat.getColor(context, notificationAccentColor))
             .setCategory(NotificationCompat.CATEGORY_PROGRESS)
             .setProgress(downloadState.contentLength?.toInt() ?: 0, bytesCopied.toInt(), isIndeterminate)
             .setOngoing(true)
@@ -103,7 +105,11 @@ internal object DownloadNotification {
     /**
      * Build the notification to be displayed while the download service is paused.
      */
-    fun createPausedDownloadNotification(context: Context, downloadJobState: DownloadJobState): Notification {
+    fun createPausedDownloadNotification(
+        context: Context,
+        downloadJobState: DownloadJobState,
+        notificationAccentColor: Int
+    ): Notification {
         val channelId = ensureChannelExists(context)
 
         val downloadState = downloadJobState.state
@@ -111,7 +117,7 @@ internal object DownloadNotification {
             .setSmallIcon(R.drawable.mozac_feature_download_ic_download)
             .setContentTitle(downloadState.fileName)
             .setContentText(context.getString(R.string.mozac_feature_downloads_paused_notification_text))
-            .setColor(ContextCompat.getColor(context, R.color.mozac_feature_downloads_notification))
+            .setColor(ContextCompat.getColor(context, notificationAccentColor))
             .setCategory(NotificationCompat.CATEGORY_PROGRESS)
             .setOngoing(true)
             .setWhen(downloadJobState.createdTime)
@@ -126,7 +132,11 @@ internal object DownloadNotification {
     /**
      * Build the notification to be displayed when a download finishes.
      */
-    fun createDownloadCompletedNotification(context: Context, downloadJobState: DownloadJobState): Notification {
+    fun createDownloadCompletedNotification(
+        context: Context,
+        downloadJobState: DownloadJobState,
+        notificationAccentColor: Int
+    ): Notification {
         val channelId = ensureChannelExists(context)
         val downloadState = downloadJobState.state
 
@@ -136,7 +146,7 @@ internal object DownloadNotification {
             .setWhen(downloadJobState.createdTime)
             .setOnlyAlertOnce(true)
             .setContentText(context.getString(R.string.mozac_feature_downloads_completed_notification_text2))
-            .setColor(ContextCompat.getColor(context, R.color.mozac_feature_downloads_notification))
+            .setColor(ContextCompat.getColor(context, notificationAccentColor))
             .setContentIntent(createPendingIntent(context, ACTION_OPEN, downloadState.id))
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setDeleteIntent(createDismissPendingIntent(context, downloadState.id))
@@ -147,7 +157,11 @@ internal object DownloadNotification {
     /**
      * Build the notification to be displayed when a download fails to finish.
      */
-    fun createDownloadFailedNotification(context: Context, downloadJobState: DownloadJobState): Notification {
+    fun createDownloadFailedNotification(
+        context: Context,
+        downloadJobState: DownloadJobState,
+        notificationAccentColor: Int
+    ): Notification {
         val channelId = ensureChannelExists(context)
         val downloadState = downloadJobState.state
 
@@ -155,7 +169,7 @@ internal object DownloadNotification {
             .setSmallIcon(R.drawable.mozac_feature_download_ic_download_failed)
             .setContentTitle(downloadState.fileName)
             .setContentText(context.getString(R.string.mozac_feature_downloads_failed_notification_text2))
-            .setColor(ContextCompat.getColor(context, R.color.mozac_feature_downloads_notification))
+            .setColor(ContextCompat.getColor(context, notificationAccentColor))
             .setCategory(NotificationCompat.CATEGORY_ERROR)
             .addAction(getTryAgainAction(context, downloadState.id))
             .addAction(getCancelAction(context, downloadState.id))

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
@@ -1249,7 +1249,12 @@ class AbstractFetchDownloadServiceTest {
         service.registerNotificationActionsReceiver()
         service.downloadJobs[download.id] = downloadState
 
-        val notification = DownloadNotification.createOngoingDownloadNotification(testContext, downloadState)
+        val notificationStyle = AbstractFetchDownloadService.Style()
+        val notification = DownloadNotification.createOngoingDownloadNotification(
+            testContext,
+            downloadState,
+            notificationStyle.notificationAccentColor
+        )
 
         NotificationManagerCompat.from(testContext).notify(downloadState.foregroundServiceId, notification)
 

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadNotificationTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadNotificationTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.feature.downloads
 
 import android.os.Build
 import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.feature.downloads.AbstractFetchDownloadService.DownloadJobState
@@ -156,5 +157,146 @@ class DownloadNotificationTest {
 
         val summary = DownloadNotification.getSummaryList(testContext, listOf(download1, download2))
         assertEquals(listOf("mozilla.txt 10%", "mozilla2.txt 20%"), summary)
+    }
+
+    @Test
+    fun getOngoingNotificationAccentColor() {
+        val download = DownloadJobState(
+            job = null,
+            state = DownloadState(fileName = "mozilla.txt", url = "mozilla.org/mozilla.txt", contentLength = 100L,
+                currentBytesCopied = 10,
+                status = DownloadState.Status.DOWNLOADING),
+            foregroundServiceId = 1,
+            downloadDeleted = false,
+            currentBytesCopied = 10,
+            status = DownloadState.Status.DOWNLOADING
+        )
+
+        val style = AbstractFetchDownloadService.Style()
+
+        val notification = DownloadNotification.createOngoingDownloadNotification(
+            testContext,
+            download,
+            notificationAccentColor = style.notificationAccentColor
+        )
+
+        val accentColor = ContextCompat.getColor(testContext, style.notificationAccentColor)
+
+        assertEquals(accentColor, notification.color)
+    }
+
+    @Test
+    fun getPausedNotificationAccentColor() {
+        val download = DownloadJobState(
+            job = null,
+            state = DownloadState(fileName = "mozilla.txt", url = "mozilla.org/mozilla.txt", contentLength = 100L,
+                currentBytesCopied = 10,
+                status = DownloadState.Status.PAUSED),
+            foregroundServiceId = 1,
+            downloadDeleted = false,
+            currentBytesCopied = 10,
+            status = DownloadState.Status.PAUSED
+        )
+
+        val style = AbstractFetchDownloadService.Style()
+
+        val notification = DownloadNotification.createPausedDownloadNotification(
+            testContext,
+            download,
+            notificationAccentColor = style.notificationAccentColor
+        )
+
+        val accentColor = ContextCompat.getColor(testContext, style.notificationAccentColor)
+
+        assertEquals(accentColor, notification.color)
+    }
+
+    @Test
+    fun getCompletedNotificationAccentColor() {
+        val download = DownloadJobState(
+            job = null,
+            state = DownloadState(fileName = "mozilla.txt", url = "mozilla.org/mozilla.txt", contentLength = 100L,
+                currentBytesCopied = 10,
+                status = DownloadState.Status.COMPLETED),
+            foregroundServiceId = 1,
+            downloadDeleted = false,
+            currentBytesCopied = 10,
+            status = DownloadState.Status.COMPLETED
+        )
+
+        val style = AbstractFetchDownloadService.Style()
+
+        val notification = DownloadNotification.createDownloadCompletedNotification(
+            testContext,
+            download,
+            notificationAccentColor = style.notificationAccentColor
+        )
+
+        val accentColor = ContextCompat.getColor(testContext, style.notificationAccentColor)
+
+        assertEquals(accentColor, notification.color)
+    }
+
+    @Test
+    fun getFailedNotificationAccentColor() {
+        val download = DownloadJobState(
+            job = null,
+            state = DownloadState(fileName = "mozilla.txt", url = "mozilla.org/mozilla.txt", contentLength = 100L,
+                currentBytesCopied = 10,
+                status = DownloadState.Status.FAILED),
+            foregroundServiceId = 1,
+            downloadDeleted = false,
+            currentBytesCopied = 10,
+            status = DownloadState.Status.FAILED
+        )
+
+        val style = AbstractFetchDownloadService.Style()
+
+        val notification = DownloadNotification.createDownloadFailedNotification(
+            testContext,
+            download,
+            notificationAccentColor = style.notificationAccentColor
+        )
+
+        val accentColor = ContextCompat.getColor(testContext, style.notificationAccentColor)
+
+        assertEquals(accentColor, notification.color)
+    }
+
+    @Test
+    fun getGroupNotificationAccentColor() {
+        val download1 = DownloadJobState(
+            job = null,
+            state = DownloadState(fileName = "mozilla.txt", url = "mozilla.org/mozilla.txt", contentLength = 100L,
+                currentBytesCopied = 10,
+                status = DownloadState.Status.DOWNLOADING),
+            foregroundServiceId = 1,
+            downloadDeleted = false,
+            currentBytesCopied = 10,
+            status = DownloadState.Status.DOWNLOADING
+        )
+
+        val download2 = DownloadJobState(
+            job = null,
+            state = DownloadState(fileName = "mozilla.txt", url = "mozilla.org/mozilla.txt", contentLength = 100L,
+                currentBytesCopied = 10,
+                status = DownloadState.Status.DOWNLOADING),
+            foregroundServiceId = 1,
+            downloadDeleted = false,
+            currentBytesCopied = 10,
+            status = DownloadState.Status.DOWNLOADING
+        )
+
+        val style = AbstractFetchDownloadService.Style()
+
+        val notification = DownloadNotification.createDownloadGroupNotification(
+            testContext,
+            listOf(download1, download2),
+            notificationAccentColor = style.notificationAccentColor
+        )
+
+        val accentColor = ContextCompat.getColor(testContext, style.notificationAccentColor)
+
+        assertEquals(accentColor, notification.color)
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **feature-prompts**:
   * 🚒 Bug fixed [issue #9229](https://github.com/mozilla-mobile/android-components/issues/9229) - Dismiss SelectLoginPrompt from the current tab when opening a new one ensuring the new one can show it's own. When returning to the previous tab users should focus a login field to see the SelectLoginPrompt again.
 
+* **feature-downloads**:
+  * Allow browsers to change the download notification accent color by providing `Style()` in `AbstractFetchDownloadService`, for more information see [#9299](https://github.com/mozilla-mobile/android-components/issues/9299).
+
 * **feature-accounts-push**
   * Rolling back to previous behaviour of renewing push registration token when the `subscriptionExpired` flag is observed.
 


### PR DESCRIPTION
Fenix side: https://github.com/mozilla-mobile/fenix/pull/17231

**Warning to reviewer**: I'm amateur. Please double check everything 😊

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
