### PR TITLE
Closes #8370: Remove EngineSessionState.toJSON().

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionState.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionState.kt
@@ -17,15 +17,6 @@ private const val GECKO_STATE_KEY = "GECKO_STATE"
 class GeckoEngineSessionState internal constructor(
     internal val actualState: GeckoSession.SessionState?
 ) : EngineSessionState {
-    override fun toJSON() = JSONObject().apply {
-        if (actualState != null) {
-            // GeckoView provides a String representing the entire session state. We
-            // store this String using a single Map entry with key GECKO_STATE_KEY.
-
-            put(GECKO_STATE_KEY, actualState.toString())
-        }
-    }
-
     override fun writeTo(writer: JsonWriter) {
         with(writer) {
             beginObject()

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionStateTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionStateTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.engine.gecko
 
+import android.util.JsonWriter
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.mock
 import org.json.JSONObject
@@ -14,19 +15,22 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mozilla.geckoview.GeckoSession
+import java.io.ByteArrayOutputStream
 
 @RunWith(AndroidJUnit4::class)
 class GeckoEngineSessionStateTest {
 
     @Test
-    @Suppress("DEPRECATION")
-    fun toJSON() {
+    fun writeTo() {
         val geckoState: GeckoSession.SessionState = mock()
         doReturn("<state>").`when`(geckoState).toString()
 
         val state = GeckoEngineSessionState(geckoState)
 
-        val json = state.toJSON()
+        val stream = ByteArrayOutputStream()
+        val writer = JsonWriter(stream.writer())
+        state.writeTo(writer)
+        val json = JSONObject(stream.toString())
 
         assertEquals(1, json.length())
         assertTrue(json.has("GECKO_STATE"))

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionState.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionState.kt
@@ -17,15 +17,6 @@ private const val GECKO_STATE_KEY = "GECKO_STATE"
 class GeckoEngineSessionState internal constructor(
     internal val actualState: GeckoSession.SessionState?
 ) : EngineSessionState {
-    override fun toJSON() = JSONObject().apply {
-        if (actualState != null) {
-            // GeckoView provides a String representing the entire session state. We
-            // store this String using a single Map entry with key GECKO_STATE_KEY.
-
-            put(GECKO_STATE_KEY, actualState.toString())
-        }
-    }
-
     override fun writeTo(writer: JsonWriter) {
         with(writer) {
             beginObject()

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionStateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionStateTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.engine.gecko
 
+import android.util.JsonWriter
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.mock
 import org.json.JSONObject
@@ -14,19 +15,22 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mozilla.geckoview.GeckoSession
+import java.io.ByteArrayOutputStream
 
 @RunWith(AndroidJUnit4::class)
 class GeckoEngineSessionStateTest {
 
     @Test
-    @Suppress("DEPRECATION")
-    fun toJSON() {
+    fun writeTo() {
         val geckoState: GeckoSession.SessionState = mock()
         doReturn("<state>").`when`(geckoState).toString()
 
         val state = GeckoEngineSessionState(geckoState)
 
-        val json = state.toJSON()
+        val stream = ByteArrayOutputStream()
+        val writer = JsonWriter(stream.writer())
+        state.writeTo(writer)
+        val json = JSONObject(stream.toString())
 
         assertEquals(1, json.length())
         assertTrue(json.has("GECKO_STATE"))

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionState.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionState.kt
@@ -17,15 +17,6 @@ private const val GECKO_STATE_KEY = "GECKO_STATE"
 class GeckoEngineSessionState internal constructor(
     internal val actualState: GeckoSession.SessionState?
 ) : EngineSessionState {
-    override fun toJSON() = JSONObject().apply {
-        if (actualState != null) {
-            // GeckoView provides a String representing the entire session state. We
-            // store this String using a single Map entry with key GECKO_STATE_KEY.
-
-            put(GECKO_STATE_KEY, actualState.toString())
-        }
-    }
-
     override fun writeTo(writer: JsonWriter) {
         with(writer) {
             beginObject()

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionStateTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionStateTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.engine.gecko
 
+import android.util.JsonWriter
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.mock
 import org.json.JSONObject
@@ -14,19 +15,22 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mozilla.geckoview.GeckoSession
+import java.io.ByteArrayOutputStream
 
 @RunWith(AndroidJUnit4::class)
 class GeckoEngineSessionStateTest {
 
     @Test
-    @Suppress("DEPRECATION")
-    fun toJSON() {
+    fun writeTo() {
         val geckoState: GeckoSession.SessionState = mock()
         doReturn("<state>").`when`(geckoState).toString()
 
         val state = GeckoEngineSessionState(geckoState)
 
-        val json = state.toJSON()
+        val stream = ByteArrayOutputStream()
+        val writer = JsonWriter(stream.writer())
+        state.writeTo(writer)
+        val json = JSONObject(stream.toString())
 
         assertEquals(1, json.length())
         assertTrue(json.has("GECKO_STATE"))

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSessionState.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSessionState.kt
@@ -14,22 +14,6 @@ import org.json.JSONObject
 class SystemEngineSessionState(
     internal val bundle: Bundle?
 ) : EngineSessionState {
-    override fun toJSON(): JSONObject {
-        if (bundle == null) {
-            return JSONObject()
-        }
-
-        return JSONObject().apply {
-            bundle.keySet().forEach { key ->
-                val value = bundle[key]
-
-                if (shouldSerialize(value)) {
-                    put(key, value)
-                }
-            }
-        }
-    }
-
     override fun writeTo(writer: JsonWriter) {
         writer.beginObject()
 

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionStateTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionStateTest.kt
@@ -20,36 +20,6 @@ import java.io.ByteArrayOutputStream
 
 @RunWith(AndroidJUnit4::class)
 class SystemEngineSessionStateTest {
-
-    @Test
-    @Suppress("DEPRECATION")
-    fun toJSON() {
-        val state = SystemEngineSessionState(Bundle().apply {
-            putString("k0", "v0")
-            putInt("k1", 1)
-            putBoolean("k2", true)
-            putStringArrayList("k3", ArrayList<String>(listOf("Hello", "World")))
-            putDouble("k4", 5.0)
-            putFloat("k5", 1.0f)
-        })
-
-        val json = state.toJSON()
-
-        assertEquals(5, json.length())
-
-        assertTrue(json.has("k0"))
-        assertTrue(json.has("k1"))
-        assertTrue(json.has("k2"))
-        assertTrue(json.has("k4"))
-        assertTrue(json.has("k5"))
-
-        assertEquals("v0", json.get("k0"))
-        assertEquals(1, json.get("k1"))
-        assertEquals(true, json.get("k2"))
-        assertEquals(5.0, json.get("k4"))
-        assertEquals(1.0f, json.get("k5"))
-    }
-
     @Test
     fun fromJSON() {
         val json = JSONObject().apply {
@@ -77,42 +47,6 @@ class SystemEngineSessionStateTest {
         assertEquals(true, bundle.get("k2"))
         assertEquals(5.0, bundle.get("k3"))
         assertEquals(1.0f, bundle.get("k4"))
-    }
-
-    @Test
-    @Suppress("DEPRECATION")
-    fun toJSONAndfromJSON() {
-        val raw = SystemEngineSessionState(Bundle().apply {
-            putString("k0", "v0")
-            putInt("k1", 1)
-            putBoolean("k2", true)
-            putStringArrayList("k3", ArrayList<String>(listOf("Hello", "World")))
-            putDouble("k4", 5.0)
-            putFloat("k5", 1.0f)
-            putFloat("k6", 42.25f)
-            putDouble("k7", 23.23)
-        }).toJSON().toString()
-
-        val bundle = SystemEngineSessionState.fromJSON(JSONObject(raw)).bundle!!
-
-        assertEquals(7, bundle.size())
-
-        assertTrue(bundle.containsKey("k0"))
-        assertTrue(bundle.containsKey("k1"))
-        assertTrue(bundle.containsKey("k2"))
-        assertFalse(bundle.containsKey("k3"))
-        assertTrue(bundle.containsKey("k4"))
-        assertTrue(bundle.containsKey("k5"))
-        assertTrue(bundle.containsKey("k6"))
-        assertTrue(bundle.containsKey("k7"))
-
-        assertEquals("v0", bundle.get("k0"))
-        assertEquals(1, bundle.get("k1"))
-        assertEquals(true, bundle.get("k2"))
-        assertEquals(5, bundle.get("k4")) // JSONObject converts to Int
-        assertEquals(1, bundle.get("k5")) // JSONObject converts to Int
-        assertEquals(42.25, bundle.get("k6")) // Implicit conversion to Double
-        assertEquals(23.23, bundle.get("k7"))
     }
 
     @Test

--- a/components/browser/session-storage/src/test/java/mozilla/components/browser/session/storage/SessionStorageTest.kt
+++ b/components/browser/session-storage/src/test/java/mozilla/components/browser/session/storage/SessionStorageTest.kt
@@ -402,8 +402,6 @@ class FakeEngine(
 private class FakeEngineSessionState(
     val value: String
 ) : EngineSessionState {
-    override fun toJSON(): JSONObject = throw NotImplementedError()
-
     override fun writeTo(writer: JsonWriter) {
         writer.beginObject()
 

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSessionState.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSessionState.kt
@@ -5,7 +5,6 @@
 package mozilla.components.concept.engine
 
 import android.util.JsonWriter
-import org.json.JSONObject
 
 /**
  * The state of an [EngineSession]. An instance can be obtained from [EngineSession.saveState]. Creating a new
@@ -13,17 +12,6 @@ import org.json.JSONObject
  * session.
  */
 interface EngineSessionState {
-    /**
-     * Create a JSON representation of this state that can be saved to disk.
-     *
-     * When reading JSON from disk [Engine.createSessionState] can be used to turn it back into an [EngineSessionState]
-     * instance.
-     */
-    // There's no deadline for removal. But we should migrate our code away from this at some point:
-    // https://github.com/mozilla-mobile/android-components/issues/8370
-    @Deprecated("Use writeTo() instead.")
-    fun toJSON(): JSONObject
-
     /**
      * Writes this state as JSON to the given [JsonWriter].
      *

--- a/components/feature/recentlyclosed/src/androidTest/java/mozilla/components/feature/recentlyclosed/RecentlyClosedTabsStorageTest.kt
+++ b/components/feature/recentlyclosed/src/androidTest/java/mozilla/components/feature/recentlyclosed/RecentlyClosedTabsStorageTest.kt
@@ -241,6 +241,5 @@ class RecentlyClosedTabsStorageTest {
             writer.beginObject()
             writer.endObject()
         }
-        override fun toJSON() = JSONObject()
     }
 }

--- a/components/feature/tab-collections/src/androidTest/java/mozilla/components/feature/tab/collections/TabCollectionStorageTest.kt
+++ b/components/feature/tab-collections/src/androidTest/java/mozilla/components/feature/tab/collections/TabCollectionStorageTest.kt
@@ -378,7 +378,6 @@ class FakeEngine : Engine {
 }
 
 class FakeEngineSessionState : EngineSessionState {
-    override fun toJSON() = JSONObject()
     override fun writeTo(writer: JsonWriter) {
         writer.beginObject()
         writer.endObject()


### PR DESCRIPTION
It has been deprecated for a while and nothing should be using it anymore now.