### PR TITLE
Closes #8497: Make RecentlyClosedMiddleware listen to UndoAction.ClearRecoverableTabs.

### DIFF
--- a/components/feature/recentlyclosed/build.gradle
+++ b/components/feature/recentlyclosed/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     implementation Dependencies.androidx_lifecycle_livedata
     kapt Dependencies.androidx_room_compiler
 
+    testImplementation project(':browser-session')
     testImplementation project(':support-test')
     testImplementation project(':support-test-libstate')
 
@@ -69,7 +70,6 @@ dependencies {
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.kotlin_coroutines
     testImplementation Dependencies.testing_coroutines
-    testImplementation project(':support-test')
 
     androidTestImplementation project(':support-android-test')
     androidTestImplementation Dependencies.androidx_room_testing

--- a/components/feature/recentlyclosed/src/test/java/mozilla/components/feature/recentlyclosed/RecentlyClosedMiddlewareTest.kt
+++ b/components/feature/recentlyclosed/src/test/java/mozilla/components/feature/recentlyclosed/RecentlyClosedMiddlewareTest.kt
@@ -9,9 +9,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.runBlockingTest
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.session.undo.UndoMiddleware
 import mozilla.components.browser.state.action.RecentlyClosedAction
 import mozilla.components.browser.state.action.TabListAction
+import mozilla.components.browser.state.action.UndoAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.state.recover.RecoverableTab
@@ -29,7 +31,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 
@@ -62,264 +63,273 @@ class RecentlyClosedMiddlewareTest {
     )
 
     @Test
-    fun `closed tab storage stores the provided tab on add tab action`() =
-        runBlockingTest {
-            val storage = mockStorage()
-            val middleware = spy(RecentlyClosedMiddleware(testContext, 5, engine, lazy { storage }, scope))
+    fun `closed tab storage stores the provided tab on add tab action`() {
+        val storage = mockStorage()
+        val middleware = RecentlyClosedMiddleware(testContext, 5, engine, lazy { storage }, scope)
 
-            val store = BrowserStore(
-                initialState = BrowserState(),
-                middleware = listOf(middleware)
-            )
+        val store = BrowserStore(
+            initialState = BrowserState(),
+            middleware = listOf(middleware)
+        )
 
-            store.dispatch(RecentlyClosedAction.AddClosedTabsAction(listOf(closedTab))).joinBlocking()
-            dispatcher.advanceUntilIdle()
-            store.waitUntilIdle()
+        store.dispatch(RecentlyClosedAction.AddClosedTabsAction(listOf(closedTab))).joinBlocking()
+        dispatcher.advanceUntilIdle()
+        store.waitUntilIdle()
 
-            verify(storage).addTabsToCollectionWithMax(
-                listOf(closedTab), 5
-            )
-        }
+        verify(storage).addTabsToCollectionWithMax(
+            listOf(closedTab), 5
+        )
+    }
 
     @Test
-    fun `closed tab storage adds normal tabs removed with TabListAction`() =
-        runBlockingTest {
-            val storage = mockStorage()
-            val middleware = spy(RecentlyClosedMiddleware(testContext, 5, engine, lazy { storage }, scope))
+    fun `closed tab storage adds normal tabs removed with TabListAction`() {
+        val storage = mockStorage()
+        val middleware = RecentlyClosedMiddleware(testContext, 5, engine, lazy { storage }, scope)
 
-            val tab = createTab("https://www.mozilla.org", private = false, id = "1234")
-            val tab2 = createTab("https://www.firefox.com", private = false, id = "5678")
+        val tab = createTab("https://www.mozilla.org", private = false, id = "1234")
+        val tab2 = createTab("https://www.firefox.com", private = false, id = "5678")
 
-            val store = spy(
-                BrowserStore(
-                    initialState = BrowserState(
-                        tabs = listOf(tab, tab2)
-                    ),
-                    middleware = listOf(middleware)
+        var sessionManager: SessionManager? = null
+        val lookup: () -> SessionManager = { sessionManager!! }
+
+        val store = BrowserStore(
+            initialState = BrowserState(
+                tabs = listOf(tab, tab2)
+            ),
+            middleware = listOf(UndoMiddleware(lookup, mainScope = scope), middleware)
+        )
+
+        sessionManager = SessionManager(engine = mock(), store = store)
+
+        store.dispatch(TabListAction.RemoveTabsAction(listOf("1234", "5678"))).joinBlocking()
+        store.dispatch(UndoAction.ClearRecoverableTabs(store.state.undoHistory.tag)).joinBlocking()
+
+        dispatcher.advanceUntilIdle()
+        store.waitUntilIdle()
+
+        val closedTabCaptor = argumentCaptor<List<RecoverableTab>>()
+        verify(storage).addTabsToCollectionWithMax(
+            closedTabCaptor.capture(),
+            eq(5)
+        )
+        assertEquals(2, closedTabCaptor.value.size)
+        assertEquals(tab.content.title, closedTabCaptor.value[0].title)
+        assertEquals(tab.content.url, closedTabCaptor.value[0].url)
+        assertEquals(tab2.content.title, closedTabCaptor.value[1].title)
+        assertEquals(tab2.content.url, closedTabCaptor.value[1].url)
+        assertEquals(
+            tab.engineState.engineSessionState,
+            closedTabCaptor.value[0].state
+        )
+        assertEquals(
+            tab2.engineState.engineSessionState,
+            closedTabCaptor.value[1].state
+        )
+    }
+
+    @Test
+    fun `closed tab storage adds a normal tab removed with TabListAction`() {
+        val storage = mockStorage()
+        val middleware = RecentlyClosedMiddleware(testContext, 5, engine, lazy { storage }, scope)
+
+        val tab = createTab("https://www.mozilla.org", private = false, id = "1234")
+
+        var sessionManager: SessionManager? = null
+        val lookup: () -> SessionManager = { sessionManager!! }
+
+        val store = BrowserStore(
+            initialState = BrowserState(
+                tabs = listOf(tab)
+            ),
+            middleware = listOf(UndoMiddleware(lookup, mainScope = scope), middleware)
+        )
+
+        sessionManager = SessionManager(engine = mock(), store = store)
+
+        store.dispatch(TabListAction.RemoveTabAction("1234")).joinBlocking()
+        store.dispatch(UndoAction.ClearRecoverableTabs(store.state.undoHistory.tag)).joinBlocking()
+
+        dispatcher.advanceUntilIdle()
+        store.waitUntilIdle()
+
+        val closedTabCaptor = argumentCaptor<List<RecoverableTab>>()
+        verify(storage).addTabsToCollectionWithMax(
+            closedTabCaptor.capture(),
+            eq(5)
+        )
+        assertEquals(1, closedTabCaptor.value.size)
+        assertEquals(tab.content.title, closedTabCaptor.value[0].title)
+        assertEquals(tab.content.url, closedTabCaptor.value[0].url)
+        assertEquals(
+            tab.engineState.engineSessionState,
+            closedTabCaptor.value[0].state
+        )
+    }
+
+    @Test
+    fun `closed tab storage does not add a private tab removed with TabListAction`() {
+        val storage = mockStorage()
+        val middleware = RecentlyClosedMiddleware(testContext, 5, engine, lazy { storage }, scope)
+
+        val tab = createTab("https://www.mozilla.org", private = true, id = "1234")
+
+        val store = BrowserStore(
+            initialState = BrowserState(
+                tabs = listOf(tab)
+            ),
+            middleware = listOf(middleware)
+        )
+
+        store.dispatch(TabListAction.RemoveTabAction("1234")).joinBlocking()
+        dispatcher.advanceUntilIdle()
+        store.waitUntilIdle()
+
+        verify(storage).getTabs()
+        verifyNoMoreInteractions(storage)
+    }
+
+    @Test
+    fun `closed tab storage adds all normals tab removed with TabListAction RemoveAllNormalTabsAction`() {
+        val storage = mockStorage()
+        val middleware = RecentlyClosedMiddleware(testContext, 5, engine, lazy { storage }, scope)
+
+        val tab = createTab("https://www.mozilla.org", private = false, id = "1234")
+        val tab2 = createTab("https://www.firefox.com", private = true, id = "3456")
+
+        var sessionManager: SessionManager? = null
+        val lookup: () -> SessionManager = { sessionManager!! }
+
+        val store = BrowserStore(
+            initialState = BrowserState(
+                tabs = listOf(tab, tab2)
+            ),
+            middleware = listOf(UndoMiddleware(lookup, mainScope = scope), middleware)
+        )
+
+        sessionManager = SessionManager(engine = mock(), store = store)
+
+        store.dispatch(TabListAction.RemoveAllNormalTabsAction).joinBlocking()
+        store.dispatch(UndoAction.ClearRecoverableTabs(store.state.undoHistory.tag)).joinBlocking()
+
+        dispatcher.advanceUntilIdle()
+        store.waitUntilIdle()
+
+        val closedTabCaptor = argumentCaptor<List<RecoverableTab>>()
+        verify(storage).addTabsToCollectionWithMax(
+            closedTabCaptor.capture(),
+            eq(5)
+        )
+        assertEquals(1, closedTabCaptor.value.size)
+        assertEquals(tab.content.title, closedTabCaptor.value[0].title)
+        assertEquals(tab.content.url, closedTabCaptor.value[0].url)
+        assertEquals(
+            tab.engineState.engineSessionState,
+            closedTabCaptor.value[0].state
+        )
+    }
+
+    @Test
+    fun `closed tab storage adds all normal tabs and no private tabs removed with TabListAction RemoveAllTabsAction`() {
+        val storage = mockStorage()
+        val middleware = RecentlyClosedMiddleware(testContext, 5, engine, lazy { storage }, scope)
+
+        val tab = createTab("https://www.mozilla.org", private = false, id = "1234")
+        val tab2 = createTab("https://www.firefox.com", private = true, id = "3456")
+
+        var sessionManager: SessionManager? = null
+        val lookup: () -> SessionManager = { sessionManager!! }
+
+        val store = BrowserStore(
+            initialState = BrowserState(
+                tabs = listOf(tab, tab2)
+            ),
+            middleware = listOf(UndoMiddleware(lookup, mainScope = scope), middleware)
+        )
+
+        sessionManager = SessionManager(engine = mock(), store = store)
+
+        store.dispatch(TabListAction.RemoveAllTabsAction).joinBlocking()
+        store.dispatch(UndoAction.ClearRecoverableTabs(store.state.undoHistory.tag)).joinBlocking()
+
+        dispatcher.advanceUntilIdle()
+        store.waitUntilIdle()
+
+        val closedTabCaptor = argumentCaptor<List<RecoverableTab>>()
+        verify(storage).addTabsToCollectionWithMax(
+            closedTabCaptor.capture(),
+            eq(5)
+        )
+        assertEquals(1, closedTabCaptor.value.size)
+        assertEquals(tab.content.title, closedTabCaptor.value[0].title)
+        assertEquals(tab.content.url, closedTabCaptor.value[0].url)
+        assertEquals(
+            tab.engineState.engineSessionState,
+            closedTabCaptor.value[0].state
+        )
+    }
+
+    @Test
+    fun `fetch the tabs from the recently closed storage and load into browser state on initialize tab state action`() {
+        val storage = mockStorage(tabs = listOf(closedTab))
+
+        val middleware = RecentlyClosedMiddleware(testContext, 5, engine, lazy { storage }, scope)
+        val store = BrowserStore(initialState = BrowserState(), middleware = listOf(middleware))
+
+        // Wait for Init action of store to be processed
+        store.waitUntilIdle()
+
+        // Now wait for Middleware to process Init action and store to process action from middleware
+        dispatcher.advanceUntilIdle()
+        store.waitUntilIdle()
+
+        verify(storage).getTabs()
+        assertEquals(closedTab, store.state.closedTabs[0])
+    }
+
+    @Test
+    fun `recently closed storage removes the provided tab on remove tab action`() {
+        val storage = mockStorage()
+        val middleware = RecentlyClosedMiddleware(testContext, 5, engine, lazy { storage }, scope)
+
+        val store = BrowserStore(
+            initialState = BrowserState(
+                closedTabs = listOf(
+                    closedTab
                 )
-            )
+            ),
+            middleware = listOf(middleware)
+        )
 
-            store.dispatch(TabListAction.RemoveTabsAction(listOf("1234", "5678"))).joinBlocking()
-            dispatcher.advanceUntilIdle()
-            store.waitUntilIdle()
+        store.dispatch(RecentlyClosedAction.RemoveClosedTabAction(closedTab)).joinBlocking()
+        dispatcher.advanceUntilIdle()
+        store.waitUntilIdle()
 
-            val closedTabCaptor = argumentCaptor<List<RecoverableTab>>()
-            verify(storage).addTabsToCollectionWithMax(
-                closedTabCaptor.capture(),
-                eq(5)
-            )
-            assertEquals(2, closedTabCaptor.value.size)
-            assertEquals(tab.content.title, closedTabCaptor.value[0].title)
-            assertEquals(tab.content.url, closedTabCaptor.value[0].url)
-            assertEquals(tab2.content.title, closedTabCaptor.value[1].title)
-            assertEquals(tab2.content.url, closedTabCaptor.value[1].url)
-            assertEquals(
-                tab.engineState.engineSessionState,
-                closedTabCaptor.value[0].state
-            )
-            assertEquals(
-                tab2.engineState.engineSessionState,
-                closedTabCaptor.value[1].state
-            )
-        }
+        dispatcher.advanceUntilIdle()
+        store.waitUntilIdle()
+        verify(storage).removeTab(closedTab)
+    }
 
     @Test
-    fun `closed tab storage adds a normal tab removed with TabListAction`() =
-        runBlockingTest {
-            val storage = mockStorage()
-            val middleware = spy(RecentlyClosedMiddleware(testContext, 5, engine, lazy { storage }, scope))
-
-            val tab = createTab("https://www.mozilla.org", private = false, id = "1234")
-
-            val store = spy(
-                BrowserStore(
-                    initialState = BrowserState(
-                        tabs = listOf(tab)
-                    ),
-                    middleware = listOf(middleware)
+    fun `recently closed storage removes all tabs on remove all tabs action`() {
+        val storage = mockStorage()
+        val middleware = RecentlyClosedMiddleware(testContext, 5, engine, lazy { storage }, scope)
+        val store = BrowserStore(
+            initialState = BrowserState(
+                closedTabs = listOf(
+                    closedTab
                 )
-            )
+            ),
+            middleware = listOf(middleware)
+        )
 
-            store.dispatch(TabListAction.RemoveTabAction("1234")).joinBlocking()
-            dispatcher.advanceUntilIdle()
-            store.waitUntilIdle()
+        store.dispatch(RecentlyClosedAction.RemoveAllClosedTabAction).joinBlocking()
+        dispatcher.advanceUntilIdle()
+        store.waitUntilIdle()
 
-            val closedTabCaptor = argumentCaptor<List<RecoverableTab>>()
-            verify(storage).addTabsToCollectionWithMax(
-                closedTabCaptor.capture(),
-                eq(5)
-            )
-            assertEquals(1, closedTabCaptor.value.size)
-            assertEquals(tab.content.title, closedTabCaptor.value[0].title)
-            assertEquals(tab.content.url, closedTabCaptor.value[0].url)
-            assertEquals(
-                tab.engineState.engineSessionState,
-                closedTabCaptor.value[0].state
-            )
-        }
-
-    @Test
-    fun `closed tab storage does not add a private tab removed with TabListAction`() =
-        runBlockingTest {
-            val storage = mockStorage()
-            val middleware = spy(RecentlyClosedMiddleware(testContext, 5, engine, lazy { storage }, scope))
-
-            val tab = createTab("https://www.mozilla.org", private = true, id = "1234")
-
-            val store = spy(
-                BrowserStore(
-                    initialState = BrowserState(
-                        tabs = listOf(tab)
-                    ),
-                    middleware = listOf(middleware)
-                )
-            )
-
-            store.dispatch(TabListAction.RemoveTabAction("1234")).joinBlocking()
-            dispatcher.advanceUntilIdle()
-            store.waitUntilIdle()
-
-            verify(storage).getTabs()
-            verifyNoMoreInteractions(storage)
-        }
-
-    @Test
-    fun `closed tab storage adds all normals tab removed with TabListAction RemoveAllNormalTabsAction`() =
-        runBlockingTest {
-            val storage = mockStorage()
-            val middleware = spy(RecentlyClosedMiddleware(testContext, 5, engine, lazy { storage }, scope))
-
-            val tab = createTab("https://www.mozilla.org", private = false, id = "1234")
-            val tab2 = createTab("https://www.firefox.com", private = true, id = "3456")
-
-            val store = spy(
-                BrowserStore(
-                    initialState = BrowserState(
-                        tabs = listOf(tab, tab2)
-                    ),
-                    middleware = listOf(middleware)
-                )
-            )
-
-            store.dispatch(TabListAction.RemoveAllNormalTabsAction).joinBlocking()
-            dispatcher.advanceUntilIdle()
-            store.waitUntilIdle()
-
-            val closedTabCaptor = argumentCaptor<List<RecoverableTab>>()
-            verify(storage).addTabsToCollectionWithMax(
-                closedTabCaptor.capture(),
-                eq(5)
-            )
-            assertEquals(1, closedTabCaptor.value.size)
-            assertEquals(tab.content.title, closedTabCaptor.value[0].title)
-            assertEquals(tab.content.url, closedTabCaptor.value[0].url)
-            assertEquals(
-                tab.engineState.engineSessionState,
-                closedTabCaptor.value[0].state
-            )
-        }
-
-    @Test
-    fun `closed tab storage adds all normal tabs and no private tabs removed with TabListAction RemoveAllTabsAction`() =
-        runBlockingTest {
-            val storage = mockStorage()
-            val middleware = spy(RecentlyClosedMiddleware(testContext, 5, engine, lazy { storage }, scope))
-
-            val tab = createTab("https://www.mozilla.org", private = false, id = "1234")
-            val tab2 = createTab("https://www.firefox.com", private = true, id = "3456")
-
-            val store = spy(
-                BrowserStore(
-                    initialState = BrowserState(
-                        tabs = listOf(tab, tab2)
-                    ),
-                    middleware = listOf(middleware)
-                )
-            )
-
-            store.dispatch(TabListAction.RemoveAllTabsAction).joinBlocking()
-            dispatcher.advanceUntilIdle()
-            store.waitUntilIdle()
-
-            val closedTabCaptor = argumentCaptor<List<RecoverableTab>>()
-            verify(storage).addTabsToCollectionWithMax(
-                closedTabCaptor.capture(),
-                eq(5)
-            )
-            assertEquals(1, closedTabCaptor.value.size)
-            assertEquals(tab.content.title, closedTabCaptor.value[0].title)
-            assertEquals(tab.content.url, closedTabCaptor.value[0].url)
-            assertEquals(
-                tab.engineState.engineSessionState,
-                closedTabCaptor.value[0].state
-            )
-        }
-
-    @Test
-    fun `fetch the tabs from the recently closed storage and load into browser state on initialize tab state action`() =
-        runBlockingTest {
-            val storage = mockStorage(tabs = listOf(closedTab))
-
-            val middleware = spy(RecentlyClosedMiddleware(testContext, 5, engine, lazy { storage }, scope))
-            val store = BrowserStore(initialState = BrowserState(), middleware = listOf(middleware))
-
-            // Wait for Init action of store to be processed
-            store.waitUntilIdle()
-
-            // Now wait for Middleware to process Init action and store to process action from middleware
-            dispatcher.advanceUntilIdle()
-            store.waitUntilIdle()
-
-            verify(storage).getTabs()
-            assertEquals(closedTab, store.state.closedTabs[0])
-        }
-
-    @Test
-    fun `recently closed storage removes the provided tab on remove tab action`() =
-        runBlockingTest {
-            val storage = mockStorage()
-            val middleware = spy(RecentlyClosedMiddleware(testContext, 5, engine, lazy { storage }, scope))
-
-            val store = BrowserStore(
-                initialState = BrowserState(
-                    closedTabs = listOf(
-                        closedTab
-                    )
-                ),
-                middleware = listOf(middleware)
-            )
-
-            store.dispatch(RecentlyClosedAction.RemoveClosedTabAction(closedTab)).joinBlocking()
-            dispatcher.advanceUntilIdle()
-            store.waitUntilIdle()
-
-            dispatcher.advanceUntilIdle()
-            store.waitUntilIdle()
-            verify(storage).removeTab(closedTab)
-        }
-
-    @Test
-    fun `recently closed storage removes all tabs on remove all tabs action`() =
-        runBlockingTest {
-            val storage = mockStorage()
-            val middleware = spy(RecentlyClosedMiddleware(testContext, 5, engine, lazy { storage }, scope))
-            val store = BrowserStore(
-                initialState = BrowserState(
-                    closedTabs = listOf(
-                        closedTab
-                    )
-                ),
-                middleware = listOf(middleware)
-            )
-
-            store.dispatch(RecentlyClosedAction.RemoveAllClosedTabAction).joinBlocking()
-            dispatcher.advanceUntilIdle()
-            store.waitUntilIdle()
-
-            dispatcher.advanceUntilIdle()
-            store.waitUntilIdle()
-            verify(storage).removeAllTabs()
-        }
+        dispatcher.advanceUntilIdle()
+        store.waitUntilIdle()
+        verify(storage).removeAllTabs()
+    }
 }
 
 private fun mockStorage(


### PR DESCRIPTION
With that closed tabs will not immediately show up in "closed tab" and instead we will
wait for the "undo" timeout and only if the user didn't "undo" then the tab will move
to the list of closed tabs.

Previously selecting "undo" caused the tab to exist in the tabs tray as well as in
the list of closed tabs.

This should unblock the UI test failure in https://github.com/mozilla-mobile/fenix/pull/17401. 