### PR TITLE
Issue #9409: RecentlyClosedMiddleware: Run database operations on single thread.

### DIFF
--- a/components/feature/recentlyclosed/src/main/java/mozilla/components/feature/recentlyclosed/RecentlyClosedMiddleware.kt
+++ b/components/feature/recentlyclosed/src/main/java/mozilla/components/feature/recentlyclosed/RecentlyClosedMiddleware.kt
@@ -6,7 +6,7 @@ package mozilla.components.feature.recentlyclosed
 
 import android.content.Context
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -21,6 +21,7 @@ import mozilla.components.concept.engine.Engine
 import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.MiddlewareContext
 import mozilla.components.lib.state.Store
+import java.util.concurrent.Executors
 
 /**
  * [Middleware] implementation for handling [RecentlyClosedAction]s and syncing the closed tabs in
@@ -31,7 +32,7 @@ class RecentlyClosedMiddleware(
     private val maxSavedTabs: Int,
     private val engine: Engine,
     private val storage: Lazy<Storage> = lazy { RecentlyClosedTabsStorage(applicationContext, engine = engine) },
-    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+    private val scope: CoroutineScope = CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
 ) : Middleware<BrowserState, BrowserAction> {
 
     @Suppress("ComplexMethod")


### PR DESCRIPTION
The only way how I can see us run into the constraint crash is when those coroutines run out of order
on the multithreaded dispatcher. Let's try with a single thread dispatcher and see if that affects
the crash rate.