### PR TITLE
Uplift to 70: For #9405: Do not select PWA session when creating it.

### DIFF
--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessor.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessor.kt
@@ -83,6 +83,7 @@ class WebAppIntentProcessor(
     private fun createSession(webAppManifest: WebAppManifest, url: String): String {
         return addTabUseCase.invoke(
             url = url,
+            selectTab = false,
             source = Source.HOME_SCREEN,
             webAppManifest = webAppManifest,
             customTabConfig = webAppManifest.toCustomTabConfig()

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessorTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessorTest.kt
@@ -73,6 +73,7 @@ class WebAppIntentProcessorTest {
         val addTabUseCase: TabsUseCases.AddNewTabUseCase = mock()
         whenever(addTabUseCase.invoke(
             url = "https://mozilla.com",
+            selectTab = false,
             source = SessionState.Source.HOME_SCREEN,
             customTabConfig = CustomTabConfig(
                 externalAppType = ExternalAppType.PROGRESSIVE_WEB_APP,
@@ -114,6 +115,7 @@ class WebAppIntentProcessorTest {
 
         verify(addTabUseCase).invoke(
             url = "https://mozilla.com",
+            selectTab = false,
             source = SessionState.Source.HOME_SCREEN,
             customTabConfig = CustomTabConfig(
                 externalAppType = ExternalAppType.PROGRESSIVE_WEB_APP,


### PR DESCRIPTION
To fix https://github.com/mozilla-mobile/fenix/issues/17199 on 70/85.