### PR TITLE
feature-contextmenu: Remove dependency on browser-session.

### DIFF
--- a/components/feature/contextmenu/build.gradle
+++ b/components/feature/contextmenu/build.gradle
@@ -28,7 +28,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 }
 
 dependencies {
-    implementation project(":browser-session")
+    implementation project(":browser-state")
     implementation project(':concept-engine')
     implementation project(':feature-tabs')
     implementation project(':feature-app-links')
@@ -46,6 +46,7 @@ dependencies {
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 
+    testImplementation project(':browser-session')
     testImplementation project(':support-test')
     testImplementation project(':support-test-libstate')
 }

--- a/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuFeature.kt
+++ b/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuFeature.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
-import mozilla.components.browser.session.Session
 import mozilla.components.browser.state.selector.findTabOrCustomTab
 import mozilla.components.browser.state.selector.findTabOrCustomTabOrSelectedTab
 import mozilla.components.browser.state.state.SessionState
@@ -30,9 +29,9 @@ internal const val FRAGMENT_TAG = "mozac_feature_contextmenu_dialog"
 /**
  * Feature for displaying a context menu after long-pressing web content.
  *
- * This feature will subscribe to the currently selected [Session] and display the context menu based on
- * [Session.Observer.onLongPress] events. Once the context menu is closed or the user selects an item from the context
- * menu the related [HitResult] will be consumed.
+ * This feature will subscribe to the currently selected tab and display a context menu based on
+ * the [HitResult] in its `ContentState`. Once the context menu is closed or the user selects an
+ * item from the context menu the related [HitResult] will be consumed.
  *
  * @property fragmentManager The [FragmentManager] to be used when displaying a context menu (fragment).
  * @property store The [BrowserStore] this feature should subscribe to.


### PR DESCRIPTION
Only the unit tests are still needing `SessionManager`, so we can remove the dependency for the component itself.