### PR TITLE
Fix unit test classpath in browser-session-storage

### DIFF
--- a/components/browser/session-storage/build.gradle
+++ b/components/browser/session-storage/build.gradle
@@ -48,7 +48,8 @@ dependencies {
 
     testImplementation project(':support-test')
     testImplementation project(':support-test-libstate')
-
+    testImplementation project(':browser-session')
+    testImplementation project(':feature-tabs')
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric


### PR DESCRIPTION
Android Studio is giving some grief here. The new android tests depend on the `feature-tabs` and `browser-session` modules which causes class loading issues in our unit tests. Declaring these dependencies explicitly works around this.