### PR TITLE
Issue #8598: Change signature for ActivityDelegate

### DIFF
--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -302,9 +302,9 @@ class PromptFeature private constructor(
      * other apps like file chooser requests.
      *
      * @param requestCode The code of the app that requested the intent.
-     * @param intent The result of the request.
+     * @param data The result of the request.
      */
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+    override fun onActivityResult(requestCode: Int, data: Intent?, resultCode: Int): Boolean {
         return filePicker.onActivityResult(requestCode, resultCode, data)
     }
 

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
@@ -613,7 +613,7 @@ class PromptFeatureTest {
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, filePickerRequest))
             .joinBlocking()
 
-        feature.onActivityResult(FILE_PICKER_ACTIVITY_REQUEST_CODE, RESULT_OK, intent)
+        feature.onActivityResult(FILE_PICKER_ACTIVITY_REQUEST_CODE, intent, RESULT_OK)
         store.waitUntilIdle()
         assertTrue(onSingleFileSelectionWasCalled)
         assertNull(tab()?.content?.promptRequest)
@@ -647,7 +647,7 @@ class PromptFeatureTest {
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, filePickerRequest))
             .joinBlocking()
 
-        feature.onActivityResult(FILE_PICKER_ACTIVITY_REQUEST_CODE, RESULT_OK, intent)
+        feature.onActivityResult(FILE_PICKER_ACTIVITY_REQUEST_CODE, intent, RESULT_OK)
         store.waitUntilIdle()
         assertTrue(onMultipleFileSelectionWasCalled)
         assertNull(tab()?.content?.promptRequest)
@@ -669,7 +669,7 @@ class PromptFeatureTest {
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, filePickerRequest))
             .joinBlocking()
 
-        feature.onActivityResult(FILE_PICKER_ACTIVITY_REQUEST_CODE, RESULT_CANCELED, intent)
+        feature.onActivityResult(FILE_PICKER_ACTIVITY_REQUEST_CODE, intent, RESULT_CANCELED)
         store.waitUntilIdle()
         assertTrue(onDismissWasCalled)
         assertNull(tab()?.content?.promptRequest)

--- a/components/support/base/src/main/java/mozilla/components/support/base/feature/ActivityResultHandler.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/feature/ActivityResultHandler.kt
@@ -18,5 +18,5 @@ interface ActivityResultHandler {
      *
      * @return true if the result was consumed and no other component needs to be notified.
      */
-    fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean
+    fun onActivityResult(requestCode: Int, data: Intent?, resultCode: Int): Boolean
 }

--- a/components/support/base/src/main/java/mozilla/components/support/base/feature/ViewBoundFeatureWrapper.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/feature/ViewBoundFeatureWrapper.kt
@@ -162,7 +162,7 @@ class ViewBoundFeatureWrapper<T : LifecycleAwareFeature>() {
      * the [LifecycleAwareFeature] was cleared already.
      */
     @Synchronized
-    fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+    fun onActivityResult(requestCode: Int, data: Intent?, resultCode: Int): Boolean {
         val feature = feature ?: return false
 
         if (feature !is ActivityResultHandler) {
@@ -171,7 +171,7 @@ class ViewBoundFeatureWrapper<T : LifecycleAwareFeature>() {
             )
         }
 
-        return feature.onActivityResult(requestCode, resultCode, data)
+        return feature.onActivityResult(requestCode, data, resultCode)
     }
 
     @Synchronized

--- a/components/support/base/src/test/java/mozilla/components/support/base/feature/ViewBoundFeatureWrapperTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/feature/ViewBoundFeatureWrapperTest.kt
@@ -59,7 +59,7 @@ class ViewBoundFeatureWrapperTest {
     @Test
     fun `Calling onActivityResult on an empty wrapper returns false`() {
         val wrapper = ViewBoundFeatureWrapper<MockFeature>()
-        assertFalse(wrapper.onActivityResult(0, RESULT_OK, mock()))
+        assertFalse(wrapper.onActivityResult(0, mock(), RESULT_OK))
     }
 
     @Test
@@ -72,14 +72,14 @@ class ViewBoundFeatureWrapperTest {
             view = mock()
         )
 
-        assertTrue(wrapper.onActivityResult(1, RESULT_OK, null))
+        assertTrue(wrapper.onActivityResult(1, null, RESULT_OK))
         assertTrue(feature.onActivityResultHandled)
 
         assertFalse(ViewBoundFeatureWrapper(
             feature = MockFeatureWithActivityResultHandler(onActivityResult = false),
             owner = MockedLifecycleOwner(MockedLifecycle(Lifecycle.State.CREATED)),
             view = mock()
-        ).onActivityResult(0, RESULT_OK, mock()))
+        ).onActivityResult(0, mock(), RESULT_OK))
     }
 
     @Test
@@ -425,7 +425,7 @@ private class MockFeatureWithActivityResultHandler(
     var onActivityResultHandled = false
         private set
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+    override fun onActivityResult(requestCode: Int, data: Intent?, resultCode: Int): Boolean {
         onActivityResultHandled = true
         return onActivityResult
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **support-base**
+  * ⚠️ **This is a breaking change**: Update the signature of `ActivityResultHandler.onActivityResult` to avoid conflict with internal Android APIs.
+
 # 71.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v71.0.0...v72.0.0)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
@@ -29,6 +29,7 @@ import mozilla.components.feature.sitepermissions.SitePermissionsRules
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.AutoplayAction
 import mozilla.components.feature.toolbar.ToolbarFeature
 import mozilla.components.lib.state.ext.consumeFlow
+import mozilla.components.support.base.feature.ActivityResultHandler
 import mozilla.components.support.base.feature.PermissionsFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
@@ -46,7 +47,7 @@ import org.mozilla.samples.browser.integration.FindInPageIntegration
  * UI code specific to the app or to custom tabs can be found in the subclasses.
  */
 @SuppressWarnings("LargeClass")
-abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
+abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, ActivityResultHandler {
     private val sessionFeature = ViewBoundFeatureWrapper<SessionFeature>()
     private val toolbarFeature = ViewBoundFeatureWrapper<ToolbarFeature>()
     private val contextMenuIntegration = ViewBoundFeatureWrapper<ContextMenuIntegration>()
@@ -59,6 +60,10 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
 
     protected val sessionId: String?
         get() = arguments?.getString(SESSION_ID_KEY)
+
+    private val activityResultHandler: List<ViewBoundFeatureWrapper<*>> = listOf(
+        promptFeature
+    )
 
     @CallSuper
     @Suppress("LongMethod")
@@ -238,8 +243,8 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
     }
 
     @CallSuper
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        promptFeature.withFeature { it.onActivityResult(requestCode, resultCode, data) }
+    override fun onActivityResult(requestCode: Int, data: Intent?, resultCode: Int): Boolean {
+        return activityResultHandler.any { it.onActivityResult(requestCode, data, resultCode) }
     }
 
     companion object {


### PR DESCRIPTION
TIL Java [does not consider the return type](https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.2) as part of the method signature uniqueness.

Adding the `ActivityResultHandler` as an implementation of  activities or fragments is not allowed because of the method signatures clashing. In order to avoid that, this PR switches the last two parameters instead.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
