### PR TITLE
Setup publishing of multiplatform dummy library.

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -467,4 +467,4 @@ projects:
   multiplatform-lib-dummy:
     path: components/multiplatform/lib-dummy
     description: 'A dummy multiplatform library for testing purposes'
-    publish: false
+    publish: true

--- a/components/multiplatform/lib-dummy/build.gradle.kts
+++ b/components/multiplatform/lib-dummy/build.gradle.kts
@@ -3,25 +3,23 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 plugins {
     kotlin("multiplatform")
     id("com.android.library")
+    id("maven-publish")
 }
 
+group = "org.mozilla.multiplatform"
+version = (gradle.rootProject.ext.get("artifactVersion") as String)
+
 kotlin {
-    android()
+    android() {
+        publishLibraryVariants("release")
+    }
 
     ios {
         binaries {
             framework {
-                baseName = "shared"
+                baseName = "dummy"
             }
         }
-    }
-
-    // Block from https://github.com/cashapp/sqldelight/issues/2044#issuecomment-721299517
-    val onPhone = System.getenv("SDK_NAME")?.startsWith("iphoneos") ?: false
-    if (onPhone) {
-        iosArm64("ios")
-    } else {
-        iosX64("ios")
     }
 
     sourceSets {

--- a/settings.gradle
+++ b/settings.gradle
@@ -90,6 +90,7 @@ gradle.projectsLoaded { ->
         configData.targetSdkVersion
     )
     gradle.rootProject.ext.buildConfig = buildconfig
+    gradle.rootProject.ext.artifactVersion = version
 }
 
 def runCmd(cmd, workingDir, successMessage) {


### PR DESCRIPTION
This adds the gradle config for publishing the multiplatform library. Luckily the multiplatform does most of the heavy lifting. I expect this to not work on taskcluster though: Other than the other components, this one will create multiple artifacts instead of just one.

This is how it looks like if, for testing, I publish this to my GitHub packages repository:
https://github.com/pocmo/android-components/packages