### PR TITLE
Update GeckoView Nightly to 86.0.20210106093742

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -6,7 +6,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Nightly Version.
      */
-    const val nightly_version = "86.0.20210105160452"
+    const val nightly_version = "86.0.20210106093742"
 
     /**
      * GeckoView Beta Version.


### PR DESCRIPTION
For some reason the bot hasn't opened a PR yet? Opening manually since I see a Gecko crash in Nightly that happens on certain sites and that is supposed to be fixed. (CC @st3fan) 