### PR TITLE
For fenix#17451: add Log.Priority.VERBOSE.

### DIFF
--- a/components/support/base/src/main/java/mozilla/components/support/base/log/Log.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/log/Log.kt
@@ -104,6 +104,7 @@ object Log {
         DEBUG(android.util.Log.DEBUG),
         INFO(android.util.Log.INFO),
         WARN(android.util.Log.WARN),
-        ERROR(android.util.Log.ERROR)
+        ERROR(android.util.Log.ERROR),
+        VERBOSE(android.util.Log.VERBOSE)
     }
 }

--- a/components/support/base/src/test/java/mozilla/components/support/base/log/sink/AndroidLogSinkTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/log/sink/AndroidLogSinkTest.kt
@@ -24,6 +24,19 @@ class AndroidLogSinkTest {
     }
 
     @Test
+    fun `verbose log will be print to Android log`() {
+        val sink = AndroidLogSink()
+        sink.log(Log.Priority.VERBOSE, "Tag", message = "Hello World!")
+
+        val logs = ShadowLog.getLogs()
+        assertEquals(1, logs.size)
+        assertEquals("Hello World!", logs.last().msg)
+        assertEquals("Tag", logs.last().tag)
+        assertNull(logs.last().throwable)
+        assertEquals(android.util.Log.VERBOSE, logs.last().type)
+    }
+
+    @Test
     fun `debug log will be print to Android log`() {
         val sink = AndroidLogSink()
         sink.log(Log.Priority.DEBUG, "Tag", message = "Hello World!")

--- a/components/support/rustlog/src/main/java/mozilla/components/support/rustlog/RustLog.kt
+++ b/components/support/rustlog/src/main/java/mozilla/components/support/rustlog/RustLog.kt
@@ -110,7 +110,7 @@ internal class CrashReporterOnLog(private val crashReporter: CrashReporting? = n
 @VisibleForTesting
 internal fun Log.Priority.asLevelFilter(includePII: Boolean): LogLevelFilter {
     return when (this) {
-        Log.Priority.DEBUG -> {
+        Log.Priority.VERBOSE, Log.Priority.DEBUG -> {
             if (includePII) {
                 LogLevelFilter.TRACE
             } else {

--- a/components/support/rustlog/src/test/java/mozilla/components/support/rustlog/RustLogTest.kt
+++ b/components/support/rustlog/src/test/java/mozilla/components/support/rustlog/RustLogTest.kt
@@ -109,6 +109,9 @@ class RustLogTest {
 
     @Test
     fun `log priority to level filter`() {
+        assertEquals(LogLevelFilter.DEBUG, Log.Priority.VERBOSE.asLevelFilter(false))
+        assertEquals(LogLevelFilter.TRACE, Log.Priority.VERBOSE.asLevelFilter(true))
+
         assertEquals(LogLevelFilter.DEBUG, Log.Priority.DEBUG.asLevelFilter(false))
         assertEquals(LogLevelFilter.TRACE, Log.Priority.DEBUG.asLevelFilter(true))
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -57,6 +57,7 @@ permalink: /changelog/
 
 * **support-base**
   * 🌟 Add an `ActivityResultHandler` for features that want to consume the result.
+  * Add `Log.Priority.VERBOSE`.
 
 * **concept-engine**
   * 🌟 Added a new `ActivityDelegate` for handling intent requests from the engine.


### PR DESCRIPTION
https://github.com/mozilla-mobile/fenix/issues/17451

Fenix doesn't want to log debug or verbose messages. However, verbose is
currently missing from ac. If the feature is added in the future, we'll
probably unintentionally log verbose messages. To avoid this, I'm adding
it now and will ignore verbose in a follow-up fenix PR.

I didn't add Logger.verbose because it's not needed to fulfill this
regression prevention requirement.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
