### PR TITLE
Add a link to new app services testing doc

### DIFF
--- a/docs/contribute/app_services_upgrade.md
+++ b/docs/contribute/app_services_upgrade.md
@@ -6,6 +6,8 @@ permalink: /contributing/app-services-upgrades
 
 Upgrading to a newer [version of App Services][as_version] upgrades the dependencies for multiple components, so it can be prudent to run a quick smoke test before it lands to ensure new functionality works and there are no regressions in the existing components.
 
+## Automated PR testing
+
 A quick first step is to run the automated smoke test on the Android Components PR by commenting:
 
 ```
@@ -13,6 +15,8 @@ bors try
 ```
 
 This will run the `test-ui-browser` task, which will execute on-device tests of a sample browser built against the A-S version. If it's totally broken, that should blow up.
+
+## Fenix
 
 The next step is to build a [local version of Android Components][local_build] against [Fenix][fenix] and test the followings items:
  - Check general storage components works by adding/editing/removing: bookmarks, history

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,6 +33,7 @@ Before contributing, please review our [Community Participation Guidelines](http
 * [Deprecating components and code]({{ site.baseurl }}/contributing/deprecating)
 * [Merge day process]({{ site.baseurl }}/contributing/merge-day)
 * [Updating the tracking protection lists process]({{ site.baseurl }}/contributing/update-tracking-protection-list)
+* [Updating to a newer Application Services]({{ site.baseurl }}/contributing/app-services-upgrades)
 
 ### Accepted RFCs
 


### PR DESCRIPTION
Forgot to add a visible link to the new doc. 🙃 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
