### PR TITLE
Issue #9409: Replace closed tab on insert and switch back to IO scope

### DIFF
--- a/components/feature/recentlyclosed/src/androidTest/java/mozilla/components/feature/recentlyclosed/RecentlyClosedTabsStorageTest.kt
+++ b/components/feature/recentlyclosed/src/androidTest/java/mozilla/components/feature/recentlyclosed/RecentlyClosedTabsStorageTest.kt
@@ -121,6 +121,31 @@ class RecentlyClosedTabsStorageTest {
     }
 
     @Test
+    fun testAllowAddingSameTabTwice() = runBlockingTest {
+        // Test tab
+        val closedTab = RecoverableTab(
+            id = "first-tab",
+            title = "Mozilla",
+            url = "https://mozilla.org",
+            lastAccess = System.currentTimeMillis()
+        )
+
+        storage.addTabsToCollectionWithMax(listOf(closedTab), 2)
+        dispatcher.advanceUntilIdle()
+
+        val updatedTab = closedTab.copy(title = "updated")
+        storage.addTabsToCollectionWithMax(listOf(updatedTab), 2)
+        dispatcher.advanceUntilIdle()
+
+        val tabs = storage.getTabs().first()
+
+        Assert.assertEquals(1, tabs.size)
+        Assert.assertEquals(updatedTab.url, tabs[0].url)
+        Assert.assertEquals(updatedTab.title, tabs[0].title)
+        Assert.assertEquals(updatedTab.lastAccess, tabs[0].lastAccess)
+    }
+
+    @Test
     fun testRemovingAllTabs() = runBlockingTest {
         // Test tab
         val closedTab = RecoverableTab(

--- a/components/feature/recentlyclosed/src/main/java/mozilla/components/feature/recentlyclosed/RecentlyClosedMiddleware.kt
+++ b/components/feature/recentlyclosed/src/main/java/mozilla/components/feature/recentlyclosed/RecentlyClosedMiddleware.kt
@@ -6,7 +6,7 @@ package mozilla.components.feature.recentlyclosed
 
 import android.content.Context
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -21,7 +21,6 @@ import mozilla.components.concept.engine.Engine
 import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.MiddlewareContext
 import mozilla.components.lib.state.Store
-import java.util.concurrent.Executors
 
 /**
  * [Middleware] implementation for handling [RecentlyClosedAction]s and syncing the closed tabs in
@@ -32,7 +31,7 @@ class RecentlyClosedMiddleware(
     private val maxSavedTabs: Int,
     private val engine: Engine,
     private val storage: Lazy<Storage> = lazy { RecentlyClosedTabsStorage(applicationContext, engine = engine) },
-    private val scope: CoroutineScope = CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 ) : Middleware<BrowserState, BrowserAction> {
 
     @Suppress("ComplexMethod")

--- a/components/feature/recentlyclosed/src/main/java/mozilla/components/feature/recentlyclosed/db/RecentlyClosedTabDao.kt
+++ b/components/feature/recentlyclosed/src/main/java/mozilla/components/feature/recentlyclosed/db/RecentlyClosedTabDao.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.recentlyclosed.db
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
@@ -16,7 +17,7 @@ import kotlinx.coroutines.flow.Flow
  */
 @Dao
 internal interface RecentlyClosedTabDao {
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertTab(tab: RecentlyClosedTabEntity): Long
 
     @Delete


### PR DESCRIPTION
Switching to a single dedicated thread which would run everything in correct order didn't fix this. So, the only explanation we have is that we're somehow getting tabs removed in quick succession and then the scheduled inserts run one after the other, although we can't reproduce that locally. Either way this would seem fine to just allow, instead of guarding against.