### PR TITLE
Closes #9325: engine-gecko: Introduce blocked schemes

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -84,6 +84,8 @@ class GeckoEngineSession(
     // It mimics GeckoView debug log statements, hence the unintuitive tag and messages.
     private val fnprmsLogger = Logger("GeckoSession")
 
+    private val logger = Logger("GeckoEngineSession")
+
     internal lateinit var geckoSession: GeckoSession
     internal var currentUrl: String? = null
     internal var lastLoadRequestUri: String? = null
@@ -143,6 +145,12 @@ class GeckoEngineSession(
         flags: LoadUrlFlags,
         additionalHeaders: Map<String, String>?
     ) {
+        val scheme = Uri.parse(url).normalizeScheme().scheme
+        if (BLOCKED_SCHEMES.contains(scheme)) {
+            logger.error("URL scheme not allowed. Aborting load.")
+            return
+        }
+
         if (initialLoad) {
             initialLoadRequest = LoadRequest(url, parent, flags, additionalHeaders)
         }
@@ -1068,6 +1076,7 @@ class GeckoEngineSession(
         internal const val PROGRESS_STOP = 100
         internal const val MOZ_NULL_PRINCIPAL = "moz-nullprincipal:"
         internal const val ABOUT_BLANK = "about:blank"
+        internal val BLOCKED_SCHEMES = listOf("content", "file", "resource") // See 1684761 and 1684947
 
         /**
          * Provides an ErrorType corresponding to the error code provided.

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -418,6 +418,26 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun `loadUrl doesn't load URLs with blocked schemes`() {
+        val engineSession = GeckoEngineSession(mock(), geckoSessionProvider = geckoSessionProvider)
+
+        engineSession.loadUrl("file://test.txt")
+        engineSession.loadUrl("FILE://test.txt")
+        verify(geckoSession, never()).load(GeckoSession.Loader().uri("file://test.txt"))
+        verify(geckoSession, never()).load(GeckoSession.Loader().uri("FILE://test.txt"))
+
+        engineSession.loadUrl("content://authority/path/id")
+        engineSession.loadUrl("CoNtEnT://authority/path/id")
+        verify(geckoSession, never()).load(GeckoSession.Loader().uri("content://authority/path/id"))
+        verify(geckoSession, never()).load(GeckoSession.Loader().uri("CoNtEnT://authority/path/id"))
+
+        engineSession.loadUrl("resource://package/test.text")
+        engineSession.loadUrl("RESOURCE://package/test.text")
+        verify(geckoSession, never()).load(GeckoSession.Loader().uri("resource://package/test.text"))
+        verify(geckoSession, never()).load(GeckoSession.Loader().uri("RESOURCE://package/test.text"))
+    }
+
+    @Test
     fun loadData() {
         val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -84,6 +84,8 @@ class GeckoEngineSession(
     // It mimics GeckoView debug log statements, hence the unintuitive tag and messages.
     private val fnprmsLogger = Logger("GeckoSession")
 
+    private val logger = Logger("GeckoEngineSession")
+
     internal lateinit var geckoSession: GeckoSession
     internal var currentUrl: String? = null
     internal var lastLoadRequestUri: String? = null
@@ -143,6 +145,12 @@ class GeckoEngineSession(
         flags: LoadUrlFlags,
         additionalHeaders: Map<String, String>?
     ) {
+        val scheme = Uri.parse(url).normalizeScheme().scheme
+        if (BLOCKED_SCHEMES.contains(scheme)) {
+            logger.error("URL scheme not allowed. Aborting load.")
+            return
+        }
+
         if (initialLoad) {
             initialLoadRequest = LoadRequest(url, parent, flags, additionalHeaders)
         }
@@ -1068,6 +1076,7 @@ class GeckoEngineSession(
         internal const val PROGRESS_STOP = 100
         internal const val MOZ_NULL_PRINCIPAL = "moz-nullprincipal:"
         internal const val ABOUT_BLANK = "about:blank"
+        internal val BLOCKED_SCHEMES = listOf("content", "file", "resource") // See 1684761 and 1684947
 
         /**
          * Provides an ErrorType corresponding to the error code provided.

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -418,6 +418,26 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun `loadUrl doesn't load URLs with blocked schemes`() {
+        val engineSession = GeckoEngineSession(mock(), geckoSessionProvider = geckoSessionProvider)
+
+        engineSession.loadUrl("file://test.txt")
+        engineSession.loadUrl("FILE://test.txt")
+        verify(geckoSession, never()).load(GeckoSession.Loader().uri("file://test.txt"))
+        verify(geckoSession, never()).load(GeckoSession.Loader().uri("FILE://test.txt"))
+
+        engineSession.loadUrl("content://authority/path/id")
+        engineSession.loadUrl("CoNtEnT://authority/path/id")
+        verify(geckoSession, never()).load(GeckoSession.Loader().uri("content://authority/path/id"))
+        verify(geckoSession, never()).load(GeckoSession.Loader().uri("CoNtEnT://authority/path/id"))
+
+        engineSession.loadUrl("resource://package/test.text")
+        engineSession.loadUrl("RESOURCE://package/test.text")
+        verify(geckoSession, never()).load(GeckoSession.Loader().uri("resource://package/test.text"))
+        verify(geckoSession, never()).load(GeckoSession.Loader().uri("RESOURCE://package/test.text"))
+    }
+
+    @Test
     fun loadData() {
         val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -84,6 +84,8 @@ class GeckoEngineSession(
     // It mimics GeckoView debug log statements, hence the unintuitive tag and messages.
     private val fnprmsLogger = Logger("GeckoSession")
 
+    private val logger = Logger("GeckoEngineSession")
+
     internal lateinit var geckoSession: GeckoSession
     internal var currentUrl: String? = null
     internal var lastLoadRequestUri: String? = null
@@ -143,6 +145,12 @@ class GeckoEngineSession(
         flags: LoadUrlFlags,
         additionalHeaders: Map<String, String>?
     ) {
+        val scheme = Uri.parse(url).normalizeScheme().scheme
+        if (BLOCKED_SCHEMES.contains(scheme)) {
+            logger.error("URL scheme not allowed. Aborting load.")
+            return
+        }
+
         if (initialLoad) {
             initialLoadRequest = LoadRequest(url, parent, flags, additionalHeaders)
         }
@@ -1068,6 +1076,7 @@ class GeckoEngineSession(
         internal const val PROGRESS_STOP = 100
         internal const val MOZ_NULL_PRINCIPAL = "moz-nullprincipal:"
         internal const val ABOUT_BLANK = "about:blank"
+        internal val BLOCKED_SCHEMES = listOf("content", "file", "resource") // See 1684761 and 1684947
 
         /**
          * Provides an ErrorType corresponding to the error code provided.

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -418,6 +418,26 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun `loadUrl doesn't load URLs with blocked schemes`() {
+        val engineSession = GeckoEngineSession(mock(), geckoSessionProvider = geckoSessionProvider)
+
+        engineSession.loadUrl("file://test.txt")
+        engineSession.loadUrl("FILE://test.txt")
+        verify(geckoSession, never()).load(GeckoSession.Loader().uri("file://test.txt"))
+        verify(geckoSession, never()).load(GeckoSession.Loader().uri("FILE://test.txt"))
+
+        engineSession.loadUrl("content://authority/path/id")
+        engineSession.loadUrl("CoNtEnT://authority/path/id")
+        verify(geckoSession, never()).load(GeckoSession.Loader().uri("content://authority/path/id"))
+        verify(geckoSession, never()).load(GeckoSession.Loader().uri("CoNtEnT://authority/path/id"))
+
+        engineSession.loadUrl("resource://package/test.text")
+        engineSession.loadUrl("RESOURCE://package/test.text")
+        verify(geckoSession, never()).load(GeckoSession.Loader().uri("resource://package/test.text"))
+        verify(geckoSession, never()).load(GeckoSession.Loader().uri("RESOURCE://package/test.text"))
+    }
+
+    @Test
     fun loadData() {
         val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1684761.