### PR TITLE
For #9351 - Get camera image even with "Don't keep activities"

### DIFF
--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/file/FilePicker.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/file/FilePicker.kt
@@ -28,6 +28,15 @@ import mozilla.components.support.ktx.android.content.isPermissionGranted
 import mozilla.components.support.ktx.android.net.isUnderPrivateAppDirectory
 
 /**
+ * The image capture intent doesn't return the URI where the image is saved,
+ * so we track it here.
+ *
+ * Top-level scoped to survive activity recreation in the "Don't keep activities" scenario.
+ */
+@VisibleForTesting
+internal var captureUri: Uri? = null
+
+/**
  * @property container The [Activity] or [Fragment] which hosts the file picker.
  * @property store The [BrowserStore] this feature should subscribe to.
  * @property onNeedToRequestPermissions a callback invoked when permissions
@@ -42,12 +51,6 @@ internal class FilePicker(
 ) : PermissionsFeature {
 
     private val logger = Logger("FilePicker")
-
-    /**
-     * The image capture intent doesn't return the URI where the image is saved,
-     * so we track it here.
-     */
-    private var captureUri: Uri? = null
 
     /**
      * Cache of the current request to be used after permission is granted.
@@ -197,6 +200,8 @@ internal class FilePicker(
                 }
             } ?: request.onDismiss()
         }
+
+        captureUri = null
     }
 
     private fun saveCaptureUriIfPresent(intent: Intent) =

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **feature-prompts**:
+  * 🚒 Bug fixed [issue #9351] Camera images are available even with "Don't keep activities" enabled.
+
 * **ui-autocomplete**:
   * Pasting from the clipboard now cleans up any unwanted uri schemes.
 


### PR DESCRIPTION
The previous functionality was already based on saving the camera photo in a
specific file and then us reading it from there but what that file name was was
lost in the case of the activity being destroyed as being the case with "Don't
keep activities".
By making that file name top level it will now be available for the entire
duration of the app.

<img src="https://user-images.githubusercontent.com/11428869/103904104-7edc8680-5105-11eb-889a-6210887c77df.gif" width="33%" />
[video](https://drive.google.com/file/d/1kZKBa_bhiOJ7eXhHF3WTkGxaDaWb5CRS/view?usp=sharing)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
