### PR TITLE
For #9382: Disable task optimization for pushes to 'master'

### DIFF
--- a/taskcluster/ac_taskgraph/__init__.py
+++ b/taskcluster/ac_taskgraph/__init__.py
@@ -35,9 +35,11 @@ def _import_modules(modules):
 
 
 def get_decision_parameters(graph_config, parameters):
+    # Environment is defined in .taskcluster.yml
     pr_number = os.environ.get("MOBILE_PULL_REQUEST_NUMBER", None)
     parameters["pull_request_number"] = None if pr_number is None else int(pr_number)
     parameters["base_rev"] = os.environ.get("MOBILE_BASE_REV")
+    parameters["head_ref"] = os.environ.get("MOBILE_HEAD_REF")
     version = get_version()
     parameters["version"] = version
     parameters.setdefault("next_version", None)

--- a/taskcluster/ac_taskgraph/loader/build_config.py
+++ b/taskcluster/ac_taskgraph/loader/build_config.py
@@ -135,6 +135,11 @@ def loader(kind, path, config, params, loaded_tasks):
     elif params["tasks_for"] == "github-push":
         if params["base_rev"] in _GIT_ZERO_HASHES:
             logger.warn("base_rev is a zero hash, meaning there is no previous push. Building every component...")
+        elif params["head_ref"] == "refs/heads/master":
+            # Disable the affected_components optimization to make sure we execute all tests to get
+            # a complete code coverage report for pushes to 'master'.
+            # See https://github.com/mozilla-mobile/android-components/issues/9382#issuecomment-760506327
+            logger.info("head_ref is refs/heads/master. Building every component...")
         else:
             logger.info("Processing push for commit range %s -> %s" % (params["base_rev"], params["head_rev"]))
             files_changed = get_files_changed_push(params["base_repository"], params["base_rev"], params["head_rev"])


### PR DESCRIPTION
See https://github.com/mozilla-mobile/android-components/issues/9382#issuecomment-760506327 for context. In summary, we'd like to run _every_ task whenever a push to master happens. This will get us complete test coverage reports.

@bhearsum I'm not familiar with this code. At first glance, this seems correct?

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
