### PR TITLE
Closes #9403: Don't submit network exception during 'sendCommand' failures

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
@@ -163,7 +163,17 @@ class FxaDeviceConstellation(
         }
 
         if (result != null) {
-            crashReporter?.submitCaughtException(SendCommandException(result))
+            when (result) {
+                // Don't submit network exceptions to our crash reporter. They're just noise.
+                is FxaException.Network -> {
+                    logger.warn("Failed to 'sendCommandToDevice' due to a network exception")
+                }
+                else -> {
+                    logger.warn("Failed to 'sendCommandToDevice'", result)
+                    crashReporter?.submitCaughtException(SendCommandException(result))
+                }
+            }
+
             false
         } else {
             true

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaDeviceConstellationTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaDeviceConstellationTest.kt
@@ -45,6 +45,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.never
 import org.mockito.Mockito.reset
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
@@ -221,6 +222,20 @@ class FxaDeviceConstellationTest {
         assertFalse(success)
         verify(constellation.crashReporter!!).submitCaughtException(exceptionCaptor.capture())
         assertSame(exception, exceptionCaptor.value.cause)
+    }
+
+    @Test
+    fun `send command to device won't report network exceptions`() = runBlocking(coroutinesTestRule.testDispatcher) {
+        val exception = FxaException.Network("timeout!")
+        doAnswer { throw exception }.`when`(account).sendSingleTab(any(), any(), any())
+
+        val success = constellation.sendCommandToDevice(
+            "targetID", DeviceCommandOutgoing.SendTab("Mozilla", "https://www.mozilla.org")
+        )
+
+        assertFalse(success)
+        verify(constellation.crashReporter!!, never()).submitCaughtException(any())
+        Unit
     }
 
     @Test


### PR DESCRIPTION
They're just noise, not actionable in practice (we already pass up "action failed" flag up the callstack).


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
