### PR TITLE
Support invoking GoToHistoryIndexUseCase with session id

### DIFF
--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
@@ -236,8 +236,9 @@ class SessionUseCases(
          * Navigates to a specific index in the [HistoryState] of the given session.
          * Invalid index values will be ignored.
          *
-         * @param index the index in the session's [HistoryState] to navigate to
-         * @param session the session whose [HistoryState] is being accessed
+         * @param index the index in the session's [HistoryState] to navigate to.
+         * @param session the session whose [HistoryState] is being accessed, defaulting
+         * to the selected session.
          */
         operator fun invoke(index: Int, session: Session? = sessionManager.selectedSession) {
             if (session == null) {
@@ -248,6 +249,35 @@ class SessionUseCases(
                 session.id,
                 index
             ))
+        }
+
+        /**
+         * Navigates to a specific index in the [HistoryState] of the given session.
+         * Invalid index values will be ignored.
+         *
+         * @param index the index in the session's [HistoryState] to navigate to.
+         * @param sessionId the ID of the session whose [HistoryState] is being accessed,
+         * defaulting to the ID of the selected session.
+         */
+        operator fun invoke(index: Int, sessionId: String? = sessionManager.selectedSession?.id) {
+            if (sessionId == null) {
+                return
+            }
+
+            store.dispatch(EngineAction.GoToHistoryIndexAction(
+                sessionId,
+                index
+            ))
+        }
+
+        /**
+         * Navigates to a specific index in the [HistoryState] of the selected session.
+         * Invalid index values will be ignored.
+         *
+         * @param index the index in the session's [HistoryState] to navigate to.
+         */
+        operator fun invoke(index: Int) {
+            invoke(index, sessionManager.selectedSession)
         }
     }
 

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -167,8 +167,14 @@ class SessionUseCasesTest {
         useCases.goToHistoryIndex(session = null, index = 0)
         verify(store, never()).dispatch(EngineAction.GoToHistoryIndexAction(selectedSessionId, 0))
 
+        useCases.goToHistoryIndex(sessionId = null, index = 0)
+        verify(store, never()).dispatch(EngineAction.GoToHistoryIndexAction(selectedSessionId, 0))
+
         useCases.goToHistoryIndex(session = selectedSession, index = 0)
         verify(store).dispatch(EngineAction.GoToHistoryIndexAction(selectedSessionId, 0))
+
+        useCases.goToHistoryIndex(sessionId = "test", index = 0)
+        verify(store).dispatch(EngineAction.GoToHistoryIndexAction("test", 0))
 
         useCases.goToHistoryIndex(index = 0)
         verify(store, times(2)).dispatch(EngineAction.GoToHistoryIndexAction(selectedSessionId, 0))


### PR DESCRIPTION
This is needed to remove SessionManager from `TabHistoryDialogFragment` in Fenix.