### PR TITLE
Closes #8913: Migrate feature-app-links to browser-state

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -6,9 +6,7 @@
 
 package mozilla.components.browser.session
 
-import android.content.Intent
 import android.graphics.Bitmap
-import mozilla.components.browser.session.engine.request.LaunchIntentMetadata
 import mozilla.components.browser.session.ext.syncDispatch
 import mozilla.components.browser.session.ext.toSecurityInfoState
 import mozilla.components.browser.state.action.ContentAction.RemoveWebAppManifestAction
@@ -82,7 +80,6 @@ class Session(
         fun onContentPermissionRequested(session: Session, permissionRequest: PermissionRequest): Boolean = false
         fun onAppPermissionRequested(session: Session, permissionRequest: PermissionRequest): Boolean = false
         fun onRecordingDevicesChanged(session: Session, devices: List<RecordingDevice>) = Unit
-        fun onLaunchIntentRequest(session: Session, url: String, appIntent: Intent?) = Unit
     }
 
     /**
@@ -145,19 +142,6 @@ class Session(
     var canGoForward: Boolean by Delegates.observable(false) { _, old, new ->
         notifyObservers(old, new) { onNavigationStateChanged(this@Session, canGoBack, new) }
         store?.syncDispatch(UpdateForwardNavigationStateAction(id, canGoForward))
-    }
-
-    /**
-     * Set when a launch intent is received.
-     */
-    var launchIntentMetadata: LaunchIntentMetadata by Delegates.observable(LaunchIntentMetadata.blank) { _, _, new ->
-        notifyObservers {
-            onLaunchIntentRequest(
-                this@Session,
-                new.url,
-                new.appIntent
-            )
-        }
     }
 
     /**

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -10,7 +10,6 @@ import android.net.Uri
 import android.os.Environment
 import androidx.core.net.toUri
 import mozilla.components.browser.session.Session
-import mozilla.components.browser.session.engine.request.LaunchIntentMetadata
 import mozilla.components.browser.session.ext.toElement
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.ContentAction
@@ -19,6 +18,7 @@ import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.MediaAction
 import mozilla.components.browser.state.action.MediaSessionAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
+import mozilla.components.browser.state.state.AppIntentState
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.LoadRequestState
 import mozilla.components.browser.state.state.content.DownloadState
@@ -122,7 +122,7 @@ internal class EngineObserver(
     }
 
     override fun onLaunchIntentRequest(url: String, appIntent: Intent?) {
-        session.launchIntentMetadata = LaunchIntentMetadata(url, appIntent)
+        store?.dispatch(ContentAction.UpdateAppIntentAction(session.id, AppIntentState(url, appIntent)))
     }
 
     override fun onTitleChange(title: String) {

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.state.state.SessionState.Source
-import mozilla.components.browser.session.engine.request.LaunchIntentMetadata
 import mozilla.components.browser.session.ext.toSecurityInfoState
 import mozilla.components.browser.session.ext.toTabSessionState
 import mozilla.components.browser.state.action.ContentAction
@@ -185,22 +184,6 @@ class SessionTest {
 
         assertEquals("https://www.mozilla.org", session.url)
         verify(observer, never()).onUrlChanged(eq(session), eq("https://www.mozilla.org"))
-        verifyNoMoreInteractions(observer)
-    }
-
-    @Test
-    fun `observer is notified when launch intent request is triggered`() {
-        val observer = mock(Session.Observer::class.java)
-
-        val session = Session("https://www.mozilla.org")
-        session.register(observer)
-
-        session.launchIntentMetadata = LaunchIntentMetadata(
-            "https://www.mozilla.org", mock()
-        )
-
-        verify(observer, times(1)).onLaunchIntentRequest(eq(session), eq("https://www.mozilla.org"),
-            any())
         verifyNoMoreInteractions(observer)
     }
 
@@ -525,7 +508,6 @@ class SessionTest {
         defaultObserver.onLoadingStateChanged(session, true)
         defaultObserver.onNavigationStateChanged(session, true, true)
         defaultObserver.onLoadRequest(session, "https://www.mozilla.org", true, true)
-        defaultObserver.onLaunchIntentRequest(session, "https://www.mozilla.org", null)
         defaultObserver.onSearch(session, "")
         defaultObserver.onSecurityChanged(session, Session.SecurityInfo())
         defaultObserver.onCustomTabConfigChanged(session, null)

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -17,6 +17,7 @@ import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.CrashAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
 import mozilla.components.browser.state.selector.findTab
+import mozilla.components.browser.state.state.AppIntentState
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.content.FindResultState
 import mozilla.components.browser.state.store.BrowserStore
@@ -1148,19 +1149,16 @@ class EngineObserverTest {
     }
 
     @Test
-    fun `onLaunchIntentRequest is set to launchIntentMetadata`() {
+    fun `onLaunchIntentRequest dispatches UpdateAppIntentAction`() {
         val url = "https://www.mozilla.org"
         val session = Session(url)
 
-        val observer = EngineObserver(session, mock())
+        val store: BrowserStore = mock()
+        val observer = EngineObserver(session, store)
         val intent: Intent = mock()
         observer.onLaunchIntentRequest(url = url, appIntent = intent)
 
-        val appUrl = session.launchIntentMetadata.url
-        val appIntent = session.launchIntentMetadata.appIntent
-
-        assertEquals(url, appUrl)
-        assertEquals(intent, appIntent)
+        verify(store).dispatch(ContentAction.UpdateAppIntentAction(session.id, AppIntentState(url, intent)))
     }
 
     @Test

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -8,6 +8,7 @@ import android.content.ComponentCallbacks2
 import android.graphics.Bitmap
 import mozilla.components.browser.state.search.RegionState
 import mozilla.components.browser.state.search.SearchEngine
+import mozilla.components.browser.state.state.AppIntentState
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.ClosedTab
 import mozilla.components.browser.state.state.ClosedTabSessionState
@@ -523,6 +524,17 @@ sealed class ContentAction : BrowserAction() {
      * Updates the [ContentState] of the given [sessionId] to indicate whether or not desktop mode is enabled.
      */
     data class UpdateDesktopModeAction(val sessionId: String, val enabled: Boolean) : ContentAction()
+
+    /**
+     * Updates the [AppIntentState] of the [ContentState] with the given [sessionId].
+     */
+    data class UpdateAppIntentAction(val sessionId: String, val appIntent: AppIntentState) :
+        ContentAction()
+
+    /**
+     * Removes the [AppIntentState] of the [ContentState] with the given [sessionId].
+     */
+    data class ConsumeAppIntentAction(val sessionId: String) : ContentAction()
 }
 
 /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
@@ -204,6 +204,12 @@ internal object ContentStateReducer {
             is ContentAction.UpdatePermissionHighlightsStateAction -> updateContentState(state, action.sessionId) {
                 it.copy(permissionHighlights = action.highlights)
             }
+            is ContentAction.UpdateAppIntentAction -> updateContentState(state, action.sessionId) {
+                it.copy(appIntent = action.appIntent)
+            }
+            is ContentAction.ConsumeAppIntentAction -> updateContentState(state, action.sessionId) {
+                it.copy(appIntent = null)
+            }
         }
     }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/AppIntentState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/AppIntentState.kt
@@ -2,15 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.browser.session.engine.request
+package mozilla.components.browser.state.state
 
 import android.content.Intent
 
-class LaunchIntentMetadata(
+/**
+ * State keeping track of app intents to launch.
+ *
+ * @param url the URL to launch in an external app.
+ * @param appIntent the [Intent] to launch.
+ */
+data class AppIntentState(
     val url: String,
     val appIntent: Intent?
-) {
-    companion object {
-        val blank = LaunchIntentMetadata("about:blank", null)
-    }
-}
+)

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
@@ -57,6 +57,7 @@ import mozilla.components.concept.engine.window.WindowRequest
  * @property recordingDevices List of recording devices (e.g. camera or microphone) currently in use
  * by web content.
  * @property desktopMode true if desktop mode is enabled, otherwise false.
+ * @property appIntent the last received [AppIntentState].
  */
 data class ContentState(
     val url: String,
@@ -88,5 +89,6 @@ data class ContentState(
     val loadRequest: LoadRequestState? = null,
     val refreshCanceled: Boolean = false,
     val recordingDevices: List<RecordingDevice> = emptyList(),
-    val desktopMode: Boolean = false
+    val desktopMode: Boolean = false,
+    val appIntent: AppIntentState? = null
 )

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.state.action
 import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.state.selector.findCustomTab
+import mozilla.components.browser.state.state.AppIntentState
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.LoadRequestState
 import mozilla.components.browser.state.state.SecurityInfoState
@@ -697,5 +698,43 @@ class ContentActionTest {
         ).joinBlocking()
 
         assertTrue(tab.content.permissionHighlights.isAutoPlayBlocking)
+    }
+
+    @Test
+    fun `UpdateAppIntentAction updates request`() {
+        assertNull(tab.content.promptRequest)
+
+        val appIntent1: AppIntentState = mock()
+
+        store.dispatch(
+            ContentAction.UpdateAppIntentAction(tab.id, appIntent1)
+        ).joinBlocking()
+
+        assertEquals(appIntent1, tab.content.appIntent)
+
+        val appIntent2: AppIntentState = mock()
+
+        store.dispatch(
+            ContentAction.UpdateAppIntentAction(tab.id, appIntent2)
+        ).joinBlocking()
+
+        assertEquals(appIntent2, tab.content.appIntent)
+    }
+
+    @Test
+    fun `ConsumeAppIntentAction removes request`() {
+        val appIntent: AppIntentState = mock()
+
+        store.dispatch(
+            ContentAction.UpdateAppIntentAction(tab.id, appIntent)
+        ).joinBlocking()
+
+        assertEquals(appIntent, tab.content.appIntent)
+
+        store.dispatch(
+            ContentAction.ConsumeAppIntentAction(tab.id)
+        ).joinBlocking()
+
+        assertNull(tab.content.appIntent)
     }
 }

--- a/components/feature/app-links/build.gradle
+++ b/components/feature/app-links/build.gradle
@@ -27,8 +27,14 @@ android {
     }
 }
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions.freeCompilerArgs += [
+            "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi"
+    ]
+}
+
 dependencies {
-    implementation project(':browser-session')
+    implementation project(':browser-state')
     implementation project(':concept-engine')
     implementation project(':support-base')
     implementation project(':support-ktx')
@@ -38,7 +44,7 @@ dependencies {
     implementation Dependencies.kotlin_coroutines
 
     testImplementation project(':support-test')
-
+    testImplementation project(':support-test-libstate')
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_coroutines

--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksFeatureTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksFeatureTest.kt
@@ -8,15 +8,25 @@ import android.content.Context
 import android.content.Intent
 import androidx.fragment.app.FragmentManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.browser.session.LegacySessionManager
-import mozilla.components.browser.session.Session
-import mozilla.components.browser.session.SessionManager
-import mozilla.components.concept.engine.Engine
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import mozilla.components.browser.state.action.ContentAction
+import mozilla.components.browser.state.action.TabListAction
+import mozilla.components.browser.state.selector.findTab
+import mozilla.components.browser.state.state.AppIntentState
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.support.test.any
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyBoolean
@@ -33,16 +43,19 @@ import org.mockito.Mockito.verifyNoMoreInteractions
 @RunWith(AndroidJUnit4::class)
 class AppLinksFeatureTest {
 
+    private val testDispatcher = TestCoroutineDispatcher()
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule(testDispatcher)
+
+    private lateinit var store: BrowserStore
     private lateinit var mockContext: Context
-    private lateinit var mockSessionManager: SessionManager
     private lateinit var mockFragmentManager: FragmentManager
     private lateinit var mockUseCases: AppLinksUseCases
     private lateinit var mockGetRedirect: AppLinksUseCases.GetAppLinkRedirect
     private lateinit var mockOpenRedirect: AppLinksUseCases.OpenAppLinkRedirect
     private lateinit var mockEngineSession: EngineSession
-    private lateinit var mockLegacySessionManager: LegacySessionManager
     private lateinit var mockDialog: RedirectDialogFragment
-
     private lateinit var feature: AppLinksFeature
 
     private val webUrl = "https://example.com"
@@ -51,11 +64,9 @@ class AppLinksFeatureTest {
 
     @Before
     fun setup() {
+        store = BrowserStore()
         mockContext = mock()
 
-        val engine = mock<Engine>()
-        mockLegacySessionManager = mock()
-        mockSessionManager = spy(SessionManager(engine, delegate = mockLegacySessionManager))
         mockFragmentManager = mock()
         `when`(mockFragmentManager.beginTransaction()).thenReturn(mock())
         mockUseCases = mock()
@@ -77,81 +88,59 @@ class AppLinksFeatureTest {
 
         feature = spy(AppLinksFeature(
             context = mockContext,
-            sessionManager = mockSessionManager,
+            store = store,
             fragmentManager = mockFragmentManager,
             useCases = mockUseCases,
             dialog = mockDialog
-        ))
+        )).also {
+            it.start()
+        }
     }
 
-    private fun createSession(isPrivate: Boolean, url: String = "https://mozilla.com"): Session {
-        val session = mock<Session>()
-        `when`(session.private).thenReturn(isPrivate)
-        `when`(session.url).thenReturn(url)
-        return session
-    }
-
-    private fun userTapsOnSession(url: String, private: Boolean) {
-        feature.observer.onLaunchIntentRequest(
-            createSession(private),
-            url = url,
-            appIntent = mock()
-        )
-    }
-
-    @Test
-    @Suppress("DEPRECATION")
-    // TODO Migrate to browser-state: https://github.com/mozilla-mobile/android-components/issues/8913
-    fun `when valid sessionId is provided, observe its session`() {
-        feature = AppLinksFeature(
-            mockContext,
-            sessionManager = mockSessionManager,
-            sessionId = "123",
-            useCases = mockUseCases
-        )
-        val mockSession = createSession(false)
-        `when`(mockLegacySessionManager.findSessionById(anyString())).thenReturn(mockSession)
-
-        feature.start()
-
-        verify(mockSession).register(feature.observer)
-    }
-
-    @Test
-    @Suppress("DEPRECATION")
-    // TODO Migrate to browser-state: https://github.com/mozilla-mobile/android-components/issues/8913
-    fun `when sessionId is NOT provided, observe selected session`() {
-        feature = AppLinksFeature(
-            mockContext,
-            sessionManager = mockSessionManager,
-            useCases = mockUseCases
-        )
-
-        feature.start()
-
-        verify(mockSessionManager).register(feature.observer)
-    }
-
-    @Test
-    @Suppress("DEPRECATION")
-    // TODO Migrate to browser-state: https://github.com/mozilla-mobile/android-components/issues/8913
-    fun `when start is called must register SessionManager observers`() {
-        feature.start()
-        verify(mockSessionManager).register(feature.observer)
-    }
-
-    @Test
-    @Suppress("DEPRECATION")
-    // TODO Migrate to browser-state: https://github.com/mozilla-mobile/android-components/issues/8913
-    fun `when stop is called must unregister SessionManager observers `() {
+    @After
+    fun teardown() {
         feature.stop()
-        verify(mockSessionManager).unregister(feature.observer)
+    }
+
+    @Test
+    fun `feature observes app intents when started`() {
+        val tab = createTab(webUrl)
+        store.dispatch(TabListAction.AddTabAction(tab)).joinBlocking()
+        verify(feature, never()).handleAppIntent(any(), any(), any())
+
+        val intent: Intent = mock()
+        val appIntent = AppIntentState(intentUrl, intent)
+        store.dispatch(ContentAction.UpdateAppIntentAction(tab.id, appIntent)).joinBlocking()
+        testDispatcher.advanceUntilIdle()
+
+        val tabWithPendingAppIntent = store.state.findTab(tab.id)!!
+        assertNotNull(tabWithPendingAppIntent.content.appIntent)
+        verify(feature).handleAppIntent(tabWithPendingAppIntent, intentUrl, intent)
+
+        store.waitUntilIdle()
+        val tabWithConsumedAppIntent = store.state.findTab(tab.id)!!
+        assertNull(tabWithConsumedAppIntent.content.appIntent)
+    }
+
+    @Test
+    fun `feature doesn't observes app intents when stopped`() {
+        val tab = createTab(webUrl)
+        store.dispatch(TabListAction.AddTabAction(tab)).joinBlocking()
+        verify(feature, never()).handleAppIntent(any(), any(), any())
+
+        feature.stop()
+
+        val intent: Intent = mock()
+        val appIntent = AppIntentState(intentUrl, intent)
+        store.dispatch(ContentAction.UpdateAppIntentAction(tab.id, appIntent)).joinBlocking()
+        testDispatcher.advanceUntilIdle()
+        verify(feature, never()).handleAppIntent(any(), any(), any())
     }
 
     @Test
     fun `in non-private mode an external app is opened without a dialog`() {
-        feature.start()
-        userTapsOnSession(intentUrl, false)
+        val tab = createTab(webUrl)
+        feature.handleAppIntent(tab, intentUrl, mock())
 
         verifyNoMoreInteractions(mockDialog)
         verify(mockOpenRedirect).invoke(any(), anyBoolean(), any(), any())
@@ -159,8 +148,8 @@ class AppLinksFeatureTest {
 
     @Test
     fun `in private mode an external app dialog is shown`() {
-        feature.start()
-        userTapsOnSession(intentUrl, true)
+        val tab = createTab(webUrl, private = true)
+        feature.handleAppIntent(tab, intentUrl, mock())
 
         verify(mockDialog).showNow(eq(mockFragmentManager), anyString())
         verify(mockOpenRedirect, never()).invoke(any(), anyBoolean(), any(), any())
@@ -168,8 +157,8 @@ class AppLinksFeatureTest {
 
     @Test
     fun `reused redirect dialog if exists`() {
-        feature.start()
-        userTapsOnSession(intentUrl, true)
+        val tab = createTab(webUrl, private = true)
+        feature.handleAppIntent(tab, intentUrl, mock())
 
         val dialog = feature.getOrCreateDialog()
         assertEquals(dialog, feature.getOrCreateDialog())
@@ -177,14 +166,14 @@ class AppLinksFeatureTest {
 
     @Test
     fun `redirect dialog is only added once`() {
-        feature.start()
-        userTapsOnSession(intentUrl, true)
+        val tab = createTab(webUrl, private = true)
+        feature.handleAppIntent(tab, intentUrl, mock())
 
         verify(mockDialog).showNow(eq(mockFragmentManager), anyString())
 
         doReturn(mockDialog).`when`(feature).getOrCreateDialog()
         doReturn(mockDialog).`when`(mockFragmentManager).findFragmentByTag(RedirectDialogFragment.FRAGMENT_TAG)
-        userTapsOnSession(intentUrl, true)
+        feature.handleAppIntent(tab, intentUrl, mock())
         verify(mockDialog, times(1)).showNow(mockFragmentManager, RedirectDialogFragment.FRAGMENT_TAG)
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,6 +33,9 @@ permalink: /changelog/
 * **feature-qr**
   * QR Scanner can now scan inverted QR codes, by decoding inverted source when the decoding the original source fails.
 
+* **feature-app-links**
+  * ⚠️ **This is a breaking change**: Migrated this component to use `browser-state` instead of `browser-session`. It is now required to pass a `BrowserStore` instance (instead of `SessionManager`) to `AppLinksFeature`.
+
 # 70.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v69.0.0...v70.0.0)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.mapNotNull
 import mozilla.components.browser.state.selector.findCustomTabOrSelectedTab
 import mozilla.components.browser.toolbar.display.DisplayToolbar
+import mozilla.components.feature.app.links.AppLinksFeature
 import mozilla.components.feature.downloads.DownloadsFeature
 import mozilla.components.feature.downloads.manager.FetchDownloadManager
 import mozilla.components.feature.privatemode.feature.SecureWindowFeature
@@ -51,6 +52,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
     private val toolbarFeature = ViewBoundFeatureWrapper<ToolbarFeature>()
     private val contextMenuIntegration = ViewBoundFeatureWrapper<ContextMenuIntegration>()
     private val downloadsFeature = ViewBoundFeatureWrapper<DownloadsFeature>()
+    private val appLinksFeature = ViewBoundFeatureWrapper<AppLinksFeature>()
     private val promptFeature = ViewBoundFeatureWrapper<PromptFeature>()
     private val findInPageIntegration = ViewBoundFeatureWrapper<FindInPageIntegration>()
     private val sitePermissionsFeature = ViewBoundFeatureWrapper<SitePermissionsFeature>()
@@ -144,6 +146,19 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
             ),
             owner = this,
             view = layout)
+
+        appLinksFeature.set(
+            feature = AppLinksFeature(
+                context = requireContext(),
+                store = components.store,
+                sessionId = sessionId,
+                fragmentManager = parentFragmentManager,
+                launchInApp = { components.preferences.getBoolean(DefaultComponents.PREF_LAUNCH_EXTERNAL_APP, false) },
+                loadUrlUseCase = components.sessionUseCases.loadUrl
+            ),
+            owner = this,
+            view = layout
+        )
 
         promptFeature.set(
             feature = PromptFeature(

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -208,8 +208,7 @@ open class DefaultComponents(private val applicationContext: Context) {
             interceptLinkClicks = true,
             launchInApp = {
                 applicationContext.components.preferences.getBoolean(PREF_LAUNCH_EXTERNAL_APP, false)
-            },
-            launchFromInterceptor = true
+            }
         )
     }
 


### PR DESCRIPTION
Migrating app-links to browser-state. Pretty much straight forward. Also added the `AppLinksFeature` to Sample Browser to make it easier to test. Two comments inline.