### PR TITLE
Add dummy multiplatform component.

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -464,3 +464,7 @@ projects:
     description: 'A Gradle plugin to generate code for Glean metrics.'
     publish: true
     artifact-type: jar
+  multiplatform-lib-dummy:
+    path: components/multiplatform/lib-dummy
+    description: 'A dummy multiplatform library for testing purposes'
+    publish: false

--- a/build.gradle
+++ b/build.gradle
@@ -357,7 +357,9 @@ tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach() {
 
     autoCorrect = true
 
+    exclude "**/build.gradle.kts"
     exclude "**/src/androidTest/**"
+    exclude "**/src/iosTest/**"
     exclude "**/src/test/**"
     exclude "**/test/src/**"
     exclude "**/build/**"

--- a/components/multiplatform/lib-dummy/build.gradle.kts
+++ b/components/multiplatform/lib-dummy/build.gradle.kts
@@ -1,0 +1,79 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+
+plugins {
+    kotlin("multiplatform")
+    id("com.android.library")
+}
+
+kotlin {
+    android()
+
+    ios {
+        binaries {
+            framework {
+                baseName = "shared"
+            }
+        }
+    }
+
+    // Block from https://github.com/cashapp/sqldelight/issues/2044#issuecomment-721299517
+    val onPhone = System.getenv("SDK_NAME")?.startsWith("iphoneos") ?: false
+    if (onPhone) {
+        iosArm64("ios")
+    } else {
+        iosX64("ios")
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {}
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test-common"))
+                implementation(kotlin("test-annotations-common"))
+            }
+        }
+        val androidMain by getting {
+            dependencies {
+                implementation("com.google.android.material:material:1.2.1")
+            }
+        }
+        val androidTest by getting {
+            dependencies {
+                implementation(kotlin("test-junit"))
+                implementation("junit:junit:4.13")
+            }
+        }
+        val iosMain by getting {
+            dependencies {}
+        }
+        val iosTest by getting {
+            dependencies {}
+        }
+    }
+}
+
+android {
+    compileSdkVersion(29)
+    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
+    defaultConfig {
+        minSdkVersion(24)
+        targetSdkVersion(29)
+    }
+}
+
+val packForXcode by tasks.creating(Sync::class) {
+    group = "build"
+    val mode = System.getenv("CONFIGURATION") ?: "DEBUG"
+    val sdkName = System.getenv("SDK_NAME") ?: "iphonesimulator"
+    val targetName = "ios" + if (sdkName.startsWith("iphoneos")) "Arm64" else "X64"
+    val framework = kotlin.targets.getByName<KotlinNativeTarget>(targetName).binaries.getFramework(mode)
+    inputs.property("mode", mode)
+    dependsOn(framework.linkTask)
+    val targetDir = File(buildDir, "xcode-frameworks")
+    from({ framework.outputDirectory })
+    into(targetDir)
+}
+
+tasks.getByName("build").dependsOn(packForXcode)

--- a/components/multiplatform/lib-dummy/src/androidMain/AndroidManifest.xml
+++ b/components/multiplatform/lib-dummy/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.multiplatform.lib.dummy" />

--- a/components/multiplatform/lib-dummy/src/androidMain/kotlin/mozilla/components/multiplatform/lib/dummy/DummyDelegate.kt
+++ b/components/multiplatform/lib-dummy/src/androidMain/kotlin/mozilla/components/multiplatform/lib/dummy/DummyDelegate.kt
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.multiplatform.lib.dummy
+
+/**
+ * Android-specific [DummyDelegate] implementation.
+ */
+actual class DummyDelegate {
+    /**
+     * Returns an Android-specific dummy value.
+     */
+    actual fun getValue(): String {
+        return "Android"
+    }
+}

--- a/components/multiplatform/lib-dummy/src/androidTest/kotlin/mozilla/components/multiplatform/lib/dummy/DummyDelegateTest.kt
+++ b/components/multiplatform/lib-dummy/src/androidTest/kotlin/mozilla/components/multiplatform/lib/dummy/DummyDelegateTest.kt
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.multiplatform.lib.dummy
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DummyDelegateTest {
+    @Test
+    fun getValue() {
+        val dummy = Dummy(DummyDelegate())
+        assertEquals("Dummy Android", dummy.getValue())
+    }
+}

--- a/components/multiplatform/lib-dummy/src/commonMain/kotlin/mozilla/components/multiplatform/lib/dummy/Dummy.kt
+++ b/components/multiplatform/lib-dummy/src/commonMain/kotlin/mozilla/components/multiplatform/lib/dummy/Dummy.kt
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.multiplatform.lib.dummy
+
+/**
+ * Platform-specific delegate that will get invoked by [Dummy].
+ */
+expect class DummyDelegate {
+    /**
+     * Returns a platform-specific dummy value.
+     */
+    fun getValue(): String
+}
+
+/**
+ * A dummy class for testing purposes.
+ */
+class Dummy(
+    private val delegate: DummyDelegate
+) {
+    /**
+     * Returns a platform-specific dummy value.
+     */
+    fun getValue(): String {
+        return "Dummy ${delegate.getValue()}"
+    }
+}

--- a/components/multiplatform/lib-dummy/src/iosMain/kotlin/mozilla/components/multiplatform/lib/dummy/DummyDelegate.kt
+++ b/components/multiplatform/lib-dummy/src/iosMain/kotlin/mozilla/components/multiplatform/lib/dummy/DummyDelegate.kt
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.multiplatform.lib.dummy
+
+/**
+ * iOS-specific [DummyDelegate] implementation.
+ */
+actual class DummyDelegate {
+    /**
+     * Returns an iOS-specific dummy value.
+     */
+    actual fun getValue(): String {
+        return "iOS"
+    }
+}

--- a/components/multiplatform/lib-dummy/src/iosTest/kotlin/mozilla/components/multiplatform/lib/dummy/DummyDelegateTest.kt
+++ b/components/multiplatform/lib-dummy/src/iosTest/kotlin/mozilla/components/multiplatform/lib/dummy/DummyDelegateTest.kt
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.multiplatform.lib.dummy
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DummyDelegateTest {
+    @Test
+    fun getValue() {
+        val dummy = Dummy(DummyDelegate())
+        assertEquals("Dummy iOS", dummy.getValue())
+    }
+}

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -76,6 +76,7 @@ treeherder:
         lib-push-amazon: lib-push-amazon
         lib-push-firebase: lib-push-firebase
         lib-state: lib-state
+        multiplatform-lib-dummy: multiplatform-lib-dummy
         samples-browser-beta: samples-browser-beta
         samples-browser-release: samples-browser-release
         samples-browser-system: samples-browser-system


### PR DESCRIPTION
This patch adds a dummy multiplatform component for testing purposes, with targets for Android and iOS.