### PR TITLE
For #9480 - Treat GV INPUT_RESULT_IGNORED as INPUT_RESULT_HANDLED

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -169,10 +169,17 @@ class GeckoEngineView @JvmOverloads constructor(
     override fun canScrollVerticallyDown() =
         true // waiting for this issue https://bugzilla.mozilla.org/show_bug.cgi?id=1507569
 
+    @Suppress("MagicNumber")
     override fun getInputResult(): EngineView.InputResult {
         // Direct mapping of GeckoView's returned values.
-        // There should be a 1-1 relation. If not fail fast to allow for a quick fix.
-        return EngineView.InputResult.values().first { it.value == geckoView.inputResult }
+        // If not fail fast to allow for a quick fix.
+        val input = geckoView.inputResult
+        return when (input) {
+            0 -> EngineView.InputResult.INPUT_RESULT_UNHANDLED
+            1, 3 -> EngineView.InputResult.INPUT_RESULT_HANDLED
+            2 -> EngineView.InputResult.INPUT_RESULT_HANDLED_CONTENT
+            else -> throw IllegalArgumentException("Unexpected geckoView.inputResult: \"${geckoView.inputResult}\"")
+        }
     }
 
     override fun setVerticalClipping(clippingHeight: Int) {


### PR DESCRIPTION
This prevents a crash because of unhandled input value.
After testing it a bit manually this would result in the app behaving the same
as currently.
More investigations are to follow separately.

video - https://drive.google.com/file/d/1CQdlF9neYHDd075wbYG43Bq2zhdBuPIT/view?usp=sharing

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR does not need a changeloc entry
- [x] **Accessibility**: The code in this PR follows does not include any a11y user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
