### PR TITLE
SDK-158 Add a NimbusDisabled object for builds that don't need nimbus

### DIFF
--- a/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/Nimbus.kt
+++ b/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/Nimbus.kt
@@ -44,7 +44,7 @@ interface NimbusApi : Observable<NimbusApi.Observer> {
      *
      * @return A list of [EnrolledExperiment]s
      */
-    fun getActiveExperiments(): List<EnrolledExperiment>
+    fun getActiveExperiments(): List<EnrolledExperiment> = listOf()
 
     /**
      * Get the currently enrolled branch for the given experiment
@@ -53,25 +53,27 @@ interface NimbusApi : Observable<NimbusApi.Observer> {
      *
      * @return A String representing the branch-id or "slug"
      */
-    fun getExperimentBranch(experimentId: String): String?
+    fun getExperimentBranch(experimentId: String): String? = null
 
     /**
      * Refreshes the experiments from the endpoint. Should be called at least once after
      * initialization
      */
-    fun updateExperiments()
+    fun updateExperiments() = Unit
 
     /**
      * Opt out of a specific experiment
      *
      * @param experimentId The string experiment-id or "slug" for which to opt out of
      */
-    fun optOut(experimentId: String)
+    fun optOut(experimentId: String) = Unit
 
     /**
      * Control the opt out for all experiments at once. This is likely a user action.
      */
     var globalUserParticipation: Boolean
+        get() = false
+        set(_) = Unit
 
     /**
      * Interface to be implemented by classes that want to observe experiment updates
@@ -239,3 +241,16 @@ class Nimbus(
             osVersion = Build.VERSION.RELEASE)
     }
 }
+
+/**
+ * An empty implementation of the `NimbusApi` to allow clients who have not enabled Nimbus (either
+ * by feature flags, or by not using a server endpoint.
+ *
+ * Any implementations using this class will report that the user has not been enrolled into any
+ * experiments, and will not report anything to Glean. Importantly, any calls to
+ * `getExperimentBranch(slug)` will return `null`, i.e. as if the user is not enrolled into the
+ * experiment.
+ */
+class NimbusDisabled(
+    private val delegate: Observable<NimbusApi.Observer> = ObserverRegistry()
+) : NimbusApi, Observable<NimbusApi.Observer> by delegate

--- a/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/NimbusTest.kt
+++ b/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/NimbusTest.kt
@@ -68,4 +68,12 @@ class NimbusTest {
         assertEquals("mozilla.components.service.nimbus.test", expContext.appId)
         // If we could control more of the context here we might be able to better test it
     }
+
+    @Test
+    fun `NimbusDisabled is empty`() {
+        val nimbus: NimbusApi = NimbusDisabled()
+        nimbus.updateExperiments()
+        assert(nimbus.getActiveExperiments().isEmpty()) { "getActiveExperiments should be empty" }
+        assertEquals(null, nimbus.getExperimentBranch("test-experiment"))
+    }
 }

--- a/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/NimbusTest.kt
+++ b/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/NimbusTest.kt
@@ -73,7 +73,7 @@ class NimbusTest {
     fun `NimbusDisabled is empty`() {
         val nimbus: NimbusApi = NimbusDisabled()
         nimbus.updateExperiments()
-        assert(nimbus.getActiveExperiments().isEmpty()) { "getActiveExperiments should be empty" }
+        assertTrue("getActiveExperiments should be empty", nimbus.getActiveExperiments().isEmpty())
         assertEquals(null, nimbus.getExperimentBranch("test-experiment"))
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,9 @@ permalink: /changelog/
 * **feature-app-links**
   * ⚠️ **This is a breaking change**: Migrated this component to use `browser-state` instead of `browser-session`. It is now required to pass a `BrowserStore` instance (instead of `SessionManager`) to `AppLinksFeature`.
 
+* **service-numbus**
+  * Added a `NimbusDisabled` class to provide implementers who are not able to use Nimbus yet.
+
 # 70.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v69.0.0...v70.0.0)


### PR DESCRIPTION
This is the AC part of [SDK-158][1] to remove a call into Rust when Nimbus is disabled.

It should be uplifted to AC 70.0 once landed.

[1]: https://jira.mozilla.com/browse/SDK-158

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- ~[ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.