### PR TITLE
Closes #9439: Narrow BrowserMenu fix to only Huawei and Xiaomi devices

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
@@ -186,9 +186,11 @@ internal fun PopupWindow.displayPopup(
     val fitsUp = availableHeightToTop >= containerHeight
     val fitsDown = availableHeightToBottom >= containerHeight
 
-    // On specific Android versions the PopupWindow would get placed at the wrong location
+    // On specific Huawei and Xiaomi Android versions the PopupWindow would get placed at the wrong location
     // if using `showAsDropDown`. Force using `showAtLocation` in this cases.
-    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
+    if ((Build.MANUFACTURER.equals("huawei", ignoreCase = true) ||
+            Build.MANUFACTURER.equals("xiaomi", ignoreCase = true)) &&
+            Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
         showAtAnchorLocation(anchor, availableHeightToTop < availableHeightToBottom)
         return
     }

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
@@ -35,6 +35,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.Shadows
@@ -477,7 +478,7 @@ class BrowserMenuTest {
 
     @Config(sdk = [Build.VERSION_CODES.LOLLIPOP, Build.VERSION_CODES.LOLLIPOP_MR1, Build.VERSION_CODES.M])
     @Test
-    fun `displayPopup on lower Android versions should directly call showAtAnchorLocation even if it fits`() {
+    fun `displayPopup on lower Android versions should not directly call showAtAnchorLocation if it fits`() {
         // Constructing the test the same as the above one.
         // The only difference is the Android SDK based on which another PopupWindow method should be used.
 
@@ -498,7 +499,7 @@ class BrowserMenuTest {
         popupWindow.displayPopup(containerView, anchor, BrowserMenu.Orientation.UP)
 
         assertEquals(popupWindow.animationStyle, R.style.Mozac_Browser_Menu_Animation_OverflowMenuBottom)
-        verify(popupWindow).showAtLocation(anchor, Gravity.END or Gravity.BOTTOM, 0, 0)
+        verify(popupWindow, never()).showAtLocation(anchor, Gravity.END or Gravity.BOTTOM, 0, 0)
     }
 
     @Test


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
