### PR TITLE
Allow clients more control over what `InlineAutocompleteEditText` pastes.

### DIFF
--- a/components/support/utils/src/main/java/mozilla/components/support/utils/SafeUrl.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/SafeUrl.kt
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.utils
+
+import android.content.Context
+
+/**
+ * Collection of methods used for ensuring the validity and security of URLs.
+ */
+object SafeUrl {
+    /**
+     * Remove recursively the schemes declared in [R.array.mozac_url_schemes_blocklist]
+     * from the front of [unsafeText].
+     */
+    fun stripUnsafeUrlSchemes(context: Context, unsafeText: CharSequence?): String? {
+        val urlSchemesBlocklist = context.resources.getStringArray(R.array.mozac_url_schemes_blocklist)
+        var safeUrl = unsafeText.toString()
+        if (safeUrl.isEmpty()) {
+            return safeUrl
+        }
+
+        @Suppress("ControlFlowWithEmptyBody", "EmptyWhileBlock")
+        while (urlSchemesBlocklist.find {
+                if (safeUrl.startsWith(it, true)) {
+                    safeUrl = safeUrl.replaceFirst(Regex(it, RegexOption.IGNORE_CASE), "")
+                    true
+                } else {
+                    false
+                }
+            } != null) {
+        }
+
+        return safeUrl
+    }
+}

--- a/components/support/utils/src/main/res/values/arrays.xml
+++ b/components/support/utils/src/main/res/values/arrays.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <!--
+    List of url schemes used by methods of SafeUrl.
+    -->
+    <string-array name="mozac_url_schemes_blocklist" />
+</resources>

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/SafeUrlTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/SafeUrlTest.kt
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.utils
+
+import android.content.Context
+import android.content.res.Resources
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doReturn
+
+@RunWith(AndroidJUnit4::class)
+class SafeUrlTest {
+    @Test
+    fun `WHEN schemes blocklist is empty THEN stripUnsafeUrlSchemes should return the initial String`() {
+        val resources = mock<Resources>()
+        val context = mock<Context>()
+        doReturn(resources).`when`(context).resources
+        doReturn(emptyArray<String>()).`when`(resources).getStringArray(R.array.mozac_url_schemes_blocklist)
+
+        val result = SafeUrl.stripUnsafeUrlSchemes(context, "unsafeText")
+
+        assertEquals("unsafeText", result)
+    }
+
+    @Test
+    fun `WHEN schemes blocklist contains items not found in the argument THEN stripUnsafeUrlSchemes should return the initial String`() {
+        val resources = mock<Resources>()
+        val context = mock<Context>()
+        doReturn(resources).`when`(context).resources
+        doReturn(arrayOf("alien")).`when`(resources).getStringArray(R.array.mozac_url_schemes_blocklist)
+
+        val result = SafeUrl.stripUnsafeUrlSchemes(context, "thisIsAnOkText")
+
+        assertEquals("thisIsAnOkText", result)
+    }
+
+    @Test
+    fun `WHEN schemes blocklist contains items found in the argument THEN stripUnsafeUrlSchemes should recursively remove them from the front`() {
+        val resources = mock<Resources>()
+        val context = mock<Context>()
+        doReturn(resources).`when`(context).resources
+        doReturn(arrayOf("one", "two")).`when`(resources).getStringArray(R.array.mozac_url_schemes_blocklist)
+
+        val result = SafeUrl.stripUnsafeUrlSchemes(context, "two" + "one" + "one" + "two" + "safeText")
+        assertEquals("safeText", result)
+
+        val result2 = SafeUrl.stripUnsafeUrlSchemes(context, "one" + "two" + "one" + "two" + "safeText" + "one")
+        assertEquals("safeText" + "one", result2)
+    }
+}

--- a/components/ui/autocomplete/build.gradle
+++ b/components/ui/autocomplete/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 
     implementation Dependencies.androidx_appcompat
 
+    implementation project(":support-utils")
+
     testImplementation project(":support-test")
 
     testImplementation Dependencies.androidx_test_junit

--- a/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
+++ b/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
@@ -4,6 +4,10 @@
 
 package mozilla.components.ui.autocomplete
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Build
 import android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
 import android.view.KeyEvent
 import android.view.ViewParent
@@ -20,12 +24,17 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.robolectric.Robolectric.buildAttributeSet
+import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 class InlineAutocompleteEditTextTest {
@@ -423,5 +432,92 @@ class InlineAutocompleteEditTextTest {
         et.setText("", shouldAutoComplete = false)
         // assigning here so it verifies the setter, not the getter
         verify(et, never()).isEnabled = true
+    }
+
+    @Test
+    fun `WHEN onTextContextMenuItem is called for options other than paste THEN we should not paste() and just call super`() {
+        val editText = spy(InlineAutocompleteEditText(testContext, attributes))
+
+        editText.onTextContextMenuItem(android.R.id.copy)
+        editText.onTextContextMenuItem(android.R.id.shareText)
+        editText.onTextContextMenuItem(android.R.id.cut)
+        editText.onTextContextMenuItem(android.R.id.selectAll)
+
+        verify(editText, never()).paste(anyInt(), anyInt(), anyBoolean())
+        verify(editText, times(4)).callOnTextContextMenuItemSuper(anyInt())
+    }
+
+    @Test
+    fun `WHEN onTextContextMenuItem is called for paste THEN we should paste() and not call super`() {
+        val editText = spy(InlineAutocompleteEditText(testContext, attributes))
+
+        editText.onTextContextMenuItem(android.R.id.paste)
+
+        verify(editText).paste(anyInt(), anyInt(), anyBoolean())
+        verify(editText, never()).callOnTextContextMenuItemSuper(anyInt())
+    }
+
+    @Test
+    fun `WHEN onTextContextMenuItem is called for pasteAsPlainText THEN we should paste() and not call super`() {
+        val editText = spy(InlineAutocompleteEditText(testContext, attributes))
+
+        editText.onTextContextMenuItem(android.R.id.pasteAsPlainText)
+
+        verify(editText).paste(anyInt(), anyInt(), anyBoolean())
+        verify(editText, never()).callOnTextContextMenuItemSuper(anyInt())
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP, Build.VERSION_CODES.LOLLIPOP_MR1])
+    fun `GIVEN an Android L device, WHEN onTextContextMenuItem is called for paste THEN we should paste() with formatting`() {
+        val editText = spy(InlineAutocompleteEditText(testContext, attributes))
+
+        editText.onTextContextMenuItem(android.R.id.paste)
+
+        verify(editText).paste(anyInt(), anyInt(), eq(true))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.M, Build.VERSION_CODES.N, Build.VERSION_CODES.O, Build.VERSION_CODES.P])
+    fun `GIVEN an Android M device, WHEN onTextContextMenuItem is called for paste THEN we should paste() without formatting`() {
+        val editText = spy(InlineAutocompleteEditText(testContext, attributes))
+
+        editText.onTextContextMenuItem(android.R.id.paste)
+
+        verify(editText).paste(anyInt(), anyInt(), eq(false))
+    }
+
+    @Test
+    fun `GIVEN no previous text WHEN paste is selected THEN paste() should be called with 0,0`() {
+        val editText = spy(InlineAutocompleteEditText(testContext, attributes))
+
+        editText.onTextContextMenuItem(android.R.id.paste)
+
+        verify(editText).paste(eq(0), eq(0), eq(false))
+    }
+
+    @Test
+    fun `GIVEN 5 chars previous text WHEN paste is selected THEN paste() should be called with 0,5`() {
+        val editText = spy(InlineAutocompleteEditText(testContext, attributes))
+        editText.setText("chars")
+        editText.selectAll()
+
+        editText.onTextContextMenuItem(android.R.id.paste)
+
+        verify(editText).paste(eq(0), eq(5), eq(false))
+    }
+
+    @Test
+    fun `WHEN paste() is called with new text THEN we will display the new text`() {
+        val editText = spy(InlineAutocompleteEditText(testContext, attributes))
+        (testContext.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager).apply {
+            setPrimaryClip(ClipData.newPlainText("Test", "test"))
+        }
+
+        assertEquals("", editText.text.toString())
+
+        editText.paste(0, 0, false)
+
+        assertEquals("test", editText.text.toString())
     }
 }

--- a/components/ui/autocomplete/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/ui/autocomplete/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,2 @@
+mock-maker-inline
+// This allows mocking final classes (classes are final by default in Kotlin)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **ui-autocomplete**:
+  * Pasting from the clipboard now cleans up any unwanted uri schemes.
+
 * **support-utils**:
   * 🌟 Added SafeUrl#stripUnsafeUrlSchemes that can cleanup unwanted uri schemes. Interested clients can specify what these are by overwriting "mozac_url_schemes_blocklist".
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **support-utils**:
+  * 🌟 Added SafeUrl#stripUnsafeUrlSchemes that can cleanup unwanted uri schemes. Interested clients can specify what these are by overwriting "mozac_url_schemes_blocklist".
+
 * **feature-prompts**:
   * 🚒 Bug fixed [issue #9229](https://github.com/mozilla-mobile/android-components/issues/9229) - Dismiss SelectLoginPrompt from the current tab when opening a new one ensuring the new one can show it's own. When returning to the previous tab users should focus a login field to see the SelectLoginPrompt again.
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
