### PR TITLE
For #9418 - Add support for sharing actual website images

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -17,17 +17,18 @@ import mozilla.components.browser.state.state.EngineState
 import mozilla.components.browser.state.state.LoadRequestState
 import mozilla.components.browser.state.state.MediaSessionState
 import mozilla.components.browser.state.state.MediaState
-import mozilla.components.browser.state.state.content.PermissionHighlightsState
 import mozilla.components.browser.state.state.ReaderState
+import mozilla.components.browser.state.state.SearchState
 import mozilla.components.browser.state.state.SecurityInfoState
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.TrackingProtectionState
+import mozilla.components.browser.state.state.UndoHistoryState
 import mozilla.components.browser.state.state.WebExtensionState
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.state.content.FindResultState
-import mozilla.components.browser.state.state.SearchState
-import mozilla.components.browser.state.state.UndoHistoryState
+import mozilla.components.browser.state.state.content.PermissionHighlightsState
+import mozilla.components.browser.state.state.content.ShareInternetResourceState
 import mozilla.components.browser.state.state.recover.RecoverableTab
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
@@ -38,8 +39,8 @@ import mozilla.components.concept.engine.history.HistoryItem
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.engine.media.Media
 import mozilla.components.concept.engine.media.RecordingDevice
-import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.mediasession.MediaSession
+import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.search.SearchRequest
 import mozilla.components.concept.engine.webextension.WebExtensionBrowserAction
@@ -1033,6 +1034,28 @@ sealed class DownloadAction : BrowserAction() {
      * Restores the given [download] from the storage.
      */
     data class RestoreDownloadStateAction(val download: DownloadState) : DownloadAction()
+}
+
+/**
+ * [BrowserAction] implementations related to updating the session state of internet resources to be shared.
+ */
+sealed class ShareInternetResourceAction : BrowserAction() {
+    /**
+     * Starts the sharing process of an Internet resource.
+     */
+    data class AddShareAction(
+        val tabId: String,
+        val internetResource: ShareInternetResourceState
+    ) : ShareInternetResourceAction()
+
+    /**
+     * Previous share request is considered completed.
+     * File was successfully shared with other apps / user may have aborted the process or the operation
+     * may have failed. In either case the previous share request is considered completed.
+     */
+    data class ConsumeShareAction(
+        val tabId: String
+    ) : ShareInternetResourceAction()
 }
 
 /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
@@ -12,15 +12,16 @@ import mozilla.components.browser.state.action.CustomTabListAction
 import mozilla.components.browser.state.action.DownloadAction
 import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.InitAction
-import mozilla.components.browser.state.action.MediaAction
-import mozilla.components.browser.state.action.ReaderAction
-import mozilla.components.browser.state.action.SearchAction
-import mozilla.components.browser.state.action.SystemAction
-import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.action.LastAccessAction
+import mozilla.components.browser.state.action.MediaAction
 import mozilla.components.browser.state.action.MediaSessionAction
+import mozilla.components.browser.state.action.ReaderAction
 import mozilla.components.browser.state.action.RecentlyClosedAction
 import mozilla.components.browser.state.action.RestoreCompleteAction
+import mozilla.components.browser.state.action.SearchAction
+import mozilla.components.browser.state.action.ShareInternetResourceAction
+import mozilla.components.browser.state.action.SystemAction
+import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
 import mozilla.components.browser.state.action.UndoAction
 import mozilla.components.browser.state.action.WebExtensionAction
@@ -59,6 +60,7 @@ internal object BrowserStateReducer {
             is CrashAction -> CrashReducer.reduce(state, action)
             is LastAccessAction -> LastAccessReducer.reduce(state, action)
             is UndoAction -> UndoReducer.reduce(state, action)
+            is ShareInternetResourceAction -> ShareInternetResourceStateReducer.reduce(state, action)
         }
     }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ShareInternetResourceStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ShareInternetResourceStateReducer.kt
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.reducer
+
+import androidx.annotation.VisibleForTesting
+import mozilla.components.browser.state.action.ShareInternetResourceAction
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.ContentState
+
+internal object ShareInternetResourceStateReducer {
+    fun reduce(state: BrowserState, action: ShareInternetResourceAction): BrowserState {
+        return when (action) {
+            is ShareInternetResourceAction.AddShareAction -> updateTheContentState(state, action.tabId) {
+                it.copy(share = action.internetResource)
+            }
+            is ShareInternetResourceAction.ConsumeShareAction -> updateTheContentState(state, action.tabId) {
+                it.copy(share = null)
+            }
+        }
+    }
+}
+
+@VisibleForTesting
+internal inline fun updateTheContentState(
+    state: BrowserState,
+    tabId: String,
+    crossinline update: (ContentState) -> ContentState
+): BrowserState {
+    return state.updateTabState(tabId) { current ->
+        current.createCopy(content = update(current.content))
+    }
+}

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
@@ -9,6 +9,7 @@ import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.state.content.FindResultState
 import mozilla.components.browser.state.state.content.HistoryState
 import mozilla.components.browser.state.state.content.PermissionHighlightsState
+import mozilla.components.browser.state.state.content.ShareInternetResourceState
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.engine.media.RecordingDevice
@@ -33,6 +34,7 @@ import mozilla.components.concept.engine.window.WindowRequest
  * be used as a preview in e.g. a tab switcher.
  * @property icon the icon of the page currently loaded by this session.
  * @property download Last unhandled download request.
+ * @property share Last unhandled request to share an internet resource that first needs to be downloaded.
  * @property hitResult the target of the latest long click operation.
  * @property promptRequest the last received [PromptRequest].
  * @property findResults the list of results of the latest "find in page" operation.
@@ -70,6 +72,7 @@ data class ContentState(
     val thumbnail: Bitmap? = null,
     val icon: Bitmap? = null,
     val download: DownloadState? = null,
+    val share: ShareInternetResourceState? = null,
     val hitResult: HitResult? = null,
     val promptRequest: PromptRequest? = null,
     val findResults: List<FindResultState> = emptyList(),

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/ShareInternetResourceState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/ShareInternetResourceState.kt
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.state.content
+
+import mozilla.components.concept.fetch.Response
+
+/**
+ * Value type that represents an Internet resource selected to be shared.
+ *
+ * @property url The full url to the content that should be shared.
+ * @property contentType Content type (MIME type) to indicate the media type of the resource.
+ * @property private Indicates if the share operation initiated from a private session.
+ * @property response A response object associated with this request, when provided can be
+ * used instead of performing a manual a download.
+ */
+data class ShareInternetResourceState(
+    val url: String,
+    val contentType: String? = null,
+    val private: Boolean = false,
+    val response: Response? = null
+)

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/reducer/ShareInternetResourceStateReducerTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/reducer/ShareInternetResourceStateReducerTest.kt
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.reducer
+
+import mozilla.components.browser.state.action.ShareInternetResourceAction
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.ContentState
+import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.browser.state.state.content.ShareInternetResourceState
+import mozilla.components.concept.fetch.Response
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ShareInternetResourceStateReducerTest {
+
+    @Test
+    fun `reduce - AddShareAction should add the internetResource in the ContentState`() {
+        val reducer = ShareInternetResourceStateReducer
+        val state = BrowserState(tabs = listOf(TabSessionState("tabId", ContentState("contentStateUrl"))))
+        val response: Response = mock()
+        val action = ShareInternetResourceAction.AddShareAction(
+            "tabId",
+            ShareInternetResourceState("internetResourceUrl", "type", true, response)
+        )
+
+        assertNull(state.tabs[0].content.share)
+
+        val result = reducer.reduce(state, action)
+
+        val shareState = result.tabs[0].content.share!!
+        assertEquals("internetResourceUrl", shareState.url)
+        assertEquals("type", shareState.contentType)
+        assertTrue(shareState.private)
+        assertEquals(response, shareState.response)
+    }
+
+    @Test
+    fun `reduce - ConsumeShareAction should remove the ShareInternetResourceState ContentState`() {
+        val reducer = ShareInternetResourceStateReducer
+        val shareState: ShareInternetResourceState = mock()
+        val state = BrowserState(
+            tabs = listOf(
+                TabSessionState("tabId", ContentState("contentStateUrl", share = shareState))
+            )
+        )
+        val action = ShareInternetResourceAction.ConsumeShareAction("tabId")
+
+        assertNotNull(state.tabs[0].content.share)
+
+        val result = reducer.reduce(state, action)
+
+        assertNull(result.tabs[0].content.share)
+    }
+
+    @Test
+    fun `updateTheContentState will return a new BrowserState with updated ContentState`() {
+        val initialContentState = ContentState("emptyStateUrl")
+        val browserState = BrowserState(tabs = listOf(TabSessionState("tabId", initialContentState)))
+
+        val result = updateTheContentState(browserState, "tabId") { it.copy(url = "updatedUrl") }
+
+        assertFalse(browserState == result)
+        assertEquals("updatedUrl", result.tabs[0].content.url)
+    }
+}

--- a/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuUseCases.kt
+++ b/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuUseCases.kt
@@ -5,7 +5,9 @@
 package mozilla.components.feature.contextmenu
 
 import mozilla.components.browser.state.action.ContentAction
+import mozilla.components.browser.state.action.ShareInternetResourceAction
 import mozilla.components.browser.state.state.content.DownloadState
+import mozilla.components.browser.state.state.content.ShareInternetResourceState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.HitResult
 
@@ -44,6 +46,21 @@ class ContextMenuUseCases(
         }
     }
 
+    /**
+     * Usecase allowing adding a new [ShareInternetResourceState] to the [BrowserStore]
+     */
+    class InjectShareInternetResourceUseCase(
+        private val store: BrowserStore
+    ) {
+        /**
+         * Adds a specific [ShareInternetResourceState] to the [BrowserStore].
+         */
+        operator fun invoke(tabId: String, internetResource: ShareInternetResourceState) {
+            store.dispatch(ShareInternetResourceAction.AddShareAction(tabId, internetResource))
+        }
+    }
+
     val consumeHitResult = ConsumeHitResultUseCase(store)
     val injectDownload = InjectDownloadUseCase(store)
+    val injectShareFromInternet = InjectShareInternetResourceUseCase(store)
 }

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/share/ShareDownloadFeature.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/share/ShareDownloadFeature.kt
@@ -1,0 +1,238 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.downloads.share
+
+import android.content.Context
+import android.webkit.MimeTypeMap
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.WorkerThread
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import mozilla.components.browser.state.action.BrowserAction
+import mozilla.components.browser.state.action.ShareInternetResourceAction
+import mozilla.components.browser.state.selector.findTabOrCustomTabOrSelectedTab
+import mozilla.components.browser.state.state.content.ShareInternetResourceState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.fetch.Client
+import mozilla.components.concept.fetch.Request
+import mozilla.components.concept.fetch.Response
+import mozilla.components.lib.state.Middleware
+import mozilla.components.lib.state.ext.flowScoped
+import mozilla.components.support.base.feature.LifecycleAwareFeature
+import mozilla.components.support.base.log.logger.Logger
+import mozilla.components.support.ktx.android.content.shareMedia
+import mozilla.components.support.ktx.kotlin.getDataUrlImageExtension
+import mozilla.components.support.ktx.kotlin.sanitizeURL
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import kotlin.math.absoluteValue
+import kotlin.random.Random
+
+/**
+ * Default mime type for base64 images data URLs not containing the media type.
+ */
+@VisibleForTesting
+internal const val DEFAULT_IMAGE_EXTENSION = "jpg"
+
+/**
+ * At most time to allow fo the file to be downloaded and the share intent chooser to appear.
+ */
+private const val OPERATION_TIMEOUT_MILLIS = 1000L
+
+/**
+ * At most characters to be sent for subject / message in the share to operation.
+ */
+@VisibleForTesting
+internal const val CHARACTERS_IN_SHARE_TEXT_LIMIT = 200
+
+/**
+ * Coroutine dispatcher used for the cleanup of old cached files. Defaults to IO.
+ */
+@VisibleForTesting
+internal var cleanupCacheCoroutineDispatcher = IO
+
+/**
+ * Subdirectory of Context.getCacheDir() where the resources to be shared are stored.
+ *
+ * Location must be kept in sync with the paths our FileProvider can share from.
+ */
+@VisibleForTesting
+internal var cacheDirName = "mozac_share_cache"
+
+/**
+ * [Middleware] implementation for sharing online resources.
+ *
+ * This will intercept only [ShareInternetResourceAction] [BrowserAction]s.
+ *
+ * Following which it will transparently
+ *  - download internet resources while respecting the private mode related to cookies handling
+ *  - temporarily cache the downloaded resources
+ *  - automatically open the platform app chooser to share the cached files with other installed Android apps.
+ *
+ * with a 1 second timeout to ensure a smooth UX.
+ *
+ * To finish the process in this small timeframe the feature is recommended to be used only for images.
+ *
+ *  @param context Android context used for various platform interactions
+ *  @param httpClient Client used for downloading internet resources
+ *  @param store a reference to the application's [BrowserStore]
+ */
+@Suppress("TooManyFunctions")
+class ShareDownloadFeature(
+    private val context: Context,
+    private val httpClient: Client,
+    private val store: BrowserStore,
+    private val tabId: String?
+) : LifecycleAwareFeature {
+    private val logger = Logger("ShareDownloadMiddleware")
+
+    @VisibleForTesting
+    internal var scope: CoroutineScope? = null
+
+    override fun start() {
+        scope = store.flowScoped { flow ->
+            flow.mapNotNull { state -> state.findTabOrCustomTabOrSelectedTab(tabId) }
+                .ifChanged { it.content.share }
+                .collect { state ->
+                    state.content.share?.let { shareState ->
+                        logger.debug("Starting the sharing process")
+                        startSharing(shareState)
+
+                        // This is a fire and forget action, not something that we want lingering the tab state.
+                        store.dispatch(ShareInternetResourceAction.ConsumeShareAction(state.id))
+                    }
+                }
+        }
+    }
+
+    override fun stop() {
+        scope?.cancel()
+    }
+
+    init {
+        CoroutineScope(cleanupCacheCoroutineDispatcher).launch {
+            cleanupCache()
+        }
+    }
+
+    @VisibleForTesting
+    internal fun startSharing(internetResource: ShareInternetResourceState) {
+        val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+            when (throwable) {
+                is InterruptedException -> {
+                    logger.warn("Share failed: operation timeout reached")
+                }
+                is IOException,
+                is RuntimeException,
+                is NullPointerException -> {
+                    logger.warn("Share failed: $throwable")
+                }
+            }
+        }
+
+        scope?.launch(coroutineExceptionHandler) {
+            withTimeout(OPERATION_TIMEOUT_MILLIS) {
+                val download = download(internetResource)
+                share(
+                    contentType = internetResource.contentType,
+                    filePath = download.canonicalPath,
+                    message = sanitizeLongUrls(internetResource.url)
+                )
+            }
+        }
+    }
+
+    @WorkerThread
+    @VisibleForTesting
+    internal fun download(internetResource: ShareInternetResourceState): File {
+        val request = Request(internetResource.url.sanitizeURL(), private = internetResource.private)
+        val response = if (internetResource.response == null) {
+            httpClient.fetch(request)
+        } else {
+            requireNotNull(internetResource.response)
+        }
+
+        if (response.status != Response.SUCCESS) {
+            // We experienced a problem trying to fetch the file, nothing more we can do.
+            throw(RuntimeException("Resource is not available to download"))
+        }
+
+        val fileExtension = '.' + getFileExtension(request.url)
+        val tempFile = getTempFile(fileExtension)
+        response.body.useStream { input ->
+            FileOutputStream(tempFile).use { output -> input.copyTo(output) }
+        }
+
+        return tempFile
+    }
+
+    @VisibleForTesting
+    internal fun share(
+        filePath: String,
+        contentType: String?,
+        subject: String? = null,
+        message: String? = null
+    ) = context.shareMedia(filePath, contentType, subject, message)
+
+    @VisibleForTesting
+    internal fun getFilename(fileExtension: String) =
+        Random.nextInt().absoluteValue.toString() + fileExtension
+
+    @VisibleForTesting
+    internal fun getTempFile(fileExtension: String) =
+        File(getMediaShareCacheDirectory(), getFilename(fileExtension))
+
+    @VisibleForTesting
+    internal fun getCacheDirectory() = File(context.cacheDir, cacheDirName)
+
+    @VisibleForTesting
+    internal fun getFileExtension(resourceUrl: String): String {
+        return if (resourceUrl.startsWith("data")) {
+            resourceUrl.getDataUrlImageExtension()
+        } else {
+            MimeTypeMap.getFileExtensionFromUrl(resourceUrl).ifBlank { DEFAULT_IMAGE_EXTENSION }
+        }
+    }
+
+    @VisibleForTesting
+    internal fun getMediaShareCacheDirectory(): File {
+        val mediaShareCacheDir = getCacheDirectory()
+        if (!mediaShareCacheDir.exists()) {
+            mediaShareCacheDir.mkdirs()
+        }
+        return mediaShareCacheDir
+    }
+
+    @VisibleForTesting
+    internal fun cleanupCache() {
+        logger.debug("Deleting previous cache of shared files")
+        getCacheDirectory().listFiles()?.forEach { it.delete() }
+    }
+
+    /**
+     * Ensure url is not too long to be cumbersome from a UX standpoint.
+     *
+     * @param url to check
+     * @return new [String]
+     *   - with at most [CHARACTERS_IN_SHARE_TEXT_LIMIT] characters for HTTP URLs
+     *   - empty for data URLs
+     */
+    @VisibleForTesting
+    internal fun sanitizeLongUrls(url: String): String {
+        return if (url.startsWith("data")) {
+            ""
+        } else {
+            url.take(CHARACTERS_IN_SHARE_TEXT_LIMIT)
+        }
+    }
+}

--- a/components/feature/downloads/src/main/res/xml/feature_downloads_file_paths.xml
+++ b/components/feature/downloads/src/main/res/xml/feature_downloads_file_paths.xml
@@ -4,4 +4,7 @@
    - You can obtain one at http://mozilla.org/MPL/2.0/.  -->
 <paths>
     <external-path name="Download" path="." />
+
+    <!-- Offer access only to files under Context.getCacheDir()/media_share_cache/ -->
+    <cache-path name="mediaShareCache" path="mozac_share_cache"/>
 </paths>

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/share/ShareDownloadFeatureTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/share/ShareDownloadFeatureTest.kt
@@ -1,0 +1,343 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.downloads.share
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
+import mozilla.components.browser.state.action.ShareInternetResourceAction
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.ContentState
+import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.browser.state.state.content.ShareInternetResourceState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.fetch.Client
+import mozilla.components.concept.fetch.MutableHeaders
+import mozilla.components.concept.fetch.Request
+import mozilla.components.concept.fetch.Response
+import mozilla.components.support.test.any
+import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import java.io.File
+import java.nio.charset.StandardCharsets
+
+@RunWith(AndroidJUnit4::class)
+class ShareDownloadFeatureTest {
+    // When writing new tests initialize ShareDownloadFeature with this class' context property
+    // When creating new directories use class' context property#cacheDir as a parent
+    // This will ensure the effectiveness of @After. Otherwise leftover files may be left on the machine running tests.
+
+    private val testDispatcher = TestCoroutineDispatcher()
+    private lateinit var context: Context
+    private val testCacheDirName = "testCacheDir"
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule(testDispatcher)
+
+    @Before
+    fun `setup`() {
+        // Effectively reset context mock
+        context = spy(testContext)
+        doReturn(File(testCacheDirName)).`when`(context).cacheDir
+    }
+
+    @After
+    fun `cleanup`() {
+        context.cacheDir.deleteRecursively()
+    }
+
+    @Test
+    fun `cleanupCache should automatically be called when this class is initialized`() = runBlocking {
+        cleanupCacheCoroutineDispatcher = Dispatchers.Main
+        val cacheDir = File(context.cacheDir, cacheDirName).also { dir ->
+            dir.mkdirs()
+            File(dir, "leftoverFile").also { file ->
+                file.createNewFile()
+            }
+        }
+
+        assertTrue(cacheDir.listFiles()!!.isNotEmpty())
+
+        ShareDownloadFeature(context, mock(), mock(), null)
+
+        assertTrue(cacheDir.listFiles()!!.isEmpty())
+    }
+
+    @Test
+    fun `ShareFeature starts the share process for AddShareAction which is immediately consumed`() {
+        val store = spy(BrowserStore(BrowserState(
+            tabs = listOf(TabSessionState("123", ContentState(url = "https://www.mozilla.org")))
+        )))
+        val shareFeature = spy(ShareDownloadFeature(context, mock(), store, "123"))
+        doNothing().`when`(shareFeature).startSharing(any())
+        val download = ShareInternetResourceState(url = "testDownload")
+        val action = ShareInternetResourceAction.AddShareAction("123", download)
+        shareFeature.start()
+
+        store.dispatch(action).joinBlocking()
+        testDispatcher.advanceUntilIdle()
+
+        verify(shareFeature).startSharing(download)
+        verify(store).dispatch(ShareInternetResourceAction.ConsumeShareAction("123"))
+    }
+
+    @Test
+    fun `cleanupCache should delete all files from the cache directory`() = runBlocking {
+        val shareFeature = spy(ShareDownloadFeature(context, mock(), mock(), null))
+        val testDir = File(context.cacheDir, cacheDirName).also { dir ->
+            dir.mkdirs()
+            File(dir, "testFile").also { file ->
+                file.createNewFile()
+            }
+        }
+
+        doReturn(testDir).`when`(shareFeature).getCacheDirectory()
+        assertTrue(testDir.listFiles()!!.isNotEmpty())
+
+        shareFeature.cleanupCache()
+
+        assertTrue(testDir.listFiles()!!.isEmpty())
+    }
+
+    @Test
+    fun `startSharing() will download and then share the selected download`() = runBlocking {
+        val shareFeature = spy(ShareDownloadFeature(context, mock(), mock(), null))
+        val shareState = ShareInternetResourceState(url = "testUrl", contentType = "contentType")
+        val downloadedFile = File("filePath")
+        doReturn(downloadedFile).`when`(shareFeature).download(any())
+        shareFeature.scope = TestCoroutineScope()
+
+        shareFeature.startSharing(shareState)
+
+        verify(shareFeature).download(shareState)
+        verify(shareFeature).share(downloadedFile.canonicalPath, "contentType", null, "testUrl")
+        Unit
+    }
+
+    @Test
+    fun `startSharing() will not use a too long HTTP url as message`() = runBlocking {
+        val shareFeature = spy(ShareDownloadFeature(context, mock(), mock(), null))
+        val maxSizeUrl = "a".repeat(CHARACTERS_IN_SHARE_TEXT_LIMIT)
+        val tooLongUrl = maxSizeUrl + 'x'
+        val shareState = ShareInternetResourceState(url = tooLongUrl, contentType = "contentType")
+        val downloadedFile = File("filePath")
+        doReturn(downloadedFile).`when`(shareFeature).download(any())
+        shareFeature.scope = TestCoroutineScope()
+
+        shareFeature.startSharing(shareState)
+
+        verify(shareFeature).download(shareState)
+        verify(shareFeature).share(downloadedFile.canonicalPath, "contentType", null, maxSizeUrl)
+        Unit
+    }
+
+    @Test
+    fun `startSharing() will use an empty String as message for data URLs`() = runBlocking {
+        val shareFeature = spy(ShareDownloadFeature(context, mock(), mock(), null))
+        val shareState = ShareInternetResourceState(url = "data:image/png;base64,longstring", contentType = "contentType")
+        val downloadedFile = File("filePath")
+        doReturn(downloadedFile).`when`(shareFeature).download(any())
+        shareFeature.scope = TestCoroutineScope()
+
+        shareFeature.startSharing(shareState)
+
+        verify(shareFeature).download(shareState)
+        verify(shareFeature).share(downloadedFile.canonicalPath, "contentType", null, "")
+        Unit
+    }
+
+    @Test
+    fun `download() will persist in cache the response#body() if available`() {
+        val shareFeature = ShareDownloadFeature(context, mock(), mock(), null)
+        val inputStream = "test".byteInputStream(StandardCharsets.UTF_8)
+        val responseFromShareState = mock<Response>()
+        doReturn(Response.Body(inputStream)).`when`(responseFromShareState).body
+        val shareState = ShareInternetResourceState("randomUrl.jpg", response = responseFromShareState)
+        doReturn(Response.SUCCESS).`when`(responseFromShareState).status
+
+        val result = shareFeature.download(shareState)
+
+        assertTrue(result.exists())
+        assertTrue(result.name.endsWith(".jpg"))
+        assertEquals(cacheDirName, result.parentFile!!.name)
+        assertEquals("test", result.inputStream().bufferedReader().use { it.readText() })
+    }
+
+    @Test(expected = RuntimeException::class)
+    fun `download() will throw an error if the request is not successful`() {
+        val shareFeature = ShareDownloadFeature(context, mock(), mock(), null)
+        val inputStream = "test".byteInputStream(StandardCharsets.UTF_8)
+        val responseFromShareState = mock<Response>()
+        doReturn(Response.Body(inputStream)).`when`(responseFromShareState).body
+        val shareState =
+            ShareInternetResourceState("randomUrl.jpg", response = responseFromShareState)
+        doReturn(500).`when`(responseFromShareState).status
+
+        shareFeature.download(shareState)
+    }
+
+    @Test
+    fun `download() will download from the provided url the response#body() if is unavailable`() {
+        val client: Client = mock()
+        val inputStream = "clientTest".byteInputStream(StandardCharsets.UTF_8)
+        doAnswer { Response("randomUrl.png", 200, MutableHeaders(), Response.Body(inputStream)) }
+            .`when`(client).fetch(any())
+        val shareFeature = ShareDownloadFeature(context, client, mock(), null)
+        val shareState = ShareInternetResourceState("randomUrl.png")
+
+        val result = shareFeature.download(shareState)
+
+        assertTrue(result.exists())
+        assertTrue(result.name.endsWith(".png"))
+        assertEquals(mozilla.components.feature.downloads.share.cacheDirName, result.parentFile!!.name)
+        assertEquals("clientTest", result.inputStream().bufferedReader().use { it.readText() })
+    }
+
+    @Test
+    fun `download() will create a not private Request if not in private mode`() {
+        val client: Client = mock()
+        val requestCaptor = argumentCaptor<Request>()
+        val inputStream = "clientTest".byteInputStream(StandardCharsets.UTF_8)
+        doAnswer { Response("randomUrl.png", 200, MutableHeaders(), Response.Body(inputStream)) }
+            .`when`(client).fetch(requestCaptor.capture())
+        val shareFeature = ShareDownloadFeature(context, client, mock(), null)
+        val shareState = ShareInternetResourceState("randomUrl.png", private = false)
+
+        shareFeature.download(shareState)
+
+        assertFalse(requestCaptor.value.private)
+    }
+
+    @Test
+    fun `download() will create a private Request if in private mode`() {
+        val client: Client = mock()
+        val requestCaptor = argumentCaptor<Request>()
+        val inputStream = "clientTest".byteInputStream(StandardCharsets.UTF_8)
+        doAnswer { Response("randomUrl.png", 200, MutableHeaders(), Response.Body(inputStream)) }
+            .`when`(client).fetch(requestCaptor.capture())
+        val shareFeature = ShareDownloadFeature(context, client, mock(), null)
+        val shareState = ShareInternetResourceState("randomUrl.png", private = true)
+
+        shareFeature.download(shareState)
+
+        assertTrue(requestCaptor.value.private)
+    }
+
+    @Test
+    fun `getFilename(extension) will return a String with the extension suffix`() {
+        val shareFeature = ShareDownloadFeature(context, mock(), mock(), null)
+        val testExtension = "testExtension"
+
+        val result = shareFeature.getFilename(testExtension)
+
+        assertTrue(result.endsWith(testExtension))
+        assertTrue(result.length > testExtension.length)
+    }
+
+    @Test
+    fun `getTempFile(extension) will return a File from the cache dir and with name ending in extension`() {
+        val shareFeature = spy(ShareDownloadFeature(context, mock(), mock(), null))
+        val testExtension = "testExtension"
+
+        val result = shareFeature.getTempFile(testExtension)
+
+        assertTrue(result.name.endsWith(testExtension))
+        assertEquals(shareFeature.getCacheDirectory().toString(), result.parent)
+    }
+
+    @Test
+    fun `getCacheDirectory() will return a new directory in the app's cache`() {
+        val shareFeature = ShareDownloadFeature(context, mock(), mock(), null)
+
+        val result = shareFeature.getCacheDirectory()
+
+        assertEquals(testCacheDirName, result.parent)
+        assertEquals(cacheDirName, result.name)
+    }
+
+    @Test
+    fun `getMediaShareCacheDirectory creates the needed files if they don't exist`() {
+        val shareFeature = spy(ShareDownloadFeature(context, mock(), mock(), null))
+        assertFalse(context.cacheDir.exists())
+
+        val result = shareFeature.getMediaShareCacheDirectory()
+
+        assertEquals(cacheDirName, result.name)
+        assertTrue(result.exists())
+
+        // // cleanup for future test runs
+        // result.deleteRecursively()
+    }
+
+    @Test
+    fun `getFileExtension returns a default extension if one cannot be extracted from the data url`() {
+        val shareFeature = ShareDownloadFeature(context, mock(), mock(), null)
+        val base64Image = "data:;base64,testImage"
+
+        val result = shareFeature.getFileExtension(base64Image)
+
+        assertEquals(DEFAULT_IMAGE_EXTENSION, result)
+    }
+
+    @Test
+    fun `getFileExtension returns an extension based on the media type included in the the data url`() {
+        val shareFeature = ShareDownloadFeature(context, mock(), mock(), null)
+        val base64Image = "data:image/gif;base64,testImage"
+
+        val result = shareFeature.getFileExtension(base64Image)
+
+        assertEquals("gif", result)
+    }
+
+    @Test
+    fun `getFileExtension returns an extension based on the resource url`() {
+        val shareFeature = ShareDownloadFeature(context, mock(), mock(), null)
+        val imageUrl = "http://website/image.jpg"
+
+        val result = shareFeature.getFileExtension(imageUrl)
+
+        assertEquals("jpg", result)
+    }
+
+    @Test
+    fun `sanitizeLongUrls should return an empty string for a data url`() {
+        val shareFeature = ShareDownloadFeature(context, mock(), mock(), null)
+
+        val result = shareFeature.sanitizeLongUrls("data:image/png;base64,longstring")
+
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `sanitizeLongUrls should return at most CHARACTERS_IN_SHARE_TEXT_LIMIT for HTTP urls`() {
+        val maxSizeUrl = "a".repeat(CHARACTERS_IN_SHARE_TEXT_LIMIT)
+        val tooLongUrl = maxSizeUrl + 'x'
+        val shareFeature = ShareDownloadFeature(context, mock(), mock(), null)
+
+        val result = shareFeature.sanitizeLongUrls(tooLongUrl)
+
+        assertEquals(CHARACTERS_IN_SHARE_TEXT_LIMIT, result.length)
+        assertEquals(maxSizeUrl, result)
+    }
+}

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
@@ -179,3 +179,15 @@ fun String.urlEncode(): String {
 fun String.takeOrReplace(maximumLength: Int, replacement: String): String {
     return if (this.length > maximumLength) replacement else this
 }
+
+/**
+ * Returns the extension (without ".") declared in the mime type of this data url.
+ * In the event that this data url does not contain a mime type or image extension could be read
+ * for any reason [defaultExtension] will be returned
+ *
+ * @param defaultExtension default extension if one could not be read from the mime type. Default is "jpg".
+ */
+fun String.getDataUrlImageExtension(defaultExtension: String = "jpg"): String {
+    return ("data:image\\/([a-zA-Z0-9-.+]+).*").toRegex()
+        .find(this)?.groups?.get(1)?.value ?: defaultExtension
+}

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/content/ContextTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/content/ContextTest.kt
@@ -7,32 +7,49 @@ package mozilla.components.support.ktx.android.content
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.app.Activity
 import android.app.ActivityManager
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.content.Intent.ACTION_SEND
+import android.content.Intent.EXTRA_INTENT
+import android.content.Intent.EXTRA_STREAM
+import android.content.Intent.EXTRA_SUBJECT
+import android.content.Intent.EXTRA_TEXT
+import android.content.Intent.EXTRA_TITLE
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.hardware.camera2.CameraManager
+import android.os.Build
+import androidx.core.content.FileProvider
 import androidx.core.content.getSystemService
+import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.ktx.R
 import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.fakes.FakeContext
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.Robolectric
 import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
 import org.robolectric.shadows.ShadowApplication
 import org.robolectric.shadows.ShadowCameraCharacteristics
 import org.robolectric.shadows.ShadowProcess
-import java.lang.AssertionError
-import java.lang.IllegalStateException
+import java.io.File
 
 @RunWith(AndroidJUnit4::class)
 class ContextTest {
@@ -81,6 +98,79 @@ class ContextTest {
 
         assertTrue(result)
         assertEquals(FLAG_ACTIVITY_NEW_TASK, argCaptor.value.flags)
+    }
+
+    @Test
+    @Config(shadows = [ShadowFileProvider::class])
+    fun `shareMedia invokes startActivity`() {
+        val context = spy(testContext)
+        val argCaptor = argumentCaptor<Intent>()
+
+        val result = context.shareMedia("filePath", "*/*", "subject", "message")
+
+        verify(context).startActivity(argCaptor.capture())
+        assertTrue(result)
+        // verify all the properties we set for the share Intent
+        val chooserIntent = argCaptor.value
+        val chooserTitle: String = chooserIntent.extras!![EXTRA_TITLE] as String
+        val shareIntent: Intent = chooserIntent.extras!![EXTRA_INTENT] as Intent
+
+        assertTrue(chooserIntent.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0)
+        assertTrue(chooserIntent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+        assertEquals(context.getString(R.string.mozac_support_ktx_menu_share_with), chooserTitle)
+        assertEquals(ACTION_SEND, shareIntent.action)
+        assertEquals(ShadowFileProvider.FAKE_URI_RESULT, shareIntent.extras!![EXTRA_STREAM])
+        assertEquals("subject", shareIntent.extras!![EXTRA_SUBJECT])
+        assertEquals("message", shareIntent.extras!![EXTRA_TEXT])
+        assertTrue(shareIntent.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0)
+        assertTrue(shareIntent.flags and Intent.FLAG_ACTIVITY_NEW_DOCUMENT != 0)
+    }
+
+    @Suppress("UNREACHABLE_CODE")
+    @Test
+    @Config(shadows = [ShadowFileProvider::class])
+    fun `shareMedia returns false if the chooser could not be shown`() {
+        val context = spy(object : FakeContext() {
+            override fun startActivity(intent: Intent?) = throw ActivityNotFoundException()
+            override fun getApplicationContext() = testContext
+        })
+        doReturn(testContext.resources).`when`(context).resources
+
+        val result = context.shareMedia("filePath", "*/*", "subject", "message")
+
+        assertFalse(result)
+    }
+
+    @Test
+    @Ignore("Robolectric does not support API level >=29")
+    @Config(shadows = [ShadowFileProvider::class], sdk = [Build.VERSION_CODES.Q])
+    fun `shareMedia will show a thumbnail starting with Android 10`() {
+        val context = spy(testContext)
+        val argCaptor = argumentCaptor<Intent>()
+
+        val result = context.shareMedia("filePath", "*/*", "subject", "message")
+
+        verify(context).startActivity(argCaptor.capture())
+        assertTrue(result)
+        // verify all the properties we set for the share Intent
+        val chooserIntent = argCaptor.value
+        assertEquals(1, chooserIntent.clipData!!.itemCount)
+        assertEquals(ShadowFileProvider.FAKE_URI_RESULT, chooserIntent.clipData!!.getItemAt(0).uri)
+    }
+
+    @Test
+    @Config(shadows = [ShadowFileProvider::class], sdk = [Build.VERSION_CODES.LOLLIPOP, Build.VERSION_CODES.P])
+    fun `shareMedia will not show a thumbnail prior to Android 10`() {
+        val context = spy(testContext)
+        val argCaptor = argumentCaptor<Intent>()
+
+        val result = context.shareMedia("filePath", "*/*", "subject", "message")
+
+        verify(context).startActivity(argCaptor.capture())
+        assertTrue(result)
+        // verify all the properties we set for the share Intent
+        val chooserIntent = argCaptor.value
+        assertNull(chooserIntent.clipData)
     }
 
     @Test
@@ -172,4 +262,18 @@ class ContextTest {
         whenever(cameraManager.cameraIdList).thenThrow(AssertionError("Test"))
         assertFalse(context.hasCamera())
     }
+}
+
+@Implements(FileProvider::class)
+object ShadowFileProvider {
+    val FAKE_URI_RESULT = "fakeUri".toUri()
+
+    @Implementation
+    @JvmStatic
+    @Suppress("UNUSED_PARAMETER")
+    fun getUriForFile(
+        context: Context?,
+        authority: String?,
+        file: File
+    ) = FAKE_URI_RESULT
 }

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
@@ -191,4 +191,22 @@ class StringTest {
 
         assertEquals("test.2020.12.01.txt", "test.2020.12.01.txt".sanitizeFileName())
     }
+
+    @Test
+    fun `getDataUrlImageExtension returns a default extension if one cannot be extracted from the data url`() {
+        val base64Image = "data:;base64,testImage"
+
+        val result = base64Image.getDataUrlImageExtension()
+
+        assertEquals("jpg", result)
+    }
+
+    @Test
+    fun `getDataUrlImageExtension returns an extension based on the media type included in the the data url`() {
+        val base64Image = "data:image/gif;base64,testImage"
+
+        val result = base64Image.getDataUrlImageExtension()
+
+        assertEquals("gif", result)
+    }
 }

--- a/components/support/test/src/main/java/mozilla/components/support/test/fakes/FakeContext.kt
+++ b/components/support/test/src/main/java/mozilla/components/support/test/fakes/FakeContext.kt
@@ -41,7 +41,7 @@ import java.io.InputStream
  *
  * The current implementation just throws for most access.
  */
-class FakeContext(
+open class FakeContext(
     private val sharedPreferences: SharedPreferences = FakeSharedPreferences()
 ) : Context() {
     override fun getAssets(): AssetManager = throw NotImplementedError()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,13 @@ permalink: /changelog/
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
 * **feature-downloads**:
+  * 🌟 New `ShareDownloadFeature` will listen for `AddShareAction` and download, cache locally and then share internet resources.
+  * ⚠️ **This is a breaking change**: This is a breaking change with clients expected to create and register a new instance of the this new feature otherwise the "Share image" from the browser contextual menu will do nothing.
+
+* **support-ktx**
+  * 🌟 Added `Context.shareMedia` that allows to easily share a specific locally stored file through the Android share menu.
+
+* **feature-downloads**:
   * 🚒 Bug fixed [issue #9441](https://github.com/mozilla-mobile/android-components/issues/9441) - Don't ask for redundant system files permission if not required.
   * 🚒 Bug fixed [issue #9526](https://github.com/mozilla-mobile/android-components/issues/9526) - Downloads with generic content types use the correct file extension.
 


### PR DESCRIPTION
Prior to this when the user selected to share an image from the contextual menu
the apps would only share the URL, not the actual resource.

This patch adds a new `ShareDownloadFeature` that will listen for
`AddShareAction` and download, cache locally and then share the Internet
resource contained in Action's state.

Giving the time needed to actually download these resources this feature is
only used for image sharing, not for other types of potentially bigger
resource types.

This is a breaking change with clients expected to create and register a new
instance of the this new feature otherwise the "Share image" from the
browser contextual menu will do nothing.

Usage on Android 11:
<img src="https://user-images.githubusercontent.com/11428869/104742711-744c6d80-5753-11eb-8b32-b65a1b4230da.gif" width="40%" />
[video](https://drive.google.com/file/d/1W6T7lfU822BNfHKY_ej1ttn3UZO34Eie/view?usp=sharing)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this in this PR does not include any user facing features.

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
