### PR TITLE
Uplift l10n changes to 70

### DIFF
--- a/components/browser/awesomebar/src/main/res/values-bn/strings.xml
+++ b/components/browser/awesomebar/src/main/res/values-bn/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Description for the button to accept the search suggestion and continue editing the search. -->
+    <string name="mozac_browser_awesomebar_edit_suggestion">পরামর্শ গ্রহণ এবং সম্পাদনা করুন</string>
+</resources>

--- a/components/browser/awesomebar/src/main/res/values-lo/strings.xml
+++ b/components/browser/awesomebar/src/main/res/values-lo/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Description for the button to accept the search suggestion and continue editing the search. -->
+    <string name="mozac_browser_awesomebar_edit_suggestion">ຍອມຮັບ ແລະ ແກ້ໄຂຄຳແນະນຳ</string>
+</resources>

--- a/components/browser/awesomebar/src/main/res/values-sat/strings.xml
+++ b/components/browser/awesomebar/src/main/res/values-sat/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Description for the button to accept the search suggestion and continue editing the search. -->
-    <string name="mozac_browser_awesomebar_edit_suggestion">ᱵᱟᱛᱟᱣᱢᱮᱸ ᱟᱨ ᱥᱩᱡᱷᱟᱹᱣ ᱥᱟᱯᱲᱟᱣ ᱢᱮᱸ</string>
+    <string name="mozac_browser_awesomebar_edit_suggestion">ᱵᱟᱛᱟᱣᱢᱮ ᱟᱨ ᱥᱩᱡᱷᱟᱹᱣ ᱥᱟᱯᱲᱟᱣ ᱢᱮ</string>
 </resources>

--- a/components/browser/engine-system/src/main/res/values-br/strings.xml
+++ b/components/browser/engine-system/src/main/res/values-br/strings.xml
@@ -4,7 +4,7 @@
     <string name="mozac_browser_engine_system_alert_title">Ar bajenn war %1$s a lâr:</string>
     <!-- Text for the message of an auth dialog displayed by a web page.
     %1$s will be replaced by the hostname or a description of the protected area/site, %2$s will be replaced with the URL of the current page (displaying the dialog). -->
-    <string name="mozac_browser_engine_system_auth_message">Emañ ar proksi %2$s ocʼh azgoulenn un anv arveriad hag ur ger-tremen. Emañ al lecʼhienn o lavarout: “%1$s&quot;</string>
+    <string name="mozac_browser_engine_system_auth_message">Emañ ar proksi %2$s ocʼh azgoulenn un anv arveriad hag ur ger-tremen. Emañ al lecʼhienn o lavarout: “%1$s”</string>
     <!-- Text for the message of an auth dialog displayed by a web page. %1$s will be replaced with the URL of the current page (displaying the dialog). -->
     <string name="mozac_browser_engine_system_auth_no_realm_message">Emañ ar proksi %1$s ocʼh azgoulenn un anv arveriad hag ur ger-tremen.</string>
 </resources>

--- a/components/browser/engine-system/src/main/res/values-es/strings.xml
+++ b/components/browser/engine-system/src/main/res/values-es/strings.xml
@@ -3,7 +3,7 @@
     <!-- Text for the title of an alert dialog displayed by a web page. %1$s will be replaced with the URL of the current page (displaying the dialog). -->
     <string name="mozac_browser_engine_system_alert_title">La página en %1$s dice:</string>
     <!-- Text for the message of an auth dialog displayed by a web page.
-    %1$s will be replaced by the realm, %2$s will be replaced with the URL of the current page (displaying the dialog). -->
+    %1$s will be replaced by the hostname or a description of the protected area/site, %2$s will be replaced with the URL of the current page (displaying the dialog). -->
     <string name="mozac_browser_engine_system_auth_message">%2$s está solicitando tu nombre de usuario y contraseña. El sitio dice: “%1$s”</string>
     <!-- Text for the message of an auth dialog displayed by a web page. %1$s will be replaced with the URL of the current page (displaying the dialog). -->
     <string name="mozac_browser_engine_system_auth_no_realm_message">%1$s está solicitando tu nombre de usuario y contraseña.</string>

--- a/components/browser/engine-system/src/main/res/values-sat/strings.xml
+++ b/components/browser/engine-system/src/main/res/values-sat/strings.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Text for the title of an alert dialog displayed by a web page. %1$s will be replaced with the URL of the current page (displaying the dialog). -->
-    <string name="mozac_browser_engine_system_alert_title">%1$s ᱴᱷᱮᱱ ᱢᱮᱸᱱᱟᱜ ᱥᱟᱦᱴᱟ ᱢᱮᱸᱱᱮᱜᱼᱟᱭ:</string>
+    <string name="mozac_browser_engine_system_alert_title">%1$s ᱴᱷᱮᱱ ᱢᱮᱱᱟᱜ ᱥᱟᱦᱴᱟ ᱢᱮᱱᱮᱜᱼᱟᱭ:</string>
     <!-- Text for the message of an auth dialog displayed by a web page.
     %1$s will be replaced by the hostname or a description of the protected area/site, %2$s will be replaced with the URL of the current page (displaying the dialog). -->
-    <string name="mozac_browser_engine_system_auth_message">%2$s ᱫᱚ ᱟᱢᱟᱜ ᱭᱩᱡᱟᱹᱨᱱᱮᱢ ᱟᱨ ᱯᱟᱥᱥᱣᱟᱹᱨᱰ ᱠᱷᱚᱡ ᱠᱟᱱᱟᱭ ᱾ ᱥᱟᱭᱴ ᱮ ᱢᱮᱸᱱᱮᱜᱼᱟᱭ: “%1$s”</string>
+    <string name="mozac_browser_engine_system_auth_message">%2$s ᱫᱚ ᱟᱢᱟᱜ ᱭᱩᱡᱟᱹᱨᱱᱮᱢ ᱟᱨ ᱯᱟᱥᱥᱣᱟᱹᱨᱰ ᱠᱷᱚᱡ ᱠᱟᱱᱟᱭ ᱾ ᱥᱟᱭᱴ ᱮ ᱢᱮᱱᱮᱜᱼᱟᱭ: “%1$s”</string>
     <!-- Text for the message of an auth dialog displayed by a web page. %1$s will be replaced with the URL of the current page (displaying the dialog). -->
     <string name="mozac_browser_engine_system_auth_no_realm_message">%1$s ᱫᱚ ᱟᱢᱟᱜ ᱭᱩᱡᱟᱹᱨᱱᱮᱢ ᱟᱨ ᱯᱟᱥᱣᱟᱹᱨᱰ ᱠᱷᱚᱡ ᱠᱟᱱᱟᱭ ᱾</string>
 </resources>

--- a/components/browser/errorpages/src/main/res/values-ast/strings.xml
+++ b/components/browser/errorpages/src/main/res/values-ast/strings.xml
@@ -171,7 +171,7 @@
     <!-- This string contains markup. The URL should not be localized. -->
     <string name="mozac_browser_errorpages_malformed_uri_message_alternative"><![CDATA[<ul>
         <li>Les direiciones web suelen escribise asina <strong>https://www.softastur.org/</strong></li>
-        <li>Asegúrate de que tas usando barres inclinaes a la drecha (ye dicir, <strong>/</strong>).</li>
+        <li>Asegúrate de que tas usando barres inclinaes a la derecha (ye dicir, <strong>/</strong>).</li>
       </ul>]]></string>
 
     <!-- The document title and heading of an error page. -->

--- a/components/browser/errorpages/src/main/res/values-ast/strings.xml
+++ b/components/browser/errorpages/src/main/res/values-ast/strings.xml
@@ -1,14 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <!-- The default document title of an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_page_title">Hebo un problema al cargar la páxina</string>
-
     <!-- The button that appears at the bottom of an error page. -->
     <string name="mozac_browser_errorpages_page_refresh">Retentar</string>
-
-    <!-- The button that appears at the bottom of an error page. -->
-    <string name="mozac_browser_errorpages_page_go_back">Dir p\'atrás</string>
 
     <!-- The document title and heading of an error page shown when a website cannot be loaded for an unknown reason. -->
     <string name="mozac_browser_errorpages_generic_title">Nun pue completase la solicitú</string>
@@ -31,7 +25,7 @@
     <!-- The error message shown when a website sends has an invalid or expired SSL certificate. -->
     <string name="mozac_browser_errorpages_security_bad_cert_message"><![CDATA[<ul>
         <li>Esto podría ser un problema cola configuración del sirvidor o que daquién tea tentando de suplantate nel sirvidor.</li>
-        <li>Si nel pasáu te coneutesti con ésitu al sirvidor, el fallu quiciabes seya temporal polo que refresca la páxina dempués.</li>
+        <li>Si nel pasáu te conectesti con ésitu al sirvidor, el fallu quiciabes seya temporal polo que refresca la páxina dempués.</li>
       </ul>]]></string>
 
     <!-- The text shown inside the advanced button used to expand the advanced options. It's only shown when a website has an invalid SSL certificate. -->
@@ -49,7 +43,7 @@
     <string name="mozac_browser_errorpages_net_interrupt_title">Interrumpióse la conexón</string>
 
     <!-- The error message shown when the user's network connection is interrupted while connecting to a website. -->
-    <string name="mozac_browser_errorpages_net_interrupt_message"><![CDATA[<p>El restolador coneutóse con ésitu mas la conexón interrumpióse mentanto se tresfería información. Volvi tentalo, por favor.</p>
+    <string name="mozac_browser_errorpages_net_interrupt_message"><![CDATA[<p>El restolador conectóse con ésitu mas la conexón interrumpióse mentanto se tresfería información. Volvi tentalo, por favor.</p>
       <ul>
         <li>Seique\'l sitiu ta temporalmente non disponible o perocupáu. Volvi tentalo nun momentu.</li>
         <li>Si nun yes a cargar nenguna páxina, comprueba la conexón Wi-Fi o móvil del preséu.</li>
@@ -68,7 +62,7 @@
       </ul>]]></string>
 
     <!-- The document title and heading of the error page shown when a website could not be reached. -->
-    <string name="mozac_browser_errorpages_connection_failure_title">Nun pue coneutase</string>
+    <string name="mozac_browser_errorpages_connection_failure_title">Nun pue conectase</string>
 
     <!-- The error message shown when a website could not be reached. -->
     <string name="mozac_browser_errorpages_connection_failure_message"><![CDATA[<ul>
@@ -92,12 +86,12 @@
       </ul>]]></string>
 
     <!-- The document title and heading of the error page shown when a website cannot be loaded because the browser is in offline mode. -->
-    <string name="mozac_browser_errorpages_offline_title">Mou desconeutáu</string>
+    <string name="mozac_browser_errorpages_offline_title">Mou desconectáu</string>
     <!-- The error message shown when a website cannot be loaded because the browser is in offline mode. -->
-    <string name="mozac_browser_errorpages_offline_message"><![CDATA[<p>El restolador ta operando nel mou desconeutáu y nun pue coneutase col elementu solicitáu.</p>
+    <string name="mozac_browser_errorpages_offline_message"><![CDATA[<p>El restolador ta operando nel mou desconectáu y nun pue conectase col elementu solicitáu.</p>
       <ul>
-        <li>¿El preséu ta coneutáu a una rede activa?</li>
-        <li>Primi «Retentar» pa cambiar al mou coneutáu y recargar la páxina.</li>
+        <li>¿El preséu ta conectáu a una rede activa?</li>
+        <li>Primi «Retentar» pa cambiar al mou conectáu y recargar la páxina.</li>
       </ul>]]></string>
 
     <!-- The document title and heading of the error page shown when the browser prevents loading a website on a restricted port. -->
@@ -148,10 +142,10 @@
       </ul>]]></string>
 
     <!-- The document title and heading of an error page. -->
-    <string name="mozac_browser_errorpages_unknown_host_title">Nun s\'alcontró la direición</string>
+    <string name="mozac_browser_errorpages_unknown_host_title">Nun s\'atopó la direición</string>
 
     <!-- In the example, the two URLs in markup do not need to be translated. -->
-    <string name="mozac_browser_errorpages_unknown_host_message"><![CDATA[<p>El restolador nun pudo alcontrar el sirvidor agospiador de la direición apurrida.</p>
+    <string name="mozac_browser_errorpages_unknown_host_message"><![CDATA[<p>El restolador nun pudo atopar el sirvidor agospiador de la direición apurrida.</p>
       <ul>
         <li>Comprueba que nun s\'introduxeren fallos al teclexar la direición:
           <strong>ww</strong>.softastur.org en cuentes de
@@ -183,14 +177,14 @@
     <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_unknown_protocol_title">Desconozse\'l protocolu</string>
 
-    <string name="mozac_browser_errorpages_unknown_protocol_message"><![CDATA[<p>La direición especifica un protocolu (por exemplu, <q>wxyz://</q>) que\'l restolador nun reconoz, polo que nun se pue coneutar afayadizamente col sitiu.</p>
+    <string name="mozac_browser_errorpages_unknown_protocol_message"><![CDATA[<p>La direición especifica un protocolu (por exemplu, <q>wxyz://</q>) que\'l restolador nun reconoz, polo que nun se pue conectar afayadizamente col sitiu.</p>
       <ul>
         <li>¿Tas tentando d\'acceder a servicios multimedia o que nun son de testu? Comprueba\'l sitiu pa ver más requirimientos.</li>
         <li>Dalgunos protocolos riquen software o plugins de terceros enantes de que\'l restolador puea reconocelos.</li>
       </ul>]]></string>
 
     <!-- The document title and heading of an error page. -->
-    <string name="mozac_browser_errorpages_file_not_found_title">Nun s\'alcontró\'l ficheru</string>
+    <string name="mozac_browser_errorpages_file_not_found_title">Nun s\'atopó\'l ficheru</string>
 
     <string name="mozac_browser_errorpages_file_not_found_message"><![CDATA[<ul>
         <li>¿Pue ser que l\'elementu se renomare, desaniciare o moviere?</li>
@@ -216,12 +210,12 @@
       </ul>]]></string>
 
     <!-- The document title and heading of an error page. -->
-    <string name="mozac_browser_errorpages_unknown_proxy_host_title">Nun s\'alcontró\'l sirvidor del proxy</string>
+    <string name="mozac_browser_errorpages_unknown_proxy_host_title">Nun s\'atopó\'l sirvidor del proxy</string>
 
-    <string name="mozac_browser_errorpages_unknown_proxy_host_message"><![CDATA[<p>El restolador ta configuráu pa usar un sirvidor proxy mas esti últimu nun pudo alcontrase.</p>
+    <string name="mozac_browser_errorpages_unknown_proxy_host_message"><![CDATA[<p>El restolador ta configuráu pa usar un sirvidor proxy mas esti últimu nun pudo atopase.</p>
       <ul>
         <li>¿La configuración del proxy del restolador ye correuta? Comprueba los axustes y volvi tentalo.</li>
-        <li>¿El preséu ta coneutáu a una rede activa?</li>
+        <li>¿El preséu ta conectáu a una rede activa?</li>
         <li>¿Entá tienes problemes? Consulta al to alministrador de redes o fornidor d\'internet pa más asistencia.</li>
       </ul>]]></string>
 

--- a/components/browser/errorpages/src/main/res/values-bn/strings.xml
+++ b/components/browser/errorpages/src/main/res/values-bn/strings.xml
@@ -1,14 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <!-- The default document title of an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_page_title">পাতা লোড হতে সমস্যা হচ্ছে</string>
-
     <!-- The button that appears at the bottom of an error page. -->
     <string name="mozac_browser_errorpages_page_refresh">আবার চেষ্টা করুন</string>
-
-    <!-- The button that appears at the bottom of an error page. -->
-    <string name="mozac_browser_errorpages_page_go_back">ফিরে যান</string>
 
     <!-- The document title and heading of an error page shown when a website cannot be loaded for an unknown reason. -->
     <string name="mozac_browser_errorpages_generic_title">অনুরোধ পূরণ করা সম্ভব নয়</string>
@@ -28,6 +22,14 @@
     <!-- The document title and heading of the error page shown when a website sends has an invalid or expired SSL certificate. -->
     <string name="mozac_browser_errorpages_security_bad_cert_title">নিরাপদ সংযোগ স্থাপনে ব্যর্থ হয়েছে</string>
 
+    <!-- The error message shown when a website sends has an invalid or expired SSL certificate. -->
+    <string name="mozac_browser_errorpages_security_bad_cert_message"><![CDATA[
+      <ul>
+        <li>সম্ভবত সার্ভারের কনফিগারেশনে সমস্যা হয়েছে অথবা কোনো ব্যক্তি এই সার্ভারের পরিচয় জাল করার চেষ্টা করছে।</li>
+        <li>আপনি যদি আগে এই সার্ভারের সাথে সফলভাবে সংযোগ স্থাপন করে থাকেন, তাহলে সম্ভবত কোনো অস্থায়ী কারণে এই সমস্যা দেখা দিয়েছে এবং কিছুক্ষণ পর আবার চেষ্টা করুন।</li>
+      </ul>
+    ]]></string>
+
     <!-- The text shown inside the advanced button used to expand the advanced options. It's only shown when a website has an invalid SSL certificate. -->
     <string name="mozac_browser_errorpages_security_bad_cert_advanced">উন্নতপর্যায়ের...</string>
     <!-- The text shown inside the advanced options button used to go back. It's only shown if the user has expanded the advanced options. -->
@@ -46,6 +48,11 @@
 
     <!-- The document title and heading of the error page shown when a website responds in an unexpected way and the browser cannot continue. -->
     <string name="mozac_browser_errorpages_unknown_socket_type_title">সার্ভার থেকে অপ্রত্যাশিত প্রতিক্রিয়া দেখাচ্ছে</string>
+
+    <!-- The error message shown when a website responds in an unexpected way and the browser cannot continue. -->
+    <string name="mozac_browser_errorpages_unknown_socket_type_message"><![CDATA[
+      <p>সাইটটি একটি নেটওয়ার্ক অনুরোধের অপ্রত্যাশিত উত্তর দিয়েছে যার ফলে ব্রাউজার এটি চালিয়ে যেতে পারছে না।</p>
+    ]]></string>
 
     <!-- The document title and heading of the error page shown when the browser gets stuck in an infinite loop when loading a website. -->
     <string name="mozac_browser_errorpages_redirect_loop_title">পাতাটি সঠিকভাবে পুনঃনির্দেশনা দিচ্ছে না</string>

--- a/components/browser/errorpages/src/main/res/values-br/strings.xml
+++ b/components/browser/errorpages/src/main/res/values-br/strings.xml
@@ -10,17 +10,21 @@
     <string name="mozac_browser_errorpages_page_go_back">Distreiñ</string>
 
     <!-- The document title and heading of an error page shown when a website cannot be loaded for an unknown reason. -->
-    <string name="mozac_browser_errorpages_generic_title">Nʼhaller ket echuiñ an azgoulenn-mañ.</string>
+    <string name="mozac_browser_errorpages_generic_title">Nʼhaller ket echuiñ an azgoulenn-mañ</string>
     <!-- The error message shown when a website cannot be loaded for an unknown reason. -->
-    <string name="mozac_browser_errorpages_generic_message"><![CDATA[<p>Titouroù ouzhpenn diwar-benn ar gudenn-mañ pe ar fazi-mañ nʼint ket hegerz evit poent.</p>]]></string>
+    <string name="mozac_browser_errorpages_generic_message"><![CDATA[
+      <p>Titouroù ouzhpenn diwar-benn ar gudenn-mañ pe ar fazi-mañ nʼint ket hegerz evit poent.</p>
+    ]]></string>
 
     <!-- The document title and heading of the error page shown when a website sends back unusual and incorrect credentials for an SSL certificate. -->
     <string name="mozac_browser_errorpages_security_ssl_title">Cʼhwitadenn war ar cʼhennaskañ diarvar</string>
     <!-- The error message shown when a website sends back unusual and incorrect credentials for an SSL certificate. -->
-    <string name="mozac_browser_errorpages_security_ssl_message"><![CDATA[<ul>
-         <li>Nʼhall ket bezañ diskouezet ar bajennad emaocʼh o klask gwelout rak nʼhall ket bezañ gwiriet dilested ar roadennoù bet degemeret.</li>
-         <li>Kit e darempred gant percʼhenned al lecʼhienn evit kas keloù dezho a-zivout ar gudenn-mañ.</li>
-       </ul>]]></string>
+    <string name="mozac_browser_errorpages_security_ssl_message"><![CDATA[
+      <ul>
+        <li>Nʼhall ket bezañ diskouezet ar bajennad emaocʼh o klask gwelout rak nʼhall ket bezañ gwiriet dilested ar roadennoù bet degemeret.</li>
+        <li>Kit e darempred gant percʼhenned al lecʼhienn evit kas keloù dezho a-zivout ar gudenn-mañ.</li>
+       </ul>
+    ]]></string>
 
     <!-- The document title and heading of the error page shown when a website sends has an invalid or expired SSL certificate. -->
     <string name="mozac_browser_errorpages_security_bad_cert_title">Cʼhwitadenn war ar cʼhennaskañ diarvar</string>
@@ -55,7 +59,7 @@
     <!-- The error message shown when a website took long to load. -->
     <string name="mozac_browser_errorpages_net_timeout_message"><![CDATA[<p>Nʼhe deus ket respontet al lecʼhienn azgoulennet dʼan azgoulenn kennaskañ ha ne cʼhortoz ket mui ar merdeer evit ar respont.</p>
  <ul>
- <li>Marteze eo soulgarget pe sacʼhet an dafariad ? Klaskit diwezhatocʼh.</li> <li>Nʼocʼh ket evit gweladenniñ lecʼhiennoù all ? Gwiriañ ar cʼhennaskañ ouzh ar rouedad.</li>
+ <li>Marteze eo soulgarget pe sacʼhet an dafariad? Klaskit diwezhatocʼh.</li> <li>Nʼocʼh ket evit gweladenniñ lecʼhiennoù all? Gwiriañ ar cʼhennaskañ ouzh ar rouedad.</li>
 <li>Ha gwarezet eo hocʼh urzhiataer gant un tanvoger pe ur proksi? Arventennoù fall a cʼhallfe gwallemellout gant ho merdeiñ.</li><li>Trubuilhoù cʼhoazh? Kit e darempred gant ardoer ho reizhiad pe ho pourchaser internet evit kaout skoazell.</li></ul>]]></string>
 
     <!-- The document title and heading of the error page shown when a website could not be reached. -->
@@ -79,7 +83,7 @@
     <!-- The error message shown when the browser gets stuck in an infinite loop when loading a website. -->
     <string name="mozac_browser_errorpages_redirect_loop_message"><![CDATA[<p>Ne glask ket mui ar merdeer kavout an ergorenn azgoulennet. Emañ al lecʼhienn ocʼh adheñchañ an azgoulenn ken na vo biken echuet.</p>
  <ul>
- <li>Ha diweredekaet pe cʼhennet hocʼh eus an toupinoù azgoulennet gant al lecʼhienn-mañ ?</li>
+ <li>Ha diweredekaet pe cʼhennet hocʼh eus an toupinoù azgoulennet gant al lecʼhienn-mañ?</li>
  <li>Ma nʼeo ket diskoulmet ar gudenn ur wech bet degemeret an toupinoù ez eus ur gudenn gant kefluniadur an dafariad ha nʼeus ket gant hocʼh urzhiataer.</li>
  </ul>]]></string>
 
@@ -87,8 +91,8 @@
     <string name="mozac_browser_errorpages_offline_title">Mod ezlinenn</string>
 
     <!-- The error message shown when a website cannot be loaded because the browser is in offline mode. -->
-    <string name="mozac_browser_errorpages_offline_message"><![CDATA[<p>Emañ ar merdeer o labourat gant e vod ezlinenn ha n&apos;hall ket kennaskañ ouzh an ergorenn bet goulennet.</p>
- <ul><li>Ha kennasket eo an trevnad ouzh ur rouedad oberiant ?</li>
+    <string name="mozac_browser_errorpages_offline_message"><![CDATA[<p>Emañ ar merdeer o labourat gant e vod ezlinenn ha nʼhall ket kennaskañ ouzh an ergorenn bet goulennet.</p>
+ <ul><li>Ha kennasket eo an trevnad ouzh ur rouedad oberiant?</li>
  <li>Pouezit war "Klask en-dro" evit trecʼhaoliñ etrezek ar mod enlinenn hag adkargañ ar bajennad.</li>
  </ul>]]></string>
 
@@ -159,12 +163,12 @@
     <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_unknown_protocol_title">Komenad dianav</string>
 
-    <string name="mozac_browser_errorpages_unknown_protocol_message"><![CDATA[<p>Ur cʼhomenad (d.l.e. <q>wxyz://</q>) nad eo ket anavezet gant ar merdeer zo erspizet gant ar chomlecʼh, neuze nʼeo ket ar merdeer evit kennaskañ mat ouzh al lecʼhienn.</p><ul><li>Hag emaocʼh o klask tizhout liesvedia pe gwazerezhioù andestenn ? Gwiriit war al lecʼhienn mar bez ezhomm paramantadurioù all.</li><li>Goulennet e vez meziantoù ouzhpenn pe enlugelladoù gant komenadoù zo a-raok ma vo gouest ar merdeer dʼo anavezout.</li></ul>]]></string>
+    <string name="mozac_browser_errorpages_unknown_protocol_message"><![CDATA[<p>Ur cʼhomenad (d.l.e. <q>wxyz://</q>) nad eo ket anavezet gant ar merdeer zo erspizet gant ar chomlecʼh, neuze nʼeo ket ar merdeer evit kennaskañ mat ouzh al lecʼhienn.</p><ul><li>Hag emaocʼh o klask tizhout liesvedia pe gwazerezhioù andestenn? Gwiriit war al lecʼhienn mar bez ezhomm paramantadurioù all.</li><li>Goulennet e vez meziantoù ouzhpenn pe enlugelladoù gant komenadoù zo a-raok ma vo gouest ar merdeer dʼo anavezout.</li></ul>]]></string>
 
     <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_file_not_found_title">Restr dianav</string>
 
-    <string name="mozac_browser_errorpages_file_not_found_message"><![CDATA[<ul><li>Gwiriañ ha dilecʼhiet eo bet, adanvet pe dilamet an ergorenn.</li><li>Gwiriañ anv ar chomlecʼh rak marteze ez eus fazioù pennlizherennoù pe fazioù skrivañ all.</li><li>Hag an aotreoù hocʼh eus evit haeziñ an ergorenn goulennet ?</li></ul>]]></string>
+    <string name="mozac_browser_errorpages_file_not_found_message"><![CDATA[<ul><li>Gwiriañ ha dilecʼhiet eo bet, adanvet pe dilamet an ergorenn.</li><li>Gwiriañ anv ar chomlecʼh rak marteze ez eus fazioù pennlizherennoù pe fazioù skrivañ all.</li><li>Hag an aotreoù hocʼh eus evit haeziñ an ergorenn goulennet?</li></ul>]]></string>
 
     <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_file_access_denied_title">Nacʼhet eo bet haeziñ dʼar restr</string>
@@ -174,12 +178,12 @@
     <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_proxy_connection_refused_title">Dafariad ar proksi en deus nacʼhet ar cʼhennaskañ</string>
 
-    <string name="mozac_browser_errorpages_proxy_connection_refused_message"><![CDATA[<p>Kefluniet eo ar merdeer evit ober gant un dafariad proksi, met nacʼhet eo bet ar cʼhennaskañ gant ar proksi.</p><ul><li>Ha kefluniet mat eo proksi ar merdeer ? Gwiriit an arventennoù ha klaskit en-dro.</li><li>Ha gwazerezh ar proksi a aotre kennaskadurioù diouzh ar rouedad-mañ ?</li><li>Trubuilhoù cʼhoazh ? Kit e darempred gant ardoer ar rouedad pe ho pourchaser internet a-benn kaout skoazell.</li></ul>]]></string>
+    <string name="mozac_browser_errorpages_proxy_connection_refused_message"><![CDATA[<p>Kefluniet eo ar merdeer evit ober gant un dafariad proksi, met nacʼhet eo bet ar cʼhennaskañ gant ar proksi.</p><ul><li>Ha kefluniet mat eo proksi ar merdeer? Gwiriit an arventennoù ha klaskit en-dro.</li><li>Ha gwazerezh ar proksi a aotre kennaskadurioù diouzh ar rouedad-mañ?</li><li>Trubuilhoù cʼhoazh? Kit e darempred gant ardoer ar rouedad pe ho pourchaser internet a-benn kaout skoazell.</li></ul>]]></string>
 
     <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_unknown_proxy_host_title">Nʼeo ket bet kavet an dafariad proksi</string>
 
-    <string name="mozac_browser_errorpages_unknown_proxy_host_message"><![CDATA[<p>Kefluniet eo ar merdeer evit ober gant un dafariad proksi, met nʼeo ket bet kavet ar proksi.</p><ul><li>Ha kefluniet mat eo proksi ar merdeer ? Gwiriit an arventennoù ha klaskit en-dro.</li><li>Ha kennasket eo an trevnad ouzh ur rouedad oberiant?</li><li>Trubuilhoù cʼhoazh ? Kit e darempred gant ardoer ar rouedad pe ho pourchaser internet a-benn kaout skoazell.</li></ul>]]></string>
+    <string name="mozac_browser_errorpages_unknown_proxy_host_message"><![CDATA[<p>Kefluniet eo ar merdeer evit ober gant un dafariad proksi, met nʼeo ket bet kavet ar proksi.</p><ul><li>Ha kefluniet mat eo proksi ar merdeer? Gwiriit an arventennoù ha klaskit en-dro.</li><li>Ha kennasket eo an trevnad ouzh ur rouedad oberiant?</li><li>Trubuilhoù cʼhoazh? Kit e darempred gant ardoer ar rouedad pe ho pourchaser internet a-benn kaout skoazell.</li></ul>]]></string>
 
     <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_safe_browsing_malware_uri_title">Kudenn lecʼhienn dagus</string>

--- a/components/browser/errorpages/src/main/res/values-es/strings.xml
+++ b/components/browser/errorpages/src/main/res/values-es/strings.xml
@@ -1,16 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- The default document title of an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_page_title">Problema al cargar la página</string>
 
     <!-- The button that appears at the bottom of an error page. -->
     <string name="mozac_browser_errorpages_page_refresh">Reintentar</string>
 
-    <!-- The button that appears at the bottom of an error page. -->
-    <string name="mozac_browser_errorpages_page_go_back">Regresar</string>
-
     <!-- The document title and heading of an error page shown when a website cannot be loaded for an unknown reason. -->
-    <string name="mozac_browser_errorpages_generic_title">No se puede completar solicitud</string>
+    <string name="mozac_browser_errorpages_generic_title">No se pudo completar la solicitud</string>
     <!-- The error message shown when a website cannot be loaded for an unknown reason. -->
     <string name="mozac_browser_errorpages_generic_message"><![CDATA[
 	<p>Actualmente, no hay información adicional disponible para este problema o error.</p>
@@ -51,30 +46,27 @@
 
     <!-- The document title and heading of the error page shown when the user's network connection is interrupted while connecting to a website. -->
     <string name="mozac_browser_errorpages_net_interrupt_title">La conexión ha sido interrumpida</string>
+
     <!-- The error message shown when the user's network connection is interrupted while connecting to a website. -->
-    <string name="mozac_browser_errorpages_net_interrupt_message"><![CDATA[
-	<p>El navegador se conectó con éxito, pero se interrumpió la conexión mientras se transfería la información. Vuelva a intentarlo.</p>
+    <string name="mozac_browser_errorpages_net_interrupt_message"><![CDATA[<p>El navegador se conectó exitosamente, pero se interrumpió la conexión mientras se transfería la información. Vuelva a intentarlo.</p>
 	<ul>
 		<li>El sitio podría no estar disponible temporalmente o estar demasiado ocupado. Vuelva a intentarlo en unos minutos.</li>
 		<li>Si no puede cargar ninguna página, revise la conexión wifi o de datos de su dispositivo móvil.</li>
-	</ul>
-	]]></string>
+	</ul>]]></string>
 
     <!-- The document title and heading of the error page shown when a website takes too long to load. -->
     <string name="mozac_browser_errorpages_net_timeout_title">La conexión ha caducado</string>
     <!-- The error message shown when a website took long to load. -->
-    <string name="mozac_browser_errorpages_net_timeout_message"><![CDATA[
-	<p>El sitio solicitado no respondió a una petición de conexión y el navegador ha dejado de esperar una respuesta.</p>
+    <string name="mozac_browser_errorpages_net_timeout_message"><![CDATA[<p>El sitio solicitado no respondió a una petición de conexión y el navegador ha dejado de esperar una respuesta.</p>
 	<ul>
 		<li>¿Podría estar experimentando el servidor una alta demanda o un corte temporal? Vuelva a intentarlo más tarde.</li>
 		<li>¿No puede navegar por otros sitios? Compruebe la conexión de red del equipo.</li>
-		<li>¿Su red o equipo está protegido por un firewall o un proxy? Una configuración incorrecta puede interferir con la navegación web.</li>
-		<li>¿Todavía con problemas? Consulte con su administrador de red o proveedor de Internet para obtener asistencia técnica.</li>
-	</ul>
-	]]></string>
+		<li>¿Su red o equipo está protegido por un firewall o un proxy? Una configuración incorrecta podría interferir con la navegación web.</li>
+		<li>¿Aun con problemas? Consulte con su administrador de red o proveedor de Internet para obtener asistencia técnica.</li>
+	</ul>]]></string>
 
     <!-- The document title and heading of the error page shown when a website could not be reached. -->
-    <string name="mozac_browser_errorpages_connection_failure_title">No se puede conectar</string>
+    <string name="mozac_browser_errorpages_connection_failure_title">Imposible conectar</string>
     <!-- The error message shown when a website could not be reached. -->
     <string name="mozac_browser_errorpages_connection_failure_message"><![CDATA[
 	<ul>
@@ -84,36 +76,32 @@
 	]]></string>
 
     <!-- The document title and heading of the error page shown when a website responds in an unexpected way and the browser cannot continue. -->
-    <string name="mozac_browser_errorpages_unknown_socket_type_title">Respuesta inesperada del servidor</string>
+    <string name="mozac_browser_errorpages_unknown_socket_type_title">Respuesta inesperada del servidor, y el navegador no puede continuar</string>
     <!-- The error message shown when a website responds in an unexpected way and the browser cannot continue. -->
     <string name="mozac_browser_errorpages_unknown_socket_type_message"><![CDATA[
 	<p>El sitio respondió a la solicitud de red de una forma inesperada y el navegador no puede continuar.</p>
 	]]></string>
 
     <!-- The document title and heading of the error page shown when the browser gets stuck in an infinite loop when loading a website. -->
-    <string name="mozac_browser_errorpages_redirect_loop_title">La página no está redirigiendo adecuadamente</string>
+    <string name="mozac_browser_errorpages_redirect_loop_title">La página no está redirigiendo de manera adecuada</string>
     <!-- The error message shown when the browser gets stuck in an infinite loop when loading a website. -->
-    <string name="mozac_browser_errorpages_redirect_loop_message"><![CDATA[
-	<p>El navegador se ha detenido intentando recuperar el elemento solicitado. El sitio está redirigiendo la solicitud de una forma que nunca se va a completar.</p>
+    <string name="mozac_browser_errorpages_redirect_loop_message"><![CDATA[<p>El navegador se ha detenido tratando recuperar el elemento solicitado. El sitio está redirigiendo la solicitud de una forma que nunca se va a completar.</p>
 	<ul>
 		<li>¿Tiene desactivadas o bloqueadas las cookies requeridas por este sitio?</li>
 		<li>Si aceptar las cookies del sitio no resuelve el problema, es probable que sea un problema de configuración del servidor y no de su equipo.</li>
-	</ul>
-	]]></string>
+	</ul>]]></string>
 
     <!-- The document title and heading of the error page shown when a website cannot be loaded because the browser is in offline mode. -->
-    <string name="mozac_browser_errorpages_offline_title">Modo sin conexión</string>
+    <string name="mozac_browser_errorpages_offline_title">Modo desconectado</string>
     <!-- The error message shown when a website cannot be loaded because the browser is in offline mode. -->
-    <string name="mozac_browser_errorpages_offline_message"><![CDATA[
-	<p>El navegador está operando en modo sin conexión y no puede conectarse con el elemento solicitado.</p>
+    <string name="mozac_browser_errorpages_offline_message"><![CDATA[<p>El navegador está operando en modo sin conexión y no pudo conectarse con el elemento solicitado.</p>
 	<ul>
 		<li>¿Está conectado el equipo a una red activa?</li>
 		<li>Pulse "Volver a intentarlo" para pasar al modo con conexión y recargar la página.</li>
-	</ul>
-	]]></string>
+	</ul>]]></string>
 
     <!-- The document title and heading of the error page shown when the browser prevents loading a website on a restricted port. -->
-    <string name="mozac_browser_errorpages_port_blocked_title">Puerto restringido por razones de seguridad</string>
+    <string name="mozac_browser_errorpages_port_blocked_title">Puerto restringido, por razones de seguridad</string>
     <!-- The error message shown when the browser prevents loading a website on a restricted port. -->
     <string name="mozac_browser_errorpages_port_blocked_message"><![CDATA[
 	<p>La dirección solicitada especificaba un puerto (p. ej., <q>mozilla.org:80</q> para el puerto 80 de mozilla.org) que suele usarse para propósitos <em>distintos</em> a navegar por Internet. El navegador ha cancelado la solicitud para su protección y seguridad.</p>
@@ -222,7 +210,7 @@
 	]]></string>
 
     <!-- The document title and heading of an error page. -->
-    <string name="mozac_browser_errorpages_file_access_denied_title">El acceso al archivo ha sido denegado</string>
+    <string name="mozac_browser_errorpages_file_access_denied_title">El acceso al archivo ha sido denegado archivo</string>
     <string name="mozac_browser_errorpages_file_access_denied_message"><![CDATA[
 	<ul>
 		<li>Puede haberse eliminado o movido, o sus permisos de archivo pueden estar impidiendo el acceso.</li>

--- a/components/browser/errorpages/src/main/res/values-fa/strings.xml
+++ b/components/browser/errorpages/src/main/res/values-fa/strings.xml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- The default document title of an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_page_title">مشکل در بارگیری صفحه</string>
 
     <!-- The button that appears at the bottom of an error page. -->
     <string name="mozac_browser_errorpages_page_refresh">تلاش مجدد</string>
-
-    <!-- The button that appears at the bottom of an error page. -->
-    <string name="mozac_browser_errorpages_page_go_back">بازگشت</string>
 
     <!-- The document title and heading of an error page shown when a website cannot be loaded for an unknown reason. -->
     <string name="mozac_browser_errorpages_generic_title">درخواست کامل نیست</string>
@@ -110,10 +105,10 @@
     <!-- In the example, the two URLs in markup do not need to be translated. -->
     <string name="mozac_browser_errorpages_unknown_host_message"><![CDATA[<p> مرورگر نتوانست سرور میزبان را برای آدرس ارائه شده پیدا کند. </p>
       <ul>
-        <li> آدرس را برای خطاهای تایپ کردن از قبیل بررسی کنید
-          <strong> ww </strong> .example.com به جای آن
+        <li> آدرس را برای خطاهای تایپی از قبیل موارد مقابل بررسی کنید:
+          <strong> ww </strong> .example.com به جای
           <strong> www </strong> .example.com. </li>
-        <li> اگر قادر به بارگیری هیچ صفحه ای نیستید ، اطلاعات دستگاه یا اتصال Wi-Fi خود را بررسی کنید. </li>
+        <li> اگر قادر به بارگیری هیچ صفحه‌ای نیستید، اطلاعات دستگاه یا اتصال Wi-Fi خود را بررسی کنید. </li>
       </ul>]]></string>
 
     <!-- The document title and heading of an error page. -->

--- a/components/browser/errorpages/src/main/res/values-iw/strings.xml
+++ b/components/browser/errorpages/src/main/res/values-iw/strings.xml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- The default document title of an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_page_title">בעיה בטעינת הדף</string>
 
     <!-- The button that appears at the bottom of an error page. -->
     <string name="mozac_browser_errorpages_page_refresh">ניסיון חוזר</string>
-
-    <!-- The button that appears at the bottom of an error page. -->
-    <string name="mozac_browser_errorpages_page_go_back">חזרה</string>
 
     <!-- The document title and heading of an error page shown when a website cannot be loaded for an unknown reason. -->
     <string name="mozac_browser_errorpages_generic_title">לא ניתן להשלים את הבקשה</string>
@@ -169,7 +164,7 @@
     <string name="mozac_browser_errorpages_unknown_host_title">הכתובת לא נמצאה</string>
 
     <!-- In the example, the two URLs in markup do not need to be translated. -->
-    <string name="mozac_browser_errorpages_unknown_host_message"><![CDATA[<p>האתר לא הצליח למצוא את השרת המארח לכתובת שסופקה.</p>
+    <string name="mozac_browser_errorpages_unknown_host_message"><![CDATA[<p>הדפדפן לא הצליח למצוא את השרת המארח לכתובת שסופקה.</p>
       <ul>
         <li>יש לבדוק שהכתובת אינה מכילה שגיאות כגון
           <strong>ww</strong>.example.com במקום

--- a/components/browser/errorpages/src/main/res/values-sat/strings.xml
+++ b/components/browser/errorpages/src/main/res/values-sat/strings.xml
@@ -4,10 +4,10 @@
     <string name="mozac_browser_errorpages_page_title">ᱥᱟᱦᱴᱟ ᱞᱟᱫᱮ ᱰᱤᱜᱟᱹᱣ</string>
 
     <!-- The button that appears at the bottom of an error page. -->
-    <string name="mozac_browser_errorpages_page_refresh">ᱫᱚᱦᱲᱟᱹ ᱪᱮᱥᱴᱟᱭ ᱢᱮᱸ</string>
+    <string name="mozac_browser_errorpages_page_refresh">ᱫᱚᱦᱲᱟᱹ ᱪᱮᱥᱴᱟᱭ ᱢᱮ</string>
 
     <!-- The button that appears at the bottom of an error page. -->
-    <string name="mozac_browser_errorpages_page_go_back">ᱯᱟᱹᱪᱷᱞᱟᱹ ᱥᱮᱫᱽ ᱥᱮᱱᱚᱜ ᱢᱮᱸ</string>
+    <string name="mozac_browser_errorpages_page_go_back">ᱯᱟᱹᱪᱷᱞᱟᱹ ᱥᱮᱫᱽ ᱥᱮᱱᱚᱜ ᱢᱮ</string>
 
     <!-- The document title and heading of an error page shown when a website cannot be loaded for an unknown reason. -->
     <string name="mozac_browser_errorpages_generic_title">ᱱᱮᱦᱚᱨ ᱵᱟᱝ ᱯᱩᱨᱟᱹᱣ ᱞᱮᱱᱟ</string>
@@ -23,7 +23,7 @@
     <string name="mozac_browser_errorpages_security_ssl_message"><![CDATA[
       ¶•<ul>¶
        • <li>ᱚᱠᱟ ᱥᱟᱦᱴᱟ ᱧᱮᱞ ᱞᱟᱹᱜᱤᱫ ᱠᱷᱚᱡᱚᱜ ᱠᱟᱱ ᱛᱟᱦᱮᱸᱡ ᱚᱱᱟ ᱫᱚ ᱰᱟᱴᱟ ᱨᱮᱭᱟᱜ ᱚᱛᱷᱮᱱᱴᱤᱥᱤᱴᱭ ᱫᱚ ᱵᱟᱝ ᱯᱩᱥᱴᱟᱹᱣ ᱫᱟᱲᱮᱞᱟᱱᱟ ᱾</li>
-        <li>ᱫᱚᱭᱟᱠᱟᱛᱮ ᱣᱮᱵᱥᱟᱭᱤᱴ ᱢᱟᱞᱤᱠ ᱡᱩᱜᱟᱡᱩᱜ ᱮᱢ ᱟᱨ ᱦᱩᱲᱟᱹᱜ ᱵᱟᱵᱚᱫᱽ ᱠᱷᱚᱵᱚᱨ ᱮᱢ ᱢᱮᱸ ᱾</li>¶•      
+        <li>ᱫᱚᱭᱟᱠᱟᱛᱮ ᱣᱮᱵᱥᱟᱭᱤᱴ ᱢᱟᱞᱤᱠ ᱡᱩᱜᱟᱡᱩᱜ ᱮᱢ ᱟᱨ ᱦᱩᱲᱟᱹᱜ ᱵᱟᱵᱚᱫᱽ ᱠᱷᱚᱵᱚᱨ ᱮᱢ ᱢᱮ ᱾</li>¶•      
       </ul>•
     ]]></string>
 
@@ -32,7 +32,7 @@
     <!-- The error message shown when a website sends has an invalid or expired SSL certificate. -->
     <string name="mozac_browser_errorpages_security_bad_cert_message"><![CDATA[¶
  · <ul>¶
- · <li>ᱱᱚᱶᱟ ᱥᱟᱨᱵᱷᱟᱨ ᱠᱚᱱᱯᱷᱤᱜᱽᱨᱮᱥᱚᱱ ᱥᱟᱶ ᱮᱴᱠᱮᱴᱚᱬᱮ ᱦᱩᱭ ᱫᱟᱲᱮᱭᱟᱜ-ᱟ, ᱥᱮ ᱱᱚᱶᱟ ᱡᱟᱦᱟᱸᱭ ᱦᱚᱛᱮᱛᱮ ᱤᱢᱯᱚᱨᱥᱳᱱᱮᱴ ᱨᱤᱠᱟᱹ ᱦᱩᱭ ᱫᱟᱲᱮᱭᱟᱜ-ᱟ ᱾ </li>¶•<li> ᱡᱩᱫᱤ ᱟᱢ ᱞᱟᱦᱟ ᱛᱮ ᱥᱟᱨᱵᱷᱟᱨ ᱥᱟᱶ ᱡᱚᱲᱟᱣ ᱢᱮᱸᱱᱟᱜ ᱢᱮᱸᱭᱟ, ᱤᱨᱳᱨ ᱛᱟᱦᱮᱸ ᱫᱟᱲᱮᱭᱟᱜ-ᱟ, ᱟᱨ ᱛᱟᱭᱚᱢ ᱛᱮᱢ ᱨᱤᱠᱟᱹ ᱫᱟᱲᱮᱭᱟᱜ-ᱟ ᱾</li>¶•</ul>¶•
+ · <li>ᱱᱚᱶᱟ ᱥᱟᱨᱵᱷᱟᱨ ᱠᱚᱱᱯᱷᱤᱜᱽᱨᱮᱥᱚᱱ ᱥᱟᱶ ᱮᱴᱠᱮᱴᱚᱬᱮ ᱦᱩᱭ ᱫᱟᱲᱮᱭᱟᱜ-ᱟ, ᱥᱮ ᱱᱚᱶᱟ ᱡᱟᱦᱟᱸᱭ ᱦᱚᱛᱮᱛᱮ ᱤᱢᱯᱚᱨᱥᱳᱱᱮᱴ ᱨᱤᱠᱟᱹ ᱦᱩᱭ ᱫᱟᱲᱮᱭᱟᱜ-ᱟ ᱾ </li>¶•<li> ᱡᱩᱫᱤ ᱟᱢ ᱞᱟᱦᱟ ᱛᱮ ᱥᱟᱨᱵᱷᱟᱨ ᱥᱟᱶ ᱡᱚᱲᱟᱣ ᱢᱮᱱᱟᱜ ᱢᱮᱭᱟ, ᱤᱨᱳᱨ ᱛᱟᱦᱮᱸ ᱫᱟᱲᱮᱭᱟᱜ-ᱟ, ᱟᱨ ᱛᱟᱭᱚᱢ ᱛᱮᱢ ᱨᱤᱠᱟᱹ ᱫᱟᱲᱮᱭᱟᱜ-ᱟ ᱾</li>¶•</ul>¶•
 ]]></string>
 
     <!-- The text shown inside the advanced button used to expand the advanced options. It's only shown when a website has an invalid SSL certificate. -->
@@ -40,15 +40,15 @@
     <!-- The advanced certificate information shown when a website sends has an invalid SSL certificate. The %1$s will be replaced by the app name and %2$s will be replaced by website URL. It's only shown when a website has an invalid SSL certificate. -->
     <string name="mozac_browser_errorpages_security_bad_cert_techInfo"><![CDATA[¶•<label> ᱤᱢᱯᱚᱨᱥᱳᱱᱮᱴ ᱥᱟᱭᱤᱴ ᱡᱟᱦᱟᱸᱭ ᱠᱚ ᱨᱤᱠᱟᱹ ᱫᱟᱲᱮᱭᱟᱜ-ᱟ ᱟᱨ ᱟᱢ ᱫᱚ ᱪᱟᱞᱟᱣ ᱛᱮ ᱦᱩᱭ ᱟᱢᱟ ᱾ </label>¶•<br><br>¶•<label>ᱣᱮᱵᱽᱥᱟᱭᱤᱴ ᱟᱡᱟᱜ ᱩᱯᱨᱩᱢ ᱛᱮ ᱥᱚᱫᱚᱨ ᱫᱟᱲᱮᱭᱟᱜ-ᱟ ᱾ %1$s ᱯᱟᱹᱛᱭᱟᱹᱣ ᱵᱟᱹᱱᱩᱜ <b>%2$s</br>ᱪᱮᱫᱟᱜ ᱥᱮ ᱱᱚᱶᱟ ᱨᱮᱱᱟᱜ ᱥᱟᱨᱴᱤᱯᱷᱤᱠᱮᱴ ᱪᱟᱞᱩ ᱵᱟᱰᱟᱭ ᱵᱟᱹᱱᱩᱜ-ᱟ, ᱥᱟᱨᱴᱤᱯᱷᱤᱠᱮᱴ ᱥᱮᱞᱯᱷ ᱥᱟᱭᱤᱱ ᱜᱮᱭᱟ, ᱥᱮ ᱥᱟᱨᱵᱷᱟᱨ ᱥᱟᱨᱴᱤᱯᱷᱤᱠᱮᱴ ᱵᱟᱝ ᱥᱮᱱ ᱫᱟᱲᱮᱭᱟᱜ ᱱᱤᱦᱟᱹᱛᱤ </label>¶•]]></string>
     <!-- The text shown inside the advanced options button used to go back. It's only shown if the user has expanded the advanced options. -->
-    <string name="mozac_browser_errorpages_security_bad_cert_back">ᱛᱟᱭᱚᱢ ᱥᱮᱱᱚᱜ ᱢᱮᱸ (ᱠᱷᱚᱡᱚᱜ ᱜᱮᱭᱟ)</string>
+    <string name="mozac_browser_errorpages_security_bad_cert_back">ᱛᱟᱭᱚᱢ ᱥᱮᱱᱚᱜ ᱢᱮ (ᱠᱷᱚᱡᱚᱜ ᱜᱮᱭᱟ)</string>
     <!-- The text shown inside the advanced options button used to bypass the invalid SSL certificate. It's only shown if the user has expanded the advanced options. -->
-    <string name="mozac_browser_errorpages_security_bad_cert_accept_temporary">ᱡᱤᱢᱟ ᱦᱟᱛᱟᱣ ᱢᱮᱸ ᱟᱨ ᱥᱮᱱᱚᱜ ᱢᱮᱸ</string>
+    <string name="mozac_browser_errorpages_security_bad_cert_accept_temporary">ᱡᱤᱢᱟ ᱦᱟᱛᱟᱣ ᱢᱮ ᱟᱨ ᱥᱮᱱᱚᱜ ᱢᱮ</string>
 
     <!-- The document title and heading of the error page shown when the user's network connection is interrupted while connecting to a website. -->
     <string name="mozac_browser_errorpages_net_interrupt_title">ᱡᱚᱲᱟᱣ ᱵᱟᱝ ᱧᱮᱞ ᱞᱮᱱᱟ</string>
 
     <!-- The error message shown when the user's network connection is interrupted while connecting to a website. -->
-    <string name="mozac_browser_errorpages_net_interrupt_message"><![CDATA[¶•<p>ᱵᱽᱨᱟᱣᱡᱟᱨ ᱡᱚᱲᱟᱣ ᱞᱟᱦᱟ ᱮᱱᱟ, ᱢᱮᱸᱱᱠᱷᱟᱱ ᱡᱚᱲᱟᱣ ᱵᱟᱝ ᱧᱮᱞ ᱮᱱᱟ ᱡᱚᱠᱷᱚᱱ ᱠᱷᱚᱵᱚᱨ ᱵᱷᱮᱡᱟᱜ ᱠᱟᱱ ᱛᱟᱦᱮᱱᱟ ᱾ ᱫᱟᱭᱟ ᱠᱟᱛᱮ ᱫᱚᱦᱲᱟ ᱨᱤᱠᱟᱹᱭ ᱢᱮᱸ </p>¶•<ul>•<li>ᱥᱟᱭᱤᱴ ᱵᱟᱝ ᱧᱟᱢ ᱫᱟᱲᱮᱭᱟᱜ-ᱟ ᱥᱮ ᱠᱟᱹᱢᱤ ᱨᱮ ᱛᱟᱦᱮᱱᱟ ᱾ ᱠᱤᱪᱷᱩ ᱜᱷᱟᱹᱲᱤᱡ ᱛᱟᱭᱚᱢ ᱨᱤᱠᱟᱹᱭ ᱢᱮᱸ ᱾ </li>¶•<li> ᱡᱩᱫᱤ ᱥᱟᱦᱴᱟ ᱵᱟᱝ ᱮᱢ ᱞᱟᱫᱮ ᱫᱟᱲᱮᱭᱟᱜ ᱠᱟᱱᱟ, ᱟᱢᱟᱜ ᱰᱤᱵᱷᱟᱭᱥ ᱨᱮᱱᱟᱜ ᱰᱟᱴᱟ ᱥᱮ ᱣᱟᱭ-ᱯᱷᱟᱭ ᱡᱚᱲᱟᱣ ᱧᱮᱞ ᱞᱮᱜᱟᱭ ᱢᱮᱸ ᱾ </li>¶•</ul¶•]]></string>
+    <string name="mozac_browser_errorpages_net_interrupt_message"><![CDATA[¶•<p>ᱵᱽᱨᱟᱣᱡᱟᱨ ᱡᱚᱲᱟᱣ ᱞᱟᱦᱟ ᱮᱱᱟ, ᱢᱮᱱᱠᱷᱟᱱ ᱡᱚᱲᱟᱣ ᱵᱟᱝ ᱧᱮᱞ ᱮᱱᱟ ᱡᱚᱠᱷᱚᱱ ᱠᱷᱚᱵᱚᱨ ᱵᱷᱮᱡᱟᱜ ᱠᱟᱱ ᱛᱟᱦᱮᱱᱟ ᱾ ᱫᱟᱭᱟ ᱠᱟᱛᱮ ᱫᱚᱦᱲᱟ ᱨᱤᱠᱟᱹᱭ ᱢᱮ </p>¶•<ul>•<li>ᱥᱟᱭᱤᱴ ᱵᱟᱝ ᱧᱟᱢ ᱫᱟᱲᱮᱭᱟᱜ-ᱟ ᱥᱮ ᱠᱟᱹᱢᱤ ᱨᱮ ᱛᱟᱦᱮᱱᱟ ᱾ ᱠᱤᱪᱷᱩ ᱜᱷᱟᱹᱲᱤᱡ ᱛᱟᱭᱚᱢ ᱨᱤᱠᱟᱹᱭ ᱢᱮ ᱾ </li>¶•<li> ᱡᱩᱫᱤ ᱥᱟᱦᱴᱟ ᱵᱟᱝ ᱮᱢ ᱞᱟᱫᱮ ᱫᱟᱲᱮᱭᱟᱜ ᱠᱟᱱᱟ, ᱟᱢᱟᱜ ᱰᱤᱵᱷᱟᱭᱥ ᱨᱮᱱᱟᱜ ᱰᱟᱴᱟ ᱥᱮ ᱣᱟᱭ-ᱯᱷᱟᱭ ᱡᱚᱲᱟᱣ ᱧᱮᱞ ᱞᱮᱜᱟᱭ ᱢᱮ ᱾ </li>¶•</ul¶•]]></string>
 
     <!-- The document title and heading of the error page shown when a website takes too long to load. -->
     <string name="mozac_browser_errorpages_net_timeout_title">ᱡᱚᱯᱚᱲᱟᱣ ᱚᱠᱛᱚ ᱪᱟᱵᱟ ᱮᱱᱟ</string>
@@ -57,10 +57,10 @@
     <string name="mozac_browser_errorpages_net_timeout_message"><![CDATA[
       <p>ᱱᱮᱦᱚᱨ ᱟᱠᱟᱱ ᱥᱟᱭᱤᱴ ᱫᱚ ᱡᱩᱲᱟᱹᱣ ᱵᱟᱭ ᱟᱸᱡᱚᱢ ᱮᱫᱟᱭ ᱟᱨ ᱵᱷᱮᱡᱟ ᱨᱩᱟᱹᱲ ᱮ ᱵᱚᱸᱫᱚ ᱠᱮᱜᱼᱟᱭ ᱾</p>
       <ul>
-        <li>ᱥᱟᱹᱨᱣᱟᱹᱨ ᱦᱟᱤ ᱰᱤᱢᱟᱸᱰ ᱟᱨ ᱵᱟᱝ ᱵᱟᱛᱷᱟᱱᱤᱛ ᱟᱩᱴᱨᱮᱡ ᱞᱟᱹᱤᱫ ᱦᱩᱭ ᱠᱚᱜᱼᱟ? ᱯᱚᱨᱮ ᱪᱮᱥᱴᱟᱭ ᱢᱮᱸ ᱾</li>
-        <li>ᱟᱢ ᱪᱮᱫ ᱚᱞᱜᱟ ᱥᱟᱭᱤ ᱵᱟᱧ ᱵᱟᱨᱩᱡ ᱫᱟᱲᱟᱭᱟᱜ ᱠᱟᱱᱟᱢ? ᱥᱟᱫᱷᱚᱱ ᱨᱮᱭᱟᱜ ᱱᱮᱴᱣᱟᱨᱠ ᱡᱩᱲᱟᱹᱣ ᱧᱮᱞ ᱵᱤᱰᱟᱹᱣ ᱢᱮᱸ ᱾</li>
+        <li>ᱥᱟᱹᱨᱣᱟᱹᱨ ᱦᱟᱤ ᱰᱤᱢᱟᱸᱰ ᱟᱨ ᱵᱟᱝ ᱵᱟᱛᱷᱟᱱᱤᱛ ᱟᱩᱴᱨᱮᱡ ᱞᱟᱹᱤᱫ ᱦᱩᱭ ᱠᱚᱜᱼᱟ? ᱯᱚᱨᱮ ᱪᱮᱥᱴᱟᱭ ᱢᱮ ᱾</li>
+        <li>ᱟᱢ ᱪᱮᱫ ᱚᱞᱜᱟ ᱥᱟᱭᱤ ᱵᱟᱧ ᱵᱟᱨᱩᱡ ᱫᱟᱲᱟᱭᱟᱜ ᱠᱟᱱᱟᱢ? ᱥᱟᱫᱷᱚᱱ ᱨᱮᱭᱟᱜ ᱱᱮᱴᱣᱟᱨᱠ ᱡᱩᱲᱟᱹᱣ ᱧᱮᱞ ᱵᱤᱰᱟᱹᱣ ᱢᱮ ᱾</li>
         <li>ᱪᱮᱫ ᱟᱢᱟᱜ ᱥᱟᱫᱷᱚᱱ ᱫᱚ ᱯᱷᱟᱭᱟᱨᱣᱟᱞᱞ ᱟᱨ ᱵᱟᱝ ᱯᱨᱳᱠᱥᱭ ᱱᱮᱣᱴᱣᱟᱨᱠ ᱯᱨᱚᱴᱮᱠᱴᱮᱰ ᱜᱮᱭᱟ? ᱵᱷᱩᱞ ᱥᱟᱡᱟᱣ ᱠᱚ ᱠᱟᱹᱜᱤᱫ ᱣᱮᱵ ᱵᱨᱟᱩᱡᱤᱝ ᱨᱮ ᱵᱟᱫᱷᱟ ᱮᱢ ᱫᱟᱲᱮᱜᱼᱟᱭ ᱾</li>
-        <li>ᱱᱤᱛ ᱦᱟᱹᱵᱤᱡ ᱥᱸᱝᱠᱚᱴ ᱨᱮ?ᱜᱚᱲᱚ ᱞᱟᱹᱜᱤᱫ ᱟᱢᱤᱡ ᱱᱮᱴᱣᱟᱨᱠ ᱟᱰᱢᱤᱱᱤᱥᱴᱨᱮᱴᱚᱨ ᱟᱨ ᱵᱟᱝ ᱤᱱᱴᱚᱨᱱᱮᱴ ᱯᱨᱚᱣᱟᱭᱰᱟᱹᱨ ᱥᱟᱞᱟᱜ ᱡᱩᱜᱟᱡᱩᱜ ᱢᱮᱸ</li>
+        <li>ᱱᱤᱛ ᱦᱟᱹᱵᱤᱡ ᱥᱸᱝᱠᱚᱴ ᱨᱮ?ᱜᱚᱲᱚ ᱞᱟᱹᱜᱤᱫ ᱟᱢᱤᱡ ᱱᱮᱴᱣᱟᱨᱠ ᱟᱰᱢᱤᱱᱤᱥᱴᱨᱮᱴᱚᱨ ᱟᱨ ᱵᱟᱝ ᱤᱱᱴᱚᱨᱱᱮᱴ ᱯᱨᱚᱣᱟᱭᱰᱟᱹᱨ ᱥᱟᱞᱟᱜ ᱡᱩᱜᱟᱡᱩᱜ ᱢᱮ</li>
       </ul>
     ]]></string>
 
@@ -70,8 +70,8 @@
     <!-- The error message shown when a website could not be reached. -->
     <string name="mozac_browser_errorpages_connection_failure_message"><![CDATA[
       <ul>
-        <li>ᱥᱟᱭᱤᱴ ᱵᱮᱛᱷᱟᱱᱤᱠ ᱛᱟᱦᱮᱸ ᱠᱚᱜᱼᱟ ᱟᱨ ᱵᱟᱝ ᱡᱟᱹᱛᱤ ᱵᱤᱡᱭ ᱛᱟᱦᱮᱸ ᱠᱚᱜᱼᱟ ᱾ ᱠᱤᱪᱷᱤ ᱥᱚᱢᱚᱭ ᱯᱚᱨᱮ ᱫᱩᱦᱲᱟᱹ ᱪᱮᱥᱴᱟᱭ ᱢᱮᱸ ᱾</li>
-        <li>ᱟᱢ ᱡᱚᱫᱤ ᱥᱟᱦᱴᱟ ᱵᱟᱝ ᱞᱚᱰ ᱫᱟᱲᱮᱭᱟᱜ ᱠᱟᱱᱟᱢ, ᱥᱟᱢᱟᱜ ᱥᱟᱫᱷᱚᱱ ᱨᱮᱭᱟᱜ ᱰᱟᱴᱟ ᱟᱨ ᱵᱟᱝ Wi-Fi ᱡᱩᱲᱟᱹᱣ ᱧᱮᱞ ᱵᱤᱰᱟᱹᱣ ᱢᱮᱸ ᱾</li>
+        <li>ᱥᱟᱭᱤᱴ ᱵᱮᱛᱷᱟᱱᱤᱠ ᱛᱟᱦᱮᱸ ᱠᱚᱜᱼᱟ ᱟᱨ ᱵᱟᱝ ᱡᱟᱹᱛᱤ ᱵᱤᱡᱭ ᱛᱟᱦᱮᱸ ᱠᱚᱜᱼᱟ ᱾ ᱠᱤᱪᱷᱤ ᱥᱚᱢᱚᱭ ᱯᱚᱨᱮ ᱫᱩᱦᱲᱟᱹ ᱪᱮᱥᱴᱟᱭ ᱢᱮ ᱾</li>
+        <li>ᱟᱢ ᱡᱚᱫᱤ ᱥᱟᱦᱴᱟ ᱵᱟᱝ ᱞᱚᱰ ᱫᱟᱲᱮᱭᱟᱜ ᱠᱟᱱᱟᱢ, ᱥᱟᱢᱟᱜ ᱥᱟᱫᱷᱚᱱ ᱨᱮᱭᱟᱜ ᱰᱟᱴᱟ ᱟᱨ ᱵᱟᱝ Wi-Fi ᱡᱩᱲᱟᱹᱣ ᱧᱮᱞ ᱵᱤᱰᱟᱹᱣ ᱢᱮ ᱾</li>
       </ul>
     ]]></string>
 
@@ -119,7 +119,7 @@
     <string name="mozac_browser_errorpages_net_reset_title">ᱡᱚᱱᱚᱲᱟᱹᱣ ᱫᱚ ᱨᱤᱥᱮᱴ ᱮᱱᱟ</string>
 
     <!-- The error message shown when the Internet connection is disrupted while loading a website. -->
-    <string name="mozac_browser_errorpages_net_reset_message"><![CDATA[¶•<p>ᱡᱩᱲᱟᱹᱣ ᱱᱮᱜᱚᱥᱤᱭᱮᱴ ᱡᱚᱠᱷᱟᱜ ᱱᱮᱴᱣᱟᱨᱠ ᱞᱤᱸᱠ ᱠᱚᱴᱟᱣᱮᱱᱟ ᱾ ᱫᱟᱭᱟ ᱠᱟᱛᱮ ᱫᱚᱦᱲᱟ ᱨᱤᱠᱟᱹᱭ ᱢᱮᱸ </p>¶•<ul>•<li>ᱥᱟᱭᱤᱴ ᱵᱟᱝ ᱧᱟᱢ ᱫᱟᱲᱮᱭᱟᱜ-ᱟ ᱥᱮ ᱠᱟᱹᱢᱤ ᱨᱮ ᱛᱟᱦᱮᱱᱟ ᱾ ᱠᱤᱪᱷᱩ ᱜᱷᱟᱹᱲᱤᱡ ᱛᱟᱭᱚᱢ ᱨᱤᱠᱟᱹᱭ ᱢᱮᱸ ᱾ </li>¶•<li> ᱡᱩᱫᱤ ᱥᱟᱦᱴᱟ ᱵᱟᱝ ᱮᱢ ᱞᱟᱫᱮ ᱫᱟᱲᱮᱭᱟᱜ ᱠᱟᱱᱟ, ᱟᱢᱟᱜ ᱰᱤᱵᱷᱟᱭᱥ ᱨᱮᱱᱟᱜ ᱰᱟᱴᱟ ᱥᱮ ᱣᱟᱭ-ᱯᱷᱟᱭ ᱡᱚᱲᱟᱣ ᱧᱮᱞ ᱞᱮᱜᱟᱭ ᱢᱮᱸ ᱾ </li>¶•</ul¶•]]></string>
+    <string name="mozac_browser_errorpages_net_reset_message"><![CDATA[¶•<p>ᱡᱩᱲᱟᱹᱣ ᱱᱮᱜᱚᱥᱤᱭᱮᱴ ᱡᱚᱠᱷᱟᱜ ᱱᱮᱴᱣᱟᱨᱠ ᱞᱤᱸᱠ ᱠᱚᱴᱟᱣᱮᱱᱟ ᱾ ᱫᱟᱭᱟ ᱠᱟᱛᱮ ᱫᱚᱦᱲᱟ ᱨᱤᱠᱟᱹᱭ ᱢᱮ </p>¶•<ul>•<li>ᱥᱟᱭᱤᱴ ᱵᱟᱝ ᱧᱟᱢ ᱫᱟᱲᱮᱭᱟᱜ-ᱟ ᱥᱮ ᱠᱟᱹᱢᱤ ᱨᱮ ᱛᱟᱦᱮᱱᱟ ᱾ ᱠᱤᱪᱷᱩ ᱜᱷᱟᱹᱲᱤᱡ ᱛᱟᱭᱚᱢ ᱨᱤᱠᱟᱹᱭ ᱢᱮ ᱾ </li>¶•<li> ᱡᱩᱫᱤ ᱥᱟᱦᱴᱟ ᱵᱟᱝ ᱮᱢ ᱞᱟᱫᱮ ᱫᱟᱲᱮᱭᱟᱜ ᱠᱟᱱᱟ, ᱟᱢᱟᱜ ᱰᱤᱵᱷᱟᱭᱥ ᱨᱮᱱᱟᱜ ᱰᱟᱴᱟ ᱥᱮ ᱣᱟᱭ-ᱯᱷᱟᱭ ᱡᱚᱲᱟᱣ ᱧᱮᱞ ᱞᱮᱜᱟᱭ ᱢᱮ ᱾ </li>¶•</ul¶•]]></string>
 
     <!-- The document title and heading of the error page shown when the browser refuses to load a type of file that is considered unsafe. -->
     <string name="mozac_browser_errorpages_unsafe_content_type_title">ᱨᱮᱫ ᱯᱨᱚᱠᱟᱨ ᱵᱟᱝᱨᱟᱠᱷᱭᱟᱼᱟᱜ ᱠᱟᱱᱟ</string>
@@ -156,7 +156,7 @@
 
     <string name="mozac_browser_errorpages_invalid_content_encoding_message"><![CDATA[
       ¶•<ul>¶
-       • <li>ᱚᱠᱟ ᱥᱟᱦᱴᱟ ᱧᱮᱞ ᱞᱟᱹᱜᱤᱫ ᱠᱷᱚᱡᱚᱜ ᱠᱟᱱ ᱛᱟᱦᱮᱸᱡ ᱮᱢ ᱚᱱᱟ ᱫᱚ ᱤᱱᱣᱮᱞᱤᱰ ᱟᱨ ᱵᱟᱝ ᱵᱟᱭ ᱥᱟᱯᱯᱚᱴ ᱮᱫ ᱠᱚᱢᱯᱨᱮᱥᱥᱚᱱ ᱯᱷᱚᱨᱢ ᱨᱮ ᱢᱮᱸᱱᱟᱜ ᱠᱷᱟᱹᱛᱤᱨ ᱵᱟᱝ ᱫᱮᱠᱷᱟᱣᱜ ᱠᱟᱱᱟ ᱾</li>
+       • <li>ᱚᱠᱟ ᱥᱟᱦᱴᱟ ᱧᱮᱞ ᱞᱟᱹᱜᱤᱫ ᱠᱷᱚᱡᱚᱜ ᱠᱟᱱ ᱛᱟᱦᱮᱸᱡ ᱮᱢ ᱚᱱᱟ ᱫᱚ ᱤᱱᱣᱮᱞᱤᱰ ᱟᱨ ᱵᱟᱝ ᱵᱟᱭ ᱥᱟᱯᱯᱚᱴ ᱮᱫ ᱠᱚᱢᱯᱨᱮᱥᱥᱚᱱ ᱯᱷᱚᱨᱢ ᱨᱮ ᱢᱮᱱᱟᱜ ᱠᱷᱟᱹᱛᱤᱨ ᱵᱟᱝ ᱫᱮᱠᱷᱟᱣᱜ ᱠᱟᱱᱟ ᱾</li>
         <li>ᱫᱚᱭᱟᱠᱟᱛᱮ ᱣᱮᱵᱥᱟᱭᱤᱴ ᱢᱟᱞᱤᱠ ᱡᱩᱜᱟᱡᱩᱜ ᱮᱢ ᱟᱨ ᱦᱩᱲᱟᱹᱜ ᱵᱟᱵᱚᱫ ᱠᱷᱚᱵᱚᱨ ᱮᱢ ᱾</li>¶•      
       </ul>•
     ]]></string>
@@ -168,24 +168,24 @@
     <string name="mozac_browser_errorpages_unknown_host_message"><![CDATA[
       <p>ᱮᱢ ᱟᱠᱟᱱ ᱴᱷᱤᱠᱬᱟᱹ ᱨᱮ ᱵᱨᱟᱣᱡᱚᱨ ᱦᱚᱥᱴ ᱥᱟᱹᱨᱣᱟᱹᱨ ᱵᱟᱭ ᱧᱟᱢ ᱫᱟᱲᱮᱭᱟᱜ ᱠᱟᱱᱟᱭ ᱾</p>
       <ul>
-        <li>ᱵᱷᱩᱞ ᱴᱭᱯᱤᱝ ᱞᱟᱹᱜᱤᱫ ᱴᱷᱤᱠᱬᱟᱹ ᱠᱚ ᱧᱮᱞ ᱵᱤᱰᱟᱹᱣ ᱢᱮᱸ ᱡᱮᱢᱚᱱ
+        <li>ᱵᱷᱩᱞ ᱴᱭᱯᱤᱝ ᱞᱟᱹᱜᱤᱫ ᱴᱷᱤᱠᱬᱟᱹ ᱠᱚ ᱧᱮᱞ ᱵᱤᱰᱟᱹᱣ ᱢᱮ ᱡᱮᱢᱚᱱ
           <strong>ww</strong>.example.com ᱵᱚᱫᱚᱞ ᱛᱮ
           <strong>www</strong>.example.com.</li>
-        <li>ᱟᱢ ᱡᱩᱫᱤ ᱥᱟᱦᱴᱟ ᱵᱟᱝ ᱞᱚᱰ ᱫᱟᱲᱮᱭᱟᱜ ᱠᱟᱱᱟᱢ, ᱢᱮᱸᱱᱠᱷᱟᱱ ᱟᱢᱟᱜ ᱥᱟᱫᱷᱚᱱ ᱨᱮᱭᱟᱜ ᱰᱟᱴᱟ ᱟᱨ ᱵᱟᱝ Wi-Fi ᱡᱩᱲᱟᱹᱣ ᱧᱮᱞ ᱵᱤᱲᱟᱹᱣ ᱢᱮᱸ ᱾</li>
+        <li>ᱟᱢ ᱡᱩᱫᱤ ᱥᱟᱦᱴᱟ ᱵᱟᱝ ᱞᱚᱰ ᱫᱟᱲᱮᱭᱟᱜ ᱠᱟᱱᱟᱢ, ᱢᱮᱱᱠᱷᱟᱱ ᱟᱢᱟᱜ ᱥᱟᱫᱷᱚᱱ ᱨᱮᱭᱟᱜ ᱰᱟᱴᱟ ᱟᱨ ᱵᱟᱝ Wi-Fi ᱡᱩᱲᱟᱹᱣ ᱧᱮᱞ ᱵᱤᱲᱟᱹᱣ ᱢᱮ ᱾</li>
       </ul>
     ]]></string>
 
     <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_no_internet_title">ᱤᱱᱴᱟᱹᱨᱱᱮᱴ ᱡᱚᱱᱚᱲᱟᱣ ᱵᱟᱹᱱᱩᱜ-ᱟ</string>
     <!-- The main body text of this error page. It will be shown beneath the title -->
-    <string name="mozac_browser_errorpages_no_internet_message">ᱱᱮᱴᱣᱟᱨᱠ ᱡᱩᱲᱟᱹᱣ ᱧᱮᱞ ᱵᱤᱰᱟᱹᱣ ᱢᱮᱸ ᱟᱨ ᱵᱟᱝ ᱠᱤᱪᱷᱤ ᱥᱚᱢᱚᱭ ᱯᱚᱨᱮ ᱥᱟᱦᱴᱟ ᱫᱩᱦᱲᱟᱹ ᱨᱤᱞᱚᱰ ᱢᱮᱸ ᱾</string>
+    <string name="mozac_browser_errorpages_no_internet_message">ᱱᱮᱴᱣᱟᱨᱠ ᱡᱩᱲᱟᱹᱣ ᱧᱮᱞ ᱵᱤᱰᱟᱹᱣ ᱢᱮ ᱟᱨ ᱵᱟᱝ ᱠᱤᱪᱷᱤ ᱥᱚᱢᱚᱭ ᱯᱚᱨᱮ ᱥᱟᱦᱴᱟ ᱫᱩᱦᱲᱟᱹ ᱨᱤᱞᱚᱰ ᱢᱮ ᱾</string>
     <!-- Text that will show up on the button at the bottom of the error page -->
     <string name="mozac_browser_errorpages_no_internet_refresh_button">ᱫᱚᱦᱲᱟ ᱞᱟᱫᱤ</string>
 
     <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_malformed_uri_title">ᱵᱷᱩᱞ ᱴᱷᱤᱠᱟᱱᱟᱹ</string>
     <string name="mozac_browser_errorpages_malformed_uri_message"><![CDATA[
-      <p>ᱮᱢ ᱟᱠᱟᱱ ᱴᱷᱤᱠᱬᱟᱹ ᱫᱚ ᱵᱟᱝ ᱵᱟᱰᱟᱭ ᱯᱷᱚᱨᱢᱟᱴ ᱨᱮ ᱢᱮᱸᱱᱟᱜᱼᱟ ᱾ ᱫᱚᱭᱟᱠᱟᱛᱮ ᱡᱟᱭᱜᱟ ᱵᱟᱨ ᱨᱮ  ᱵᱷᱩᱞ ᱠᱚ ᱧᱮᱞ ᱵᱤᱰᱟᱹᱣ ᱢᱮᱸ ᱟᱨ ᱫᱩᱦᱲᱟᱹ ᱪᱮᱥᱴᱟᱭ ᱢᱮᱸ ᱾</p>
+      <p>ᱮᱢ ᱟᱠᱟᱱ ᱴᱷᱤᱠᱬᱟᱹ ᱫᱚ ᱵᱟᱝ ᱵᱟᱰᱟᱭ ᱯᱷᱚᱨᱢᱟᱴ ᱨᱮ ᱢᱮᱱᱟᱜᱼᱟ ᱾ ᱫᱚᱭᱟᱠᱟᱛᱮ ᱡᱟᱭᱜᱟ ᱵᱟᱨ ᱨᱮ  ᱵᱷᱩᱞ ᱠᱚ ᱧᱮᱞ ᱵᱤᱰᱟᱹᱣ ᱢᱮ ᱟᱨ ᱫᱩᱦᱲᱟᱹ ᱪᱮᱥᱴᱟᱭ ᱢᱮ ᱾</p>
     ]]></string>
     <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_malformed_uri_title_alternative">ᱴᱷᱤᱠᱬᱟᱹ ᱵᱟᱭ ᱴᱷᱤᱠ ᱟ</string>
@@ -204,14 +204,14 @@
     <string name="mozac_browser_errorpages_unknown_protocol_message"><![CDATA[
       <p>ᱴᱷᱤᱠᱬᱟᱹ ᱫᱚ ᱯᱨᱚᱴᱚᱠᱚᱞ ᱮ ᱫᱮᱠᱷᱟᱣᱮᱫᱟᱭ (ᱡᱮᱢᱚᱱ, <q>wxyz://</q>) ᱵᱨᱟᱣᱡᱟᱹᱨ ᱵᱟᱝ ᱪᱤᱱᱦᱟᱹᱣ ᱫᱟᱲᱮᱭᱟᱜ ᱠᱟᱱᱟ, ᱵᱟᱨᱣᱡᱟᱹᱨ ᱥᱟᱭᱤᱴ ᱨᱮ ᱵᱟᱝ ᱡᱩᱲᱟᱣᱼ ᱫᱟᱲᱮᱭᱟᱜ ᱠᱟᱱᱟ ᱾</p>
       <ul>
-        <li>ᱟᱢ ᱪᱮᱫ ᱢᱟᱹᱞᱴᱤᱢᱤᱰᱤᱭᱟ ᱟᱨ ᱵᱟᱝ ᱵᱟᱝᱼᱚᱞ ᱥᱟᱹᱨᱣᱤᱥ ᱫᱚᱨᱠᱟᱨ ᱥᱮ? ᱡᱟᱹᱥᱛᱤ ᱡᱤᱱᱤᱥ ᱞᱟᱹᱜᱤᱫ ᱥᱟᱭᱤᱴ ᱧᱮᱞ ᱵᱤᱰᱟᱹᱣ ᱢᱮᱸ ᱾</li>
+        <li>ᱟᱢ ᱪᱮᱫ ᱢᱟᱹᱞᱴᱤᱢᱤᱰᱤᱭᱟ ᱟᱨ ᱵᱟᱝ ᱵᱟᱝᱼᱚᱞ ᱥᱟᱹᱨᱣᱤᱥ ᱫᱚᱨᱠᱟᱨ ᱥᱮ? ᱡᱟᱹᱥᱛᱤ ᱡᱤᱱᱤᱥ ᱞᱟᱹᱜᱤᱫ ᱥᱟᱭᱤᱴ ᱧᱮᱞ ᱵᱤᱰᱟᱹᱣ ᱢᱮ ᱾</li>
         <li>ᱠᱤᱪᱷᱤ ᱯᱚᱨᱴᱟᱞ ᱫᱚ ᱛᱷᱟᱰ ᱯᱟᱨᱴᱭ ᱥᱚᱯᱷᱴᱣᱮᱨ ᱟᱨ ᱵᱟᱝ ᱯᱞᱟᱹᱜᱤᱱᱥ ᱫᱚᱨᱠᱟᱨ ᱚᱠᱟ ᱫᱚ ᱵᱨᱟᱩᱡᱟᱹᱨ ᱪᱤᱷᱟᱣ ᱨᱮ ᱜᱚᱲᱚᱟᱭ ᱾</li>
       </ul>
     ]]></string>
 
     <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_file_not_found_title">ᱨᱮᱫ ᱵᱟᱝ ᱧᱟᱢ ᱞᱮᱱᱟ</string>
-    <string name="mozac_browser_errorpages_file_not_found_message"><![CDATA[¶•<ul>¶•<li>ᱪᱮᱫ ᱟᱭᱴᱚᱢ ᱫᱚᱦᱲᱟ ᱛᱮ ᱧᱩᱛᱩᱢ ᱟᱹᱛᱩ ᱫᱟᱲᱮᱭᱟᱜ-ᱟ, ᱚᱪᱚᱫ, ᱥᱮ ᱫᱚᱦᱲᱟ ᱛᱷᱟᱯᱚᱱᱚᱜ-ᱟ?</li>¶•<li>ᱪᱮᱫ ᱮᱰᱨᱮᱥ ᱨᱮ ᱟᱹᱲ ᱠᱮᱯᱤᱴᱭᱞᱤᱡᱮᱥᱚᱱ, ᱥᱮ ᱮᱴᱟᱜ ᱴᱟᱭᱯᱳᱜᱽᱨᱟᱯᱷᱤᱠᱟᱞ ᱨᱮ ᱦᱩᱲᱟᱹᱜ ᱢᱮᱸᱱᱟᱜ-ᱟ?</li>¶•<li> ᱪᱮᱫ ᱟᱢ ᱴᱷᱮᱱ ᱫᱟᱣ ᱮᱢ ᱞᱟᱹᱜᱤᱫ ᱥᱟᱳᱷᱤᱥᱤᱭᱚᱱᱴ ᱯᱚᱨᱢᱤᱥᱚᱱ ᱢᱮᱸᱱᱟᱜ-ᱟ? </li>¶•</ul>¶•]]></string>
+    <string name="mozac_browser_errorpages_file_not_found_message"><![CDATA[¶•<ul>¶•<li>ᱪᱮᱫ ᱟᱭᱴᱚᱢ ᱫᱚᱦᱲᱟ ᱛᱮ ᱧᱩᱛᱩᱢ ᱟᱹᱛᱩ ᱫᱟᱲᱮᱭᱟᱜ-ᱟ, ᱚᱪᱚᱫ, ᱥᱮ ᱫᱚᱦᱲᱟ ᱛᱷᱟᱯᱚᱱᱚᱜ-ᱟ?</li>¶•<li>ᱪᱮᱫ ᱮᱰᱨᱮᱥ ᱨᱮ ᱟᱹᱲ ᱠᱮᱯᱤᱴᱭᱞᱤᱡᱮᱥᱚᱱ, ᱥᱮ ᱮᱴᱟᱜ ᱴᱟᱭᱯᱳᱜᱽᱨᱟᱯᱷᱤᱠᱟᱞ ᱨᱮ ᱦᱩᱲᱟᱹᱜ ᱢᱮᱱᱟᱜ-ᱟ?</li>¶•<li> ᱪᱮᱫ ᱟᱢ ᱴᱷᱮᱱ ᱫᱟᱣ ᱮᱢ ᱞᱟᱹᱜᱤᱫ ᱥᱟᱳᱷᱤᱥᱤᱭᱚᱱᱴ ᱯᱚᱨᱢᱤᱥᱚᱱ ᱢᱮᱱᱟᱜ-ᱟ? </li>¶•</ul>¶•]]></string>
 
     <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_file_access_denied_title">ᱨᱮᱫ ᱨᱮ ᱫᱚᱠᱷᱚᱞ ᱵᱟᱹᱰ</string>
@@ -228,9 +228,9 @@
     <string name="mozac_browser_errorpages_proxy_connection_refused_message"><![CDATA[
       <p>ᱱᱚᱶᱟ ᱵᱨᱟᱩᱡᱟᱹᱨ ᱫᱚ ᱯᱨᱚᱠᱥᱭ ᱥᱟᱹᱨᱣᱟᱹᱨ ᱞᱟᱹᱤᱫ ᱜᱮ ᱴᱷᱤᱠ ᱟᱠᱟᱱᱟ, ᱦᱮᱞᱮ ᱯᱨᱚᱠᱥᱭ ᱫᱚ ᱵᱟᱭ ᱡᱩᱰᱟᱹᱣ ᱞᱮᱱᱟᱭ ᱾</p>
       <ul>
-        <li>ᱵᱨᱟᱣᱡᱟᱹᱨ ᱯᱨᱚᱠᱥᱭ ᱠᱚᱱᱯᱷᱤᱜᱭᱩᱨᱮᱥᱚᱱ ᱴᱷᱤᱠ ᱜᱮᱭᱟ ᱥᱮ? ᱥᱟᱡᱟᱣ ᱠᱚ ᱧᱮᱞ ᱢᱮᱸ ᱟᱨ ᱫᱩᱦᱲᱟᱹ ᱪᱮᱥᱴᱟᱭ ᱢᱮᱸ</li>
+        <li>ᱵᱨᱟᱣᱡᱟᱹᱨ ᱯᱨᱚᱠᱥᱭ ᱠᱚᱱᱯᱷᱤᱜᱭᱩᱨᱮᱥᱚᱱ ᱴᱷᱤᱠ ᱜᱮᱭᱟ ᱥᱮ? ᱥᱟᱡᱟᱣ ᱠᱚ ᱧᱮᱞ ᱢᱮ ᱟᱨ ᱫᱩᱦᱲᱟᱹ ᱪᱮᱥᱴᱟᱭ ᱢᱮ</li>
         <li>ᱪᱮᱫ ᱯᱨᱚᱠᱥᱭ ᱥᱟᱹᱨᱣᱤᱥ ᱱᱚᱶᱟ ᱱᱮᱴᱣᱟᱨᱠ ᱥᱟᱞᱟᱜ ᱡᱩᱲᱟᱹᱣ ᱟᱱᱩᱢᱟᱹᱛᱭ ᱮᱢᱚ ᱟᱭ ?</li>
-        <li>ᱱᱤᱛ ᱦᱚᱸ ᱵᱟᱭ ᱴᱷᱤᱠ ᱟ? ᱜᱚᱲᱚ ᱞᱟᱹᱜᱤᱫ ᱟᱢᱟᱜ ᱱᱮᱴᱣᱟᱨᱠ ᱮᱰᱢᱤᱱᱤᱥᱴᱨᱮᱴᱚᱨ ᱟᱨ ᱵᱟᱝ ᱤᱱᱴᱚᱨᱱᱮᱴ ᱯᱨᱚᱣᱟᱭᱰᱟᱹᱨ ᱥᱟᱞᱟᱜ ᱠᱟᱛᱷᱟᱜ ᱢᱮᱸ ᱾</li>
+        <li>ᱱᱤᱛ ᱦᱚᱸ ᱵᱟᱭ ᱴᱷᱤᱠ ᱟ? ᱜᱚᱲᱚ ᱞᱟᱹᱜᱤᱫ ᱟᱢᱟᱜ ᱱᱮᱴᱣᱟᱨᱠ ᱮᱰᱢᱤᱱᱤᱥᱴᱨᱮᱴᱚᱨ ᱟᱨ ᱵᱟᱝ ᱤᱱᱴᱚᱨᱱᱮᱴ ᱯᱨᱚᱣᱟᱭᱰᱟᱹᱨ ᱥᱟᱞᱟᱜ ᱠᱟᱛᱷᱟᱜ ᱢᱮ ᱾</li>
       </ul>
     ]]></string>
 
@@ -240,9 +240,9 @@
     <string name="mozac_browser_errorpages_unknown_proxy_host_message"><![CDATA[
       <p>ᱱᱚᱶᱟ ᱵᱨᱟᱩᱡᱟᱹᱨ ᱫᱚ ᱯᱨᱚᱠᱥᱭ ᱥᱟᱹᱨᱣᱟᱹᱨ ᱞᱟᱹᱤᱫ ᱜᱮ ᱴᱷᱤᱠ ᱟᱠᱟᱱᱟ, ᱦᱮᱞᱮ ᱯᱨᱚᱠᱥᱭ ᱫᱚ ᱵᱟᱭ ᱧᱟᱢ ᱞᱟᱱᱟ ᱾</p>
       <ul>
-        <li>ᱵᱨᱟᱣᱡᱟᱹᱨ ᱯᱨᱚᱠᱥᱭ ᱠᱚᱱᱯᱷᱤᱜᱭᱩᱨᱮᱥᱚᱱ ᱴᱷᱤᱠ ᱜᱮᱭᱟ ᱥᱮ? ᱥᱟᱡᱟᱣ ᱠᱚ ᱧᱮᱞ ᱢᱮᱸ ᱟᱨ ᱫᱩᱦᱲᱟᱹ ᱪᱮᱥᱴᱟᱭ ᱢᱮᱸ</li>
+        <li>ᱵᱨᱟᱣᱡᱟᱹᱨ ᱯᱨᱚᱠᱥᱭ ᱠᱚᱱᱯᱷᱤᱜᱭᱩᱨᱮᱥᱚᱱ ᱴᱷᱤᱠ ᱜᱮᱭᱟ ᱥᱮ? ᱥᱟᱡᱟᱣ ᱠᱚ ᱧᱮᱞ ᱢᱮ ᱟᱨ ᱫᱩᱦᱲᱟᱹ ᱪᱮᱥᱴᱟᱭ ᱢᱮ</li>
         <li>ᱪᱮᱫ ᱯᱨᱚᱠᱥᱭ ᱥᱟᱹᱨᱣᱤᱥ ᱱᱚᱶᱟ ᱱᱮᱴᱣᱟᱨᱠ ᱥᱟᱞᱟᱜ ᱡᱩᱲᱟᱹᱣ ᱟᱱᱩᱢᱟᱹᱛᱭ ᱮᱢᱚ ᱟᱭ ?</li>
-        <li>ᱱᱤᱛ ᱦᱚᱸ ᱵᱟᱭ ᱴᱷᱤᱠ ᱟ? ᱜᱚᱲᱚ ᱞᱟᱹᱜᱤᱫ ᱟᱢᱟᱜ ᱱᱮᱴᱣᱟᱨᱠ ᱮᱰᱢᱤᱱᱤᱥᱴᱨᱮᱴᱚᱨ ᱟᱨ ᱵᱟᱝ ᱤᱱᱴᱚᱨᱱᱮᱴ ᱯᱨᱚᱣᱟᱭᱰᱟᱹᱨ ᱥᱟᱞᱟᱜ ᱠᱟᱛᱷᱟᱜ ᱢᱮᱸ ᱾</li>
+        <li>ᱱᱤᱛ ᱦᱚᱸ ᱵᱟᱭ ᱴᱷᱤᱠ ᱟ? ᱜᱚᱲᱚ ᱞᱟᱹᱜᱤᱫ ᱟᱢᱟᱜ ᱱᱮᱴᱣᱟᱨᱠ ᱮᱰᱢᱤᱱᱤᱥᱴᱨᱮᱴᱚᱨ ᱟᱨ ᱵᱟᱝ ᱤᱱᱴᱚᱨᱱᱮᱴ ᱯᱨᱚᱣᱟᱭᱰᱟᱹᱨ ᱥᱟᱞᱟᱜ ᱠᱟᱛᱷᱟᱜ ᱢᱮ ᱾</li>
       </ul>
     ]]></string>
 
@@ -251,7 +251,7 @@
 
     <!-- The %1$s will be replaced by the malicious website URL-->
     <string name="mozac_browser_errorpages_safe_browsing_malware_uri_message"><![CDATA[
-      <p> %1$s ᱨᱮ ᱢᱮᱸᱱᱟᱜ ᱟᱠᱟᱱᱟ ᱥᱟᱭᱴ ᱫᱚ ᱟᱴᱴᱟᱠ ᱥᱟᱭᱤᱴ ᱞᱮᱠᱷᱟ ᱛᱮ ᱠᱷᱚᱵᱚᱨ ᱟᱠᱟᱱᱟ ᱟᱨ ᱟᱢᱟᱜ ᱥᱤᱠᱭᱚᱨᱭᱴᱤ ᱞᱟᱫᱜᱤᱫ ᱚᱱᱟ ᱫᱚ ᱵᱚᱸᱫᱚ ᱟᱠᱟᱱᱟ ᱾</p>
+      <p> %1$s ᱨᱮ ᱢᱮᱱᱟᱜ ᱟᱠᱟᱱᱟ ᱥᱟᱭᱴ ᱫᱚ ᱟᱴᱴᱟᱠ ᱥᱟᱭᱤᱴ ᱞᱮᱠᱷᱟ ᱛᱮ ᱠᱷᱚᱵᱚᱨ ᱟᱠᱟᱱᱟ ᱟᱨ ᱟᱢᱟᱜ ᱥᱤᱠᱭᱚᱨᱭᱴᱤ ᱞᱟᱫᱜᱤᱫ ᱚᱱᱟ ᱫᱚ ᱵᱚᱸᱫᱚ ᱟᱠᱟᱱᱟ ᱾</p>
     ]]></string>
 
     <!-- The document title and heading of an error page. -->
@@ -259,7 +259,7 @@
 
     <!-- The %1$s will be replaced by the malicious website URL-->
     <string name="mozac_browser_errorpages_safe_browsing_unwanted_uri_message"><![CDATA[
-      <p>%1$s ᱨᱮ ᱢᱮᱸᱱᱟᱜ ᱥᱟᱭᱤᱴ ᱫᱚ ᱵᱮᱠᱟᱨ ᱥᱚᱯᱷᱴᱣᱮᱨ ᱠᱚ ᱵᱟᱛᱚᱣ ᱟᱨ ᱟᱢᱟᱜ ᱥᱮᱠᱭᱚᱨᱟᱹᱴᱭ ᱯᱨᱤᱯᱷᱮᱨᱮᱱᱥ ᱦᱤᱥᱟᱹᱵ ᱛᱮ ᱵᱞᱚᱠ ᱟᱠᱟᱱᱟ ᱾</p>
+      <p>%1$s ᱨᱮ ᱢᱮᱱᱟᱜ ᱥᱟᱭᱤᱴ ᱫᱚ ᱵᱮᱠᱟᱨ ᱥᱚᱯᱷᱴᱣᱮᱨ ᱠᱚ ᱵᱟᱛᱚᱣ ᱟᱨ ᱟᱢᱟᱜ ᱥᱮᱠᱭᱚᱨᱟᱹᱴᱭ ᱯᱨᱤᱯᱷᱮᱨᱮᱱᱥ ᱦᱤᱥᱟᱹᱵ ᱛᱮ ᱵᱞᱚᱠ ᱟᱠᱟᱱᱟ ᱾</p>
     ]]></string>
 
     <!-- The document title and heading of an error page. -->
@@ -267,13 +267,13 @@
 
     <!-- The %1$s will be replaced by the malicious website URL-->
     <string name="mozac_browser_errorpages_safe_harmful_uri_message"><![CDATA[
-      <p>%1$s ᱨᱮ ᱢᱮᱸᱱᱟᱜ ᱥᱟᱭᱤᱴ ᱫᱚ ᱠᱷᱟᱹᱛᱨᱟ ᱜᱮᱭᱟ ᱟᱨ ᱟᱢᱟᱜ ᱥᱮᱠᱭᱚᱨᱟᱹᱴᱭ ᱯᱨᱤᱯᱷᱮᱨᱮᱱᱥ ᱦᱤᱥᱟᱹᱵ ᱛᱮ ᱵᱞᱚᱠ ᱟᱠᱟᱱᱟ ᱾</p>
+      <p>%1$s ᱨᱮ ᱢᱮᱱᱟᱜ ᱥᱟᱭᱤᱴ ᱫᱚ ᱠᱷᱟᱹᱛᱨᱟ ᱜᱮᱭᱟ ᱟᱨ ᱟᱢᱟᱜ ᱥᱮᱠᱭᱚᱨᱟᱹᱴᱭ ᱯᱨᱤᱯᱷᱮᱨᱮᱱᱥ ᱦᱤᱥᱟᱹᱵ ᱛᱮ ᱵᱞᱚᱠ ᱟᱠᱟᱱᱟ ᱾</p>
     ]]></string>
 
     <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_safe_phishing_uri_title">ᱮᱲᱮ ᱥᱟᱭᱤᱴ ᱵᱟᱵᱚᱛ</string>
     <!-- The %1$s will be replaced by the malicious website URL-->
     <string name="mozac_browser_errorpages_safe_phishing_uri_message"><![CDATA[
-      <p>%1$s ᱨᱮ ᱢᱮᱸᱱᱟᱜ ᱥᱟᱭᱤᱴ ᱫᱚ ᱠᱷᱟᱹᱛᱨᱟ ᱟᱨ ᱮᱲᱮ ᱜᱮᱭᱟ ᱢᱮᱸᱱᱛᱮ ᱠᱚ ᱠᱷᱚᱵᱚᱨ ᱟᱠᱟᱫᱼᱟ ᱟᱨ ᱟᱢᱟᱜ ᱥᱮᱠᱭᱚᱨᱟᱹᱴᱭ ᱯᱨᱤᱯᱷᱮᱨᱮᱱᱥ ᱦᱤᱥᱟᱹᱵ ᱛᱮ ᱵᱞᱚᱠ ᱟᱠᱟᱱᱟ ᱾</p>
+      <p>%1$s ᱨᱮ ᱢᱮᱱᱟᱜ ᱥᱟᱭᱤᱴ ᱫᱚ ᱠᱷᱟᱹᱛᱨᱟ ᱟᱨ ᱮᱲᱮ ᱜᱮᱭᱟ ᱢᱮᱱᱛᱮ ᱠᱚ ᱠᱷᱚᱵᱚᱨ ᱟᱠᱟᱫᱼᱟ ᱟᱨ ᱟᱢᱟᱜ ᱥᱮᱠᱭᱚᱨᱟᱹᱴᱭ ᱯᱨᱤᱯᱷᱮᱨᱮᱱᱥ ᱦᱤᱥᱟᱹᱵ ᱛᱮ ᱵᱞᱚᱠ ᱟᱠᱟᱱᱟ ᱾</p>
     ]]></string>
 </resources>

--- a/components/browser/menu/src/main/res/values-bn/strings.xml
+++ b/components/browser/menu/src/main/res/values-bn/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
+    <string name="mozac_browser_menu_button">মেনু</string>
+    <!-- Label for add-ons submenu section -->
+    <string name="mozac_browser_menu_addons">অ্যাড-অন</string>
+    <!-- Label for add-ons sub menu item for add-ons manager -->
+    <string name="mozac_browser_menu_addons_manager">অ্যাড-অন ব্যবস্থাপক</string>
+</resources>

--- a/components/browser/menu/src/main/res/values-uk/strings.xml
+++ b/components/browser/menu/src/main/res/values-uk/strings.xml
@@ -7,5 +7,5 @@
     <!-- Label for add-ons submenu section -->
     <string name="mozac_browser_menu_addons">Додатки</string>
     <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager">Керування додатками</string>
+    <string name="mozac_browser_menu_addons_manager">Керувати додатками</string>
 </resources>

--- a/components/browser/menu2/src/main/res/values-bn/strings.xml
+++ b/components/browser/menu2/src/main/res/values-bn/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
+    <string name="mozac_browser_menu2_button">মেনু</string>
+    <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
+    <string name="mozac_browser_menu2_highlighted">হাইলাইট করা হয়েছে</string>
+</resources>

--- a/components/browser/menu2/src/main/res/values-sat/strings.xml
+++ b/components/browser/menu2/src/main/res/values-sat/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
-    <string name="mozac_browser_menu2_button">ᱢᱮᱸᱱᱩ</string>
+    <string name="mozac_browser_menu2_button">ᱢᱮᱱᱩ</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu2_highlighted">ᱩᱪᱷᱟᱹᱱᱟᱜ</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-ast/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-ast/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Información del sitiu</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Cargando</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Bloquióse parte del conteníu pol axuste de reproducción automática</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-be/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-be/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Інфармацыя пра сайт</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Загрузка</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Некаторае змесціва было заблакавана наладамі аўтапрайгравання</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-bn/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-bn/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">সাইটের তথ্য</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">লোড হচ্ছে</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">কিছু বিষয়বস্তু অটোপ্লে সেটিং দ্বারা ব্লক করা হয়েছে</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-cak/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-cak/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Rutzijol ruxaq</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Nusamajij</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Jun peraj chi re ri rupam xq\'at ruma ri runuk\'ulem ri ruyon nitzij</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-co/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-co/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Infurmazioni nant’à u situ</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Caricamentu…</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Certi cuntenuti sò stati bluccati da e preferenze di lettura autumatica</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-cs/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-cs/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Informace o stránce</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Načítání</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Část obsahu byla zablokována nastavením automatického přehrávání</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-cy/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-cy/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Manylion y wefan</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Llwytho</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Mae rhywfaint o gynnwys wedi’i rwystro gan osodiadau awtochwarae</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-da/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-da/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Information om webstedet</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Indlæser</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Noget indhold er blevet blokeret af indstillingen for automatisk afspilning</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-de/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-de/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Seiteninformation</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Wird geladen</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Einige Inhalte wurden durch die Einstellung zur automatischen Wiedergabe blockiert</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-dsb/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-dsb/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Sedłowe informacije</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Zacytujo se</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Někake wopśimjeśe jo se pśez wótgrawańske nastajenje zablokěrował</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-el/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-el/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Πληροφορίες ιστοσελίδας</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Φόρτωση</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Ορισμένο περιεχόμενο έχει αποκλειστεί από τη ρύθμιση αυτόματης αναπαραγωγής</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-en-rGB/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-en-rGB/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Site information</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Loading</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Some content has been blocked by the autoplay setting</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-eo/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-eo/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Informo pri retejo</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Ŝargado</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Parto de la enhavo estis blokita de la agordo pri aŭtomata ludado</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-es-rAR/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-es-rAR/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Información del sitio</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Cargando</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Se bloquearon algunos contenidos debido a la configuración de reproducción automática</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-es-rCL/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-es-rCL/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Información del sitio</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Cargando</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Algunos contenidos han sido bloqueados por los ajustes de reproducción automática</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-es-rES/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-es-rES/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Información del sitio</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Cargando</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Algunos contenidos han sido bloqueados por los ajustes de reproducción automática</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-es/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-es/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Información sobre el sitio</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Cargando</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Parte del contenido ha sido bloqueado por la configuración de reproducción automática</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-eu/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-eu/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Gunearen informazioa</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Kargatzen</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Eduki batzuk blokeatu egin dira erreprodukzio automatikoko ezarpenetan oinarrituta</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-fa/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-fa/strings.xml
@@ -6,11 +6,13 @@
     <!-- Content description: For the tracking protection toolbar icon, it is set when the site has tracking protection enabled, but none trackers have been blocked or detected. -->
     <string name="mozac_browser_toolbar_content_description_tracking_protection_on_no_trackers_blocked">محافظت در برابر ردگیری</string>
     <!-- Content description: For the tracking protection toolbar icon, it is set when the site has tracking protection enabled, and trackers have been blocked or detected.-->
-    <string name="mozac_browser_toolbar_content_description_tracking_protection_on_trackers_blocked1">استفاده از محافظ دنبال کردن برای مسدود کردن دنبال کنندگان ناشناس</string>
+    <string name="mozac_browser_toolbar_content_description_tracking_protection_on_trackers_blocked1">محافظ در برابر ردیاب‌ها، ردیاب‌ها را مسدود کرده است</string>
     <!-- Content description: For the tracking protection toolbar icon, it is set when the site has tracking protection disabled.-->
     <string name="mozac_browser_toolbar_content_description_tracking_protection_off_for_a_site1">محاظفت در برابر دنبال شدن برای این پایگاه اینترنتی خاموش شده است.</string>
     <!-- Content description: For the site security information icon (the site security icon).-->
     <string name="mozac_browser_toolbar_content_description_site_info">اطلاعات بیشتر</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">در حال بار کردن</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">برخی از محتوا توسط تنظیمات پخش خودکار مسدود شده است</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-fi/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-fi/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Sivustotiedot</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Ladataan</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Automaattisen toiston asetus on estänyt osan sisällöstä</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-fy-rNL/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-fy-rNL/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Website-ynformaasje</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Lade</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Guon ynhâld is blokkearre troch de ynstelling foar automatysk ôfspyljen</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-gd/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-gd/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Fiosrachadh mun làrach</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Ga luchdadh</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Chaidh cuid dhen t-susbaint a bhacadh an cois roghainn na fèin-chluich</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-gl/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-gl/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Información sobre o sitio</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">A cargar</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">A configuración de reprodución automática bloqueou algúns contidos</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-gn/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-gn/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Marandu tenda rehegua</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Henyhẽhína</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Ojejoko ndahetái tetepy ñemboheta ijeheguíva ñemboheko rupive</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-hr/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-hr/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Informacije o web mjestu</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Učitavanje</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Neki sadržaji su blokirani zbog postavki automatske reprodukcije</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-hsb/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-hsb/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Sydłowe informacije</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Začituje so</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Někajki wobsah je so přez wothrawanske nastajenje zablokował</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-hu/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-hu/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Oldalinformációk</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Betöltés</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Bizonyos tartalmakat letiltott az automatikus lejátszási beállítás</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-hy-rAM/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-hy-rAM/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Կայքի տեղեկությունները</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Բեռնում է</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Որոշ բովանդակություն արգելափակվել է ինքնանվագարկման կարգավորումով</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-in/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-in/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Informasi situs</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Memuat</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Beberapa konten telah diblokir dengan pengaturan putar-otomatis</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-it/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-it/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Informazioni sito</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Caricamento…</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Alcuni contenuti sono stati bloccati dall’impostazione per la riproduzione automatica</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-iw/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-iw/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">פרטי האתר</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">בטעינה</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">תוכן מסויים נחסם על־ידי ההגדרה של הניגון האוטומטי</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-ja/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-ja/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">サイト情報</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">読み込み中</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">一部のコンテンツは自動再生設定によってブロックされています</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-kab/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-kab/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Asmel n telɣut</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Asali</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Yettusewḥel kra n yigburen s aɣewwar n tɣuri tawurmant</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-kk/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-kk/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Сайт ақпараты</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Жүктелуде</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Кейбір құрама автоойнату баптауларымен бұғатталған</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-ko/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-ko/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">사이트 정보</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">읽는 중</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">자동 재생 설정에 의해 일부 콘텐츠가 차단되었습니다.</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-lt/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-lt/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Svetainės informacija</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Įkeliama</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Dalį turinio užblokavo automatinio grojimo nuostatos</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-nb-rNO/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-nb-rNO/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Informasjon om nettstedet</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Laster</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Noe av innholdet er blokkert av autoavspillings-innstillingene </string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-nl/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-nl/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Website-informatie</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Laden</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Sommige inhoud is geblokkeerd door de instelling voor automatisch afspelen</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-nn-rNO/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-nn-rNO/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Informasjon om nettstaden</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Lastar</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Noko innhald har vorte blokkert av autoavspelings-innstillingane</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-pa-rIN/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-pa-rIN/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">ਸਾਈਟ ਜਾਣਕਾਰੀ</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">ਲੋਡ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">ਕੁਝ ਸਮੱਗਰੀ ਨੂੰ ਆਪੇ-ਪਲੇਅ ਦੀ ਸੈਟਿੰਗ ਰਾਹੀਂ ਪਾਬੰਦੀ ਲਾਈ ਹੈ</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-pl/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-pl/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Informacje o witrynie</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Wczytywanie</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Część treści została zablokowana przez ustawienie automatycznego odtwarzania</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-pt-rBR/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-pt-rBR/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Informações do site</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Carregando</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Algum conteúdo foi bloqueado pela configuração de reprodução automática</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-pt-rPT/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-pt-rPT/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Informação do site</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">A carregar</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Algum conteúdo foi bloqueado pela configuração de reprodução automática</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-rm/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-rm/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Infurmaziuns davart la website</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Chargiar</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Tscherts cuntegns èn vegnids bloccads dal parameter da la reproducziun automatica</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-ru/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-ru/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Информация о сайте</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Загрузка</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Некоторый контент был заблокирован настройками автовоспроизведения</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-sat/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-sat/strings.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
-    <string name="mozac_browser_toolbar_menu_button">ᱢᱮᱸᱱᱩ</string>
+    <string name="mozac_browser_toolbar_menu_button">ᱢᱮᱱᱩ</string>
     <string name="mozac_clear_button_description">ᱯᱷᱟᱨᱪᱟ</string>
     <!-- Content description: For the tracking protection toolbar icon, it is set when the site has tracking protection enabled, but none trackers have been blocked or detected. -->
-    <string name="mozac_browser_toolbar_content_description_tracking_protection_on_no_trackers_blocked">ᱯᱟᱸᱡᱟ ᱟᱰ ᱪᱟᱹᱞᱩ ᱢᱮᱸᱱᱟᱜ-ᱟ</string>
+    <string name="mozac_browser_toolbar_content_description_tracking_protection_on_no_trackers_blocked">ᱯᱟᱸᱡᱟ ᱟᱰ ᱪᱟᱹᱞᱩ ᱢᱮᱱᱟᱜ-ᱟ</string>
     <!-- Content description: For the tracking protection toolbar icon, it is set when the site has tracking protection enabled, and trackers have been blocked or detected.-->
     <string name="mozac_browser_toolbar_content_description_tracking_protection_on_trackers_blocked1">ᱯᱟᱸᱡᱟ ᱨᱚᱯᱷᱟ ᱯᱟᱧᱡᱟ ᱫᱟᱱᱟᱲ ᱠᱚ ᱟᱠᱚᱴ ᱠᱮᱜᱼᱟᱭ</string>
     <!-- Content description: For the tracking protection toolbar icon, it is set when the site has tracking protection disabled.-->
-    <string name="mozac_browser_toolbar_content_description_tracking_protection_off_for_a_site1">ᱯᱟᱸᱡᱟ ᱨᱚᱯᱷᱟ ᱵᱚᱸᱫᱚ ᱢᱮᱸᱱᱟᱜ-ᱟ</string>
+    <string name="mozac_browser_toolbar_content_description_tracking_protection_off_for_a_site1">ᱯᱟᱸᱡᱟ ᱨᱚᱯᱷᱟ ᱵᱚᱸᱫᱚ ᱢᱮᱱᱟᱜ-ᱟ</string>
     <!-- Content description: For the site security information icon (the site security icon).-->
     <string name="mozac_browser_toolbar_content_description_site_info">ᱥᱟᱭᱤᱴ ᱨᱮᱭᱟᱜ ᱠᱷᱚᱵᱚᱨ</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->

--- a/components/browser/toolbar/src/main/res/values-sk/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-sk/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Informácie o stránke</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Načítava sa</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Niektorý obsah bol zablokovaný nastavením automatického prehrávania</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-sq/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-sq/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Të dhëna sajti</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Po ngarkohet</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Është bllokuar lëndë nga rregullimi i vetëluajtjes</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-sr/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-sr/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Информације о страници</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Учитавање</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Неки садржај је блокиран због подешавања аутоматске репродукције</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-sv-rSE/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-sv-rSE/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Webbplatsinformation</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Laddar</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">En del innehåll har blockerats av inställningen för automatisk uppspelning</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-tg/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-tg/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Маълумот дар бораи сомона</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Бор шуда истодааст</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Баъзеи муҳтаво тавассути танзими пахши худкор манъ карда шуд</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-th/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-th/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">ข้อมูลไซต์</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">กำลังโหลด</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">เนื้อหาบางส่วนถูกปิดกั้นด้วยการตั้งค่าเล่นอัตโนมัติ</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-tl/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-tl/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Impormasyon sa site</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Naglo-load</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Some content has been blocked by the autoplay setting</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-tr/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-tr/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Site bilgileri</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Yükleniyor</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Otomatik oynatma ayarınız bazı içerikleri engelledi</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-uk/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-uk/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Інформація про сайт</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Завантаження</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Деякий вміст заблоковано налаштуванням автовідтворення</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-vi/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-vi/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">Thông tin trang web</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">Đang tải</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Một số nội dung đã bị chặn bởi cài đặt tự động phát</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-zh-rCN/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-zh-rCN/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">网站信息</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">载入中</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">某些内容已被自动播放设置阻止</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-zh-rTW/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-zh-rTW/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">網站資訊</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">載入中</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">某些內容已由自動播放設定封鎖</string>
 </resources>

--- a/components/feature/addons/src/main/res/values-ast/strings.xml
+++ b/components/feature/addons/src/main/res/values-ast/strings.xml
@@ -161,7 +161,7 @@
     <!-- Error shown when something unexpected happened while trying to get the add-on list from the server -->
     <string name="mozac_feature_addons_failed_to_query_add_ons">¡Fallu al solicitar los complementos!</string>
     <!-- Error shown when unable to find a translation for an add-on field. %1$s is the locale of the user and %2$s is the default language of the add-on -->
-    <string name="mozac_feature_addons_failed_to_translate">Nun s\'alcontró la traducción de la locale %1$s nin de la llingua predeterminada %2$s</string>
+    <string name="mozac_feature_addons_failed_to_translate">Nun s\'atopó la traducción de la locale %1$s nin de la llingua predeterminada %2$s</string>
     <!-- Text shown after successfully installed an add-on. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_successfully_installed">%1$s instalóse con ésitu</string>
     <!-- Text shown after failed to install an add-on. %1$s is the add-on name. -->
@@ -205,7 +205,7 @@
     <!-- Text shown in the dialog when add-on installation is completed. %1$s is the add-on name. %2$s is the app name. -->
     <string name="mozac_feature_addons_installed_dialog_title">%1$s amestóse a %2$s</string>
     <!-- Text shown in the dialog when add-on installation is completed. %1$s is the add-on name. -->
-    <string name="mozac_feature_addons_installed_dialog_description">Abrilu nel menú</string>
+    <string name="mozac_feature_addons_installed_dialog_description">Ábrilu nel menú</string>
     <!-- Confirmation button text for the dialog when add-on installation is completed. -->
     <string name="mozac_feature_addons_installed_dialog_okay_button">Val, entiéndolo</string>
 </resources>

--- a/components/feature/addons/src/main/res/values-bn/strings.xml
+++ b/components/feature/addons/src/main/res/values-bn/strings.xml
@@ -4,6 +4,10 @@
     <string name="mozac_feature_addons_permissions_privacy_description">পড়ুন এবং গোপনীয়তা সেটিংস পরিবর্তন করুন</string>
     <!-- Description for all_urls add-on permission. -->
     <string name="mozac_feature_addons_permissions_all_urls_description">সকল ওয়েবসাইটের জন্য আপনার তথ্য ব্যবহার করুন</string>
+    <!-- Description for giving an add-on access to users's data on one site. %1$s  will be replaced by the DNS host name for which a web extension is requesting access (e.g., www.mozilla.org). -->
+    <string name="mozac_feature_addons_permissions_one_site_description">%1$s এর জন্য আপনার তথ্য ব্যাবহার করুন</string>
+    <!-- Description for giving an add-on access to users's data in multiple sites in the domain %1$s. %1$s will be replaced by the DNS domain for which a web extension is requesting access (e.g., mozilla.org). -->
+    <string name="mozac_feature_addons_permissions_sites_in_domain_description">%1$s ডোমেইনে থাকা সাইটের জন্য আপনার তথ্য ব্যবহার করুন</string>
     <!-- Description for tabs add-on permission. -->
     <string name="mozac_feature_addons_permissions_tabs_description">ব্রাউজারের ট্যাবগুলো ব্যবহার করুন</string>
     <!-- Description for unlimited_storage permission. -->
@@ -46,6 +50,8 @@
     <string name="mozac_feature_addons_permissions_tab_hide_description">ব্রাউজারের ট্যাবগুলি লুকান এবং দেখুন</string>
     <!-- Description for top_sites permission. -->
     <string name="mozac_feature_addons_permissions_top_sites_description">ব্রাউজিং ইতিহাসে প্রবেশ করুন</string>
+    <!-- Description for devtools permission. -->
+    <string name="mozac_feature_addons_permissions_devtools_description">খোলা ট্যাবগুলোতে আপনার ডাটা ব্যবহার করতে ডেভেলপার টুলগুলো সম্প্রসারিত করুন</string>
     <!-- The version on of add-on. -->
     <string name="mozac_feature_addons_version">সংস্করণ</string>
     <!-- The authors of an add-on. -->
@@ -98,8 +104,10 @@
     <string name="mozac_feature_addons_permissions_dialog_cancel">বাতিল</string>
     <!-- Accessibility content description to install add-on button. -->
     <string name="mozac_feature_addons_install_addon_content_description">অ্যাড-অন ইনস্টল করুন</string>
-    <!-- Indicates how many users have rated an add-on. %1$s will be replaced with number of users -->
-    <string name="mozac_feature_addons_user_rating_count">ইউজার: %1$s</string>
+    <!-- This is the label of a button to cancel an ongoing add-on installation. -->
+    <string name="mozac_feature_addons_install_addon_dialog_cancel">বাতিল</string>
+    <!-- Indicates how many users have rated an add-on. %1$s will be replaced with number of reviews -->
+    <string name="mozac_feature_addons_user_rating_count_2">পর্যালোচনা: %1$s</string>
     <!-- Accessibility content description for the amount of stars that add-on has, where %1$.02f will be the amount of stars and / separator and 5 the maximum number of stars e.g (2/5, 4.5/5 or 5/5)  . -->
     <string name="mozac_feature_addons_rating_content_description">%1$.02f/5</string>
     <!-- This is the title of page where all the add-ons are listed-->
@@ -120,12 +128,22 @@
     <string name="mozac_feature_addons_supported_checker_notification_channel">অ্যাড-অন পরীক্ষক সমর্থিত</string>
     <!-- The tile of the notification, this will be shown to the user when one newly supported add-on is available.-->
     <string name="mozac_feature_addons_supported_checker_notification_title">নতুন অ্যাড-অন বিদ্যমান</string>
+    <!-- The tile of the notification, this will be shown to the user when more than one newly supported add-ons are available.-->
+    <string name="mozac_feature_addons_supported_checker_notification_title_plural">নতুন অ্যাড-অন বিদ্যমান</string>
+    <!-- The content of the notification, this will be shown to the user when one newly supported add-on is available. %1$s is the add-on name and %2$s is the app name (in most cases Firefox). -->
+    <string name="mozac_feature_addons_supported_checker_notification_content_one">%1$s কে %2$s এ যুক্ত করুন</string>
+    <!-- The content of the notification, this will be shown to the user when two newly supported add-ons are available. %1$s is the first add-on name. %2$s is the second add-on name. %3$s is the app name (in most cases Firefox). -->
+    <string name="mozac_feature_addons_supported_checker_notification_content_two">%1$s এবং %2$s কে %3$s এ যুক্ত করুন</string>
     <!-- The content of the notification, this will be shown to the user when more than two newly supported add-ons are available. %1$s is the app name (in most cases Firefox). -->
     <string name="mozac_feature_addons_supported_checker_notification_content_more_than_two">এগুলোকে %1$s এ যুক্ত করুন</string>
     <!-- This is the caption for not yet supported screen caption -->
     <string name="mozac_feature_addons_not_yet_supported_caption">Firefox অ্যাড-অন প্রযুক্তি আধুনিকীকরণ করছে। এই অ্যাড-অনগুলি এমন ফ্রেমওয়ার্কগুলি ব্যবহার করে যা Firefox 75 এবং এর বাইরে উপযুক্ত নয়।</string>
+    <!-- This is the caption for not yet supported screen caption -->
+    <string name="mozac_feature_addons_not_yet_supported_caption2">আমরা বর্তমানে প্রস্তাবিত এক্সটেনশনসমূহের প্রাথমিক বাছাই এর জন্য প্রয়োজনীয় সাপোর্ট নির্মাণ করছি।</string>
     <!-- This is the caption for the add-on installation progress overlay -->
     <string name="mozac_add_on_install_progress_caption">অ্যাড-অন ডাউনলোড এবং যাচাই করা হচ্ছে ...</string>
+    <!-- Error shown when unable to find a translation for an add-on field. %1$s is the locale of the user and %2$s is the default language of the add-on -->
+    <string name="mozac_feature_addons_failed_to_translate">লোকেল %1$s কিংবা নির্ধারিত ভাষা %2$s, কোনোটির জন্যই অনুবাদ খুঁজে পাওয়া যায়নি</string>
     <!-- Text shown after successfully installed an add-on. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_successfully_installed">সফলভাবে %1$s ইনস্টল করা হয়েছে</string>
     <!-- Text shown after failed to install an add-on. %1$s is the add-on name. -->
@@ -154,10 +172,20 @@
     <string name="mozac_feature_addons_unsupported_caption_plural">%1$s অ্যাড-অনগুলো</string>
     <!-- Text link to a sumo page for learning more about unsupported add-ons. -->
     <string name="mozac_feature_addons_unsupported_learn_more">আরো জানুন</string>
+    <!-- Displayed in the "Status" field for the updater when an add-on has been correctly updated. -->
+    <string name="mozac_feature_addons_updater_status_successfully_updated">সফলভাবে আপডেট হয়েছে</string>
+    <!-- Displayed in the "Status" field for the updater when an add-on has no updates available. -->
+    <string name="mozac_feature_addons_updater_status_no_update_available">কোন আপডেট বিদ্যমান নেই</string>
     <!-- Displayed in the "Status" field for the updater when there was an error during the add-on update. -->
     <string name="mozac_feature_addons_updater_status_error">ত্রুটি</string>
+    <!-- Text shown in a dialog that displays information about the last attempt to update an add-on. This is the title of the dialog. -->
+    <string name="mozac_feature_addons_updater_dialog_title">আপডেটার তথ্য</string>
     <!-- Label in the dialog displaying information for the last attempt to update add-ons. It's followed by the date of the last attempt. -->
     <string name="mozac_feature_addons_updater_dialog_last_attempt">শেষ চেষ্টা:</string>
+    <!-- Displayed in the "Status" field for the updater when an add-on has been correctly updated -->
+    <string name="mozac_feature_addons_updater_dialog_status">অবস্থা:</string>
+    <!-- Text shown in the dialog when add-on installation is completed. %1$s is the add-on name. -->
+    <string name="mozac_feature_addons_installed_dialog_description">মেনুতে খুলুন</string>
     <!-- Confirmation button text for the dialog when add-on installation is completed. -->
     <string name="mozac_feature_addons_installed_dialog_okay_button">ঠিক আছে, বুঝতে পেরেছি</string>
 </resources>

--- a/components/feature/addons/src/main/res/values-co/strings.xml
+++ b/components/feature/addons/src/main/res/values-co/strings.xml
@@ -33,13 +33,13 @@
     <!-- Description for browser_setting permission. -->
     <string name="mozac_feature_addons_permissions_browser_setting_description">Cunsultà è mudificà e preferenze di u navigatore</string>
     <!-- Description for browser_data permission. -->
-    <string name="mozac_feature_addons_permissions_browser_data_description">Squassà a crunulogia recente di navigazione, i canistrelli, è i dati assuciati</string>
+    <string name="mozac_feature_addons_permissions_browser_data_description">Squassà a cronolugia recente di navigazione, i canistrelli, è i dati assuciati</string>
     <!-- Description for clipboard_read permission. -->
     <string name="mozac_feature_addons_permissions_clipboard_read_description">Ottene i dati da u preme’papei</string>
     <!-- Description for clipboard_write permission. -->
     <string name="mozac_feature_addons_permissions_clipboard_write_description">Aghjunghje dati ver di u preme’papei</string>
     <!-- Description for downloads permission. -->
-    <string name="mozac_feature_addons_permissions_downloads_description">Scaricà schedarii, è leghje è mudificà a crunulogia di i scaricamenti di u navigatore</string>
+    <string name="mozac_feature_addons_permissions_downloads_description">Scaricà schedarii, è leghje è mudificà a cronolugia di i scaricamenti di u navigatore</string>
     <!-- Description for downloads_open permission. -->
     <string name="mozac_feature_addons_permissions_downloads_open_description">Apre i schedarii scaricati nant’à u vostru apparechju</string>
     <!-- Description for find permission. -->
@@ -47,7 +47,7 @@
     <!-- Description for geolocation permission. -->
     <string name="mozac_feature_addons_permissions_geolocation_description">Accede à a vostra lucalizazione</string>
     <!-- Description for history permission. -->
-    <string name="mozac_feature_addons_permissions_history_description">Accede à a crunulogia di navigazione</string>
+    <string name="mozac_feature_addons_permissions_history_description">Accede à a cronolugia di navigazione</string>
     <!-- Description for management permission. -->
     <string name="mozac_feature_addons_permissions_management_description">Cuttighjà l’impiegu di l’estensioni è urganizà i temi</string>
     <!-- Description for native_messaging permission. -->
@@ -63,7 +63,7 @@
     <!-- Description for tab_hide permission. -->
     <string name="mozac_feature_addons_permissions_tab_hide_description">Affissà o piattà l’unghjette di u navigatore</string>
     <!-- Description for top_sites permission. -->
-    <string name="mozac_feature_addons_permissions_top_sites_description">Accede à a crunulogia di navigazione</string>
+    <string name="mozac_feature_addons_permissions_top_sites_description">Accede à a cronolugia di navigazione</string>
     <!-- Description for devtools permission. -->
     <string name="mozac_feature_addons_permissions_devtools_description">Stende l’impiegu di l’attrezzi di sviluppu per accede à i vostri dati in l’unghjette aperte</string>
     <!-- The version on of add-on. -->

--- a/components/feature/addons/src/main/res/values-cs/strings.xml
+++ b/components/feature/addons/src/main/res/values-cs/strings.xml
@@ -160,6 +160,8 @@
     <string name="mozac_add_on_install_progress_caption">Stahování a ověřování doplňku…</string>
     <!-- Error shown when something unexpected happened while trying to get the add-on list from the server -->
     <string name="mozac_feature_addons_failed_to_query_add_ons">Nepodařilo se získat seznam doplňků.</string>
+    <!-- Error shown when unable to find a translation for an add-on field. %1$s is the locale of the user and %2$s is the default language of the add-on -->
+    <string name="mozac_feature_addons_failed_to_translate">Překlad pro region %1$s ani pro výchozí jazyk %2$s nebyl nalezen</string>
     <!-- Text shown after successfully installed an add-on. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_successfully_installed">Doplněk %1$s byl úspěšně nainstalován</string>
     <!-- Text shown after failed to install an add-on. %1$s is the add-on name. -->

--- a/components/feature/addons/src/main/res/values-eo/strings.xml
+++ b/components/feature/addons/src/main/res/values-eo/strings.xml
@@ -4,6 +4,24 @@
     <string name="mozac_feature_addons_permissions_privacy_description">Legi kaj modifi privatecajn agordojn</string>
     <!-- Description for all_urls add-on permission. -->
     <string name="mozac_feature_addons_permissions_all_urls_description">Aliri viajn datumojn por ĉiuj retejoj</string>
+    <!-- Description for giving an add-on access to users's data on one site. %1$s  will be replaced by the DNS host name for which a web extension is requesting access (e.g., www.mozilla.org). -->
+    <string name="mozac_feature_addons_permissions_one_site_description">Aliri viajn datumojn por %1$s</string>
+    <!-- Description for giving an add-on access to users's data in multiple sites in the domain %1$s. %1$s will be replaced by the DNS domain for which a web extension is requesting access (e.g., mozilla.org). -->
+    <string name="mozac_feature_addons_permissions_sites_in_domain_description">Aliri viajn datumojn por retejoj en la nomregno %1$s</string>
+    <!-- When an add-on requires access to more than 4 sites, for example the add-on requires access for 5 sites. We will show the first 4 sites in individual entries, as in mozac_feature_addons_permissions_one_site_description,
+     then we will show another collapsed entry saying "Access your data on 1 other site". This entry it's for the singular case, when the add-on is only accessing one extra site. -->
+    <string name="mozac_feature_addons_permissions_one_extra_site_description" tools:ignore="PluralsCandidate">Aliri viajn datumojn por alia retejo</string>
+    <!-- When an add-on requires access to more than 4 sites, for example the add-on requires access for 6 sites. We will show the first 4 sites in individual entries, as in mozac_feature_addons_permissions_one_site_description,
+     then we will show another collapsed entry saying "Access your data on 2 other sites". This entry it's for the plural case, when the add-on is accessing more than one extra site.
+     %1$d will be replaced by an integer indicating the number of additional hosts for which this web extension is requesting permission. -->
+    <string name="mozac_feature_addons_permissions_extra_sites_description" tools:ignore="PluralsCandidate">Aliri viajn datumojn por %1$d aliaj retejoj</string>
+    <!-- When an add-on requires access to more than 4 domains, for example the add-on requires access for 5 domains. We will show the first 4 domains in individual entries, as in mozac_feature_addons_permissions_sites_in_domain_description,
+      then we will show another collapsed entry saying "Access your data on 1 other domain". This entry it's for the singular case, when the add-on is only accessing one extra domain. -->
+    <string name="mozac_feature_addons_permissions_one_extra_domain_description" tools:ignore="PluralsCandidate">Aliri viajn datumojn de alia nomregno</string>
+    <!-- When an add-on requires access to more than 4 domains, for example the add-on requires access for 6 domains. We will show the first 4 domains in individual entries, as in mozac_feature_addons_permissions_sites_in_domain_description,
+     then we will show another collapsed entry saying "Access your data on 2 other domains". This entry it's for the plural case, when the add-on is accessing more than one extra domain.
+     %1$d will be replaced by an integer indicating the number of additional domains for which this web extension is requesting permission. -->
+    <string name="mozac_feature_addons_permissions_extra_domains_description_plural" tools:ignore="PluralsCandidate">Aliri viajn datumojn de %1$d aliaj nomregnoj</string>
     <!-- Description for tabs add-on permission. -->
     <string name="mozac_feature_addons_permissions_tabs_description">Aliri retumilajn langetojn</string>
     <!-- Description for unlimited_storage permission. -->
@@ -108,6 +126,8 @@
     <string name="mozac_feature_addons_rating_content_description">%1$.02f/5</string>
     <!-- This is the title of page where all the add-ons are listed-->
     <string name="mozac_feature_addons_addons">Aldonaĵoj</string>
+    <!-- Label for add-ons sub menu item for add-ons manager-->
+    <string name="mozac_feature_addons_addons_manager">Administrilo de aldonaĵoj</string>
     <!-- The label of the allow button, this will be shown to the user when an add-on needs new permissions, with the button the user will indicate that they want to accept the new permissions and update the add-on-->
     <string name="mozac_feature_addons_updater_notification_allow_button">Permesi</string>
     <!-- The label of the deny button on a notification, this will be shown to the user when an add-on needs new permissions. Indicates the user denies the new permissions and prevents the add-on from be updated-->
@@ -140,6 +160,8 @@
     <string name="mozac_add_on_install_progress_caption">Aldonaĵo elŝutata kaj kontrolata…</string>
     <!-- Error shown when something unexpected happened while trying to get the add-on list from the server -->
     <string name="mozac_feature_addons_failed_to_query_add_ons">Ne eblis akiri la liston de aldonaĵoj!</string>
+    <!-- Error shown when unable to find a translation for an add-on field. %1$s is the locale of the user and %2$s is the default language of the add-on -->
+    <string name="mozac_feature_addons_failed_to_translate">Traduko netrovita, nek por la lokaĵaro %1$s nek por la norma lingvo %2$s</string>
     <!-- Text shown after successfully installed an add-on. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_successfully_installed">%1$s sukcese instalita</string>
     <!-- Text shown after failed to install an add-on. %1$s is the add-on name. -->

--- a/components/feature/addons/src/main/res/values-es-rMX/strings.xml
+++ b/components/feature/addons/src/main/res/values-es-rMX/strings.xml
@@ -4,6 +4,24 @@
     <string name="mozac_feature_addons_permissions_privacy_description">Leer y modificar ajustes de privacidad</string>
     <!-- Description for all_urls add-on permission. -->
     <string name="mozac_feature_addons_permissions_all_urls_description">Acceder a tus datos para todos los sitios web</string>
+    <!-- Description for giving an add-on access to users's data on one site. %1$s  will be replaced by the DNS host name for which a web extension is requesting access (e.g., www.mozilla.org). -->
+    <string name="mozac_feature_addons_permissions_one_site_description">Acceder a tus datos para %1$s</string>
+    <!-- Description for giving an add-on access to users's data in multiple sites in the domain %1$s. %1$s will be replaced by the DNS domain for which a web extension is requesting access (e.g., mozilla.org). -->
+    <string name="mozac_feature_addons_permissions_sites_in_domain_description">Acceder a tus datos para los sitios del dominio %1$s</string>
+    <!-- When an add-on requires access to more than 4 sites, for example the add-on requires access for 5 sites. We will show the first 4 sites in individual entries, as in mozac_feature_addons_permissions_one_site_description,
+     then we will show another collapsed entry saying "Access your data on 1 other site". This entry it's for the singular case, when the add-on is only accessing one extra site. -->
+    <string name="mozac_feature_addons_permissions_one_extra_site_description" tools:ignore="PluralsCandidate">Acceder a tus datos en 1 sitio más</string>
+    <!-- When an add-on requires access to more than 4 sites, for example the add-on requires access for 6 sites. We will show the first 4 sites in individual entries, as in mozac_feature_addons_permissions_one_site_description,
+     then we will show another collapsed entry saying "Access your data on 2 other sites". This entry it's for the plural case, when the add-on is accessing more than one extra site.
+     %1$d will be replaced by an integer indicating the number of additional hosts for which this web extension is requesting permission. -->
+    <string name="mozac_feature_addons_permissions_extra_sites_description" tools:ignore="PluralsCandidate">Acceder a tus datos en %1$d sitios más</string>
+    <!-- When an add-on requires access to more than 4 domains, for example the add-on requires access for 5 domains. We will show the first 4 domains in individual entries, as in mozac_feature_addons_permissions_sites_in_domain_description,
+      then we will show another collapsed entry saying "Access your data on 1 other domain". This entry it's for the singular case, when the add-on is only accessing one extra domain. -->
+    <string name="mozac_feature_addons_permissions_one_extra_domain_description" tools:ignore="PluralsCandidate">Acceder a tus datos en 1 dominio más</string>
+    <!-- When an add-on requires access to more than 4 domains, for example the add-on requires access for 6 domains. We will show the first 4 domains in individual entries, as in mozac_feature_addons_permissions_sites_in_domain_description,
+     then we will show another collapsed entry saying "Access your data on 2 other domains". This entry it's for the plural case, when the add-on is accessing more than one extra domain.
+     %1$d will be replaced by an integer indicating the number of additional domains for which this web extension is requesting permission. -->
+    <string name="mozac_feature_addons_permissions_extra_domains_description_plural" tools:ignore="PluralsCandidate">Acceder a tus datos en %1$d dominios más</string>
     <!-- Description for tabs add-on permission. -->
     <string name="mozac_feature_addons_permissions_tabs_description">Acceder a las pestañas del navegador</string>
     <!-- Description for unlimited_storage permission. -->
@@ -108,6 +126,8 @@
     <string name="mozac_feature_addons_rating_content_description">%1$.02f/5</string>
     <!-- This is the title of page where all the add-ons are listed-->
     <string name="mozac_feature_addons_addons">Complementos</string>
+    <!-- Label for add-ons sub menu item for add-ons manager-->
+    <string name="mozac_feature_addons_addons_manager">Administrador de complementos</string>
     <!-- The label of the allow button, this will be shown to the user when an add-on needs new permissions, with the button the user will indicate that they want to accept the new permissions and update the add-on-->
     <string name="mozac_feature_addons_updater_notification_allow_button">Permitir</string>
     <!-- The label of the deny button on a notification, this will be shown to the user when an add-on needs new permissions. Indicates the user denies the new permissions and prevents the add-on from be updated-->
@@ -140,6 +160,8 @@
     <string name="mozac_add_on_install_progress_caption">Descargando y verificando complemento…</string>
     <!-- Error shown when something unexpected happened while trying to get the add-on list from the server -->
     <string name="mozac_feature_addons_failed_to_query_add_ons">¡Error al consultar complementos!</string>
+    <!-- Error shown when unable to find a translation for an add-on field. %1$s is the locale of the user and %2$s is the default language of the add-on -->
+    <string name="mozac_feature_addons_failed_to_translate">No se encontró la traducción para la localización %1$s ni en el idioma predeterminado %2$s</string>
     <!-- Text shown after successfully installed an add-on. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_successfully_installed">%1$s instalado correctamente</string>
     <!-- Text shown after failed to install an add-on. %1$s is the add-on name. -->

--- a/components/feature/addons/src/main/res/values-gd/strings.xml
+++ b/components/feature/addons/src/main/res/values-gd/strings.xml
@@ -4,6 +4,24 @@
     <string name="mozac_feature_addons_permissions_privacy_description">roghainnean na prìobhaideachd a leughadh is atharrachadh</string>
     <!-- Description for all_urls add-on permission. -->
     <string name="mozac_feature_addons_permissions_all_urls_description">cothrom fhaighinn air an dàta agad airson a h-uile làrach-lìn</string>
+    <!-- Description for giving an add-on access to users's data on one site. %1$s  will be replaced by the DNS host name for which a web extension is requesting access (e.g., www.mozilla.org). -->
+    <string name="mozac_feature_addons_permissions_one_site_description">Cothrom fhaighinn air an dàta agad airson %1$s</string>
+    <!-- Description for giving an add-on access to users's data in multiple sites in the domain %1$s. %1$s will be replaced by the DNS domain for which a web extension is requesting access (e.g., mozilla.org). -->
+    <string name="mozac_feature_addons_permissions_sites_in_domain_description">Cothrom fhaighinn air an dàta air fad agad airson làraichean air an àrainn %1$s</string>
+    <!-- When an add-on requires access to more than 4 sites, for example the add-on requires access for 5 sites. We will show the first 4 sites in individual entries, as in mozac_feature_addons_permissions_one_site_description,
+     then we will show another collapsed entry saying "Access your data on 1 other site". This entry it's for the singular case, when the add-on is only accessing one extra site. -->
+    <string name="mozac_feature_addons_permissions_one_extra_site_description" tools:ignore="PluralsCandidate">Cothrom fhaighinn air an dàta agad air aon làrach eile</string>
+    <!-- When an add-on requires access to more than 4 sites, for example the add-on requires access for 6 sites. We will show the first 4 sites in individual entries, as in mozac_feature_addons_permissions_one_site_description,
+     then we will show another collapsed entry saying "Access your data on 2 other sites". This entry it's for the plural case, when the add-on is accessing more than one extra site.
+     %1$d will be replaced by an integer indicating the number of additional hosts for which this web extension is requesting permission. -->
+    <string name="mozac_feature_addons_permissions_extra_sites_description" tools:ignore="PluralsCandidate">Cothrom fhaighinn air an dàta agad air làraichean (%1$d) eile</string>
+    <!-- When an add-on requires access to more than 4 domains, for example the add-on requires access for 5 domains. We will show the first 4 domains in individual entries, as in mozac_feature_addons_permissions_sites_in_domain_description,
+      then we will show another collapsed entry saying "Access your data on 1 other domain". This entry it's for the singular case, when the add-on is only accessing one extra domain. -->
+    <string name="mozac_feature_addons_permissions_one_extra_domain_description" tools:ignore="PluralsCandidate">Cothrom fhaighinn air an dàta agad air aon àrainn eile</string>
+    <!-- When an add-on requires access to more than 4 domains, for example the add-on requires access for 6 domains. We will show the first 4 domains in individual entries, as in mozac_feature_addons_permissions_sites_in_domain_description,
+     then we will show another collapsed entry saying "Access your data on 2 other domains". This entry it's for the plural case, when the add-on is accessing more than one extra domain.
+     %1$d will be replaced by an integer indicating the number of additional domains for which this web extension is requesting permission. -->
+    <string name="mozac_feature_addons_permissions_extra_domains_description_plural" tools:ignore="PluralsCandidate">Cothrom fhaighinn air an dàta agad air àrainnean (%1$d) eile</string>
     <!-- Description for tabs add-on permission. -->
     <string name="mozac_feature_addons_permissions_tabs_description">cothrom fhaighinn air tabaichean a’ bhrabhsair</string>
     <!-- Description for unlimited_storage permission. -->
@@ -108,6 +126,8 @@
     <string name="mozac_feature_addons_rating_content_description">%1$.02f/5</string>
     <!-- This is the title of page where all the add-ons are listed-->
     <string name="mozac_feature_addons_addons">Tuilleadain</string>
+    <!-- Label for add-ons sub menu item for add-ons manager-->
+    <string name="mozac_feature_addons_addons_manager">Manaidsear nan tuilleadan</string>
     <!-- The label of the allow button, this will be shown to the user when an add-on needs new permissions, with the button the user will indicate that they want to accept the new permissions and update the add-on-->
     <string name="mozac_feature_addons_updater_notification_allow_button">Ceadaich</string>
     <!-- The label of the deny button on a notification, this will be shown to the user when an add-on needs new permissions. Indicates the user denies the new permissions and prevents the add-on from be updated-->
@@ -140,6 +160,8 @@
     <string name="mozac_add_on_install_progress_caption">A’ luchdadh a-nuas is a’ dearbhadh an tuilleadain…</string>
     <!-- Error shown when something unexpected happened while trying to get the add-on list from the server -->
     <string name="mozac_feature_addons_failed_to_query_add_ons">Dh’fhàillig ceasnachadh na tuilleadan!</string>
+    <!-- Error shown when unable to find a translation for an add-on field. %1$s is the locale of the user and %2$s is the default language of the add-on -->
+    <string name="mozac_feature_addons_failed_to_translate">Cha deach eadar-theangachadh (%1$s) a lorg no sa chànan bhunaiteach (%2$s)</string>
     <!-- Text shown after successfully installed an add-on. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_successfully_installed">Chaidh %1$s a stàladh</string>
     <!-- Text shown after failed to install an add-on. %1$s is the add-on name. -->

--- a/components/feature/addons/src/main/res/values-gd/strings.xml
+++ b/components/feature/addons/src/main/res/values-gd/strings.xml
@@ -161,7 +161,7 @@
     <!-- Error shown when something unexpected happened while trying to get the add-on list from the server -->
     <string name="mozac_feature_addons_failed_to_query_add_ons">Dh’fhàillig ceasnachadh na tuilleadan!</string>
     <!-- Error shown when unable to find a translation for an add-on field. %1$s is the locale of the user and %2$s is the default language of the add-on -->
-    <string name="mozac_feature_addons_failed_to_translate">Cha deach eadar-theangachadh (%1$s) a lorg no sa chànan bhunaiteach (%2$s)</string>
+    <string name="mozac_feature_addons_failed_to_translate">Cha deach eadar-theangachadh (%1$s) no a’ chànan bhunaiteach (%2$s) a lorg</string>
     <!-- Text shown after successfully installed an add-on. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_successfully_installed">Chaidh %1$s a stàladh</string>
     <!-- Text shown after failed to install an add-on. %1$s is the add-on name. -->

--- a/components/feature/addons/src/main/res/values-lo/strings.xml
+++ b/components/feature/addons/src/main/res/values-lo/strings.xml
@@ -4,6 +4,24 @@
     <string name="mozac_feature_addons_permissions_privacy_description">ອ່ານ ແລະ ແກ້ໄຂການຕັ້ງຄ່າຄວາມເປັນສາວນຕົວ</string>
     <!-- Description for all_urls add-on permission. -->
     <string name="mozac_feature_addons_permissions_all_urls_description">ເຂົ້າເຖິງຂໍ້ມູນຂອງທ່ານສຳລັບເວັບໄຊທທັງຫມົດ</string>
+    <!-- Description for giving an add-on access to users's data on one site. %1$s  will be replaced by the DNS host name for which a web extension is requesting access (e.g., www.mozilla.org). -->
+    <string name="mozac_feature_addons_permissions_one_site_description">ເຂົ້າເຖິງຂໍ້ມູນຂອງທ່ານສຳລັບ %1$s</string>
+    <!-- Description for giving an add-on access to users's data in multiple sites in the domain %1$s. %1$s will be replaced by the DNS domain for which a web extension is requesting access (e.g., mozilla.org). -->
+    <string name="mozac_feature_addons_permissions_sites_in_domain_description">ເຂົ້າເຖິງຂໍ້ມູນຂອງທ່ານສຳລັບເວັບໄຊທໃນໂດເມນ %1$s</string>
+    <!-- When an add-on requires access to more than 4 sites, for example the add-on requires access for 5 sites. We will show the first 4 sites in individual entries, as in mozac_feature_addons_permissions_one_site_description,
+     then we will show another collapsed entry saying "Access your data on 1 other site". This entry it's for the singular case, when the add-on is only accessing one extra site. -->
+    <string name="mozac_feature_addons_permissions_one_extra_site_description" tools:ignore="PluralsCandidate">ເຂົ້າເຖິງຂໍ້ມູນຂອງທ່ານໃນອີກ 1 ເວັບໄຊທ</string>
+    <!-- When an add-on requires access to more than 4 sites, for example the add-on requires access for 6 sites. We will show the first 4 sites in individual entries, as in mozac_feature_addons_permissions_one_site_description,
+     then we will show another collapsed entry saying "Access your data on 2 other sites". This entry it's for the plural case, when the add-on is accessing more than one extra site.
+     %1$d will be replaced by an integer indicating the number of additional hosts for which this web extension is requesting permission. -->
+    <string name="mozac_feature_addons_permissions_extra_sites_description" tools:ignore="PluralsCandidate">ເຂົ້າເຖິງຂໍ້ມູນຂອງທ່ານໃນອີກ %1$d ເວັບໄຊທ</string>
+    <!-- When an add-on requires access to more than 4 domains, for example the add-on requires access for 5 domains. We will show the first 4 domains in individual entries, as in mozac_feature_addons_permissions_sites_in_domain_description,
+      then we will show another collapsed entry saying "Access your data on 1 other domain". This entry it's for the singular case, when the add-on is only accessing one extra domain. -->
+    <string name="mozac_feature_addons_permissions_one_extra_domain_description" tools:ignore="PluralsCandidate">ເຂົ້າເຖິງຂໍ້ມູນຂອງທ່ານໃນອີກ 1 ໂດເມນ</string>
+    <!-- When an add-on requires access to more than 4 domains, for example the add-on requires access for 6 domains. We will show the first 4 domains in individual entries, as in mozac_feature_addons_permissions_sites_in_domain_description,
+     then we will show another collapsed entry saying "Access your data on 2 other domains". This entry it's for the plural case, when the add-on is accessing more than one extra domain.
+     %1$d will be replaced by an integer indicating the number of additional domains for which this web extension is requesting permission. -->
+    <string name="mozac_feature_addons_permissions_extra_domains_description_plural" tools:ignore="PluralsCandidate">ເຂົ້າເຖິງຂໍ້ມູນຂອງທ່ານໃນອີກ %1$d ໂດເມນ</string>
     <!-- Description for tabs add-on permission. -->
     <string name="mozac_feature_addons_permissions_tabs_description">ເຂົ້າເຖິງແທັບຂອງບຣາວເຊີ</string>
     <!-- Description for unlimited_storage permission. -->
@@ -102,12 +120,14 @@
     <string name="mozac_feature_addons_install_addon_content_description">ຕິດຕັ້ງ Add-on</string>
     <!-- This is the label of a button to cancel an ongoing add-on installation. -->
     <string name="mozac_feature_addons_install_addon_dialog_cancel">ຍົກເລີກ</string>
-    <!-- Indicates how many users have rated an add-on. %1$s will be replaced with number of users -->
-    <string name="mozac_feature_addons_user_rating_count">ຜູ້ໃຊ້: %1$s</string>
+    <!-- Indicates how many users have rated an add-on. %1$s will be replaced with number of reviews -->
+    <string name="mozac_feature_addons_user_rating_count_2">ກວດຄືນ: %1$s</string>
     <!-- Accessibility content description for the amount of stars that add-on has, where %1$.02f will be the amount of stars and / separator and 5 the maximum number of stars e.g (2/5, 4.5/5 or 5/5)  . -->
     <string name="mozac_feature_addons_rating_content_description">%1$.02f/5</string>
     <!-- This is the title of page where all the add-ons are listed-->
     <string name="mozac_feature_addons_addons">Add-ons</string>
+    <!-- Label for add-ons sub menu item for add-ons manager-->
+    <string name="mozac_feature_addons_addons_manager">ຕົວຈັດການ Add-ons</string>
     <!-- The label of the allow button, this will be shown to the user when an add-on needs new permissions, with the button the user will indicate that they want to accept the new permissions and update the add-on-->
     <string name="mozac_feature_addons_updater_notification_allow_button">ອະນຸຍາດ</string>
     <!-- The label of the deny button on a notification, this will be shown to the user when an add-on needs new permissions. Indicates the user denies the new permissions and prevents the add-on from be updated-->
@@ -140,6 +160,8 @@
     <string name="mozac_add_on_install_progress_caption">ກຳລັງດາວໂຫລດ ແລະ ກວດສອບ add-on…</string>
     <!-- Error shown when something unexpected happened while trying to get the add-on list from the server -->
     <string name="mozac_feature_addons_failed_to_query_add_ons">ບໍ່ສາມາດສອບຖາມ Add-ons ໄດ້!</string>
+    <!-- Error shown when unable to find a translation for an add-on field. %1$s is the locale of the user and %2$s is the default language of the add-on -->
+    <string name="mozac_feature_addons_failed_to_translate">ບໍ່ພົບການແປສຳລັບພາສາ %1$s ແລະ ພາສາພື້ນຖານ %2$s</string>
     <!-- Text shown after successfully installed an add-on. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_successfully_installed">ສຳເລັດການຕິດຕັ້ງ %1$s</string>
     <!-- Text shown after failed to install an add-on. %1$s is the add-on name. -->

--- a/components/feature/addons/src/main/res/values-mix/strings.xml
+++ b/components/feature/addons/src/main/res/values-mix/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <!-- The version on of add-on. -->
+    <string name="mozac_feature_addons_version">Versión</string>
+    </resources>

--- a/components/feature/addons/src/main/res/values-nb-rNO/strings.xml
+++ b/components/feature/addons/src/main/res/values-nb-rNO/strings.xml
@@ -205,7 +205,7 @@
     <!-- Text shown in the dialog when add-on installation is completed. %1$s is the add-on name. %2$s is the app name. -->
     <string name="mozac_feature_addons_installed_dialog_title">%1$s er lagt til i %2$s</string>
     <!-- Text shown in the dialog when add-on installation is completed. %1$s is the add-on name. -->
-    <string name="mozac_feature_addons_installed_dialog_description">Åpne den i menyen</string>
+    <string name="mozac_feature_addons_installed_dialog_description">Åpne det i menyen</string>
     <!-- Confirmation button text for the dialog when add-on installation is completed. -->
     <string name="mozac_feature_addons_installed_dialog_okay_button">Ok, jeg forstår</string>
 </resources>

--- a/components/feature/addons/src/main/res/values-nn-rNO/strings.xml
+++ b/components/feature/addons/src/main/res/values-nn-rNO/strings.xml
@@ -157,7 +157,7 @@
     <!-- This is the caption for not yet supported screen caption -->
     <string name="mozac_feature_addons_not_yet_supported_caption2">Vi utviklar for tida støtte for eit første utval av tilrådde utvidingar.</string>
     <!-- This is the caption for the add-on installation progress overlay -->
-    <string name="mozac_add_on_install_progress_caption">Lastar ned ogstadfestar tiillegget…</string>
+    <string name="mozac_add_on_install_progress_caption">Lastar ned og stadfestar tiillegget…</string>
     <!-- Error shown when something unexpected happened while trying to get the add-on list from the server -->
     <string name="mozac_feature_addons_failed_to_query_add_ons">Mislykka førespurnad om tlleggsprogram!</string>
     <!-- Error shown when unable to find a translation for an add-on field. %1$s is the locale of the user and %2$s is the default language of the add-on -->

--- a/components/feature/addons/src/main/res/values-ru/strings.xml
+++ b/components/feature/addons/src/main/res/values-ru/strings.xml
@@ -5,23 +5,23 @@
     <!-- Description for all_urls add-on permission. -->
     <string name="mozac_feature_addons_permissions_all_urls_description">Доступ к вашим данным для всех веб-сайтов</string>
     <!-- Description for giving an add-on access to users's data on one site. %1$s  will be replaced by the DNS host name for which a web extension is requesting access (e.g., www.mozilla.org). -->
-    <string name="mozac_feature_addons_permissions_one_site_description">Доступ к вашим данным для %1$s</string>
+    <string name="mozac_feature_addons_permissions_one_site_description">Доступ к вашим данным на %1$s</string>
     <!-- Description for giving an add-on access to users's data in multiple sites in the domain %1$s. %1$s will be replaced by the DNS domain for which a web extension is requesting access (e.g., mozilla.org). -->
-    <string name="mozac_feature_addons_permissions_sites_in_domain_description">Доступ к вашим данным для сайтов в домене %1$s</string>
+    <string name="mozac_feature_addons_permissions_sites_in_domain_description">Доступ к вашим данным для сайтов на домене %1$s</string>
     <!-- When an add-on requires access to more than 4 sites, for example the add-on requires access for 5 sites. We will show the first 4 sites in individual entries, as in mozac_feature_addons_permissions_one_site_description,
      then we will show another collapsed entry saying "Access your data on 1 other site". This entry it's for the singular case, when the add-on is only accessing one extra site. -->
-    <string name="mozac_feature_addons_permissions_one_extra_site_description" tools:ignore="PluralsCandidate">Получать доступ к вашим данных на ещё одном сайте</string>
+    <string name="mozac_feature_addons_permissions_one_extra_site_description" tools:ignore="PluralsCandidate">Получать доступ к вашим данным на ещё одном сайте</string>
     <!-- When an add-on requires access to more than 4 sites, for example the add-on requires access for 6 sites. We will show the first 4 sites in individual entries, as in mozac_feature_addons_permissions_one_site_description,
      then we will show another collapsed entry saying "Access your data on 2 other sites". This entry it's for the plural case, when the add-on is accessing more than one extra site.
      %1$d will be replaced by an integer indicating the number of additional hosts for which this web extension is requesting permission. -->
-    <string name="mozac_feature_addons_permissions_extra_sites_description" tools:ignore="PluralsCandidate">Получать доступ к вашим данных на ещё %1$d сайтах</string>
+    <string name="mozac_feature_addons_permissions_extra_sites_description" tools:ignore="PluralsCandidate">Получать доступ к вашим данным на ещё %1$d сайтах</string>
     <!-- When an add-on requires access to more than 4 domains, for example the add-on requires access for 5 domains. We will show the first 4 domains in individual entries, as in mozac_feature_addons_permissions_sites_in_domain_description,
       then we will show another collapsed entry saying "Access your data on 1 other domain". This entry it's for the singular case, when the add-on is only accessing one extra domain. -->
-    <string name="mozac_feature_addons_permissions_one_extra_domain_description" tools:ignore="PluralsCandidate">Получать доступ к вашим данных на ещё одном домене</string>
+    <string name="mozac_feature_addons_permissions_one_extra_domain_description" tools:ignore="PluralsCandidate">Получать доступ к вашим данным на ещё одном домене</string>
     <!-- When an add-on requires access to more than 4 domains, for example the add-on requires access for 6 domains. We will show the first 4 domains in individual entries, as in mozac_feature_addons_permissions_sites_in_domain_description,
      then we will show another collapsed entry saying "Access your data on 2 other domains". This entry it's for the plural case, when the add-on is accessing more than one extra domain.
      %1$d will be replaced by an integer indicating the number of additional domains for which this web extension is requesting permission. -->
-    <string name="mozac_feature_addons_permissions_extra_domains_description_plural" tools:ignore="PluralsCandidate">Получать доступ к вашим данных на ещё %1$d доменах</string>
+    <string name="mozac_feature_addons_permissions_extra_domains_description_plural" tools:ignore="PluralsCandidate">Получать доступ к вашим данным на ещё %1$d доменах</string>
     <!-- Description for tabs add-on permission. -->
     <string name="mozac_feature_addons_permissions_tabs_description">Доступ к вкладкам браузера</string>
     <!-- Description for unlimited_storage permission. -->

--- a/components/feature/addons/src/main/res/values-sat/strings.xml
+++ b/components/feature/addons/src/main/res/values-sat/strings.xml
@@ -1,71 +1,71 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Description for privacy add-on permission. -->
-    <string name="mozac_feature_addons_permissions_privacy_description">ᱱᱤᱥᱚᱱ ᱥᱟᱡᱟᱣ ᱠᱚ ᱯᱟᱲᱦᱟᱣ ᱢᱮᱸ ᱟᱨ ᱵᱚᱫᱚᱞ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_privacy_description">ᱱᱤᱥᱚᱱ ᱥᱟᱡᱟᱣ ᱠᱚ ᱯᱟᱲᱦᱟᱣ ᱢᱮ ᱟᱨ ᱵᱚᱫᱚᱞ ᱢᱮ</string>
     <!-- Description for all_urls add-on permission. -->
-    <string name="mozac_feature_addons_permissions_all_urls_description">ᱡᱚᱛᱚ ᱣᱮᱵᱥᱟᱭᱤᱴ ᱞᱟᱹᱜᱤᱛ ᱟᱢᱟᱜ ᱰᱟᱴᱟ ᱟᱹᱛᱩᱨ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_all_urls_description">ᱡᱚᱛᱚ ᱣᱮᱵᱥᱟᱭᱤᱴ ᱞᱟᱹᱜᱤᱛ ᱟᱢᱟᱜ ᱰᱟᱴᱟ ᱟᱹᱛᱩᱨ ᱢᱮ</string>
     <!-- Description for giving an add-on access to users's data on one site. %1$s  will be replaced by the DNS host name for which a web extension is requesting access (e.g., www.mozilla.org). -->
-    <string name="mozac_feature_addons_permissions_one_site_description">%1$s ᱞᱟᱹᱜᱤᱛ ᱟᱢᱟᱜ ᱰᱟᱴᱟ ᱟᱹᱛᱩᱨ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_one_site_description">%1$s ᱞᱟᱹᱜᱤᱛ ᱟᱢᱟᱜ ᱰᱟᱴᱟ ᱟᱹᱛᱩᱨ ᱢᱮ</string>
     <!-- Description for giving an add-on access to users's data in multiple sites in the domain %1$s. %1$s will be replaced by the DNS domain for which a web extension is requesting access (e.g., mozilla.org). -->
-    <string name="mozac_feature_addons_permissions_sites_in_domain_description">ᱟᱢᱟᱜ ᱰᱟᱴᱟ ᱟᱹᱛᱩᱨ ᱢᱮᱸ ᱚᱱᱟ ᱥᱟᱭᱤᱴ ᱠᱚ ᱞᱟᱹᱜᱤᱛ ᱡᱟ %1$s ᱰᱚᱢᱮᱸᱱ ᱨᱮ ᱢᱮᱸᱱᱟᱜᱼᱟ</string>
+    <string name="mozac_feature_addons_permissions_sites_in_domain_description">ᱟᱢᱟᱜ ᱰᱟᱴᱟ ᱟᱹᱛᱩᱨ ᱢᱮ ᱚᱱᱟ ᱥᱟᱭᱤᱴ ᱠᱚ ᱞᱟᱹᱜᱤᱛ ᱡᱟ %1$s ᱰᱚᱢᱮᱱ ᱨᱮ ᱢᱮᱱᱟᱜᱼᱟ</string>
     <!-- When an add-on requires access to more than 4 sites, for example the add-on requires access for 5 sites. We will show the first 4 sites in individual entries, as in mozac_feature_addons_permissions_one_site_description,
      then we will show another collapsed entry saying "Access your data on 1 other site". This entry it's for the singular case, when the add-on is only accessing one extra site. -->
-    <string name="mozac_feature_addons_permissions_one_extra_site_description" tools:ignore="PluralsCandidate">ᱟᱢᱟᱜ ᱰᱟᱴᱟ 1 ᱚᱞᱜᱟ ᱥᱟᱭᱤᱴ ᱨᱮ ᱟᱹᱛᱩᱨ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_one_extra_site_description" tools:ignore="PluralsCandidate">ᱟᱢᱟᱜ ᱰᱟᱴᱟ 1 ᱚᱞᱜᱟ ᱥᱟᱭᱤᱴ ᱨᱮ ᱟᱹᱛᱩᱨ ᱢᱮ</string>
     <!-- When an add-on requires access to more than 4 sites, for example the add-on requires access for 6 sites. We will show the first 4 sites in individual entries, as in mozac_feature_addons_permissions_one_site_description,
      then we will show another collapsed entry saying "Access your data on 2 other sites". This entry it's for the plural case, when the add-on is accessing more than one extra site.
      %1$d will be replaced by an integer indicating the number of additional hosts for which this web extension is requesting permission. -->
-    <string name="mozac_feature_addons_permissions_extra_sites_description" tools:ignore="PluralsCandidate">ᱟᱢᱟᱜ ᱰᱟᱴᱟ %1$d ᱚᱞᱜᱟ ᱥᱟᱭᱤᱴ ᱠᱚᱨᱮ ᱟᱹᱛᱩᱨ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_extra_sites_description" tools:ignore="PluralsCandidate">ᱟᱢᱟᱜ ᱰᱟᱴᱟ %1$d ᱚᱞᱜᱟ ᱥᱟᱭᱤᱴ ᱠᱚᱨᱮ ᱟᱹᱛᱩᱨ ᱢᱮ</string>
     <!-- When an add-on requires access to more than 4 domains, for example the add-on requires access for 5 domains. We will show the first 4 domains in individual entries, as in mozac_feature_addons_permissions_sites_in_domain_description,
       then we will show another collapsed entry saying "Access your data on 1 other domain". This entry it's for the singular case, when the add-on is only accessing one extra domain. -->
-    <string name="mozac_feature_addons_permissions_one_extra_domain_description" tools:ignore="PluralsCandidate">ᱟᱢᱟᱜ ᱰᱟᱴᱟ 1 ᱚᱞᱜᱟ ᱰᱚᱢᱮᱸᱱ ᱨᱮ ᱟᱹᱛᱩᱨ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_one_extra_domain_description" tools:ignore="PluralsCandidate">ᱟᱢᱟᱜ ᱰᱟᱴᱟ 1 ᱚᱞᱜᱟ ᱰᱚᱢᱮᱱ ᱨᱮ ᱟᱹᱛᱩᱨ ᱢᱮ</string>
     <!-- When an add-on requires access to more than 4 domains, for example the add-on requires access for 6 domains. We will show the first 4 domains in individual entries, as in mozac_feature_addons_permissions_sites_in_domain_description,
      then we will show another collapsed entry saying "Access your data on 2 other domains". This entry it's for the plural case, when the add-on is accessing more than one extra domain.
      %1$d will be replaced by an integer indicating the number of additional domains for which this web extension is requesting permission. -->
-    <string name="mozac_feature_addons_permissions_extra_domains_description_plural" tools:ignore="PluralsCandidate">ᱟᱢᱟᱜ ᱰᱟᱴᱟ %1$d ᱚᱞᱜᱟ ᱰᱚᱢᱮᱸᱱ ᱠᱚᱨᱮ ᱟᱹᱛᱩᱨ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_extra_domains_description_plural" tools:ignore="PluralsCandidate">ᱟᱢᱟᱜ ᱰᱟᱴᱟ %1$d ᱚᱞᱜᱟ ᱰᱚᱢᱮᱱ ᱠᱚᱨᱮ ᱟᱹᱛᱩᱨ ᱢᱮ</string>
     <!-- Description for tabs add-on permission. -->
-    <string name="mozac_feature_addons_permissions_tabs_description">ᱵᱨᱟᱩᱡᱚᱨ ᱴᱮᱵ ᱟᱹᱛᱩᱨ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_tabs_description">ᱵᱨᱟᱩᱡᱚᱨ ᱴᱮᱵ ᱟᱹᱛᱩᱨ ᱢᱮ</string>
     <!-- Description for unlimited_storage permission. -->
-    <string name="mozac_feature_addons_permissions_unlimited_storage_description">ᱟᱸᱱᱞᱭᱴᱮᱰ ᱠᱞᱟᱭᱮᱸᱴ ᱰᱟᱴᱟ ᱫᱚᱦᱚᱭ ᱢᱮᱸ  </string>
+    <string name="mozac_feature_addons_permissions_unlimited_storage_description">ᱟᱸᱱᱞᱭᱴᱮᱰ ᱠᱞᱟᱭᱮᱸᱴ ᱰᱟᱴᱟ ᱫᱚᱦᱚᱭ ᱢᱮ  </string>
     <!-- Description for navigation permission. -->
-    <string name="mozac_feature_addons_permissions_web_navigation_description">ᱵᱨᱟᱩᱡᱟᱹᱨ ᱨᱮᱭᱟᱜ ᱠᱟᱹᱢᱤ ᱟᱹᱛᱩᱨ ᱢᱮᱸ ᱯᱟᱱᱛᱮ ᱜᱷᱚᱰᱤ</string>
+    <string name="mozac_feature_addons_permissions_web_navigation_description">ᱵᱨᱟᱩᱡᱟᱹᱨ ᱨᱮᱭᱟᱜ ᱠᱟᱹᱢᱤ ᱟᱹᱛᱩᱨ ᱢᱮ ᱯᱟᱱᱛᱮ ᱜᱷᱚᱰᱤ</string>
     <!-- Description for bookmarks permission. -->
-    <string name="mozac_feature_addons_permissions_bookmarks_description">ᱵᱩᱠᱢᱟᱨᱠ ᱠᱚ ᱯᱟᱹᱲᱦᱟᱣ ᱢᱮᱸ ᱟᱨ ᱵᱚᱫᱚᱞ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_bookmarks_description">ᱵᱩᱠᱢᱟᱨᱠ ᱠᱚ ᱯᱟᱹᱲᱦᱟᱣ ᱢᱮ ᱟᱨ ᱵᱚᱫᱚᱞ ᱢᱮ</string>
     <!-- Description for browser_setting permission. -->
-    <string name="mozac_feature_addons_permissions_browser_setting_description">ᱵᱨᱟᱩᱡᱟᱹᱨ ᱥᱟᱡᱚᱣ ᱠᱚ ᱯᱟᱹᱲᱦᱟᱣ ᱢᱮᱸ ᱟᱨ ᱵᱚᱫᱚᱞ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_browser_setting_description">ᱵᱨᱟᱩᱡᱟᱹᱨ ᱥᱟᱡᱚᱣ ᱠᱚ ᱯᱟᱹᱲᱦᱟᱣ ᱢᱮ ᱟᱨ ᱵᱚᱫᱚᱞ ᱢᱮ</string>
     <!-- Description for browser_data permission. -->
-    <string name="mozac_feature_addons_permissions_browser_data_description">ᱱᱤᱛᱚᱜᱟ ᱵᱨᱟᱩᱡᱤᱝ ᱦᱤᱛᱟᱹᱞ, ᱠᱩᱠᱤ ᱠᱚ, ᱟᱨ ᱥᱚᱸᱵᱚᱸᱫᱷ ᱰᱟᱴᱟ ᱯᱷᱟᱨᱪᱟᱭ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_browser_data_description">ᱱᱤᱛᱚᱜᱟ ᱵᱨᱟᱩᱡᱤᱝ ᱦᱤᱛᱟᱹᱞ, ᱠᱩᱠᱤ ᱠᱚ, ᱟᱨ ᱥᱚᱸᱵᱚᱸᱫᱷ ᱰᱟᱴᱟ ᱯᱷᱟᱨᱪᱟᱭ ᱢᱮ</string>
     <!-- Description for clipboard_read permission. -->
-    <string name="mozac_feature_addons_permissions_clipboard_read_description">ᱨᱮᱴᱚᱵᱼᱵᱚᱰ ᱠᱷᱚᱱ ᱰᱟᱴᱟ ᱧᱟᱢ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_clipboard_read_description">ᱨᱮᱴᱚᱵᱼᱵᱚᱰ ᱠᱷᱚᱱ ᱰᱟᱴᱟ ᱧᱟᱢ ᱢᱮ</string>
     <!-- Description for clipboard_write permission. -->
-    <string name="mozac_feature_addons_permissions_clipboard_write_description">ᱨᱮᱴᱚᱵᱼᱵᱚᱰ ᱨᱮ ᱰᱟᱴᱟ ᱟᱫᱮᱨ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_clipboard_write_description">ᱨᱮᱴᱚᱵᱼᱵᱚᱰ ᱨᱮ ᱰᱟᱴᱟ ᱟᱫᱮᱨ ᱢᱮ</string>
     <!-- Description for downloads permission. -->
-    <string name="mozac_feature_addons_permissions_downloads_description">ᱨᱮᱫ ᱰᱟᱩᱱᱞᱳᱰ ᱢᱮᱸ ᱟᱨ ᱯᱟᱲᱦᱟᱣ ᱢᱮᱸ ᱟᱨ ᱵᱨᱟᱩᱡᱤᱝ ᱰᱟᱩᱱᱞᱳᱰ ᱦᱤᱛᱟᱹᱞ ᱵᱚᱫᱚᱞ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_downloads_description">ᱨᱮᱫ ᱰᱟᱩᱱᱞᱳᱰ ᱢᱮ ᱟᱨ ᱯᱟᱲᱦᱟᱣ ᱢᱮ ᱟᱨ ᱵᱨᱟᱩᱡᱤᱝ ᱰᱟᱩᱱᱞᱳᱰ ᱦᱤᱛᱟᱹᱞ ᱵᱚᱫᱚᱞ ᱢᱮ</string>
     <!-- Description for downloads_open permission. -->
-    <string name="mozac_feature_addons_permissions_downloads_open_description">ᱨᱮᱫ ᱠᱚ ᱡᱷᱤᱡ ᱢᱮᱸ ᱡᱟᱦᱟᱸ ᱟᱢᱟᱜ ᱥᱟᱫᱷᱚᱱ ᱨᱮ ᱰᱟᱩᱱᱞᱳᱰ ᱦᱚᱭ ᱠᱟᱱᱟ</string>
+    <string name="mozac_feature_addons_permissions_downloads_open_description">ᱨᱮᱫ ᱠᱚ ᱡᱷᱤᱡ ᱢᱮ ᱡᱟᱦᱟᱸ ᱟᱢᱟᱜ ᱥᱟᱫᱷᱚᱱ ᱨᱮ ᱰᱟᱩᱱᱞᱳᱰ ᱦᱚᱭ ᱠᱟᱱᱟ</string>
     <!-- Description for find permission. -->
-    <string name="mozac_feature_addons_permissions_find_description">ᱥᱟᱱᱟᱢ ᱡᱷᱤᱡ ᱴᱮᱵ ᱠᱚᱣᱟᱜ ᱚᱱᱚᱞ ᱯᱟᱲᱦᱟᱣ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_find_description">ᱥᱟᱱᱟᱢ ᱡᱷᱤᱡ ᱴᱮᱵ ᱠᱚᱣᱟᱜ ᱚᱱᱚᱞ ᱯᱟᱲᱦᱟᱣ ᱢᱮ</string>
     <!-- Description for geolocation permission. -->
-    <string name="mozac_feature_addons_permissions_geolocation_description">ᱟᱢᱟᱜ ᱡᱟᱭᱜᱟ ᱟᱹᱛᱩᱨ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_geolocation_description">ᱟᱢᱟᱜ ᱡᱟᱭᱜᱟ ᱟᱹᱛᱩᱨ ᱢᱮ</string>
     <!-- Description for history permission. -->
-    <string name="mozac_feature_addons_permissions_history_description">ᱵᱨᱟᱩᱡᱤᱝ ᱦᱤᱛᱟᱹᱞ ᱟᱹᱛᱩᱨ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_history_description">ᱵᱨᱟᱩᱡᱤᱝ ᱦᱤᱛᱟᱹᱞ ᱟᱹᱛᱩᱨ ᱢᱮ</string>
     <!-- Description for management permission. -->
     <string name="mozac_feature_addons_permissions_management_description">ᱯᱟᱥᱱᱟᱣ ᱵᱮᱵᱷᱟᱨ ᱨᱮ ᱱᱚᱡᱚᱨ ᱫᱚᱦᱚ ᱟᱨ ᱩᱭᱦᱟᱹᱨ ᱵᱮᱵᱚᱥᱛᱷᱟ</string>
     <!-- Description for native_messaging permission. -->
-    <string name="mozac_feature_addons_permissions_native_messaging_description">ᱱᱟᱶᱟ ᱮᱯᱯ ᱪᱷᱟᱰᱤ ᱠᱟᱛᱮ ᱚᱠᱜᱟ ᱮᱯᱯ ᱠᱚᱛᱮ ᱠᱷᱚᱵᱚᱨ ᱵᱚᱫᱚᱞ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_native_messaging_description">ᱱᱟᱶᱟ ᱮᱯᱯ ᱪᱷᱟᱰᱤ ᱠᱟᱛᱮ ᱚᱠᱜᱟ ᱮᱯᱯ ᱠᱚᱛᱮ ᱠᱷᱚᱵᱚᱨ ᱵᱚᱫᱚᱞ ᱢᱮ</string>
     <!-- Description for notifications permission. -->
     <string name="mozac_feature_addons_permissions_notifications_description">ᱤᱛᱞᱟᱹᱭ ᱠᱚ ᱩᱫᱩᱜ ᱟᱢᱟᱭ</string>
     <!-- Description for pkcs11 permission. -->
     <string name="mozac_feature_addons_permissions_pkcs11_description">ᱠᱨᱭᱯᱴᱚᱜᱨᱟᱯᱷᱭᱠ ᱚᱛᱷᱮᱱᱴᱤᱠᱮᱥᱚᱱ ᱥᱟᱹᱨᱣᱤᱥ ᱠᱚ ᱮᱢᱚᱜᱼᱟᱭ</string>
     <!-- Description for proxy permission. -->
-    <string name="mozac_feature_addons_permissions_proxy_description">ᱵᱨᱟᱩᱡᱟᱹᱨ ᱯᱨᱚᱠᱥᱤ ᱥᱟᱡᱟᱣ ᱠᱚ ᱥᱟᱢᱲᱟᱣ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_proxy_description">ᱵᱨᱟᱩᱡᱟᱹᱨ ᱯᱨᱚᱠᱥᱤ ᱥᱟᱡᱟᱣ ᱠᱚ ᱥᱟᱢᱲᱟᱣ ᱢᱮ</string>
     <!-- Description for sessions permission. -->
-    <string name="mozac_feature_addons_permissions_sessions_description">ᱱᱤᱛᱚᱜᱼᱟᱜ ᱵᱚᱸᱫᱚᱼᱟᱜ ᱴᱮᱵ ᱠᱚ ᱟᱹᱛᱩᱨ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_sessions_description">ᱱᱤᱛᱚᱜᱼᱟᱜ ᱵᱚᱸᱫᱚᱼᱟᱜ ᱴᱮᱵ ᱠᱚ ᱟᱹᱛᱩᱨ ᱢᱮ</string>
     <!-- Description for tab_hide permission. -->
-    <string name="mozac_feature_addons_permissions_tab_hide_description">ᱵᱨᱟᱩᱡᱚᱨ ᱴᱮᱵ ᱠᱚ ᱩᱠᱩ ᱟᱨ ᱩᱫᱩᱜ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_tab_hide_description">ᱵᱨᱟᱩᱡᱚᱨ ᱴᱮᱵ ᱠᱚ ᱩᱠᱩ ᱟᱨ ᱩᱫᱩᱜ ᱢᱮ</string>
     <!-- Description for top_sites permission. -->
-    <string name="mozac_feature_addons_permissions_top_sites_description">ᱵᱨᱟᱩᱡᱤᱝ ᱦᱤᱛᱟᱹᱞ ᱟᱹᱛᱩᱨ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_top_sites_description">ᱵᱨᱟᱩᱡᱤᱝ ᱦᱤᱛᱟᱹᱞ ᱟᱹᱛᱩᱨ ᱢᱮ</string>
     <!-- Description for devtools permission. -->
-    <string name="mozac_feature_addons_permissions_devtools_description">ᱟᱢᱟᱜ ᱰᱟᱴᱟ ᱠᱷᱩᱞᱟᱹ ᱴᱮᱵ ᱠᱚᱨᱮ ᱟᱹᱛᱩᱨ ᱞᱟᱹᱜᱤᱫ ᱛᱮ ᱵᱟᱲᱦᱟᱣᱟᱜ ᱴᱩᱞ ᱚᱥᱟᱨ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_devtools_description">ᱟᱢᱟᱜ ᱰᱟᱴᱟ ᱠᱷᱩᱞᱟᱹ ᱴᱮᱵ ᱠᱚᱨᱮ ᱟᱹᱛᱩᱨ ᱞᱟᱹᱜᱤᱫ ᱛᱮ ᱵᱟᱲᱦᱟᱣᱟᱜ ᱴᱩᱞ ᱚᱥᱟᱨ ᱢᱮ</string>
     <!-- The version on of add-on. -->
     <string name="mozac_feature_addons_version">ᱟᱨᱩᱯᱷᱮᱨᱟᱣ</string>
     <!-- The authors of an add-on. -->
@@ -75,7 +75,7 @@
     <!-- The developer website (Homepage) of the add-on. -->
     <string name="mozac_feature_addons_home_page">ᱚᱲᱟᱜ ᱥᱟᱦᱴᱟ</string>
     <!-- A link where users can find more information about add-ons permissions. -->
-    <string name="mozac_feature_addons_learn_more">ᱪᱷᱟᱹᱲ ᱵᱟᱵᱚᱛ ᱡᱟᱹᱥᱛᱤ ᱵᱟᱰᱟᱭ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_learn_more">ᱪᱷᱟᱹᱲ ᱵᱟᱵᱚᱛ ᱡᱟᱹᱥᱛᱤ ᱵᱟᱰᱟᱭ ᱢᱮ</string>
     <!-- The rating of the add-on. -->
     <string name="mozac_feature_addons_rating">ᱫᱚᱨ ᱴᱷᱟᱣᱠᱟ</string>
     <!-- The settings of the add-on. -->
@@ -87,7 +87,7 @@
     <!-- Indicates the add-on is allowed in private browsing mode. -->
     <string name="mozac_feature_addons_settings_allow_in_private_browsing">ᱱᱤᱡᱚᱨᱟᱜ ᱵᱨᱟᱩᱡᱤᱝ ᱨᱮ ᱪᱟᱹᱞᱩ ᱪᱷᱚᱭ ᱮᱢ</string>
     <!-- Indicates the add-on is allowed in private browsing mode. -->
-    <string name="mozac_feature_addons_settings_run_in_private_browsing">ᱱᱤᱡᱚᱨᱟᱜ ᱵᱨᱟᱩᱡᱤᱝ ᱨᱮ ᱪᱟᱹᱞᱩᱭ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_settings_run_in_private_browsing">ᱱᱤᱡᱚᱨᱟᱜ ᱵᱨᱟᱩᱡᱤᱝ ᱨᱮ ᱪᱟᱹᱞᱩᱭ ᱢᱮ</string>
     <!-- Indicates the add-on is enabled. -->
     <string name="mozac_feature_addons_enabled">ᱮᱢ ᱪᱷᱚ</string>
     <!-- Indicates the add-on is disabled. -->
@@ -107,17 +107,17 @@
     <!-- Displays a page with all the permissions of an add-on. -->
     <string name="mozac_feature_addons_permissions">ᱪᱷᱟᱹᱰ ᱠᱚ</string>
     <!-- This is button that remove (uninstall an add-on). -->
-    <string name="mozac_feature_addons_remove">ᱚᱪᱚᱜ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_remove">ᱚᱪᱚᱜ ᱢᱮ</string>
     <!-- This is the title of a dialog that asks the users if they to install or not an add-on. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_permissions_dialog_title">%1$s ᱥᱮᱞᱮᱫᱽ ᱟᱢ?</string>
     <!-- This is the subtitle of a dialog that asks the users if they want to install or not an add-on, the subtitle lists the permissions that this add-on requires, the permissions will dynamically be listed after the ":". -->
     <string name="mozac_feature_addons_permissions_dialog_subtitle">ᱱᱚᱶᱟ ᱨᱮ ᱟᱢᱟᱜ ᱚᱱᱩᱢᱚᱛᱤ ᱫᱚᱨᱠᱟᱨ ᱟ:</string>
     <!-- This is a button to add (install) an add-on . -->
-    <string name="mozac_feature_addons_permissions_dialog_add">ᱥᱮᱞᱮᱫᱽ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_permissions_dialog_add">ᱥᱮᱞᱮᱫᱽ ᱢᱮ</string>
     <!-- This is a button to cancel the add-on installation . -->
     <string name="mozac_feature_addons_permissions_dialog_cancel">ᱵᱟᱹᱰᱨᱟᱹ</string>
     <!-- Accessibility content description to install add-on button. -->
-    <string name="mozac_feature_addons_install_addon_content_description">ᱮᱰ-ᱚᱱ ᱵᱚᱦᱟᱞ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_install_addon_content_description">ᱮᱰ-ᱚᱱ ᱵᱚᱦᱟᱞ ᱢᱮ</string>
     <!-- This is the label of a button to cancel an ongoing add-on installation. -->
     <string name="mozac_feature_addons_install_addon_dialog_cancel">ᱵᱟᱹᱰᱨᱟᱹ</string>
     <!-- Indicates how many users have rated an add-on. %1$s will be replaced with number of reviews -->
@@ -133,31 +133,31 @@
     <!-- The label of the deny button on a notification, this will be shown to the user when an add-on needs new permissions. Indicates the user denies the new permissions and prevents the add-on from be updated-->
     <string name="mozac_feature_addons_updater_notification_deny_button">ᱢᱟᱱᱟ</string>
     <!-- The tile of the notification, this will be shown to the user when an add-on needs new permissions, to be updated. %1$s is the name of the add-ons-->
-    <string name="mozac_feature_addons_updater_notification_title">%1$s ᱞᱟᱹᱜᱤᱫ ᱱᱟᱶᱟ ᱦᱟᱹᱞᱤᱭᱟᱜ ᱢᱮᱸᱱᱟᱜ-ᱟ</string>
+    <string name="mozac_feature_addons_updater_notification_title">%1$s ᱞᱟᱹᱜᱤᱫ ᱱᱟᱶᱟ ᱦᱟᱹᱞᱤᱭᱟᱜ ᱢᱮᱱᱟᱜ-ᱟ</string>
     <!-- The content of the notification, this will be shown when an add-on needs new permissions, to be updated. %1$d is the amount of new permissions-->
-    <string name="mozac_feature_addons_updater_notification_content" tools:ignore="PluralsCandidate">%1$d ᱱᱟᱶᱟ ᱪᱷᱟᱹᱲ ᱨᱮᱭᱟᱜ ᱫᱚᱨᱠᱟᱨ ᱢᱮᱸᱱᱟᱜ-ᱟ</string>
+    <string name="mozac_feature_addons_updater_notification_content" tools:ignore="PluralsCandidate">%1$d ᱱᱟᱶᱟ ᱪᱷᱟᱹᱲ ᱨᱮᱭᱟᱜ ᱫᱚᱨᱠᱟᱨ ᱢᱮᱱᱟᱜ-ᱟ</string>
     <!-- The content of the notification displayed when an add-on needs a new permission-->
-    <string name="mozac_feature_addons_updater_notification_content_singular">ᱢᱤᱫ ᱴᱟᱝ ᱱᱟᱶᱟ ᱪᱷᱟᱹᱲ ᱨᱮᱭᱟᱜ ᱫᱚᱨᱠᱟᱨ ᱢᱮᱸᱱᱟᱜ-ᱟ</string>
+    <string name="mozac_feature_addons_updater_notification_content_singular">ᱢᱤᱫ ᱴᱟᱝ ᱱᱟᱶᱟ ᱪᱷᱟᱹᱲ ᱨᱮᱭᱟᱜ ᱫᱚᱨᱠᱟᱨ ᱢᱮᱱᱟᱜ-ᱟ</string>
     <!-- Name of the "notification channel" used for displaying a notification for updating an add-on. See https://developer.android.com/training/notify-user/channels -->
     <string name="mozac_feature_addons_updater_notification_channel">ᱮᱰ-ᱚᱱ ᱨᱮᱭᱟᱜ ᱦᱟᱹᱞᱤᱭᱟᱜ</string>
     <!-- Name of the "notification channel" used for displaying a notification for new supported add-ons. See https://developer.android.com/training/notify-user/channels -->
     <string name="mozac_feature_addons_supported_checker_notification_channel">ᱥᱟᱹᱯᱯᱚᱨᱴᱼᱟᱜ ᱮᱰᱰᱼᱚᱱᱥ ᱧᱮᱞᱤᱡ</string>
     <!-- The tile of the notification, this will be shown to the user when one newly supported add-on is available.-->
-    <string name="mozac_feature_addons_supported_checker_notification_title">ᱱᱟᱶᱟ ᱮᱰ-ᱚᱱ ᱢᱮᱸᱱᱟᱜ-ᱟ</string>
+    <string name="mozac_feature_addons_supported_checker_notification_title">ᱱᱟᱶᱟ ᱮᱰ-ᱚᱱ ᱢᱮᱱᱟᱜ-ᱟ</string>
     <!-- The tile of the notification, this will be shown to the user when more than one newly supported add-ons are available.-->
-    <string name="mozac_feature_addons_supported_checker_notification_title_plural">ᱱᱟᱶᱟ ᱮᱰ-ᱚᱱᱥ ᱠᱚ ᱢᱮᱸᱱᱟᱜ-ᱟ</string>
+    <string name="mozac_feature_addons_supported_checker_notification_title_plural">ᱱᱟᱶᱟ ᱮᱰ-ᱚᱱᱥ ᱠᱚ ᱢᱮᱱᱟᱜ-ᱟ</string>
     <!-- The content of the notification, this will be shown to the user when one newly supported add-on is available. %1$s is the add-on name and %2$s is the app name (in most cases Firefox). -->
-    <string name="mozac_feature_addons_supported_checker_notification_content_one">%2$s ᱨᱮ %1$s ᱥᱮᱞᱮᱫᱽ ᱢᱮᱸ </string>
+    <string name="mozac_feature_addons_supported_checker_notification_content_one">%2$s ᱨᱮ %1$s ᱥᱮᱞᱮᱫᱽ ᱢᱮ </string>
     <!-- The content of the notification, this will be shown to the user when two newly supported add-ons are available. %1$s is the first add-on name. %2$s is the second add-on name. %3$s is the app name (in most cases Firefox). -->
-    <string name="mozac_feature_addons_supported_checker_notification_content_two">%1$s ᱟᱨ %2$s %3$s ᱨᱮ ᱥᱮᱞᱮᱫᱽ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_supported_checker_notification_content_two">%1$s ᱟᱨ %2$s %3$s ᱨᱮ ᱥᱮᱞᱮᱫᱽ ᱢᱮ</string>
     <!-- The content of the notification, this will be shown to the user when more than two newly supported add-ons are available. %1$s is the app name (in most cases Firefox). -->
     <string name="mozac_feature_addons_supported_checker_notification_content_more_than_two">%1$s ᱨᱮ ᱥᱮᱞᱮᱫᱽ ᱠᱚᱢ</string>
     <!-- This is the caption for not yet supported screen caption -->
     <string name="mozac_feature_addons_not_yet_supported_caption">Firefox ᱮᱰᱼᱚᱱ ᱴᱮᱠᱱᱚᱞᱚᱡᱭ ᱫᱚ ᱢᱚᱰᱮᱱᱚᱜ ᱠᱟᱱᱟ ᱾ ᱱᱚᱣᱟ ᱮᱰᱼᱚᱱ ᱯᱷᱨᱮᱢᱣᱟᱨᱠ ᱠᱚ ᱵᱮᱵᱷᱟᱨᱟᱭ ᱚᱠᱟ ᱫᱚ Firefox 75 ᱟᱨ ᱚᱱᱟ ᱞᱟᱛᱟᱨ ᱵᱷᱟᱹᱥᱚᱱ ᱥᱟᱞᱟᱜ ᱵᱟᱭ ᱠᱟᱹᱢᱤ ᱟᱭ ᱾ </string>
     <!-- This is the caption for not yet supported screen caption -->
-    <string name="mozac_feature_addons_not_yet_supported_caption2">ᱟᱞᱮ ᱫᱚ ᱱᱤᱛᱚᱜ ᱮᱛᱦᱚᱵ ᱫᱚᱭᱚᱱ ᱠᱚ ᱨᱮᱭᱟᱜ ᱢᱮᱸᱚᱠ ᱯᱟᱥᱱᱟᱣ ᱠᱚ ᱞᱟᱹᱜᱤᱫ ᱥᱟᱹᱯᱯᱚᱴ ᱞᱮ ᱛᱚᱭᱟᱨ ᱮᱜᱼᱟ ᱾</string>
+    <string name="mozac_feature_addons_not_yet_supported_caption2">ᱟᱞᱮ ᱫᱚ ᱱᱤᱛᱚᱜ ᱮᱛᱦᱚᱵ ᱫᱚᱭᱚᱱ ᱠᱚ ᱨᱮᱭᱟᱜ ᱢᱮᱚᱠ ᱯᱟᱥᱱᱟᱣ ᱠᱚ ᱞᱟᱹᱜᱤᱫ ᱥᱟᱹᱯᱯᱚᱴ ᱞᱮ ᱛᱚᱭᱟᱨ ᱮᱜᱼᱟ ᱾</string>
     <!-- This is the caption for the add-on installation progress overlay -->
-    <string name="mozac_add_on_install_progress_caption">ᱮᱰ-ᱚᱱ ᱰᱟᱩᱱᱞᱳᱰ ᱟᱨ ᱧᱮᱞ ᱢᱮᱸᱲᱟᱣ ᱦᱩᱭᱩᱜ ᱠᱟᱱᱟ ...</string>
+    <string name="mozac_add_on_install_progress_caption">ᱮᱰ-ᱚᱱ ᱰᱟᱩᱱᱞᱳᱰ ᱟᱨ ᱧᱮᱞ ᱢᱮᱲᱟᱣ ᱦᱩᱭᱩᱜ ᱠᱟᱱᱟ ...</string>
     <!-- Error shown when something unexpected happened while trying to get the add-on list from the server -->
     <string name="mozac_feature_addons_failed_to_query_add_ons">ᱮᱰ-ᱚᱱ ᱠᱚ ᱠᱩᱠᱞᱟᱹᱭ ᱰᱤᱜᱟᱹᱣᱮᱱᱟ!</string>
     <!-- Error shown when unable to find a translation for an add-on field. %1$s is the locale of the user and %2$s is the default language of the add-on -->
@@ -189,7 +189,7 @@
     <!-- Text shown in not yet supported add-ons section in AddonsManagerAdapter - plural. %1$s is the number of unsupported add-ons -->
     <string name="mozac_feature_addons_unsupported_caption_plural">%1$s ᱮᱰ-ᱚᱱᱥ</string>
     <!-- Text link to a sumo page for learning more about unsupported add-ons. -->
-    <string name="mozac_feature_addons_unsupported_learn_more">ᱰᱷᱮᱨ ᱥᱮᱬᱟᱭ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_unsupported_learn_more">ᱰᱷᱮᱨ ᱥᱮᱬᱟᱭ ᱢᱮ</string>
     <!-- Displayed in the "Status" field for the updater when an add-on has been correctly updated. -->
     <string name="mozac_feature_addons_updater_status_successfully_updated">ᱨᱟᱹᱥ ᱞᱮᱠᱟᱛᱮ ᱦᱟᱹᱞᱤᱭᱟᱜᱮᱱᱟ</string>
     <!-- Displayed in the "Status" field for the updater when an add-on has no updates available. -->
@@ -205,7 +205,7 @@
     <!-- Text shown in the dialog when add-on installation is completed. %1$s is the add-on name. %2$s is the app name. -->
     <string name="mozac_feature_addons_installed_dialog_title">%1$s %2$s ᱨᱮ ᱥᱮᱞᱮᱫᱽ ᱦᱚᱭ ᱱᱟ</string>
     <!-- Text shown in the dialog when add-on installation is completed. %1$s is the add-on name. -->
-    <string name="mozac_feature_addons_installed_dialog_description">ᱢᱮᱸᱱᱩ ᱨᱮ ᱡᱷᱤᱡ ᱢᱮᱸ</string>
+    <string name="mozac_feature_addons_installed_dialog_description">ᱢᱮᱱᱩ ᱨᱮ ᱡᱷᱤᱡ ᱢᱮ</string>
     <!-- Confirmation button text for the dialog when add-on installation is completed. -->
     <string name="mozac_feature_addons_installed_dialog_okay_button">ᱴᱷᱤᱠ, ᱵᱟᱰᱟᱭ ᱠᱮᱜᱼᱟᱹᱧ</string>
 </resources>

--- a/components/feature/addons/src/main/res/values-ta/strings.xml
+++ b/components/feature/addons/src/main/res/values-ta/strings.xml
@@ -4,6 +4,13 @@
     <string name="mozac_feature_addons_permissions_privacy_description">தனியுரிமை அமைப்புகளைப் படித்து மாற்றவும்</string>
     <!-- Description for all_urls add-on permission. -->
     <string name="mozac_feature_addons_permissions_all_urls_description">அனைத்துத் தளங்களுக்குமான உங்கள் தரவை அணுகுக</string>
+    <!-- Description for giving an add-on access to users's data on one site. %1$s  will be replaced by the DNS host name for which a web extension is requesting access (e.g., www.mozilla.org). -->
+    <string name="mozac_feature_addons_permissions_one_site_description">%1$s என்பதற்கான உங்கள் தரவை அணுக</string>
+    <!-- Description for giving an add-on access to users's data in multiple sites in the domain %1$s. %1$s will be replaced by the DNS domain for which a web extension is requesting access (e.g., mozilla.org). -->
+    <string name="mozac_feature_addons_permissions_sites_in_domain_description">%1$s களத்தில் உள்ள தளங்களுக்கான உங்கள் தரவை அணுக</string>
+    <!-- When an add-on requires access to more than 4 sites, for example the add-on requires access for 5 sites. We will show the first 4 sites in individual entries, as in mozac_feature_addons_permissions_one_site_description,
+     then we will show another collapsed entry saying "Access your data on 1 other site". This entry it's for the singular case, when the add-on is only accessing one extra site. -->
+    <string name="mozac_feature_addons_permissions_one_extra_site_description" tools:ignore="PluralsCandidate">மேலும் 1 தளத்திற்கான உங்கள் தரவை அணுக</string>
     <!-- Description for tabs add-on permission. -->
     <string name="mozac_feature_addons_permissions_tabs_description">உலாவியின் கீற்றுகளை அணுகுக</string>
     <!-- Description for unlimited_storage permission. -->

--- a/components/feature/addons/src/main/res/values-tl/strings.xml
+++ b/components/feature/addons/src/main/res/values-tl/strings.xml
@@ -144,6 +144,8 @@
     <string name="mozac_feature_addons_failed_to_query_add_ons">Bigong mag-query ng mga Add-on!</string>
     <!-- Error shown when unable to find a translation for an add-on field. %1$s is the locale of the user and %2$s is the default language of the add-on -->
     <string name="mozac_feature_addons_failed_to_translate">Hindi natagpuan ang pagsalin para sa locale na %1$s o sa wikang %2$s</string>
+    <!-- Text shown after failed to install an add-on. %1$s is the add-on name. -->
+    <string name="mozac_feature_addons_failed_to_install">Hindi nag-install ang %1$s</string>
     <!-- Text shown in not yet supported add-ons section in AddonsManagerAdapter. -->
     <string name="mozac_feature_addons_unsupported_caption">1 add-on</string>
     <!-- Text shown in not yet supported add-ons section in AddonsManagerAdapter - plural. %1$s is the number of unsupported add-ons -->

--- a/components/feature/addons/src/main/res/values-uk/strings.xml
+++ b/components/feature/addons/src/main/res/values-uk/strings.xml
@@ -127,7 +127,7 @@
     <!-- This is the title of page where all the add-ons are listed-->
     <string name="mozac_feature_addons_addons">Додатки</string>
     <!-- Label for add-ons sub menu item for add-ons manager-->
-    <string name="mozac_feature_addons_addons_manager">Керування додатками</string>
+    <string name="mozac_feature_addons_addons_manager">Керувати додатками</string>
     <!-- The label of the allow button, this will be shown to the user when an add-on needs new permissions, with the button the user will indicate that they want to accept the new permissions and update the add-on-->
     <string name="mozac_feature_addons_updater_notification_allow_button">Дозволити</string>
     <!-- The label of the deny button on a notification, this will be shown to the user when an add-on needs new permissions. Indicates the user denies the new permissions and prevents the add-on from be updated-->

--- a/components/feature/app-links/src/main/res/values-sat/strings.xml
+++ b/components/feature/app-links/src/main/res/values-sat/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- The tile for the list of external apps to open the link in -->
-    <string name="mozac_feature_applinks_open_in">... ᱨᱮ ᱡᱷᱤᱡ ᱢᱮᱸ</string>
+    <string name="mozac_feature_applinks_open_in">... ᱨᱮ ᱡᱷᱤᱡ ᱢᱮ</string>
     <!-- The description to warn users that their private browsing session changes  -->
-    <string name="mozac_feature_applinks_confirm_dialog_title">ᱮᱯ ᱨᱮ ᱡᱷᱤᱡ ᱢᱮᱸ? ᱟᱢᱟᱜ ᱠᱟᱹᱢᱤ ᱟᱨ ᱡᱟᱹᱥᱛᱤ ᱜᱷᱟᱹᱬᱤᱡ ᱱᱤᱡᱮᱨᱟᱜ ᱵᱟᱝ ᱛᱟᱦᱮᱸᱱ-ᱟ ᱾</string>
+    <string name="mozac_feature_applinks_confirm_dialog_title">ᱮᱯ ᱨᱮ ᱡᱷᱤᱡ ᱢᱮ? ᱟᱢᱟᱜ ᱠᱟᱹᱢᱤ ᱟᱨ ᱡᱟᱹᱥᱛᱤ ᱜᱷᱟᱹᱬᱤᱡ ᱱᱤᱡᱮᱨᱟᱜ ᱵᱟᱝ ᱛᱟᱦᱮᱸᱱ-ᱟ ᱾</string>
     <!-- Opens the selected time -->
-    <string name="mozac_feature_applinks_confirm_dialog_confirm">ᱡᱷᱤᱡ ᱢᱮᱸ</string>
+    <string name="mozac_feature_applinks_confirm_dialog_confirm">ᱡᱷᱤᱡ ᱢᱮ</string>
     <!-- Cancels the prompt -->
     <string name="mozac_feature_applinks_confirm_dialog_deny">ᱵᱟᱹᱰᱨᱟᱹ</string>
 </resources>

--- a/components/feature/awesomebar/src/main/res/values-sat/strings.xml
+++ b/components/feature/awesomebar/src/main/res/values-sat/strings.xml
@@ -3,5 +3,5 @@
     <!-- The description for a suggestion that represents an opened tab.
     Used to distinguish between History search suggestions from your
     browsing history and your open tabs -->
-    <string name="switch_to_tab_description">ᱴᱮᱵ ᱨᱮ ᱩᱪᱟᱹᱲᱚᱜ ᱢᱮᱸ</string>
+    <string name="switch_to_tab_description">ᱴᱮᱵ ᱨᱮ ᱩᱪᱟᱹᱲᱚᱜ ᱢᱮ</string>
 </resources>

--- a/components/feature/contextmenu/src/main/res/values-bn/strings.xml
+++ b/components/feature/contextmenu/src/main/res/values-bn/strings.xml
@@ -6,8 +6,12 @@
     <string name="mozac_feature_contextmenu_open_link_in_private_tab">লিংকটি ব্যক্তিগত ট্যাবে খুলুন</string>
     <!-- Text for context menu item to open the image in a new tab. -->
     <string name="mozac_feature_contextmenu_open_image_in_new_tab">একটি নতুন ট্যাবে ছবিটি খুলুন</string>
+    <!-- Text for context menu item to save / download the link. -->
+    <string name="mozac_feature_contextmenu_download_link">ডাউনলোড লিঙ্ক</string>
     <!-- Text for context menu item to share the link with an other app. -->
     <string name="mozac_feature_contextmenu_share_link">লিংক শেয়ার করুন</string>
+    <!-- Text for context menu item to share the image with an other app. -->
+    <string name="mozac_feature_contextmenu_share_image">ছবি শেয়ার করুন</string>
     <!-- Text for context menu item to copy the link to the clipboard. -->
     <string name="mozac_feature_contextmenu_copy_link">লিংক কপি করুন</string>
     <!-- Text for context menu item to copy the URL pointing to the image to the clipboard. -->
@@ -26,10 +30,16 @@
     <string name="mozac_feature_contextmenu_snackbar_action_switch">পরিবর্তন</string>
     <!-- Text for context menu item to open the link in an external app. -->
     <string name="mozac_feature_contextmenu_open_link_in_external_app">বাইরের অ্যাপে লিংক খুলুন</string>
-    <!-- Action shown in a text selection context menu. This will prompt a search using the selected text. The first parameter is the name of the application (For example: Fenix)-->
-    <string name="mozac_selection_context_menu_search">%s অনুসন্ধান</string>
-    <!-- Action shown in a text selection context menu. This will prompt a search in a private tab using the selected text The first parameter is the name of the application (For example: Fenix) -->
-    <string name="mozac_selection_context_menu_search_privately">%s ব্যক্তিগত অনুসন্ধান</string>
+    <!-- Text for context menu item to add to a contact. -->
+    <string name="mozac_feature_contextmenu_add_to_contact">কন্টাক্টে যোগ করুন</string>
+    <!-- Action shown in a text selection context menu. This will prompt a search using the selected text.-->
+    <string name="mozac_selection_context_menu_search_2">অনুসন্ধান</string>
+    <!-- Action shown in a text selection context menu. This will prompt a search in a private tab using the selected text-->
+    <string name="mozac_selection_context_menu_search_privately_2">ব্যক্তিগত অনুসন্ধান</string>
     <!-- Action shown in a text selection context menu. This will prompt a share of the selected text. -->
     <string name="mozac_selection_context_menu_share">শেয়ার</string>
+    <!-- Action shown in a text selection context menu. This will prompt a new email from the selected text. -->
+    <string name="mozac_selection_context_menu_email">ইমেইল</string>
+    <!-- Action shown in a text selection context menu. This will prompt a new call from the selected text. -->
+    <string name="mozac_selection_context_menu_call">কল</string>
 </resources>

--- a/components/feature/contextmenu/src/main/res/values-lo/strings.xml
+++ b/components/feature/contextmenu/src/main/res/values-lo/strings.xml
@@ -30,6 +30,14 @@
     <string name="mozac_feature_contextmenu_snackbar_action_switch">ສັບປ່ຽນ</string>
     <!-- Text for context menu item to open the link in an external app. -->
     <string name="mozac_feature_contextmenu_open_link_in_external_app">ເປີດລິ້ງນີ້ໃນ app ພາຍນອກ</string>
+    <!-- Text for context menu item to share the email with another app. -->
+    <string name="mozac_feature_contextmenu_share_email_address">ແບ່ງປັນທີ່ຢູ່ອີເມລ</string>
+    <!-- Text for context menu item to copy the email address to the clipboard. -->
+    <string name="mozac_feature_contextmenu_copy_email_address">ສຳເນົາທີ່ຢູ່ອີເມລ</string>
+    <!-- Text for confirmation "snackbar" shown after copying a email address to the clipboard. -->
+    <string name="mozac_feature_contextmenu_snackbar_email_address_copied">ທີ່ຢູ່ອີເມລໄດ້ຖືກສຳເນົາໄປໄວ້ໃນຄຣິບບອດແລ້ວ</string>
+    <!-- Text for context menu item to add to a contact. -->
+    <string name="mozac_feature_contextmenu_add_to_contact">ເພີ່ມເຂົ້າໄປໃນລາຍຊື່ຕິດຕໍ່</string>
     <!-- Action shown in a text selection context menu. This will prompt a search using the selected text.-->
     <string name="mozac_selection_context_menu_search_2">ຄົ້ນຫາ</string>
     <!-- Action shown in a text selection context menu. This will prompt a search in a private tab using the selected text-->

--- a/components/feature/contextmenu/src/main/res/values-mix/strings.xml
+++ b/components/feature/contextmenu/src/main/res/values-mix/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for context menu item to copy the link to the clipboard. -->
+    <string name="mozac_feature_contextmenu_copy_link">Ndatava link</string>
+    <!-- Action shown in a text selection context menu. This will prompt a share of the selected text. -->
+    <string name="mozac_selection_context_menu_share">Stucha</string>
+    <!-- Action shown in a text selection context menu. This will prompt a new email from the selected text. -->
+    <string name="mozac_selection_context_menu_email">Korreo</string>
+    <!-- Action shown in a text selection context menu. This will prompt a new call from the selected text. -->
+    <string name="mozac_selection_context_menu_call">Kana</string>
+</resources>

--- a/components/feature/contextmenu/src/main/res/values-sat/strings.xml
+++ b/components/feature/contextmenu/src/main/res/values-sat/strings.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Text for context menu item to open the link in a new tab. -->
-    <string name="mozac_feature_contextmenu_open_link_in_new_tab">ᱱᱟᱶᱟ ᱴᱮᱵ ᱨᱮ ᱞᱤᱸᱠ ᱡᱷᱤᱡ ᱢᱮᱸ</string>
+    <string name="mozac_feature_contextmenu_open_link_in_new_tab">ᱱᱟᱶᱟ ᱴᱮᱵ ᱨᱮ ᱞᱤᱸᱠ ᱡᱷᱤᱡ ᱢᱮ</string>
     <!-- Text for context menu item to open the link in a private tab. -->
-    <string name="mozac_feature_contextmenu_open_link_in_private_tab">ᱯᱨᱭᱣᱮᱴ ᱴᱮᱵ ᱨᱮ ᱞᱤᱸᱠ ᱡᱷᱤᱡ ᱢᱮᱸ</string>
+    <string name="mozac_feature_contextmenu_open_link_in_private_tab">ᱯᱨᱭᱣᱮᱴ ᱴᱮᱵ ᱨᱮ ᱞᱤᱸᱠ ᱡᱷᱤᱡ ᱢᱮ</string>
     <!-- Text for context menu item to open the image in a new tab. -->
-    <string name="mozac_feature_contextmenu_open_image_in_new_tab">ᱱᱟᱶᱟ ᱴᱮᱵ ᱨᱮ ᱪᱤᱛᱟᱹᱨ ᱡᱷᱤᱡ ᱢᱮᱸ</string>
+    <string name="mozac_feature_contextmenu_open_image_in_new_tab">ᱱᱟᱶᱟ ᱴᱮᱵ ᱨᱮ ᱪᱤᱛᱟᱹᱨ ᱡᱷᱤᱡ ᱢᱮ</string>
     <!-- Text for context menu item to save / download the link. -->
     <string name="mozac_feature_contextmenu_download_link">ᱰᱟᱩᱱᱞᱳᱰ ᱞᱤᱸᱠ</string>
     <!-- Text for context menu item to share the link with an other app. -->
-    <string name="mozac_feature_contextmenu_share_link">ᱞᱤᱸᱠ ᱦᱟᱹᱴᱤᱧ ᱢᱮᱸ</string>
+    <string name="mozac_feature_contextmenu_share_link">ᱞᱤᱸᱠ ᱦᱟᱹᱴᱤᱧ ᱢᱮ</string>
     <!-- Text for context menu item to share the image with an other app. -->
-    <string name="mozac_feature_contextmenu_share_image">ᱪᱤᱛᱟᱹᱨ ᱦᱟᱹᱴᱤᱧ ᱢᱮᱸ</string>
+    <string name="mozac_feature_contextmenu_share_image">ᱪᱤᱛᱟᱹᱨ ᱦᱟᱹᱴᱤᱧ ᱢᱮ</string>
     <!-- Text for context menu item to copy the link to the clipboard. -->
-    <string name="mozac_feature_contextmenu_copy_link">ᱞᱤᱸᱠ ᱱᱚᱠᱚᱞ ᱢᱮᱸ</string>
+    <string name="mozac_feature_contextmenu_copy_link">ᱞᱤᱸᱠ ᱱᱚᱠᱚᱞ ᱢᱮ</string>
     <!-- Text for context menu item to copy the URL pointing to the image to the clipboard. -->
-    <string name="mozac_feature_contextmenu_copy_image_location">ᱪᱤᱛᱟᱹᱨ ᱨᱮᱭᱟᱜ ᱡᱟᱭᱜᱟ ᱱᱚᱠᱚᱞ ᱢᱮᱸ</string>
+    <string name="mozac_feature_contextmenu_copy_image_location">ᱪᱤᱛᱟᱹᱨ ᱨᱮᱭᱟᱜ ᱡᱟᱭᱜᱟ ᱱᱚᱠᱚᱞ ᱢᱮ</string>
     <!-- Text for context menu item to save / download the image. -->
-    <string name="mozac_feature_contextmenu_save_image">ᱪᱤᱛᱟᱹᱨ ᱥᱟᱸᱪᱟᱣ ᱢᱮᱸ</string>
+    <string name="mozac_feature_contextmenu_save_image">ᱪᱤᱛᱟᱹᱨ ᱥᱟᱸᱪᱟᱣ ᱢᱮ</string>
     <!-- Text for context menu item to save / download the file. -->
-    <string name="mozac_feature_contextmenu_save_file_to_device">ᱨᱮᱫ ᱥᱟᱫᱷᱚᱱ ᱨᱮ ᱥᱟᱸᱪᱟᱣ ᱢᱮᱸ</string>
+    <string name="mozac_feature_contextmenu_save_file_to_device">ᱨᱮᱫ ᱥᱟᱫᱷᱚᱱ ᱨᱮ ᱥᱟᱸᱪᱟᱣ ᱢᱮ</string>
     <!-- Text for confirmation "snackbar" shown after opening a link in a new tab.  -->
     <string name="mozac_feature_contextmenu_snackbar_new_tab_opened">ᱱᱟᱶᱟ ᱴᱮᱵ ᱠᱷᱩᱞᱟᱹᱭ ᱮᱱᱟ</string>
     <!-- Text for confirmation "snackbar" shown after opening a link in a new private tab.  -->
@@ -27,17 +27,17 @@
     <!-- Text for confirmation "snackbar" shown after copying a link or image URL to the clipboard. -->
     <string name="mozac_feature_contextmenu_snackbar_link_copied">ᱞᱤᱸᱠ ᱨᱮᱴᱚᱵᱼᱵᱚᱰ ᱨᱮ ᱱᱚᱠᱚᱞᱮᱱᱟ</string>
     <!-- Action shown in a "snacbkar" after opening a new/private tab. Clicking this action will switch to the newly opened tab. -->
-    <string name="mozac_feature_contextmenu_snackbar_action_switch">ᱵᱚᱫᱚᱞ ᱢᱮᱸ</string>
+    <string name="mozac_feature_contextmenu_snackbar_action_switch">ᱵᱚᱫᱚᱞ ᱢᱮ</string>
     <!-- Text for context menu item to open the link in an external app. -->
-    <string name="mozac_feature_contextmenu_open_link_in_external_app">ᱞᱤᱸᱠ ᱵᱟᱦᱨᱮ ᱮᱯ ᱨᱮ ᱡᱷᱤᱡ ᱢᱮᱸ</string>
+    <string name="mozac_feature_contextmenu_open_link_in_external_app">ᱞᱤᱸᱠ ᱵᱟᱦᱨᱮ ᱮᱯ ᱨᱮ ᱡᱷᱤᱡ ᱢᱮ</string>
     <!-- Text for context menu item to share the email with another app. -->
-    <string name="mozac_feature_contextmenu_share_email_address">ᱤᱼᱢᱮᱸᱞ ᱴᱷᱤᱠᱬᱟᱹ ᱠᱚ ᱦᱟᱹᱴᱤᱧ ᱢᱮᱸ</string>
+    <string name="mozac_feature_contextmenu_share_email_address">ᱤᱼᱢᱮᱞ ᱴᱷᱤᱠᱬᱟᱹ ᱠᱚ ᱦᱟᱹᱴᱤᱧ ᱢᱮ</string>
     <!-- Text for context menu item to copy the email address to the clipboard. -->
-    <string name="mozac_feature_contextmenu_copy_email_address">ᱤᱼᱢᱮᱸᱞ ᱴᱷᱤᱠᱬᱟᱹ ᱱᱚᱠᱚᱞ ᱢᱮᱸ</string>
+    <string name="mozac_feature_contextmenu_copy_email_address">ᱤᱼᱢᱮᱞ ᱴᱷᱤᱠᱬᱟᱹ ᱱᱚᱠᱚᱞ ᱢᱮ</string>
     <!-- Text for confirmation "snackbar" shown after copying a email address to the clipboard. -->
-    <string name="mozac_feature_contextmenu_snackbar_email_address_copied">ᱤᱼᱢᱮᱸᱞ ᱴᱷᱤᱠᱬᱟᱹ ᱨᱮᱴᱚᱵᱼᱵᱚᱰ ᱨᱮ ᱱᱚᱠᱚᱞᱮᱱᱟ</string>
+    <string name="mozac_feature_contextmenu_snackbar_email_address_copied">ᱤᱼᱢᱮᱞ ᱴᱷᱤᱠᱬᱟᱹ ᱨᱮᱴᱚᱵᱼᱵᱚᱰ ᱨᱮ ᱱᱚᱠᱚᱞᱮᱱᱟ</string>
     <!-- Text for context menu item to add to a contact. -->
-    <string name="mozac_feature_contextmenu_add_to_contact">ᱥᱚᱢᱯᱚᱨᱠ ᱨᱮ ᱥᱮᱞᱮᱫᱽ ᱢᱮᱸ</string>
+    <string name="mozac_feature_contextmenu_add_to_contact">ᱥᱚᱢᱯᱚᱨᱠ ᱨᱮ ᱥᱮᱞᱮᱫᱽ ᱢᱮ</string>
     <!-- Action shown in a text selection context menu. This will prompt a search using the selected text.-->
     <string name="mozac_selection_context_menu_search_2">ᱥᱮᱸᱫᱽᱨᱟ</string>
     <!-- Action shown in a text selection context menu. This will prompt a search in a private tab using the selected text-->
@@ -45,7 +45,7 @@
     <!-- Action shown in a text selection context menu. This will prompt a share of the selected text. -->
     <string name="mozac_selection_context_menu_share">ᱦᱟᱹᱴᱤᱧ</string>
     <!-- Action shown in a text selection context menu. This will prompt a new email from the selected text. -->
-    <string name="mozac_selection_context_menu_email">ᱤᱼᱢᱮᱸᱞ</string>
+    <string name="mozac_selection_context_menu_email">ᱤᱼᱢᱮᱞ</string>
     <!-- Action shown in a text selection context menu. This will prompt a new call from the selected text. -->
     <string name="mozac_selection_context_menu_call">ᱠᱚᱞᱞ</string>
 </resources>

--- a/components/feature/contextmenu/src/main/res/values-tl/strings.xml
+++ b/components/feature/contextmenu/src/main/res/values-tl/strings.xml
@@ -18,6 +18,10 @@
     <string name="mozac_feature_contextmenu_save_image">I-save ang imahe</string>
     <!-- Action shown in a "snacbkar" after opening a new/private tab. Clicking this action will switch to the newly opened tab. -->
     <string name="mozac_feature_contextmenu_snackbar_action_switch">Lumipat</string>
+    <!-- Text for context menu item to share the email with another app. -->
+    <string name="mozac_feature_contextmenu_share_email_address">Ibahagi ang mga email</string>
+    <!-- Text for context menu item to add to a contact. -->
+    <string name="mozac_feature_contextmenu_add_to_contact">Idagdag sa contact</string>
     <!-- Action shown in a text selection context menu. This will prompt a search using the selected text.-->
     <string name="mozac_selection_context_menu_search_2">Hanapin</string>
     <!-- Action shown in a text selection context menu. This will prompt a share of the selected text. -->

--- a/components/feature/customtabs/src/main/res/values-ast/strings.xml
+++ b/components/feature/customtabs/src/main/res/values-ast/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="mozac_feature_customtabs_exit_button">Volver a l\'aplicación anterior</string>
-    </resources>
+    <string name="mozac_feature_customtabs_share_link">Compartir l\'enllaz</string>
+</resources>

--- a/components/feature/customtabs/src/main/res/values-sat/strings.xml
+++ b/components/feature/customtabs/src/main/res/values-sat/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="mozac_feature_customtabs_exit_button">ᱞᱟᱦᱟ ᱛᱮᱭᱟᱜ ᱮᱯ ᱨᱮ ᱨᱩᱟᱹᱲᱚᱜ ᱢᱮᱸ</string>
-    <string name="mozac_feature_customtabs_share_link">ᱞᱤᱸᱠ ᱦᱟᱹᱴᱤᱧ ᱢᱮᱸ</string>
+    <string name="mozac_feature_customtabs_exit_button">ᱞᱟᱦᱟ ᱛᱮᱭᱟᱜ ᱮᱯ ᱨᱮ ᱨᱩᱟᱹᱲᱚᱜ ᱢᱮ</string>
+    <string name="mozac_feature_customtabs_share_link">ᱞᱤᱸᱠ ᱦᱟᱹᱴᱤᱧ ᱢᱮ</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-ast/strings.xml
+++ b/components/feature/downloads/src/main/res/values-ast/strings.xml
@@ -23,7 +23,7 @@
     <string name="mozac_feature_downloads_could_not_open_file">Nun pudo abrise\'l ficheru</string>
 
     <!-- Message that appears when the downloaded file is a specific type that Android doesn't support opening-->
-    <string name="mozac_feature_downloads_open_not_supported1">Nun s\'alcontró nenguna aplicación p\'abrir ficheros %1$s</string>
+    <string name="mozac_feature_downloads_open_not_supported1">Nun s\'atopó nenguna aplicación p\'abrir ficheros %1$s</string>
 
     <!-- Button that pauses the download when pressed -->
     <string name="mozac_feature_downloads_button_pause">Posar</string>

--- a/components/feature/downloads/src/main/res/values-lo/strings.xml
+++ b/components/feature/downloads/src/main/res/values-lo/strings.xml
@@ -39,4 +39,8 @@
 
     <!-- Content description for close button -->
     <string name="mozac_feature_downloads_button_close">ປິດ</string>
+    <!-- Title for the third party download app chooser dialog -->
+    <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">ດຳເນີນການໂດຍໃຊ້</string>
+    <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
+    <string name="mozac_feature_downloads_unable_to_open_third_party_app">ບໍ່ສາມາດເປີດ %1$s</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-mix/strings.xml
+++ b/components/feature/downloads/src/main/res/values-mix/strings.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Name of the "notification channel" used for displaying download notification. See https://developer.android.com/training/notify-user/channels -->
+    <string name="mozac_feature_downloads_notification_channel">Snuù</string>
+
+    <!-- Alert dialog confirmation before download a file, this is the title. %1$s will be replaced with the name of the file. -->
+    <string name="mozac_feature_downloads_dialog_title2">Snuù (%1$s)</string>
+    <!-- Alert dialog confirmation before download a file, this is the positive action. -->
+    <string name="mozac_feature_downloads_dialog_download">Snuù</string>
+
+    <!-- Button that pauses the download when pressed -->
+    <string name="mozac_feature_downloads_button_pause">Kunchatu</string>
+    <!-- Button that opens the downloaded file when pressed -->
+    <string name="mozac_feature_downloads_button_open">Kuna</string>
+
+    <!-- Content description for close button -->
+    <string name="mozac_feature_downloads_button_close">Kasi</string>
+    </resources>

--- a/components/feature/downloads/src/main/res/values-ru/strings.xml
+++ b/components/feature/downloads/src/main/res/values-ru/strings.xml
@@ -23,7 +23,7 @@
     <string name="mozac_feature_downloads_could_not_open_file">Не удалось открыть файл</string>
 
     <!-- Message that appears when the downloaded file is a specific type that Android doesn't support opening-->
-    <string name="mozac_feature_downloads_open_not_supported1">Не найдено приложений, которые могут открыть файлы %1$s</string>
+    <string name="mozac_feature_downloads_open_not_supported1">Не найдено приложений, умеющих открывать файлы %1$s</string>
 
     <!-- Button that pauses the download when pressed -->
     <string name="mozac_feature_downloads_button_pause">Приостановить</string>

--- a/components/feature/downloads/src/main/res/values-sat/strings.xml
+++ b/components/feature/downloads/src/main/res/values-sat/strings.xml
@@ -28,20 +28,20 @@
     <string name="mozac_feature_downloads_open_not_supported1">%1$s ᱨᱮᱫ ᱠᱚ ᱠᱷᱩᱞᱟᱹ ᱞᱟᱹᱜᱤᱫ ᱪᱮᱫ ᱦᱚᱸ ᱮᱯᱯ ᱵᱟᱝ ᱧᱟᱢ ᱞᱟᱱᱟ</string>
 
     <!-- Button that pauses the download when pressed -->
-    <string name="mozac_feature_downloads_button_pause">ᱛᱷᱩᱠᱩᱢ ᱢᱮᱸ</string>
+    <string name="mozac_feature_downloads_button_pause">ᱛᱷᱩᱠᱩᱢ ᱢᱮ</string>
     <!-- Button that resumes the download when pressed -->
     <string name="mozac_feature_downloads_button_resume">ᱫᱩᱦᱲᱟᱹ ᱮᱦᱚᱵᱽ</string>
     <!-- Button that cancels the download when pressed -->
     <string name="mozac_feature_downloads_button_cancel">ᱵᱟᱹᱰᱨᱟᱹ</string>
     <!-- Button that opens the downloaded file when pressed -->
-    <string name="mozac_feature_downloads_button_open">ᱡᱷᱚᱡ ᱢᱮᱸ</string>
+    <string name="mozac_feature_downloads_button_open">ᱡᱷᱚᱡ ᱢᱮ</string>
     <!-- Button that restarts the download after a failed attempt -->
-    <string name="mozac_feature_downloads_button_try_again">ᱫᱚᱦᱲᱟᱹ ᱪᱮᱥᱴᱟᱭ ᱢᱮᱸ</string>
+    <string name="mozac_feature_downloads_button_try_again">ᱫᱚᱦᱲᱟᱹ ᱪᱮᱥᱴᱟᱭ ᱢᱮ</string>
 
     <!-- Content description for close button -->
-    <string name="mozac_feature_downloads_button_close">ᱵᱚᱸᱫᱚᱭ ᱢᱮᱸ</string>
+    <string name="mozac_feature_downloads_button_close">ᱵᱚᱸᱫᱚᱭ ᱢᱮ</string>
     <!-- Title for the third party download app chooser dialog -->
-    <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">ᱠᱟᱹᱢᱤ ᱠᱚ ᱪᱟᱵᱟᱭ ᱢᱮᱸ</string>
+    <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">ᱠᱟᱹᱢᱤ ᱠᱚ ᱪᱟᱵᱟᱭ ᱢᱮ</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">%1$s ᱵᱟᱝ ᱠᱷᱩᱞᱟᱹ ᱫᱟᱲᱮᱞᱟᱱᱟ</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-ur/strings.xml
+++ b/components/feature/downloads/src/main/res/values-ur/strings.xml
@@ -39,6 +39,8 @@
 
     <!-- Content description for close button -->
     <string name="mozac_feature_downloads_button_close">بند کریں</string>
+    <!-- Title for the third party download app chooser dialog -->
+    <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">عمل مکمل کریں بمع</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">%1$s کھولنے میں ناکام رہا</string>
 </resources>

--- a/components/feature/findinpage/src/main/res/values-ast/strings.xml
+++ b/components/feature/findinpage/src/main/res/values-ast/strings.xml
@@ -2,7 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Watermark/Hint for the find in page input field. -->
-    <string name="mozac_feature_findindpage_input">Alcontrar…</string>
+    <string name="mozac_feature_findindpage_input">Atopar…</string>
 
     <!-- String to show the number of results found in the page and the
     position the user is at. The first argument is the position, the second argument is the total. -->
@@ -13,12 +13,12 @@
     <string name="mozac_feature_findindpage_accessibility_result" tools:ignore="PluralsCandidate">%1$d de %2$d</string>
 
     <!-- String to be read by the accessibility service when focusing the next result button. -->
-    <string name="mozac_feature_findindpage_next_result">Alcontrar el resultáu siguiente</string>
+    <string name="mozac_feature_findindpage_next_result">Atopar el resultáu siguiente</string>
 
     <!-- String to be read by the accessibility service when focusing the previous result button. -->
-    <string name="mozac_feature_findindpage_previous_result">Alcontrar el resultáu anterior</string>
+    <string name="mozac_feature_findindpage_previous_result">Atopar el resultáu anterior</string>
 
     <!-- String to be read by the accessibility service when focusing the dismiss button in the "find in page" UI. -->
-    <string name="mozac_feature_findindpage_dismiss">Dexar d\'alcontrar na páxina</string>
+    <string name="mozac_feature_findindpage_dismiss">Dexar d\'atopar na páxina</string>
 
 </resources>

--- a/components/feature/findinpage/src/main/res/values-mix/strings.xml
+++ b/components/feature/findinpage/src/main/res/values-mix/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- String to show the number of results found in the page and the
+    position the user is at. The first argument is the position, the second argument is the total. -->
+    <string name="mozac_feature_findindpage_result">%1$d/%2$d</string>
+
+    </resources>

--- a/components/feature/findinpage/src/main/res/values-sat/strings.xml
+++ b/components/feature/findinpage/src/main/res/values-sat/strings.xml
@@ -2,7 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Watermark/Hint for the find in page input field. -->
-    <string name="mozac_feature_findindpage_input">ᱥᱟᱦᱴᱟ ᱨᱮ ᱯᱟᱱᱛᱮ ᱢᱮᱸ</string>
+    <string name="mozac_feature_findindpage_input">ᱥᱟᱦᱴᱟ ᱨᱮ ᱯᱟᱱᱛᱮ ᱢᱮ</string>
 
     <!-- String to show the number of results found in the page and the
     position the user is at. The first argument is the position, the second argument is the total. -->
@@ -13,12 +13,12 @@
     <string name="mozac_feature_findindpage_accessibility_result" tools:ignore="PluralsCandidate">%2$d ᱠᱷᱚᱱ %1$d</string>
 
     <!-- String to be read by the accessibility service when focusing the next result button. -->
-    <string name="mozac_feature_findindpage_next_result">ᱤᱱᱟᱹ ᱛᱟᱭᱚᱢᱟᱜ ᱠᱩᱲᱟᱹᱭ ᱧᱟᱢ ᱢᱮᱸ</string>
+    <string name="mozac_feature_findindpage_next_result">ᱤᱱᱟᱹ ᱛᱟᱭᱚᱢᱟᱜ ᱠᱩᱲᱟᱹᱭ ᱧᱟᱢ ᱢᱮ</string>
 
     <!-- String to be read by the accessibility service when focusing the previous result button. -->
-    <string name="mozac_feature_findindpage_previous_result">ᱞᱟᱦᱟ ᱛᱮᱭᱟᱜ ᱠᱩᱲᱟᱹᱭ ᱧᱟᱢ ᱢᱮᱸ</string>
+    <string name="mozac_feature_findindpage_previous_result">ᱞᱟᱦᱟ ᱛᱮᱭᱟᱜ ᱠᱩᱲᱟᱹᱭ ᱧᱟᱢ ᱢᱮ</string>
 
     <!-- String to be read by the accessibility service when focusing the dismiss button in the "find in page" UI. -->
-    <string name="mozac_feature_findindpage_dismiss">ᱥᱟᱦᱴᱟ ᱨᱮ ᱧᱟᱢ ᱚᱰᱚᱠ ᱵᱟᱫ ᱢᱮᱸ</string>
+    <string name="mozac_feature_findindpage_dismiss">ᱥᱟᱦᱴᱟ ᱨᱮ ᱧᱟᱢ ᱚᱰᱚᱠ ᱵᱟᱫ ᱢᱮ</string>
 
 </resources>

--- a/components/feature/media/src/main/res/values-bn/strings.xml
+++ b/components/feature/media/src/main/res/values-bn/strings.xml
@@ -16,4 +16,6 @@
     <!--This is the title of the "pause" action shown in the media notification while web content is playing media. Clicking it will pause currently playing media. On most modern Android system only an icon is visible. But screen readers may read this title. -->
     <string name="mozac_feature_media_notification_action_pause">বিরতি দিন</string>
 
-    </resources>
+    <!-- Neutral title of the media notification for when a website that is open in private mode. -->
+    <string name="mozac_feature_media_notification_private_mode">একটি সাইটে মিডিয়া চলছে</string>
+</resources>

--- a/components/feature/media/src/main/res/values-co/strings.xml
+++ b/components/feature/media/src/main/res/values-co/strings.xml
@@ -4,11 +4,11 @@
     <string name="mozac_feature_media_notification_channel">Multimedia</string>
 
     <!-- Title of notification shown when the device's camera is shared with a website (WebRTC) -->
-    <string name="mozac_feature_media_sharing_camera">L’appareghju-fotò hè attivatu</string>
+    <string name="mozac_feature_media_sharing_camera">L’apparechju-fotò hè attivatu</string>
     <!-- Title of notification shown when the device's microphone is shared with a website (WebRTC) -->
     <string name="mozac_feature_media_sharing_microphone">U microfonu hè attivatu</string>
     <!-- Title of notification shown when the device's camera and microphone is shared with a website (WebRTC) -->
-    <string name="mozac_feature_media_sharing_camera_and_microphone">L’appareghju-fotò è u microfonu sò attivati</string>
+    <string name="mozac_feature_media_sharing_camera_and_microphone">L’apparechju-fotò è u microfonu sò attivati</string>
 
     <!--This is the title of the "play" action media shown in the media notification while web content is playing media. Clicking it will resume playing paused media. On most modern Android system only an icon is visible. But screen readers may read this title. -->
     <string name="mozac_feature_media_notification_action_play">Lettura</string>

--- a/components/feature/media/src/main/res/values-mix/strings.xml
+++ b/components/feature/media/src/main/res/values-mix/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!--This is the title of the "pause" action shown in the media notification while web content is playing media. Clicking it will pause currently playing media. On most modern Android system only an icon is visible. But screen readers may read this title. -->
+    <string name="mozac_feature_media_notification_action_pause">Kunchatu</string>
+
+    </resources>

--- a/components/feature/media/src/main/res/values-sat/strings.xml
+++ b/components/feature/media/src/main/res/values-sat/strings.xml
@@ -4,17 +4,17 @@
     <string name="mozac_feature_media_notification_channel">ᱢᱤᱰᱤᱭᱟ</string>
 
     <!-- Title of notification shown when the device's camera is shared with a website (WebRTC) -->
-    <string name="mozac_feature_media_sharing_camera">ᱠᱮᱢᱨᱟ ᱪᱟᱹᱞᱩ ᱢᱮᱸᱱᱟᱜ-ᱟ</string>
+    <string name="mozac_feature_media_sharing_camera">ᱠᱮᱢᱨᱟ ᱪᱟᱹᱞᱩ ᱢᱮᱱᱟᱜ-ᱟ</string>
     <!-- Title of notification shown when the device's microphone is shared with a website (WebRTC) -->
-    <string name="mozac_feature_media_sharing_microphone">ᱢᱟᱭᱠᱨᱚᱯᱷᱚᱱ ᱪᱟᱹᱞᱩ ᱢᱮᱸᱱᱟᱜ-ᱟ</string>
+    <string name="mozac_feature_media_sharing_microphone">ᱢᱟᱭᱠᱨᱚᱯᱷᱚᱱ ᱪᱟᱹᱞᱩ ᱢᱮᱱᱟᱜ-ᱟ</string>
     <!-- Title of notification shown when the device's camera and microphone is shared with a website (WebRTC) -->
-    <string name="mozac_feature_media_sharing_camera_and_microphone">ᱠᱮᱢᱨᱟ ᱟᱨ ᱢᱟᱭᱠᱨᱚᱯᱷᱚᱱ ᱚᱱ ᱢᱮᱸᱱᱟᱜ-ᱟ</string>
+    <string name="mozac_feature_media_sharing_camera_and_microphone">ᱠᱮᱢᱨᱟ ᱟᱨ ᱢᱟᱭᱠᱨᱚᱯᱷᱚᱱ ᱚᱱ ᱢᱮᱱᱟᱜ-ᱟ</string>
 
     <!--This is the title of the "play" action media shown in the media notification while web content is playing media. Clicking it will resume playing paused media. On most modern Android system only an icon is visible. But screen readers may read this title. -->
-    <string name="mozac_feature_media_notification_action_play">ᱮᱱᱮᱡ ᱢᱮᱸ</string>
+    <string name="mozac_feature_media_notification_action_play">ᱮᱱᱮᱡ ᱢᱮ</string>
 
     <!--This is the title of the "pause" action shown in the media notification while web content is playing media. Clicking it will pause currently playing media. On most modern Android system only an icon is visible. But screen readers may read this title. -->
-    <string name="mozac_feature_media_notification_action_pause">ᱛᱷᱩᱠᱩᱢ ᱢᱮᱸ</string>
+    <string name="mozac_feature_media_notification_action_pause">ᱛᱷᱩᱠᱩᱢ ᱢᱮ</string>
 
     <!-- Neutral title of the media notification for when a website that is open in private mode. -->
     <string name="mozac_feature_media_notification_private_mode">ᱢᱤᱫᱴᱟᱹᱝ ᱥᱟᱭᱤᱴ ᱢᱤᱰᱤᱭᱟ ᱮᱱᱮᱡ ᱫᱟᱭ</string>

--- a/components/feature/prompts/src/main/res/values-ast/strings.xml
+++ b/components/feature/prompts/src/main/res/values-ast/strings.xml
@@ -79,6 +79,8 @@
     <string name="mozac_feature_prompts_nov">Pay</string>
     <!-- December month of the year (short description), used on the month chooser dialog. -->
     <string name="mozac_feature_prompts_dec">Avi</string>
+    <!-- Option in expanded select login prompt that links to login settings -->
+    <string name="mozac_feature_prompts_manage_logins">Xestión d\'anicios de sesión</string>
     <!-- Content description for expanding the saved logins options in the select login prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description">Espander los anicios de sesión suxeríos</string>
     <!-- Content description for collapsing the saved logins options in the select login prompt -->
@@ -88,6 +90,7 @@
 
     <!-- Strings shown in a dialog that appear when users try to refresh a certain kind of webpages -->
     <string name="mozac_feature_prompt_repost_title">¿Reunviar los datos a esti sitiu?</string>
+    <string name="mozac_feature_prompt_repost_message">Refrescar esta páxina podría duplicar les aiciones de recién como l\'unviu d\'un pagu o l\'espublizamientu d\'un artículu.</string>
     <!-- Pressing this will dismiss the dialog and reload the page sending again the previous data -->
     <string name="mozac_feature_prompt_repost_positive_button_text">Reunviar los datos</string>
     <!-- Pressing this will dismiss the dialog and not refresh the webpage -->

--- a/components/feature/prompts/src/main/res/values-az/strings.xml
+++ b/components/feature/prompts/src/main/res/values-az/strings.xml
@@ -87,4 +87,12 @@
     <string name="mozac_feature_prompts_collapse_logins_content_description">Məsləhət görülən hesabları daralt</string>
     <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
     <string name="mozac_feature_prompts_saved_logins">Məsləhət görülən hesablar</string>
+
+    <!-- Strings shown in a dialog that appear when users try to refresh a certain kind of webpages -->
+    <string name="mozac_feature_prompt_repost_title">Məlumat bu sayta təkrar göndərilsin?</string>
+    <string name="mozac_feature_prompt_repost_message">Bu səhifəni yeniləmə ödəniş və ya şərh yazma kimi son əməliyyatları təkrarlaya bilər.</string>
+    <!-- Pressing this will dismiss the dialog and reload the page sending again the previous data -->
+    <string name="mozac_feature_prompt_repost_positive_button_text">Təkrar göndər</string>
+    <!-- Pressing this will dismiss the dialog and not refresh the webpage -->
+    <string name="mozac_feature_prompt_repost_negative_button_text">Ləğv et</string>
 </resources>

--- a/components/feature/prompts/src/main/res/values-bn/strings.xml
+++ b/components/feature/prompts/src/main/res/values-bn/strings.xml
@@ -13,27 +13,43 @@
     <!-- Text for the title of an authentication dialog. -->
     <string name="mozac_feature_prompt_sign_in">সাইন ইন</string>
     <!-- Text for username field in an authentication dialog. -->
-    <string name="mozac_feature_prompt_username_hint">ইউজারের নাম</string>
+    <string name="mozac_feature_prompt_username_hint">ব্যবহারকারীর নাম</string>
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">পাসওয়ার্ড</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save">সংরক্ষণ করবেন না</string>
+    <!-- Negative confirmation that we should never save a login for this site -->
+    <string name="mozac_feature_prompt_never_save">কখনও সংরক্ষণ করবেন না</string>
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">সংরক্ষণ</string>
+    <!-- Negative confirmation that we should not save the updated login -->
+    <string name="mozac_feature_prompt_dont_update">হালনাগাদ করবেন না</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">আপডেট</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password">পাসওয়ার্ডের জায়গাটি খালি রাখা যাবে না</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause">লগইন সংরক্ষণ করা যায়নি</string>
-    <!-- Prompt message displayed when app detects a user has entered a password and user decides if app should save it. The first parameter is the name of the application (For example: Fenix)  -->
-    <string name="mozac_feature_prompt_logins_save_message">আপনি কি %s এই লগইনটি সংরক্ষণ করতে চান?</string>
+    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
+    <string name="mozac_feature_prompt_login_save_headline">এই লগইন সংরক্ষণ করবেন?</string>
+    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
+    <string name="mozac_feature_prompt_login_update_headline">এই লগইন হালনাগাদ করবেন?</string>
+    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
+    <string name="mozac_feature_prompt_login_add_username_headline">সংরক্ষিত পাসওয়ার্ডে ব্যবহারকারীর নাম যুক্ত করবেন?</string>
     <!-- Title of a color picker dialog, this text is shown above a color picker. -->
     <string name="mozac_feature_prompts_choose_a_color">একটি রঙ নির্বাচন করুন</string>
     <!-- Text of a confirm button in dialog requesting to open a new window. -->
     <string name="mozac_feature_prompts_allow">অনুমতি দিন</string>
     <!-- Text of a negative button in dialog requesting to open a new window. -->
     <string name="mozac_feature_prompts_deny">প্রত্যাখান করুন</string>
+    <!-- Title of the dialog shown when a user is leaving a website and there is still data not saved yet. -->
+    <string name="mozac_feature_prompt_before_unload_dialog_title">আপনি কি নিশ্চিত?</string>
+    <!-- Body text of the dialog shown when a user is leaving a website and there is still data not saved yet. -->
+    <string name="mozac_feature_prompt_before_unload_dialog_body">আপনি কি এই সাইটটি ছেড়ে যেতে চান? আপনার প্রবেশ করা ডাটা সংরক্ষণ নাও হতে পারে</string>
+    <!-- Stay button of the dialog shown when a user is leaving a website and there is still data not saved yet, this indicates that the user wants to stay in the website. -->
+    <string name="mozac_feature_prompts_before_unload_stay">থাকুন</string>
+    <!-- Leave button of the dialog shown when a user is leaving a website and there is still data not saved yet, this indicates that the user wants to leave in the website. -->
+    <string name="mozac_feature_prompts_before_unload_leave">ত্যাগ করুন</string>
     <!-- Title of the month chooser dialog. -->
     <string name="mozac_feature_prompts_set_month">একটি মাস বাছাই করুন</string>
     <!-- January (short description), used on the month chooser dialog. -->
@@ -60,4 +76,15 @@
     <string name="mozac_feature_prompts_nov">Nov</string>
     <!-- December month of the year (short description), used on the month chooser dialog. -->
     <string name="mozac_feature_prompts_dec">Dec</string>
+    <!-- Option in expanded select login prompt that links to login settings -->
+    <string name="mozac_feature_prompts_manage_logins">লগইন ব্যবস্থাপনা করুন</string>
+    <!-- Content description for expanding the saved logins options in the select login prompt -->
+    <string name="mozac_feature_prompts_expand_logins_content_description">প্রস্তাবিত লগইনগুলি সম্প্রসারিত করুন</string>
+    <!-- Content description for collapsing the saved logins options in the select login prompt -->
+    <string name="mozac_feature_prompts_collapse_logins_content_description">প্রস্তাবিত লগইনগুলি সংকুচিত করুন</string>
+    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
+    <string name="mozac_feature_prompts_saved_logins">প্রস্তাবিত লগইনগুলি</string>
+
+    <!-- Pressing this will dismiss the dialog and not refresh the webpage -->
+    <string name="mozac_feature_prompt_repost_negative_button_text">বাতিল</string>
 </resources>

--- a/components/feature/prompts/src/main/res/values-br/strings.xml
+++ b/components/feature/prompts/src/main/res/values-br/strings.xml
@@ -35,7 +35,7 @@
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_update_headline">Hizivaat an titour kennaskañ-mañ?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline">Ouzhpennañ an anv arveriad dʼar gerioù-tremen enrollet ?</string>
+    <string name="mozac_feature_prompt_login_add_username_headline">Ouzhpennañ an anv arveriad dʼar gerioù-tremen enrollet?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
     <!-- For more info take a look here https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt -->
     <string name="mozac_feature_prompts_content_description_input_label">Tikedenn evit ur vaezienn destenn.</string>

--- a/components/feature/prompts/src/main/res/values-eo/strings.xml
+++ b/components/feature/prompts/src/main/res/values-eo/strings.xml
@@ -87,4 +87,12 @@
     <string name="mozac_feature_prompts_collapse_logins_content_description">Faldi sugestitajn legitimilojn</string>
     <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
     <string name="mozac_feature_prompts_saved_logins">Sugestitaj legitimiloj</string>
+
+    <!-- Strings shown in a dialog that appear when users try to refresh a certain kind of webpages -->
+    <string name="mozac_feature_prompt_repost_title">Ĉu resendi datumojn al tiu ĉi retejo?</string>
+    <string name="mozac_feature_prompt_repost_message">Reŝargo de tiu paĝo povus ripeti ĵusajn agojn, ekzemple resendon de pago aŭ komento.</string>
+    <!-- Pressing this will dismiss the dialog and reload the page sending again the previous data -->
+    <string name="mozac_feature_prompt_repost_positive_button_text">Resendi datumojn</string>
+    <!-- Pressing this will dismiss the dialog and not refresh the webpage -->
+    <string name="mozac_feature_prompt_repost_negative_button_text">Nuligi</string>
 </resources>

--- a/components/feature/prompts/src/main/res/values-es-rMX/strings.xml
+++ b/components/feature/prompts/src/main/res/values-es-rMX/strings.xml
@@ -87,4 +87,12 @@
     <string name="mozac_feature_prompts_collapse_logins_content_description">Contraer los inicios de sesión sugeridos</string>
     <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
     <string name="mozac_feature_prompts_saved_logins">Inicios de sesión sugeridos</string>
+
+    <!-- Strings shown in a dialog that appear when users try to refresh a certain kind of webpages -->
+    <string name="mozac_feature_prompt_repost_title">¿Reenviar datos a este sitio?</string>
+    <string name="mozac_feature_prompt_repost_message">Actualizar esta página podría duplicar acciones recientes, como enviar un pago o publicar un comentario dos veces.</string>
+    <!-- Pressing this will dismiss the dialog and reload the page sending again the previous data -->
+    <string name="mozac_feature_prompt_repost_positive_button_text">Reenviar datos</string>
+    <!-- Pressing this will dismiss the dialog and not refresh the webpage -->
+    <string name="mozac_feature_prompt_repost_negative_button_text">Cancelar</string>
 </resources>

--- a/components/feature/prompts/src/main/res/values-es/strings.xml
+++ b/components/feature/prompts/src/main/res/values-es/strings.xml
@@ -26,6 +26,8 @@
 
     <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save">No guardar</string>
+    <!-- Negative confirmation that we should never save a login for this site -->
+    <string name="mozac_feature_prompt_never_save">No guardar nunca</string>
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Guardar</string>
     <!-- Negative confirmation that we should not save the updated login -->
@@ -96,4 +98,12 @@
     <string name="mozac_feature_prompts_collapse_logins_content_description">Contraer los inicios de sesión sugeridos</string>
     <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
     <string name="mozac_feature_prompts_saved_logins">Inicios de sesión sugeridos</string>
+
+    <!-- Strings shown in a dialog that appear when users try to refresh a certain kind of webpages -->
+    <string name="mozac_feature_prompt_repost_title">¿Reenviar datos a este sitio?</string>
+    <string name="mozac_feature_prompt_repost_message">La actualización de esta página podría resultar en el duplicar de medidas recientes, tal como enviar un pago o publicar un comentario dos veces. </string>
+    <!-- Pressing this will dismiss the dialog and reload the page sending again the previous data -->
+    <string name="mozac_feature_prompt_repost_positive_button_text">Reenviar datos</string>
+    <!-- Pressing this will dismiss the dialog and not refresh the webpage -->
+    <string name="mozac_feature_prompt_repost_negative_button_text">Cancelar</string>
 </resources>

--- a/components/feature/prompts/src/main/res/values-fa/strings.xml
+++ b/components/feature/prompts/src/main/res/values-fa/strings.xml
@@ -91,6 +91,8 @@
     <!-- Strings shown in a dialog that appear when users try to refresh a certain kind of webpages -->
     <string name="mozac_feature_prompt_repost_title">ارسال دوباره داده به این پایگاه؟</string>
     <string name="mozac_feature_prompt_repost_message">نوسازی این صفحه می تواند اقدامات اخیر مانند پرداخت یا ارسال نظر را دوبار تکرار کند.</string>
+    <!-- Pressing this will dismiss the dialog and reload the page sending again the previous data -->
+    <string name="mozac_feature_prompt_repost_positive_button_text">ارسال مجدد داده ها</string>
     <!-- Pressing this will dismiss the dialog and not refresh the webpage -->
     <string name="mozac_feature_prompt_repost_negative_button_text">انصراف</string>
 </resources>

--- a/components/feature/prompts/src/main/res/values-gd/strings.xml
+++ b/components/feature/prompts/src/main/res/values-gd/strings.xml
@@ -87,4 +87,12 @@
     <string name="mozac_feature_prompts_collapse_logins_content_description">Co-theannaich  na mholar de chlàraidhean a-steach</string>
     <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
     <string name="mozac_feature_prompts_saved_logins">Clàraidhean a-steach a mholamaid</string>
+
+    <!-- Strings shown in a dialog that appear when users try to refresh a certain kind of webpages -->
+    <string name="mozac_feature_prompt_repost_title">A bheil thu airson an dàta a chur gun làrach seo a-rithist?</string>
+    <string name="mozac_feature_prompt_repost_message">Ma nì thu ath-nuadhachadh air an duilleag seo, dh’fhaoidte gun dèid gnìomhan a rinn thu o chionn goirid, can pàigheadh a chur thu no beachd a phostaich thu, a dhèanamh a-rithist.</string>
+    <!-- Pressing this will dismiss the dialog and reload the page sending again the previous data -->
+    <string name="mozac_feature_prompt_repost_positive_button_text">Cuir an dàta a-rithist</string>
+    <!-- Pressing this will dismiss the dialog and not refresh the webpage -->
+    <string name="mozac_feature_prompt_repost_negative_button_text">Sguir dheth</string>
 </resources>

--- a/components/feature/prompts/src/main/res/values-lo/strings.xml
+++ b/components/feature/prompts/src/main/res/values-lo/strings.xml
@@ -79,4 +79,7 @@
     <string name="mozac_feature_prompts_nov">ພະຈິກ</string>
     <!-- December month of the year (short description), used on the month chooser dialog. -->
     <string name="mozac_feature_prompts_dec">ທັນວາ</string>
-</resources>
+    <!-- Option in expanded select login prompt that links to login settings -->
+    <string name="mozac_feature_prompts_manage_logins">ຈັດການການເຂົ້າສູ່ລະບົບ</string>
+
+    </resources>

--- a/components/feature/prompts/src/main/res/values-mix/strings.xml
+++ b/components/feature/prompts/src/main/res/values-mix/strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for confirmation for a positive action in dialog  -->
+    <string name="mozac_feature_prompts_ok">Vaá</string>
+    <!-- Text for confirmation for a negative action in dialog.  -->
+    <string name="mozac_feature_prompts_cancel">Kunchatu</string>
+
+    <!-- Text for a button that clears the selected input in the date/time picker. -->
+    <string name="mozac_feature_prompts_clear">Stòo</string>
+    <!-- Text for password field in an authentication dialog. -->
+    <string name="mozac_feature_prompt_password_hint">Tu un seè</string>
+    <!-- Negative confirmation that we should not save the new or updated login -->
+    <string name="mozac_feature_prompt_dont_save"></string>
+    <!-- Positive confirmation that we should save the new or updated login -->
+    <string name="mozac_feature_prompt_save_confirmation">Chika vaá</string>
+
+    </resources>

--- a/components/feature/prompts/src/main/res/values-sat/strings.xml
+++ b/components/feature/prompts/src/main/res/values-sat/strings.xml
@@ -7,7 +7,7 @@
     <!-- When a page shows many dialogs, this checkbox will appear for letting the user choose to prevent showing more dialogs. -->
     <string name="mozac_feature_prompts_no_more_dialogs">ᱱᱚᱶᱟ ᱥᱟᱦᱴᱟ ᱟᱠᱚᱴᱮᱢ ᱵᱟᱹᱲᱛᱤ ᱠᱟᱛᱷᱟ ᱵᱮᱱᱟᱣ ᱠᱷᱚᱱ</string>
     <!-- Text for a positive button, when an user selects a date in date/time picker. -->
-    <string name="mozac_feature_prompts_set_date">ᱥᱟᱡᱟᱣ ᱢᱮᱸ</string>
+    <string name="mozac_feature_prompts_set_date">ᱥᱟᱡᱟᱣ ᱢᱮ</string>
     <!-- Text for a button that clears the selected input in the date/time picker. -->
     <string name="mozac_feature_prompts_clear">ᱯᱷᱟᱨᱪᱟ</string>
     <!-- Text for the title of an authentication dialog. -->
@@ -21,40 +21,40 @@
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">ᱛᱤᱥ ᱦᱚᱸ ᱵᱟᱝ ᱥᱟᱸᱪᱟᱣᱜ-ᱟ</string>
     <!-- Positive confirmation that we should save the new or updated login -->
-    <string name="mozac_feature_prompt_save_confirmation">ᱥᱟᱸᱪᱟᱣ ᱢᱮᱸ</string>
+    <string name="mozac_feature_prompt_save_confirmation">ᱥᱟᱸᱪᱟᱣ ᱢᱮ</string>
     <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update">ᱟᱞᱚᱢ ᱦᱟᱹᱞᱤᱭᱟᱜ-ᱟ</string>
     <!-- Positive confirmation that we should save the updated login -->
-    <string name="mozac_feature_prompt_update_confirmation">ᱦᱟᱹᱞᱤᱭᱟᱹᱜ ᱢᱮᱸ</string>
+    <string name="mozac_feature_prompt_update_confirmation">ᱦᱟᱹᱞᱤᱭᱟᱹᱜ ᱢᱮ</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password">ᱥᱟᱵᱟᱫᱽ ᱜᱟᱫᱮᱞ ᱠᱷᱟᱹᱞᱤ ᱟᱞᱚ ᱛᱟᱦᱮᱸᱱ ᱢᱟ</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause">ᱞᱚᱜᱤᱱ ᱵᱟᱭ ᱥᱟᱸᱪᱟᱣ ᱫᱟᱲᱮᱭᱟᱜ ᱠᱟᱱᱟ</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline">ᱱᱚᱶᱟ ᱞᱚᱜᱤᱱ ᱥᱟᱸᱪᱟᱣ ᱢᱮᱸ?</string>
+    <string name="mozac_feature_prompt_login_save_headline">ᱱᱚᱶᱟ ᱞᱚᱜᱤᱱ ᱥᱟᱸᱪᱟᱣ ᱢᱮ?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline">ᱱᱚᱶᱟ ᱞᱚᱜᱤᱱ ᱦᱟᱹᱞᱤᱭᱟᱜ ᱢᱮᱸ?</string>
+    <string name="mozac_feature_prompt_login_update_headline">ᱱᱚᱶᱟ ᱞᱚᱜᱤᱱ ᱦᱟᱹᱞᱤᱭᱟᱜ ᱢᱮ?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline">ᱥᱟᱸᱪᱟᱣᱠᱟᱱ ᱫᱟᱱᱟᱝ ᱥᱟᱵᱟᱫᱽ ᱨᱮ ᱵᱮᱵᱷᱟᱨᱤᱡ ᱧᱩᱛᱩᱢ ᱥᱮᱞᱮᱫᱽ ᱟᱢ?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
     <!-- For more info take a look here https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt -->
     <string name="mozac_feature_prompts_content_description_input_label">ᱚᱱᱚᱞ ᱟᱫᱮᱨ ᱡᱟᱭᱜᱟ ᱨᱮᱭᱟᱜ ᱞᱮᱵᱮᱞ</string>
     <!-- Title of a color picker dialog, this text is shown above a color picker. -->
-    <string name="mozac_feature_prompts_choose_a_color">ᱨᱚᱝ ᱵᱟᱪᱷᱟᱣ ᱛᱟᱞᱟᱝ ᱢᱮᱸ</string>
+    <string name="mozac_feature_prompts_choose_a_color">ᱨᱚᱝ ᱵᱟᱪᱷᱟᱣ ᱛᱟᱞᱟᱝ ᱢᱮ</string>
     <!-- Text of a confirm button in dialog requesting to open a new window. -->
     <string name="mozac_feature_prompts_allow">ᱦᱮᱥᱟᱨᱤᱭᱟᱹ</string>
     <!-- Text of a negative button in dialog requesting to open a new window. -->
     <string name="mozac_feature_prompts_deny">ᱵᱟᱝ ᱦᱮᱥᱟᱨᱭ</string>
     <!-- Title of the dialog shown when a user is leaving a website and there is still data not saved yet. -->
-    <string name="mozac_feature_prompt_before_unload_dialog_title">ᱟᱢ ᱜᱚᱴᱟ ᱛᱮ ᱢᱮᱸᱱᱟᱢ-ᱟ?</string>
+    <string name="mozac_feature_prompt_before_unload_dialog_title">ᱟᱢ ᱜᱚᱴᱟ ᱛᱮ ᱢᱮᱱᱟᱢ-ᱟ?</string>
     <!-- Body text of the dialog shown when a user is leaving a website and there is still data not saved yet. -->
     <string name="mozac_feature_prompt_before_unload_dialog_body">ᱪᱮᱫ ᱟᱢ ᱱᱚᱶᱟ ᱥᱟᱭᱤᱴ ᱵᱟᱹᱜᱤ ᱥᱟᱱᱟᱢ ᱠᱟᱱᱟ? ᱰᱟᱴᱟ ᱡᱟᱦᱸᱟ ᱟᱢ ᱟᱫᱮᱨ ᱞᱮᱫᱟᱢ ᱚᱱᱟ ᱥᱟᱸᱪᱟᱣ ᱵᱟᱝ ᱦᱩᱭᱩᱜ-ᱟ</string>
     <!-- Stay button of the dialog shown when a user is leaving a website and there is still data not saved yet, this indicates that the user wants to stay in the website. -->
-    <string name="mozac_feature_prompts_before_unload_stay">ᱛᱟᱦᱮᱸᱱ ᱢᱮᱸ</string>
+    <string name="mozac_feature_prompts_before_unload_stay">ᱛᱟᱦᱮᱸᱱ ᱢᱮ</string>
     <!-- Leave button of the dialog shown when a user is leaving a website and there is still data not saved yet, this indicates that the user wants to leave in the website. -->
-    <string name="mozac_feature_prompts_before_unload_leave">ᱵᱟᱹᱜᱤ ᱢᱮᱸ</string>
+    <string name="mozac_feature_prompts_before_unload_leave">ᱵᱟᱹᱜᱤ ᱢᱮ</string>
     <!-- Title of the month chooser dialog. -->
-    <string name="mozac_feature_prompts_set_month">ᱪᱟᱸᱫᱚ ᱵᱟᱪᱷᱟᱣ ᱢᱮᱸ</string>
+    <string name="mozac_feature_prompts_set_month">ᱪᱟᱸᱫᱚ ᱵᱟᱪᱷᱟᱣ ᱢᱮ</string>
     <!-- January (short description), used on the month chooser dialog. -->
     <string name="mozac_feature_prompts_jan">ᱯᱩᱥ</string>
     <!-- February month of the year (short description), used on the month chooser dialog. -->
@@ -82,17 +82,17 @@
     <!-- Option in expanded select login prompt that links to login settings -->
     <string name="mozac_feature_prompts_manage_logins">ᱞᱚᱜᱤᱱ ᱵᱮᱵᱚᱥᱛᱷᱟ ᱠᱚ</string>
     <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description">ᱵᱟᱛᱟᱣᱟᱠᱟᱱ ᱞᱚᱜᱤᱱ ᱠᱚ ᱴᱟᱨᱟᱝ ᱪᱷᱚᱭ ᱢᱮᱸ</string>
+    <string name="mozac_feature_prompts_expand_logins_content_description">ᱵᱟᱛᱟᱣᱟᱠᱟᱱ ᱞᱚᱜᱤᱱ ᱠᱚ ᱴᱟᱨᱟᱝ ᱪᱷᱚᱭ ᱢᱮ</string>
     <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description">ᱵᱟᱛᱟᱣᱟᱠᱟᱱ ᱞᱚᱜᱤᱱ ᱠᱚ ᱠᱟᱹᱴᱤᱡ ᱪᱷᱚᱭ ᱢᱮᱸ</string>
+    <string name="mozac_feature_prompts_collapse_logins_content_description">ᱵᱟᱛᱟᱣᱟᱠᱟᱱ ᱞᱚᱜᱤᱱ ᱠᱚ ᱠᱟᱹᱴᱤᱡ ᱪᱷᱚᱭ ᱢᱮ</string>
     <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
     <string name="mozac_feature_prompts_saved_logins">ᱵᱟᱛᱟᱣᱟᱠᱟᱱ ᱞᱚᱜᱤᱱ ᱠᱚ</string>
 
     <!-- Strings shown in a dialog that appear when users try to refresh a certain kind of webpages -->
     <string name="mozac_feature_prompt_repost_title">ᱱᱚᱶᱟ ᱥᱟᱭᱤᱴ ᱞᱟᱹᱜᱤᱫ ᱰᱟᱴᱟ ᱫᱩᱦᱲᱟᱹ ᱵᱷᱮᱡᱟᱭ ᱟᱢ‌ ᱥᱮ?</string>
-    <string name="mozac_feature_prompt_repost_message">ᱥᱟᱦᱴᱟ ᱨᱤᱯᱷᱨᱮᱥ ᱞᱮᱠᱷᱟᱱ ᱱᱤᱛᱚᱜᱟᱜ ᱠᱟᱹᱢᱤ ᱠᱚ ᱰᱩᱯᱞᱤᱠᱮᱴ ᱫᱟᱲᱮᱭᱟᱜᱼᱟᱭ, ᱡᱮᱢᱚᱱ ᱯᱩᱭᱥᱟᱹ ᱵᱷᱮᱡᱟ ᱠᱚ ᱟᱨ ᱵᱟᱝ ᱠᱚᱢᱮᱸᱴ ᱠᱚ ᱵᱟᱨ ᱡᱮᱠᱷᱟ ᱵᱷᱮᱡᱟ ᱠᱚ ᱾</string>
+    <string name="mozac_feature_prompt_repost_message">ᱥᱟᱦᱴᱟ ᱨᱤᱯᱷᱨᱮᱥ ᱞᱮᱠᱷᱟᱱ ᱱᱤᱛᱚᱜᱟᱜ ᱠᱟᱹᱢᱤ ᱠᱚ ᱰᱩᱯᱞᱤᱠᱮᱴ ᱫᱟᱲᱮᱭᱟᱜᱼᱟᱭ, ᱡᱮᱢᱚᱱ ᱯᱩᱭᱥᱟᱹ ᱵᱷᱮᱡᱟ ᱠᱚ ᱟᱨ ᱵᱟᱝ ᱠᱚᱢᱮᱴ ᱠᱚ ᱵᱟᱨ ᱡᱮᱠᱷᱟ ᱵᱷᱮᱡᱟ ᱠᱚ ᱾</string>
     <!-- Pressing this will dismiss the dialog and reload the page sending again the previous data -->
-    <string name="mozac_feature_prompt_repost_positive_button_text">ᱰᱟᱴᱟ ᱫᱩᱦᱲᱟ ᱵᱷᱮᱡᱟᱭᱢᱮᱸ</string>
+    <string name="mozac_feature_prompt_repost_positive_button_text">ᱰᱟᱴᱟ ᱫᱩᱦᱲᱟ ᱵᱷᱮᱡᱟᱭᱢᱮ</string>
     <!-- Pressing this will dismiss the dialog and not refresh the webpage -->
     <string name="mozac_feature_prompt_repost_negative_button_text">ᱵᱟᱹᱰᱨᱟᱹ</string>
 </resources>

--- a/components/feature/prompts/src/main/res/values-ta/strings.xml
+++ b/components/feature/prompts/src/main/res/values-ta/strings.xml
@@ -87,4 +87,12 @@
     <string name="mozac_feature_prompts_collapse_logins_content_description">பரிந்துரைத்த உள்நுழைவுகளை விரிவாக்கு</string>
     <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
     <string name="mozac_feature_prompts_saved_logins">பரிந்துரைத்த உள்நுழைவுகள்</string>
+
+    <!-- Strings shown in a dialog that appear when users try to refresh a certain kind of webpages -->
+    <string name="mozac_feature_prompt_repost_title">இத்தளத்திற்குத் தரவை மீண்டும் அனுப்பவா?</string>
+    <string name="mozac_feature_prompt_repost_message">இந்தப் பக்கத்தைப் புதுப்பிப்பது அண்மையச் செயல்களை திரும்பச் செய்யக்கூடும், இருமுறை பணம் அனுப்புதல் அல்லது இருமுறை கருத்திடல் போன்றவை.</string>
+    <!-- Pressing this will dismiss the dialog and reload the page sending again the previous data -->
+    <string name="mozac_feature_prompt_repost_positive_button_text">தரவை மீண்டும் அனுப்பு</string>
+    <!-- Pressing this will dismiss the dialog and not refresh the webpage -->
+    <string name="mozac_feature_prompt_repost_negative_button_text">இரத்துசெய்</string>
 </resources>

--- a/components/feature/prompts/src/main/res/values-tl/strings.xml
+++ b/components/feature/prompts/src/main/res/values-tl/strings.xml
@@ -21,6 +21,8 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">i-Save</string>
 
+    <!-- Negative confirmation that we should not save the updated login -->
+    <string name="mozac_feature_prompt_dont_update">Huwag i-update</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">I-update</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->

--- a/components/feature/prompts/src/main/res/values-ur/strings.xml
+++ b/components/feature/prompts/src/main/res/values-ur/strings.xml
@@ -80,6 +80,15 @@
     <!-- December month of the year (short description), used on the month chooser dialog. -->
     <string name="mozac_feature_prompts_dec">دسمبر</string>
 
+    <!-- Option in expanded select login prompt that links to login settings -->
+    <string name="mozac_feature_prompts_manage_logins">لاگ ان بندوبست کریں</string>
+    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
+    <string name="mozac_feature_prompts_saved_logins">تجویز شدہ لاگ ان</string>
+
+    <!-- Strings shown in a dialog that appear when users try to refresh a certain kind of webpages -->
+    <string name="mozac_feature_prompt_repost_title">اس سائٹ پر ڈیٹا دوبارہ ارسال کریں؟</string>
+    <!-- Pressing this will dismiss the dialog and reload the page sending again the previous data -->
+    <string name="mozac_feature_prompt_repost_positive_button_text">ڈیٹا کو دوبارہ ارسال کریں</string>
     <!-- Pressing this will dismiss the dialog and not refresh the webpage -->
     <string name="mozac_feature_prompt_repost_negative_button_text">منسوخ کریں</string>
 </resources>

--- a/components/feature/pwa/src/main/res/values-ast/strings.xml
+++ b/components/feature/pwa/src/main/res/values-ast/strings.xml
@@ -5,6 +5,8 @@
 
     <!-- Name of the "notification channel" used for displaying site controls notification. See https://developer.android.com/training/notify-user/channels -->
     <string name="mozac_feature_pwa_site_controls_notification_channel">Controles de sitios a pantalla completa</string>
+    <!-- Text shown on the second row of the site controls notification. -->
+    <string name="mozac_feature_pwa_site_controls_notification_text">Toca pa copiar la URL d\'esta aplicación</string>
     <!-- Refresh button in site controls notification. -->
     <string name="mozac_feature_pwa_site_controls_refresh">Refrescar</string>
     <!-- Toast displayed when the website URL is copied. -->

--- a/components/feature/pwa/src/main/res/values-bn/strings.xml
+++ b/components/feature/pwa/src/main/res/values-bn/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Default shortcut label used if website has no title -->
+    <string name="mozac_feature_pwa_default_shortcut_label">ওয়েবসাইট</string>
+
+    <!-- Name of the "notification channel" used for displaying site controls notification. See https://developer.android.com/training/notify-user/channels -->
+    <string name="mozac_feature_pwa_site_controls_notification_channel">পূর্ণ পর্দার সাইট নিয়ন্ত্রণ</string>
+    <!-- Text shown on the second row of the site controls notification. -->
+    <string name="mozac_feature_pwa_site_controls_notification_text">অ্যাপের ইউআরএল অনুলিপি করাতে ট্যাপ করুন</string>
+    <!-- Refresh button in site controls notification. -->
+    <string name="mozac_feature_pwa_site_controls_refresh">রিফ্রেশ</string>
+    <!-- Toast displayed when the website URL is copied. -->
+    <string name="mozac_feature_pwa_copy_success">URL কপি হয়েছে</string>
+</resources>

--- a/components/feature/pwa/src/main/res/values-es/strings.xml
+++ b/components/feature/pwa/src/main/res/values-es/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Default shortcut label used if website has no title -->
+    <string name="mozac_feature_pwa_default_shortcut_label">Sitio web</string>
+
+    <!-- Name of the "notification channel" used for displaying site controls notification. See https://developer.android.com/training/notify-user/channels -->
+    <string name="mozac_feature_pwa_site_controls_notification_channel">Controles del sitio a pantalla completa</string>
+    <!-- Text shown on the second row of the site controls notification. -->
+    <string name="mozac_feature_pwa_site_controls_notification_text">Toca para copiar la URL de esta aplicación</string>
+    <!-- Refresh button in site controls notification. -->
+    <string name="mozac_feature_pwa_site_controls_refresh">Actualizar</string>
+    <!-- Toast displayed when the website URL is copied. -->
+    <string name="mozac_feature_pwa_copy_success">URL copiada.</string>
+</resources>

--- a/components/feature/pwa/src/main/res/values-fa/strings.xml
+++ b/components/feature/pwa/src/main/res/values-fa/strings.xml
@@ -3,6 +3,10 @@
     <!-- Default shortcut label used if website has no title -->
     <string name="mozac_feature_pwa_default_shortcut_label">پایگاه اینترنتی</string>
 
+    <!-- Name of the "notification channel" used for displaying site controls notification. See https://developer.android.com/training/notify-user/channels -->
+    <string name="mozac_feature_pwa_site_controls_notification_channel">کنترل های سایت در حالت تمام صفحه</string>
+    <!-- Text shown on the second row of the site controls notification. -->
+    <string name="mozac_feature_pwa_site_controls_notification_text">برای کپی کردن URL این برنامه ضربه بزنید</string>
     <!-- Refresh button in site controls notification. -->
     <string name="mozac_feature_pwa_site_controls_refresh">نوسازی</string>
     <!-- Toast displayed when the website URL is copied. -->

--- a/components/feature/pwa/src/main/res/values-mix/strings.xml
+++ b/components/feature/pwa/src/main/res/values-mix/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Default shortcut label used if website has no title -->
+    <string name="mozac_feature_pwa_default_shortcut_label">Sitio Web</string>
+
+    <!-- Toast displayed when the website URL is copied. -->
+    <string name="mozac_feature_pwa_copy_success">Ndatava URL</string>
+</resources>

--- a/components/feature/pwa/src/main/res/values-sat/strings.xml
+++ b/components/feature/pwa/src/main/res/values-sat/strings.xml
@@ -6,7 +6,7 @@
     <!-- Name of the "notification channel" used for displaying site controls notification. See https://developer.android.com/training/notify-user/channels -->
     <string name="mozac_feature_pwa_site_controls_notification_channel">ᱯᱩᱨᱟᱹ ᱤᱥᱠᱨᱤᱱ ᱥᱟᱭᱤᱴ ᱥᱟᱸᱢᱲᱟᱣ</string>
     <!-- Text shown on the second row of the site controls notification. -->
-    <string name="mozac_feature_pwa_site_controls_notification_text">ᱱᱚᱶᱟ ᱮᱯ ᱨᱮᱭᱟᱜ URL ᱱᱚᱠᱚᱞ ᱞᱟᱹᱜᱤᱛ ᱛᱮ ᱡᱚᱴᱮᱫ ᱢᱮᱸ</string>
+    <string name="mozac_feature_pwa_site_controls_notification_text">ᱱᱚᱶᱟ ᱮᱯ ᱨᱮᱭᱟᱜ URL ᱱᱚᱠᱚᱞ ᱞᱟᱹᱜᱤᱛ ᱛᱮ ᱡᱚᱴᱮᱫ ᱢᱮ</string>
     <!-- Refresh button in site controls notification. -->
     <string name="mozac_feature_pwa_site_controls_refresh">ᱱᱟᱶᱟ ᱟᱹᱨᱩ</string>
     <!-- Toast displayed when the website URL is copied. -->

--- a/components/feature/qr/src/main/res/values-bn/strings.xml
+++ b/components/feature/qr/src/main/res/values-bn/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Content description (not visible, for screen readers etc.): Description of an image view. -->
+    <string name="mozac_feature_qr_scanner">QR স্ক্যানার</string>
+
+    <!-- Text shown if no camera is available on the device and the QR scanner cannot be displayed. -->
+    <string name="mozac_feature_qr_scanner_no_camera">ডিভাইসে কোনো ক্যামেরা নেই</string>
+
+</resources>

--- a/components/feature/qr/src/main/res/values-es/strings.xml
+++ b/components/feature/qr/src/main/res/values-es/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <!-- Content description (not visible, for screen readers etc.): Description of an image view. -->
+    <string name="mozac_feature_qr_scanner">Escáner de QR</string>
+
     <!-- Text shown if no camera is available on the device and the QR scanner cannot be displayed. -->
     <string name="mozac_feature_qr_scanner_no_camera">No hay cámara disponible en el dispositivo</string>
 

--- a/components/feature/qr/src/main/res/values-fa/strings.xml
+++ b/components/feature/qr/src/main/res/values-fa/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Content description (not visible, for screen readers etc.): Description of an image view. -->
+    <string name="mozac_feature_qr_scanner">خواننده کد QR</string>
+
+    <!-- Text shown if no camera is available on the device and the QR scanner cannot be displayed. -->
+    <string name="mozac_feature_qr_scanner_no_camera">دوربین موجود نیست</string>
+
+</resources>

--- a/components/feature/qr/src/main/res/values-mix/strings.xml
+++ b/components/feature/qr/src/main/res/values-mix/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Content description (not visible, for screen readers etc.): Description of an image view. -->
+    <string name="mozac_feature_qr_scanner">Ndatava QR</string>
+
+    <!-- Text shown if no camera is available on the device and the QR scanner cannot be displayed. -->
+    <string name="mozac_feature_qr_scanner_no_camera">Koo ña ndatava nu kaa ndusu ku</string>
+
+</resources>

--- a/components/feature/qr/src/main/res/values-ru/strings.xml
+++ b/components/feature/qr/src/main/res/values-ru/strings.xml
@@ -2,7 +2,7 @@
 <resources>
 
     <!-- Content description (not visible, for screen readers etc.): Description of an image view. -->
-    <string name="mozac_feature_qr_scanner">Сканер QR</string>
+    <string name="mozac_feature_qr_scanner">Сканер QR-кодов</string>
 
     <!-- Text shown if no camera is available on the device and the QR scanner cannot be displayed. -->
     <string name="mozac_feature_qr_scanner_no_camera">На этом устройстве камера недоступна</string>

--- a/components/feature/readerview/src/main/res/values-sat/strings.xml
+++ b/components/feature/readerview/src/main/res/values-sat/strings.xml
@@ -10,10 +10,10 @@
     <string name="mozac_feature_readerview_serif_font_desc">ᱥᱮᱨᱤᱯᱷ ᱪᱤᱠᱤ</string>
 
     <!-- Accessible description for decreasing the font size -->
-    <string name="mozac_feature_readerview_font_size_decrease_desc">ᱪᱤᱠᱤ ᱢᱟᱯ ᱠᱚᱢ ᱢᱮᱸ</string>
+    <string name="mozac_feature_readerview_font_size_decrease_desc">ᱪᱤᱠᱤ ᱢᱟᱯ ᱠᱚᱢ ᱢᱮ</string>
 
     <!-- Accessible description for increasing the font size -->
-    <string name="mozac_feature_readerview_font_size_increase_desc">ᱪᱤᱠᱤ ᱢᱟᱯ ᱢᱟᱨᱟᱝ ᱢᱮᱸ</string>
+    <string name="mozac_feature_readerview_font_size_increase_desc">ᱪᱤᱠᱤ ᱢᱟᱯ ᱢᱟᱨᱟᱝ ᱢᱮ</string>
     <!-- Color option for the background -->
     <string name="mozac_feature_readerview_dark">ᱧᱩᱛ</string>
     <!-- Accessible description for the color option -->

--- a/components/feature/sitepermissions/src/main/res/values-ast/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-ast/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Enxamás</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">¿Permitir a %1$s qu\'atroxe datos nel almacenamientu permanente?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">¿Permitir a %1$s que reproduza conteníu con DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-be/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-be/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Ніколі</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Дазволіць %1$s захоўваць дадзеныя ў пастаянным сховішчы?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Дазволіць %1$s прайграваць змесціва, якое кантралюецца DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-cak/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-cak/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Majub\'ey</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">¿La niya\' q\'ij chi ri %1$s keruyaka\' taq tzij pa jutaqil yakoj?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">¿La niya\' q\'ij chi ri %1$s nutzïj rupam samajin ruma DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-co/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-co/strings.xml
@@ -3,22 +3,22 @@
     <!-- Title of a dialog for a notification permission request. -->
     <string name="mozac_feature_sitepermissions_notification_title">Permette à %1$s di mandà nutificazioni ?</string>
     <!-- Title of a dialog for a camera permission request. -->
-    <string name="mozac_feature_sitepermissions_camera_title">Permette à %1$s d’impiegà u vostru appareghju-fotò ?</string>
+    <string name="mozac_feature_sitepermissions_camera_title">Permette à %1$s d’impiegà u vostru apparechju-fotò ?</string>
     <!-- Title of a dialog for a microphone permission request. -->
     <string name="mozac_feature_sitepermissions_microfone_title">Permette à %1$s d’impiegà u vostru microfonu ?</string>
     <!-- Title of a dialog for a location permission request. -->
     <string name="mozac_feature_sitepermissions_location_title">Permette à %1$s d’accede à a vostra lucalizazione ?</string>
     <!-- Title of a dialog for a camera and microphone permission request. -->
-    <string name="mozac_feature_sitepermissions_camera_and_microphone">Permette à %1$s d’impiegà u vostru appareghju-fotò è u vostru microfonu ?</string>
+    <string name="mozac_feature_sitepermissions_camera_and_microphone">Permette à %1$s d’impiegà u vostru apparechju-fotò è u vostru microfonu ?</string>
     <!-- Option in a dialog for requesting a microphone permission, this option will give access to
          the first microphone-->
     <string name="mozac_feature_sitepermissions_option_microphone_one">Microfonu 1</string>
     <!-- Option in a dialog for requesting a camera permission, this option will give access to
          back facing camera-->
-    <string name="mozac_feature_sitepermissions_back_facing_camera2">Appareghju-fotò daretu</string>
+    <string name="mozac_feature_sitepermissions_back_facing_camera2">Apparechju-fotò daretu</string>
     <!-- Option in a dialog for requesting a camera permission, this option will give access to
      front facing camera-->
-    <string name="mozac_feature_sitepermissions_selfie_camera2">Appareghju-fotò davanti</string>
+    <string name="mozac_feature_sitepermissions_selfie_camera2">Apparechju-fotò davanti</string>
     <!-- Text for a positive button in a permission request dialog, this button will give
         access to this permission-->
     <string name="mozac_feature_sitepermissions_allow">Permette</string>
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Mai</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Permette à %1$s d’allucà dati in a memoria permanente ?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Permette à %1$s di leghje cuntenutu cuntrollatu da DRM ?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-cs/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-cs/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Nikdy</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Chcete povolit serveru %1$s ukládat data natrvalo?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Chcete serveru %1$s povolit přehrávat obsah chráněný pomocí DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-cy/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-cy/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Byth</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Caniatáu i %1$s storio data mewn storfa barhaus?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Caniatáu i %1$s chwarae cynnwys sy’n cael ei reoli gan DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-da/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-da/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Aldrig</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Vil du give %1$s lov til at gemme data i vedvarende lager?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Vil du give %1$s love til at afspille DRM-kontrolleret indhold?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-de/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-de/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Nie</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Soll %1$s Daten im dauerhaften Speicher speichern dürfen?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">%1$s die Wiedergabe von DRM-kontrollierten Inhalten erlauben?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-dsb/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-dsb/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Nigda</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Cośo %1$s dowóliś, daty w trajnem składowaku składowaś?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">%1$s dowóliś, aby wopśimjeśe wótgrał, kótaryž se pśez DRM wóźi?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-el/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-el/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Ποτέ</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Να επιτρέπεται στο %1$s η αποθήκευση δεδομένων σε μόνιμη αποθήκευση;</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Να επιτρέπεται στο %1$s η αναπαραγωγή περιεχομένου με έλεγχο DRM;</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-en-rGB/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-en-rGB/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Never</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Allow %1$s to store data in persistent storage?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Allow %1$s to play DRM-controlled content?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-eo/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-eo/strings.xml
@@ -31,4 +31,6 @@
     <string name="mozac_feature_sitepermissions_always_allow">Ĉiam</string>
     <!-- Text for a negative button in a permission request dialog. This will never allow and remember the decision of the user, this is the special case of the notification permission, that is only ask one time-->
     <string name="mozac_feature_sitepermissions_never_allow">Neniam</string>
+    <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_persistent_storage_title">Ĉu permesi al %1$s konservi datumojn en konstanta konservejo?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-eo/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-eo/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Neniam</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Ĉu permesi al %1$s konservi datumojn en konstanta konservejo?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Ĉu permesi al %1$s ludi enhavon protektitan de DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-es-rAR/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-es-rAR/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Nunca</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">¿Permitir que %1$s guarde datos en el almacenamiento persistente?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">¿Permitir que %1$s reproduzca contenido controlado por DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-es-rCL/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-es-rCL/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Nunca</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">¿Permitir a %1$s almacenar datos en el almacenamiento persistente?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">¿Permitir a %1$s reproducir contenido controlado por DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-es-rES/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-es-rES/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Nunca</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">¿Permitir a %1$s almacenar datos en el almacenamiento persistente?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">¿Permitir a %1$s reproducir contenido controlado por DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-es-rMX/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-es-rMX/strings.xml
@@ -31,4 +31,6 @@
     <string name="mozac_feature_sitepermissions_always_allow">Siempre</string>
     <!-- Text for a negative button in a permission request dialog. This will never allow and remember the decision of the user, this is the special case of the notification permission, that is only ask one time-->
     <string name="mozac_feature_sitepermissions_never_allow">Nunca</string>
+    <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_persistent_storage_title">¿Permitir que %1$s almacene datos en el almacenamiento persistente?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-es/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-es/strings.xml
@@ -40,4 +40,8 @@
     <string name="mozac_feature_sitepermissions_always_allow">Siempre</string>
     <!-- Text for a negative button in a permission request dialog. This will never allow and remember the decision of the user, this is the special case of the notification permission, that is only ask one time-->
     <string name="mozac_feature_sitepermissions_never_allow">Nunca</string>
+    <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_persistent_storage_title">¿Desea permitir que %1$s guarde datos en el almacenamiento persistente?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">¿Permitir que %1$s reproduzca contenido controlado por DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-eu/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-eu/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Inoiz ez</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Baimendu %1$s guneari datuak biltegiratze iraunkorrean gordetzea?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Baimendu %1$s helbideari DRM bidez kontrolatutako edukia erreproduzitzen?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-fa/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-fa/strings.xml
@@ -31,4 +31,8 @@
     <string name="mozac_feature_sitepermissions_always_allow">همیشه</string>
     <!-- Text for a negative button in a permission request dialog. This will never allow and remember the decision of the user, this is the special case of the notification permission, that is only ask one time-->
     <string name="mozac_feature_sitepermissions_never_allow">هرگز</string>
+    <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_persistent_storage_title">آیا شما به %1$s اجازه‌ می‌دهید تا اطلاعات را در حافظه دائمی دستگاه ذخیره کند؟</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">به%1$s اجازه پخش محتوای کنترل شده با DRM را می دهید؟</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-fi/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-fi/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">En koskaan</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Sallitko, että %1$s tallettaa tietoja pysyvään tallennustilaan?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Sallitko, että %1$s toistaa DRM-suojattua sisältöä?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-fy-rNL/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-fy-rNL/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Nea</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Bewarjen fan gegevens yn permaninte opslach troch %1$s tastean?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">%1$s tastean om DRM-kontrolearre ynhâld ôf te spyljen?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-gd/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-gd/strings.xml
@@ -31,4 +31,8 @@
     <string name="mozac_feature_sitepermissions_always_allow">An-còmhnaidh</string>
     <!-- Text for a negative button in a permission request dialog. This will never allow and remember the decision of the user, this is the special case of the notification permission, that is only ask one time-->
     <string name="mozac_feature_sitepermissions_never_allow">Chan ann idir</string>
+    <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_persistent_storage_title">An doir thu cead dha %1$s dàta a chumail san stòras bhuan?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">A bheil thu airson cead a thoirt dha %1$s susbaint fo smachd DRM a chluich?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-gl/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-gl/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Nunca</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Permitir que %1$s almacene datos en almacenamento persistente?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Permitir que %1$s reproduza contido controlado por DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-gn/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-gn/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Araka’eve</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">¿Emoneĩ %1$s ombyatývo mba’ekuaarã mbyatyrenda hi’arévape?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">¿Emoneĩ %1$s-pe ombohetávo tetepy DRM ohechapyre?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-hr/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-hr/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Nikada</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Dopustiti stranici %1$s spremanje podataka u trajnu pohranu?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Dopustiti stranici %1$s reprodukciju sadržaja kontroliranog DRM-om?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-hsb/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-hsb/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Ženje</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Smě %1$s daty w trajnym składowaku składować?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">%1$s dowolić, zo byšće wobsah wothrał, kotryž so přez DRM wodźi?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-hu/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-hu/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Soha</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Engedélyezi, hogy a(z) %1$s adatokat tároljon az állandó tárolóban?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Engedélyezi, hogy a(z) %1$s DRM által vezérelt tartalmat játsszon le?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-hy-rAM/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-hy-rAM/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Երբեք</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Թույլատրե՞լ %1$s-ին պահել տվյալներ մշտական պահեստում:</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Թույլատրե՞լ %1$s-ին նվագարկել DRM ղեկավարվող բովանդակություն:</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-in/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-in/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Tidak Pernah</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Izinkan %1$s untuk menyimpan data di penyimpanan persisten?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Izinkan %1$s untuk memutar konten yang dikendalikan DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-it/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-it/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Mai</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Consentire a %1$s di salvare i dati nella memoria permanente?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Consentire a %1$s di riprodurre contenuti protetti da DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-iw/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-iw/strings.xml
@@ -32,5 +32,7 @@
     <!-- Text for a negative button in a permission request dialog. This will never allow and remember the decision of the user, this is the special case of the notification permission, that is only ask one time-->
     <string name="mozac_feature_sitepermissions_never_allow">לעולם לא</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
-    <string name="mozac_feature_sitepermissions_persistent_storage_title">לאפשר ל־%1$s לשמור מידע באחסון הקבוע?</string>
+    <string name="mozac_feature_sitepermissions_persistent_storage_title">האם לאפשר ל־%1$s לשמור מידע באחסון הקבוע?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">האם לאפשר ל־%1$s לנגן תוכן מוגן DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-ja/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-ja/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">常に不許可</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">%1$s に永続ストレージへのデータの格納を許可しますか？</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">%1$s に DRM 制御されたコンテンツの再生を許可しますか？</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-kab/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-kab/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Werǧin</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Ad teǧǧeḍ %1$s ad issekles isefka deg  uselkim-ik•im?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Sireg %1$s ad d-iɣer agbur yettwasneqden sɣur DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-kk/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-kk/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Ешқашан</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">%1$s үшін деректерді тұрақты қоймада сақтауды рұқсат ету керек пе?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">%1$s үшін DRM-мен басқарылатын құраманы ойнатуды рұқсат ету керек пе?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-ko/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-ko/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">안 함</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">%1$s 페이지가 데이터를 영구 저장소에 저장하도록 허용하시겠습니까?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">%1$s에서 DRM 제어 콘텐츠를 재생하도록 허용하시겠습니까?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-lt/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-lt/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Niekada</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Leisti %1$s laikyti duomenis išliekančioje atmintyje?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Liesti %1$s groti DRM apsaugotą turinį?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-nb-rNO/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-nb-rNO/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Aldri</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Tillate %1$s å lagre data i vedvarende lagring?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Tillate %1$s å spille av DRM-kontrollert innhold?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-nl/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-nl/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Nooit</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Bewaren van gegevens in permanente opslag door %1$s toestaan?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">%1$s toestaan om DRM-gecontroleerde inhoud af te spelen?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-nn-rNO/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-nn-rNO/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Aldri</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Tillate %1$s å lagre data i vedvarande lagring?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Tillate %1$s å spele DRM-kontrollert innhald?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-pl/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-pl/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Nigdy</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Czy zezwolić witrynie „%1$s” na przechowywanie danych na urządzeniu?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Czy zezwolić witrynie „%1$s” na odtwarzanie treści chronionych przez DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-pt-rBR/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-pt-rBR/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Nunca</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Permitir ao %1$s armazenar dados em armazenamento persistente?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Permitir que %1$s reproduza conteúdo controlado por direitos autorais?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-pt-rPT/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-pt-rPT/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Nunca</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Permitir que %1$s armazene dados no armazenamento persistente?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Permitir que %1$s reproduza conteúdo controlado por DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-rm/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-rm/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Mai</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Permetter a %1$s da memorisar datas en la memoria durabla?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Permetter a %1$s da reproducir cuntegn controllà da DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-ru/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-ru/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Никогда</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Разрешить %1$s хранить данные в постоянном хранилище?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Разрешить %1$s воспроизводить защищённое DRM содержимое?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-sat/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-sat/strings.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Title of a dialog for a notification permission request. -->
-    <string name="mozac_feature_sitepermissions_notification_title">ᱤᱛᱞᱟᱹᱭ ᱠᱩᱞ ᱞᱟᱹᱜᱤᱫ ᱛᱮ %1$s ᱦᱮᱥᱟᱨᱤᱭᱟᱹ ᱮᱢᱟᱭ ᱢᱮᱸ?</string>
+    <string name="mozac_feature_sitepermissions_notification_title">ᱤᱛᱞᱟᱹᱭ ᱠᱩᱞ ᱞᱟᱹᱜᱤᱫ ᱛᱮ %1$s ᱦᱮᱥᱟᱨᱤᱭᱟᱹ ᱮᱢᱟᱭ ᱢᱮ?</string>
     <!-- Title of a dialog for a camera permission request. -->
-    <string name="mozac_feature_sitepermissions_camera_title">ᱟᱢᱟᱜ ᱠᱮᱢᱨᱟ ᱵᱮᱵᱷᱟᱨ ᱞᱟᱹᱜᱤᱛ ᱛᱮ %1$s ᱦᱮᱥᱟᱨᱤᱭᱟᱹ ᱮᱢᱟᱭ ᱢᱮᱸ?</string>
+    <string name="mozac_feature_sitepermissions_camera_title">ᱟᱢᱟᱜ ᱠᱮᱢᱨᱟ ᱵᱮᱵᱷᱟᱨ ᱞᱟᱹᱜᱤᱛ ᱛᱮ %1$s ᱦᱮᱥᱟᱨᱤᱭᱟᱹ ᱮᱢᱟᱭ ᱢᱮ?</string>
     <!-- Title of a dialog for a microphone permission request. -->
-    <string name="mozac_feature_sitepermissions_microfone_title">ᱟᱢᱟᱜ ᱢᱟᱭᱠᱨᱚᱯᱷᱚᱱ ᱵᱮᱵᱷᱟᱨ ᱞᱟᱹᱜᱤᱛ ᱛᱮ %1$s ᱦᱮᱥᱟᱨᱤᱭᱟᱹ ᱮᱢᱟᱭ ᱢᱮᱸ?</string>
+    <string name="mozac_feature_sitepermissions_microfone_title">ᱟᱢᱟᱜ ᱢᱟᱭᱠᱨᱚᱯᱷᱚᱱ ᱵᱮᱵᱷᱟᱨ ᱞᱟᱹᱜᱤᱛ ᱛᱮ %1$s ᱦᱮᱥᱟᱨᱤᱭᱟᱹ ᱮᱢᱟᱭ ᱢᱮ?</string>
     <!-- Title of a dialog for a location permission request. -->
-    <string name="mozac_feature_sitepermissions_location_title">ᱟᱢᱟᱜ ᱡᱟᱭᱜᱟ ᱵᱮᱵᱷᱟᱨ ᱞᱟᱹᱜᱤᱛ ᱛᱮ %1$s ᱦᱮᱥᱟᱨᱤᱭᱟᱹ ᱮᱢᱟᱭ ᱢᱮᱸ?</string>
+    <string name="mozac_feature_sitepermissions_location_title">ᱟᱢᱟᱜ ᱡᱟᱭᱜᱟ ᱵᱮᱵᱷᱟᱨ ᱞᱟᱹᱜᱤᱛ ᱛᱮ %1$s ᱦᱮᱥᱟᱨᱤᱭᱟᱹ ᱮᱢᱟᱭ ᱢᱮ?</string>
     <!-- Title of a dialog for a camera and microphone permission request. -->
-    <string name="mozac_feature_sitepermissions_camera_and_microphone">ᱟᱢᱟᱜ ᱠᱮᱢᱨᱟ ᱟᱨ ᱢᱟᱭᱠᱨᱚᱯᱷᱚᱱ ᱵᱮᱵᱷᱟᱨ ᱞᱟᱹᱜᱤᱛ ᱛᱮ %1$s ᱦᱮᱥᱟᱨᱤᱭᱟᱹ ᱮᱢᱟᱭ ᱢᱮᱸ?</string>
+    <string name="mozac_feature_sitepermissions_camera_and_microphone">ᱟᱢᱟᱜ ᱠᱮᱢᱨᱟ ᱟᱨ ᱢᱟᱭᱠᱨᱚᱯᱷᱚᱱ ᱵᱮᱵᱷᱟᱨ ᱞᱟᱹᱜᱤᱛ ᱛᱮ %1$s ᱦᱮᱥᱟᱨᱤᱭᱟᱹ ᱮᱢᱟᱭ ᱢᱮ?</string>
     <!-- Option in a dialog for requesting a microphone permission, this option will give access to
          the first microphone-->
     <string name="mozac_feature_sitepermissions_option_microphone_one">ᱢᱟᱭᱠᱨᱚᱯᱷᱚᱱ 1</string>
@@ -26,7 +26,7 @@
     access to this permission-->
     <string name="mozac_feature_sitepermissions_not_allow">ᱟᱞᱚ ᱢᱟᱸᱡᱩᱨᱮᱭᱟᱢ</string>
     <!-- Text for a checkbox in a permission request dialog, this will allow to not show again the prompt-->
-    <string name="mozac_feature_sitepermissions_do_not_ask_again_on_this_site2">ᱱᱤᱥᱴᱟᱹ ᱫᱤᱥᱚᱸ ᱫᱚᱦᱚᱭ ᱢᱮᱸ ᱱᱚᱶᱟ ᱥᱟᱭᱤᱴ ᱞᱟᱹᱜᱤᱫ</string>
+    <string name="mozac_feature_sitepermissions_do_not_ask_again_on_this_site2">ᱱᱤᱥᱴᱟᱹ ᱫᱤᱥᱚᱸ ᱫᱚᱦᱚᱭ ᱢᱮ ᱱᱚᱶᱟ ᱥᱟᱭᱤᱴ ᱞᱟᱹᱜᱤᱫ</string>
     <!-- Text for a positive button in a permission request dialog. This will always allow and remember the decision of the user, this is the special case of the notification permission, that is only ask one time-->
     <string name="mozac_feature_sitepermissions_always_allow">ᱡᱟᱣᱜᱮ</string>
     <!-- Text for a negative button in a permission request dialog. This will never allow and remember the decision of the user, this is the special case of the notification permission, that is only ask one time-->

--- a/components/feature/sitepermissions/src/main/res/values-sk/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-sk/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Nikdy</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Chcete stránke %1$s povoliť ukladanie údajov do trvalého úložiska?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Chcete stránke %1$s povoliť prehrávanie obsahu chráneného pomocou DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-sq/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-sq/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Kurrë</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Të lejohet %1$s të depozitojë të dhëna në depozitë të qëndrueshme?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Të lejohet %1$s të luajë lëndë nën DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-sr/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-sr/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Никад</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Дозволити %1$s да складишти податке у трајном складишту?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Дозволи %1$s да репродукује садржаја контролисаног DRM-ом?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-sv-rSE/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-sv-rSE/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Aldrig</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Tillåta %1$s att lagra data i beständig lagring?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Tillåt %1$s att spela DRM-kontrollerat innehåll?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-ta/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-ta/strings.xml
@@ -31,4 +31,6 @@
     <string name="mozac_feature_sitepermissions_always_allow">எப்போதும்</string>
     <!-- Text for a negative button in a permission request dialog. This will never allow and remember the decision of the user, this is the special case of the notification permission, that is only ask one time-->
     <string name="mozac_feature_sitepermissions_never_allow">ஒரு போதும் இல்லை</string>
-</resources>
+    <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_persistent_storage_title">நிரந்தரச் சேமிப்பில் தரவைச் சேமிக்க %1$s தளத்தை அனுமதிக்கவா?</string>
+    </resources>

--- a/components/feature/sitepermissions/src/main/res/values-tg/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-tg/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Ҳеҷ гоҳ</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Ба %1$s иҷозат медиҳед, ки маълумотро дар захирагоҳи доимӣ нигоҳ дорад?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Ба %1$s иҷозат медиҳед, ки муҳтавои идорашавандаи DRM-ро пахш кунад?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-th/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-th/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">ไม่เลย</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">อนุญาตให้ %1$s จัดเก็บข้อมูลในที่เก็บข้อมูลถาวรหรือไม่?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">อนุญาตให้ %1$s เล่นเนื้อหาที่ควบคุมด้วย DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-tr/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-tr/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Asla</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">%1$s kalıcı depolama alanında veri depolayabilsin mi?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">%1$s sitesi DRM denetimli içerikleri oynatabilsin mi?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-uk/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-uk/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Ніколи</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Дозволити %1$s зберігати дані у постійному сховищі?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Дозволити %1$s відтворювати вміст, контрольований DRM?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-vi/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-vi/strings.xml
@@ -33,4 +33,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">Không bao giờ</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">Cho phép %1$s lưu trữ dữ liệu trong bộ nhớ liên tục?</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">Cho phép %1$s phát nội dung do DRM kiểm soát?</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-zh-rCN/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-zh-rCN/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">一律拒绝</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">要允许 %1$s 持久存储数据吗？</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">要允许 %1$s 播放受 DRM 控制的内容吗？</string>
 </resources>

--- a/components/feature/sitepermissions/src/main/res/values-zh-rTW/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-zh-rTW/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_sitepermissions_never_allow">永不</string>
     <!-- Title of a dialog to require to save data in persistent storage. %1$s will be replaced with the URL of the current page -->
     <string name="mozac_feature_sitepermissions_persistent_storage_title">要允許 %1$s 將資料儲存於持續性儲存空間嗎？</string>
+    <!-- Title of a dialog to use EME. %1$s will be replaced with the URL of the current page -->
+    <string name="mozac_feature_sitepermissions_media_key_system_access_title">要允許 %1$s 播放 DRM 控制的內容嗎？</string>
 </resources>

--- a/components/feature/webnotifications/src/main/res/values-bn/strings.xml
+++ b/components/feature/webnotifications/src/main/res/values-bn/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Default Web Notification Channel Name. -->
+    <string name="mozac_feature_notification_channel_name">সাইট নোটিফিকেশন</string>
+</resources>

--- a/components/feature/webnotifications/src/main/res/values-es/strings.xml
+++ b/components/feature/webnotifications/src/main/res/values-es/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Default Web Notification Channel Name. -->
+    <string name="mozac_feature_notification_channel_name">Notificaciones del sitio</string>
+</resources>

--- a/components/feature/webnotifications/src/main/res/values-fa/strings.xml
+++ b/components/feature/webnotifications/src/main/res/values-fa/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Default Web Notification Channel Name. -->
+    <string name="mozac_feature_notification_channel_name">اعلان های سایت</string>
+</resources>

--- a/components/lib/crash/src/main/res/values-bn/strings.xml
+++ b/components/lib/crash/src/main/res/values-bn/strings.xml
@@ -20,4 +20,13 @@
 
     <!-- Label of notification showing that the crash report service is running. %1$s will be replaced with the name of the organization (e.g. Mozilla). -->
     <string name="mozac_lib_send_crash_report_in_progress">%1$s এ ক্র্যাশ প্রতিবেদন পাঠানো হচ্ছে</string>
+
+    <!-- Title of the activity that shows the list of past crashes (similar to about:crashes)-->
+    <string name="mozac_lib_crash_activity_title">ক্র্যাশ রিপোর্ট</string>
+
+    <!-- Text shown instead of crash list if no crashes have been submitted yet -->
+    <string name="mozac_lib_crash_no_crashes">কোনো ক্র্যাশের রিপোর্ট জমা দেওয়া হয়নি।</string>
+
+    <!-- Text link that will show an app chooser to share a crash report with a third-party app (e.g. gmail) -->
+    <string name="mozac_lib_crash_share">শেয়ার করুন</string>
 </resources>

--- a/components/lib/crash/src/main/res/values-es-rCL/strings.xml
+++ b/components/lib/crash/src/main/res/values-es-rCL/strings.xml
@@ -22,10 +22,10 @@
     <string name="mozac_lib_send_crash_report_in_progress">Enviando reporte de fallos a %1$s</string>
 
     <!-- Title of the activity that shows the list of past crashes (similar to about:crashes)-->
-    <string name="mozac_lib_crash_activity_title">Informes de fallos</string>
+    <string name="mozac_lib_crash_activity_title">Reportes de fallos</string>
 
     <!-- Text shown instead of crash list if no crashes have been submitted yet -->
-    <string name="mozac_lib_crash_no_crashes">No se ha enviado ningún informe de fallos.</string>
+    <string name="mozac_lib_crash_no_crashes">No se ha enviado ningún reporte de fallos.</string>
 
     <!-- Text link that will show an app chooser to share a crash report with a third-party app (e.g. gmail) -->
     <string name="mozac_lib_crash_share">Compartir</string>

--- a/components/lib/crash/src/main/res/values-sat/strings.xml
+++ b/components/lib/crash/src/main/res/values-sat/strings.xml
@@ -5,13 +5,13 @@
     <string name="mozac_lib_crash_dialog_title">ᱤᱠᱟᱹ %1$s ᱥᱟᱶ ᱛᱮ ᱫᱤᱜᱫᱷᱟ ᱦᱚᱭ ᱱᱟ ᱟᱨ ᱨᱟᱹᱯᱩᱫᱮᱱᱟ ᱾</string>
 
     <!-- Label of the checkbox for sending crash reports in the crash reporter dialog. %1$s will be replaced with the name of the organization (e.g. Mozilla). -->
-    <string name="mozac_lib_crash_dialog_checkbox">%1$s ᱴᱷᱮᱱ ᱨᱟᱹᱯᱩᱫ ᱨᱤᱯᱚᱨᱴ ᱠᱩᱞ ᱢᱮᱸ</string>
+    <string name="mozac_lib_crash_dialog_checkbox">%1$s ᱴᱷᱮᱱ ᱨᱟᱹᱯᱩᱫ ᱨᱤᱯᱚᱨᱴ ᱠᱩᱞ ᱢᱮ</string>
 
     <!-- Label of the button closing the crash reporter dialog. -->
-    <string name="mozac_lib_crash_dialog_button_close">ᱵᱚᱸᱫᱚᱭ ᱢᱮᱸ</string>
+    <string name="mozac_lib_crash_dialog_button_close">ᱵᱚᱸᱫᱚᱭ ᱢᱮ</string>
 
     <!-- Label of the button closing the crash reporter dialog and restarting the app. -->
-    <string name="mozac_lib_crash_dialog_button_restart">%1$s ᱫᱩᱦᱲᱟᱹ ᱮᱦᱚᱵᱽ ᱢᱮᱸ</string>
+    <string name="mozac_lib_crash_dialog_button_restart">%1$s ᱫᱩᱦᱲᱟᱹ ᱮᱦᱚᱵᱽ ᱢᱮ</string>
 
     <!-- Name of the "notification channel" used for displaying a notification when the app crashed and we can't show a prompt. See https://developer.android.com/training/notify-user/channels -->
     <string name="mozac_lib_crash_channel">ᱨᱟᱹᱯᱩᱫ ᱠᱚ</string>

--- a/components/support/ktx/src/main/res/values-bn/strings.xml
+++ b/components/support/ktx/src/main/res/values-bn/strings.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Text displayed when choosing which app to call with after selecting a phone number-->
+    <string name="mozac_support_ktx_menu_call_with">যার মাধ্যমে কল করবেন…</string>
+    <!-- Text displayed when choosing which app to email with after selecting an email address-->
+    <string name="mozac_support_ktx_menu_email_with">যার মাধ্যমে ইমেইল করবেন…</string>
+    <string name="mozac_support_ktx_menu_share_with">যার মাধ্যমে শেয়ার করবেন…</string>
     <string name="mozac_support_ktx_share_dialog_title">শেয়ারের মাধ্যম</string>
 </resources>

--- a/components/support/ktx/src/main/res/values-es/strings.xml
+++ b/components/support/ktx/src/main/res/values-es/strings.xml
@@ -2,6 +2,8 @@
 <resources>
     <!-- Text displayed when choosing which app to call with after selecting a phone number-->
     <string name="mozac_support_ktx_menu_call_with">Llamar con…</string>
+    <!-- Text displayed when choosing which app to email with after selecting an email address-->
+    <string name="mozac_support_ktx_menu_email_with">Enviar correo electrónico con…</string>
     <string name="mozac_support_ktx_menu_share_with">Compartir con…</string>
     <string name="mozac_support_ktx_share_dialog_title">Compartir por</string>
 </resources>

--- a/components/support/ktx/src/main/res/values-sat/strings.xml
+++ b/components/support/ktx/src/main/res/values-sat/strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Text displayed when choosing which app to call with after selecting a phone number-->
-    <string name="mozac_support_ktx_menu_call_with">ᱱᱚᱶᱟ ᱛᱮ ᱠᱚᱞᱞ ᱢᱮᱸ ...</string>
+    <string name="mozac_support_ktx_menu_call_with">ᱱᱚᱶᱟ ᱛᱮ ᱠᱚᱞᱞ ᱢᱮ ...</string>
     <!-- Text displayed when choosing which app to email with after selecting an email address-->
-    <string name="mozac_support_ktx_menu_email_with">ᱱᱚᱶᱟ ᱛᱮ ᱤᱢᱮᱸᱞ ᱢᱮᱸ ...</string>
-    <string name="mozac_support_ktx_menu_share_with">ᱱᱚᱶᱟ ᱛᱮ ᱦᱟᱹᱴᱤᱧ ᱢᱮᱸ...</string>
+    <string name="mozac_support_ktx_menu_email_with">ᱱᱚᱶᱟ ᱛᱮ ᱤᱢᱮᱞ ᱢᱮ ...</string>
+    <string name="mozac_support_ktx_menu_share_with">ᱱᱚᱶᱟ ᱛᱮ ᱦᱟᱹᱴᱤᱧ ᱢᱮ...</string>
     <string name="mozac_support_ktx_share_dialog_title">ᱫᱟᱨᱟᱭ ᱛᱮ ᱦᱟᱹᱴᱤᱧ</string>
 </resources>

--- a/components/support/migration/src/main/res/values-bn/strings.xml
+++ b/components/support/migration/src/main/res/values-bn/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Title of the notification shown the upgrade from Fennec to Fenix is complete. -->
+    <string name="mozac_support_migration_complete_notification_title">হালনাগাদ সম্পূর্ণ হয়েছে</string>
+    </resources>

--- a/components/support/migration/src/main/res/values-es/strings.xml
+++ b/components/support/migration/src/main/res/values-es/strings.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Title of the notification shown while we upgrade Fennec to Fenix. -->
+    <string name="mozac_support_migration_ongoing_notification_title">Actualización en proceso</string>
+    <!-- Text of the notification shown while we upgrade Fennec to Fenix. -->
+    <string name="mozac_support_migration_ongoing_notification_text">Firefox estará listo en un momento…</string>
     <!-- Title of the notification shown the upgrade from Fennec to Fenix is complete. -->
     <string name="mozac_support_migration_complete_notification_title">Actualización completa</string>
     <!-- Text of the notification shown the upgrade from Fennec to Fenix is complete. -->

--- a/components/ui/tabcounter/src/main/res/values-ast/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-ast/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 llingüeta abierta. Toca pa cambiar a otra.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s llingüetes abiertes. Toca pa cambiar a otra.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Llingüeta nueva</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Llingüeta privada nueva</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Zarrar la llingüeta</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">El botón del contador de llingüetes de la barra de ferramientes.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-be/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-be/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 адкрытая картка. Націсніце, каб пераключыць карткі.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">Адкрытых картак: %1$s. Націсніце, каб пераключыць карткі.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Новая картка</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Новая прыватная картка</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Закрыць картку</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Кнопка лічыльніка картак на панэлі інструментаў.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-bn/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-bn/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">নতুন ট্যাব</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">নতুন ব্যক্তিগত ট্যাব</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">ট্যাব বন্ধ করুন</string>
+    </resources>

--- a/components/ui/tabcounter/src/main/res/values-cak/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-cak/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 ruwi\' jaqon. Tachapa\' richin nak\'ëx ruwi\'.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s ruwi\' ejaqon. Tachapa\' richin nak\'ëx ruwi\'.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">K\'ak\'a\' ruwi\'</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">K\'ak\'a\' ichinan ruwi\'</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Titz\'apïx ruwi\'</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Ri rupitz\'b\'al ajilanel ruwi\' pa rukajtz\'ik samajib\'äl.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-co/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-co/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 unghjetta aperta. Picchichjà per cambià d’unghjetta.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s unghjette aperte. Picchichjà per cambià d’unghjetta.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nova unghjetta</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nova unghjetta privata</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Chjode l’unghjetta</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">U buttone di cuntatore d’unghjetta in a barra d’attrezzi.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-cs/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-cs/strings.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">Jeden otevřený panel. Klepnutím panely přepnete.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s otevřených panelů. Klepnutím přepnete panely.</string>
     <!-- Browser menu button that creates a new tab -->
     <string name="mozac_browser_menu_new_tab">Nový panel</string>
     <!-- Browser menu button that creates a private tab -->
     <string name="mozac_browser_menu_new_private_tab">Nový anonymní panel</string>
     <!-- Browser menu button to close tab. Closes the current session when pressed. -->
     <string name="mozac_close_tab">Zavřít panel</string>
-    </resources>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Tlačítko s počtem panelů na liště.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-cs/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-cs/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nový panel</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nový anonymní panel</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Zavřít panel</string>
+    </resources>

--- a/components/ui/tabcounter/src/main/res/values-cy/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-cy/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 tab agored. Tapio i newid tabiau.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s tab agored. Tapio i newid tabiau.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Tab newydd</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Tab preifat newydd</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Cau tab</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Botwm y bar offer cyfrif tabiau.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-da/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-da/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 åbent faneblad. Tryk for at skifte faneblade.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s åbne faneblade. Tryk for at skifte faneblade.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nyt faneblad</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nyt privat faneblad</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Luk faneblad</string>
+    </resources>

--- a/components/ui/tabcounter/src/main/res/values-da/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-da/strings.xml
@@ -10,4 +10,6 @@
     <string name="mozac_browser_menu_new_private_tab">Nyt privat faneblad</string>
     <!-- Browser menu button to close tab. Closes the current session when pressed. -->
     <string name="mozac_close_tab">Luk faneblad</string>
-    </resources>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Værktøjslinjeknappen til fanebladstæller.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-de/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-de/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 offener Tab. Antippen, um Tabs zu wechseln.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s offene Tabs. Antippen, um Tabs zu wechseln.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Neuer Tab</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Neuer privater Tab</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Tab schließen</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Die Schaltfläche der Tab-Zähler-Symbolleiste.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-dsb/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-dsb/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">Wócynjone rejtariki: 1. Pótusniśo, aby rejtariki pśešaltował.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">Wócynjone rejtariki: %1$s. Pótusniśo, aby rejtariki pśešaltował.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nowy rejtarik</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nowy priwatny rejtarik</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Rejtarik zacyniś</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Symbol rejtarikowego licaka na symbolowej rědce.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-el/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-el/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 ανοικτή καρτέλα. Πατήστε για εναλλαγή καρτελών.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s ανοικτές καρτέλες. Πατήστε για εναλλαγή καρτελών.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Νέα καρτέλα</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Νέα ιδιωτική καρτέλα</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Κλείσιμο καρτέλας</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Το κουμπί μέτρησης καρτελών της γραμμής εργαλείων.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-en-rGB/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-en-rGB/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 open tab. Tap to switch tabs.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s open tabs. Tap to switch tabs.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">New tab</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">New private tab</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Close tab</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">The tab counter toolbar button.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-eo/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-eo/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 malfermita langeto. Tuŝetu por ŝanĝi langeton.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s malfermitaj langetoj. Tuŝetu por ŝanĝi langetojn.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nova langeto</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nova privata langeto</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Fermi langeton</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">La ilara butono kun nombro de langetoj.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-es-rAR/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-es-rAR/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 abrir pestaña. Tocar para cambiar de pestaña.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s pestañas abiertas. Toar para cambiar de pestaña.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nueva pestaña</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nueva pestaña privada</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Cerrar pestaña</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">El botón contador de pestañas de la barra de herramientas.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-es-rCL/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-es-rCL/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 pestaña abierta. Toca para cambiar de pestaña.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s pestañas abiertas. Toca para cambiar de pestaña.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nueva pestaña</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nueva pestaña privada</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Cerrar pestaña</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">El botón contador de pestañas de la barra de herramientas.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-es-rES/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-es-rES/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 pestaña abierta. Toca para cambiar de pestaña.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s pestañas abiertas. Toca para cambiar de pestaña.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nueva pestaña</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nueva pestaña privada</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Cerrar pestaña</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">El botón contador de pestañas de la barra de herramientas.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-es/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-es/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 pestaña abierta. Toca para cambiar de pestaña.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s pestañas abiertas. Toca para cambiar de pestaña.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nueva pestaña</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nueva pestaña privada</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Cerrar pestaña</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">El botón contador de pestañas de la barra de herramientas.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-eu/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-eu/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">Irekitako fitxa bat. Sakatu fitxaz aldatzeko.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">Irekitako %1$s fitxa. Sakatu fitxaz aldatzeko.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Fitxa berria</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Fitxa pribatu berria</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Itxi fitxa</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Fitxen kontagailuaren tresna-barrako botoia.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-fa/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-fa/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">۱ زبانهٔ باز. برای تعویض ضربه بزنید.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s زبانهٔ باز. برای تغییر زبانه‌ها ضربه بزنید.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">زبانهٔ جدید</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">زبانهٔ خصوصی جدید</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">بستن زبانه</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">دکمهٔ نوار ابزار شمارندهٔ زبانه‌ها.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-fi/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-fi/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 avoin välilehti. Napauta vaihtaaksesi.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s avointa välilehteä. Napauta vaihtaaksesi.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Uusi välilehti</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Uusi yksityinen välilehti</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Sulje välilehti</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Välilehtien laskurin työkalupalkin painike.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-fr/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-fr/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 onglet ouvert. Appuyez pour changer d’onglet.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s onglets ouverts. Appuyez pour changer d’onglet.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nouvel onglet</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nouvel onglet privé</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Fermer l’onglet</string>
+    </resources>

--- a/components/ui/tabcounter/src/main/res/values-fy-rNL/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-fy-rNL/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 iepen ljepblêd. Tik om tusken ljepblêden te wikseljen.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s iepen ljepblêden. Tik om tusken ljepblêden te wikseljen.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nij ljepblêd</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nij priveeljepblêd</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Ljepblêd slute</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">De ljepblêdteller-arkbalkeknop.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-gd/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-gd/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">Tha taba fosgailte. Thoir gnogag airson leum a ghearradh gu taba eile.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">Tha tabaichean (%1$s) fosgailte. Thoir gnogag airson leum a ghearradh gu taba eile.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Taba ùr</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Taba prìobhaideach ùr</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Dùin an taba</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Putan bàr-inneal cunntair nan taba.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-gl/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-gl/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 lapela aberta. Toque para cambiar de lapela.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s lapelas abertas. Toque para cambiar de lapela.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nova lapela</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nova lapela privada</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Pechar lapela</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">O botón da barra de ferramentas do contador de lapelas.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-gn/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-gn/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 tendayke ijurujáva. Eikutu emoambue hag̃ua tendayke.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s tendayke ijurujáva. Eikutu emoambue hag̃ua tendayke.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Tendayke pyahu</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Tendayke pyahu ñemigua</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Tendayke mboty</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Pe votõ tendayke papaha tembipuru renda pegua.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-hr/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-hr/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 otvorena kartica. Dodirni za prebacivanje kartica.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s otvorene kartice. Dodirni za prebacivanje kartica.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nova kartica</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nova privatna kartica</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Zatvori karticu</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Tipka brojača kartica na alatnoj traci.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-hsb/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-hsb/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">Wočinjene rajtarki: 1. Podótkńće so, zo byšće rajtarki přepinał.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">Wočinjene rajtarki: %1$s. Podótkńće so, zo byšće rajtarki přepinał.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nowy rajtark</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nowy priwatny rajtark</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Rajtark začinić</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Symbol rajtarkoweho ličaka na symbolowej lajsće.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-hu/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-hu/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 nyitott lap. Koppintson a lapváltáshoz.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s nyitott lap. Koppintson a lapváltáshoz.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Új lap</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Új privát lap</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Lap bezárása</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">A lapszámláló eszköztárgomb.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-hy-rAM/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-hy-rAM/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 բաց ներդիր: Հպեք՝ ներդիրիըները փոխարկելու համար:</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s բաց ներդիրներ: Հպեք՝ ներդիրները փոխարկելու համար:</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Նոր ներդիր</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Նոր մասնավոր ներդիր</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Փակել ներդիրը</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Ներդիրի հաշվիչի գործիքագոտու կոճակը:</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-in/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-in/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 tab terbuka. Ketuk untuk beralih tab.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s tab terbuka. Ketuk untuk beralih tab.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Tab baru</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab"></string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Tutup tab</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Tombol bilah alat penghitung tab.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-it/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-it/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">Aperta 1 scheda. Tocca per cambiare scheda.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">Aperte %1$s schede. Tocca per cambiare scheda.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nuova scheda</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nuova scheda anonima</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Chiudi scheda</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Il pulsante nella barra degli strumenti con il numero di schede</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-iw/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-iw/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">לשונית אחת פתוחה. יש להקיש כדי להחליף לשוניות.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s לשוניות פתוחות. יש להקיש כדי להחליף לשוניות.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">לשונית חדשה</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">לשונית פרטית חדשה</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">סגירת לשונית</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">כפתור סרגל הכלים של מונה הלשוניות.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-ja/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-ja/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">開いているタブ 1 個。タップしてタブを切り替えます。</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">開いているタブ %1$s 個。タップしてタブを切り替えます。</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">新しいタブ</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">新しいプライベートタブ</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">タブを閉じる</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">タブカウンターのツールバーボタンです。</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-kab/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-kab/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 yiccer i yeldin. Sit akken ad tbeddleḍ iccer.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s waccaren yeldin. Sit akken ad tettbeddileḍ gar waccaren.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Iccer amaynut</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Iccer uslig amaynut</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Mdel iccer</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Taqeffalt n ugalis n yifecka n umesmiḍan n waccaren.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-kk/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-kk/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 ашық бет. Беттерді ауыстыру үшін шертіңіз.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s ашық бет. Беттерді ауыстыру үшін шертіңіз.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Жаңа бет</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Жаңа жекелік беті</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Бетті жабу</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Беттер санағышы болатын панель батырмасы.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-ko/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-ko/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">열린 탭 1개. 탭을 전환하려면 누르세요.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">열린 탭 %1$s개. 탭을 전환하려면 누르세요.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">새 탭</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">새 사생활 보호 탭</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">탭 닫기</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">탭 카운터 도구 모음 버튼입니다.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-lt/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-lt/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 atverta kortelė. Bakstelėkite, norėdami pereiti tarp kortelių.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s atvertos kortelės. Bakstelėkite, norėdami pereiti tarp kortelių.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nauja kortelė</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nauja privačioji kortelė</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Užverti kortelę</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Kortelių skaičiaus mygtukas priemonių juostoje.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-nb-rNO/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-nb-rNO/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 åpen fane. Trykk for å bytte fane.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s åpne faner. Trykk for å bytte fane.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Ny fane</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Ny privat fane</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Lukk fane</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Fane-teller verktøylinjeknapp.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-nl/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-nl/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 open tabblad. Tik om tussen tabbladen te wisselen.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s open tabbladen. Tik om tussen tabbladen te wisselen.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nieuw tabblad</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nieuw privétabblad</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Tabblad sluiten</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">De tabbladteller-werkbalkknop.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-nn-rNO/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-nn-rNO/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 open fane. Trykk for å byte fane.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s opne faner. Trykk for å byte fane.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Ny fane</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Ny privat fane</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Lat att fane</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Fane-teljar verktøylinjeknapp.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-oc/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-oc/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Onglet novèl</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Onglet de nav. privada</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Tampar l’onglet</string>
+    </resources>

--- a/components/ui/tabcounter/src/main/res/values-pa-rIN/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-pa-rIN/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">ਨਵੀਂ ਟੈਬ</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">ਨਵੀਂ ਪ੍ਰਾਈਵੇਟ ਟੈਬ</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">ਟੈਬ ਬੰਦ ਕਰੋ</string>
+    </resources>

--- a/components/ui/tabcounter/src/main/res/values-pl/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-pl/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">Otwarte karty: 1. Stuknij, aby przełączyć karty.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">Otwarte karty: %1$s. Stuknij, aby przełączyć karty.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nowa karta</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nowa karta prywatna</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Zamknij kartę</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Przycisk paska narzędzi z liczbą kart.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-pt-rBR/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 aba aberta. Toque para alternar abas.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s abas abertas. Toque para alternar abas.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nova aba</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nova aba privativa</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Fechar aba</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">O botão contador de abas da barra de ferramentas.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-pt-rPT/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-pt-rPT/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 separador aberto. Toque para mudar de separador.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s separadores abertos. Toque para mudar de separadores.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Novo separador</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Novo separador privado</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Fechar separador</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">O botão da barra de ferramentas com o número de separadores.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-rm/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-rm/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 tab avert. Tutgar per midar tab.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s tabs averts. Tutgar per midar tab.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nov tab</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nov tab privat</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Serrar il tab</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Il buttun en la trav d\'utensils cun il dumber da tabs.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-ru/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-ru/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 открытая вкладка. Нажмите, чтобы переключить вкладки.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">Открытых вкладок: %1$s. Нажмите, чтобы переключить вкладки.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Новая вкладка</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Новая приватная вкладка</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Закрыть вкладку</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Кнопка счётчика вкладок на панели инструментов.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-sat/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-sat/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">ᱱᱟᱶᱟ ᱴᱮᱵ</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">ᱱᱟᱶᱟ ᱱᱤᱡᱮᱨᱟᱠ ᱴᱮᱵ</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">ᱴᱮᱵ ᱵᱚᱸᱫᱽᱚᱭ ᱢᱮ</string>
+    </resources>

--- a/components/ui/tabcounter/src/main/res/values-sk/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-sk/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 otvorená karta. Ťuknutím prepnete karty.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s otvorených kariet. Ťuknutím prepnete karty.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nová karta</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nová súkromná karta</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Zavrieť kartu</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Tlačidlo počítadla kariet na paneli nástrojov.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-sl/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-sl/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 odprt zavihek. Tapnite za preklop zavihkov.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">Odprtih zavihkov: %1$s. Tapnite za preklop zavihkov.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Nov zavihek</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Nov zasebni zavihek</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Zapri zavihek</string>
+    </resources>

--- a/components/ui/tabcounter/src/main/res/values-sq/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-sq/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 skedë e hapur. Prekeni që të ndërroni skeda.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s skeda të hapura. Prekeni që të ndërroni skeda.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Skedë e re</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Skedë e re private</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Mbylle skedën</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Butoni i numrit të skedave te paneli.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-sr/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-sr/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 отворени језичак. Додирни за пребацивање језичака.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s отворених језичака. Додирни за пребацивање језичака.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Нови језичак</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Нови приватни језичак</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Затвори језичак</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Дугме за бројач језичака.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-sv-rSE/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-sv-rSE/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 öppen flik. Tryck för att växla mellan flikar.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s öppna flikar. Tryck för att växla mellan flikar.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Ny flik</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Ny privat flik</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Stäng flik</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Verktygsfältknapp för flikräknare.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-te/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-te/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">కొత్త ట్యాబు</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">కొత్త అంతరంగిక ట్యాబు</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">ట్యాబును మూసివేయి</string>
+    </resources>

--- a/components/ui/tabcounter/src/main/res/values-tg/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-tg/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 варақаи кушода. Барои гузариш байни варақаҳо, зарба занед.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s варақаи кушода. Барои гузариш байни варақаҳо, зарба занед.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Варақаи нав</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Варақаи махфии нав</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Пӯшидани варақа</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Тугмаи ҳисобкунаки варақаҳо дар навори абзорҳо.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-th/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-th/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 แท็บที่เปิด แตะเพื่อสลับไปยังแท็บ</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s แท็บที่เปิด แตะเพื่อสลับไปยังแท็บ</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">แท็บใหม่</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">แท็บส่วนตัวใหม่</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">ปิดแท็บ</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">ปุ่มแถบเครื่องมือตัวนับแท็บ</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-tl/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-tl/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Bagong tab</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Isara ang tab</string>
+    </resources>

--- a/components/ui/tabcounter/src/main/res/values-tr/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-tr/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 açık sekme. Sekme değiştirmek için dokunun.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s açık sekme. Sekme değiştirmek için dokunun.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Yeni sekme</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Yeni gizli sekme</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Sekmeyi kapat</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Sekme sayacı araç çubuğu düğmesi.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-uk/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-uk/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 відкрита вкладка. Торкніться, щоб перемкнути вкладки.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s відкритих вкладок. Торкніться, щоб перемкнути вкладки.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Нова вкладка</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Нова приватна вкладка</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Закрити вкладку</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Кнопка панелі інструментів лічильника вкладок.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-ur/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-ur/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 کھلا ٹیب۔ ٹیبز بدلنے کے لئے دبائیں۔</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">نیا ٹیب</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">نیا نجی ٹیب</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">ٹیب بند کریں</string>
+    </resources>

--- a/components/ui/tabcounter/src/main/res/values-vi/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-vi/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">1 thẻ đang mở. Chạm để chuyển thẻ.</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">%1$s thẻ đang mở. Chạm để chuyển thẻ.</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">Thẻ mới</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">Thẻ riêng tư mới</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">Đóng thẻ</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">Nút thanh công cụ bộ đếm thẻ.</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-zh-rCN/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">打开了 1 个标签页，点击即可切换。</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">打开了 %1$s 个标签页，点击即可切换。</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">新建标签页</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">新建隐私标签页</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">关闭标签页</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">标签页计数器工具栏按钮。</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-zh-rTW/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Message announced to the user when tab tray is selected with 1 tab -->
+    <string name="mozac_tab_counter_open_tab_tray_single">開啟了 1 個分頁，點擊即可切換分頁。</string>
+    <!-- Message announced to the user when tab tray is selected with multiple tabs -->
+    <string name="mozac_tab_counter_open_tab_tray_plural">開啟了 %1$s 個分頁，點擊即可切換分頁。</string>
+    <!-- Browser menu button that creates a new tab -->
+    <string name="mozac_browser_menu_new_tab">開新分頁</string>
+    <!-- Browser menu button that creates a private tab -->
+    <string name="mozac_browser_menu_new_private_tab">開新隱私分頁</string>
+    <!-- Browser menu button to close tab. Closes the current session when pressed. -->
+    <string name="mozac_close_tab">關閉分頁</string>
+    <!-- Content description of the tab counter toolbar button -->
+    <string name="mozac_tab_counter_content_description">分頁計數器工具列按鈕。</string>
+</resources>


### PR DESCRIPTION
We had a problem with the l10n automation bot and didn't get any String updates between Nov. 29 and Dec. 22. This PR brings in all updates from master so we can catch up. I did some smoke testing of Fenix 85 with these changes and didn't see any problems so far.