### PR TITLE
Closes #9392: Add share and copy link context menu options to images, audio and video

### DIFF
--- a/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
+++ b/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
@@ -313,7 +313,7 @@ data class ContextMenuCandidate(
         ) = ContextMenuCandidate(
             id = "mozac.feature.contextmenu.share_link",
             label = context.getString(R.string.mozac_feature_contextmenu_share_link),
-            showFor = { _, hitResult -> hitResult.isUri() },
+            showFor = { _, hitResult -> hitResult.isUri() || hitResult.isImage() || hitResult.isVideoAudio() },
             action = { _, hitResult ->
                 val intent = Intent(Intent.ACTION_SEND).apply {
                     type = "text/plain"
@@ -353,7 +353,7 @@ data class ContextMenuCandidate(
         ) = ContextMenuCandidate(
             id = "mozac.feature.contextmenu.copy_link",
             label = context.getString(R.string.mozac_feature_contextmenu_copy_link),
-            showFor = { _, hitResult -> hitResult.isUri() },
+            showFor = { _, hitResult -> hitResult.isUri() || hitResult.isImage() || hitResult.isVideoAudio() },
             action = { _, hitResult ->
                 clipPlaintText(context, hitResult.getLink(), hitResult.getLink(),
                     R.string.mozac_feature_contextmenu_snackbar_link_copied, snackBarParentView,

--- a/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
+++ b/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
@@ -670,11 +670,11 @@ class ContextMenuCandidateTest {
             createTab("test://www.mozilla.org"),
             HitResult.UNKNOWN("test://www.mozilla.org")))
 
-        assertFalse(shareLink.showFor(
+        assertTrue(shareLink.showFor(
             createTab("https://www.mozilla.org"),
             HitResult.IMAGE("https://www.mozilla.org")))
 
-        assertFalse(shareLink.showFor(
+        assertTrue(shareLink.showFor(
             createTab("https://www.mozilla.org"),
             HitResult.VIDEO("https://www.mozilla.org")))
 
@@ -750,11 +750,11 @@ class ContextMenuCandidateTest {
             createTab("test://www.mozilla.org"),
             HitResult.UNKNOWN("test://www.mozilla.org")))
 
-        assertFalse(copyLink.showFor(
+        assertTrue(copyLink.showFor(
             createTab("https://www.mozilla.org"),
             HitResult.IMAGE("https://www.mozilla.org")))
 
-        assertFalse(copyLink.showFor(
+        assertTrue(copyLink.showFor(
             createTab("https://www.mozilla.org"),
             HitResult.VIDEO("https://www.mozilla.org")))
 


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
