### PR TITLE
For #9463 - Fixes incorrect position of PopupWindow on devices with Android <= 6

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
@@ -258,14 +258,17 @@ private fun PopupWindow.showPopupWithDownOrientation(anchor: View) {
 }
 
 private fun PopupWindow.showAtAnchorLocation(anchor: View, isCloserToTop: Boolean) {
-    val horizontalLayoutGravity = if (anchor.isRTL) { Gravity.START } else { Gravity.END }
+    val locationOnScreen = IntArray(2)
+    anchor.getLocationOnScreen(locationOnScreen)
 
     if (isCloserToTop) {
         animationStyle = R.style.Mozac_Browser_Menu_Animation_OverflowMenuTop
-        showAtLocation(anchor, horizontalLayoutGravity or Gravity.TOP, 0, 0)
+        showAtLocation(anchor, Gravity.NO_GRAVITY,
+        locationOnScreen[0], locationOnScreen[1])
     } else {
         animationStyle = R.style.Mozac_Browser_Menu_Animation_OverflowMenuBottom
-        showAtLocation(anchor, horizontalLayoutGravity or Gravity.BOTTOM, 0, 0)
+        showAtLocation(anchor, Gravity.NO_GRAVITY,
+            locationOnScreen[0], locationOnScreen[1])
     }
 }
 

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
@@ -20,17 +20,14 @@ import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.browser.menu.view.DynamicWidthRecyclerView
 import mozilla.components.concept.menu.MenuStyle
 import mozilla.components.support.test.any
-import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
 import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.doNothing
@@ -381,70 +378,6 @@ class BrowserMenuTest {
         verify(popupWindow).showAsDropDown(anchor, 0, screenHeight - contentHeight)
     }
 
-    @Config(qualifiers = "ldltr")
-    @Test
-    fun `showAnchorAtLocation should show the menu with Gravity_START if LTR`() {
-        val containerView = createMockViewWith(y = 0)
-        val anchor = createMockViewWith(y = 0)
-        val popupWindow = spy(PopupWindow())
-        doReturn(Int.MAX_VALUE).`when`(containerView).measuredHeight
-        val captor = argumentCaptor<Int>()
-
-        popupWindow.displayPopup(containerView, anchor, BrowserMenu.Orientation.DOWN)
-
-        verify(popupWindow).showAtLocation(any(), captor.capture(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())
-        assertNotEquals(0, captor.value and Gravity.START)
-    }
-
-    @Config(qualifiers = "ldrtl")
-    @Test
-    fun `showAnchorAtLocation should show the menu with Gravity_END if RTL`() {
-        val containerView = createMockViewWith(y = 0)
-        val anchor = createMockViewWith(y = 0)
-        val popupWindow = spy(PopupWindow())
-        doReturn(Int.MAX_VALUE).`when`(containerView).measuredHeight
-        val captor = argumentCaptor<Int>()
-
-        popupWindow.displayPopup(containerView, anchor, BrowserMenu.Orientation.DOWN)
-
-        verify(popupWindow).showAtLocation(any(), captor.capture(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())
-        assertNotEquals(0, captor.value and Gravity.END)
-    }
-
-    @Test
-    fun `showAnchorAtLocation should show the menu with Gravity_BOTTOM if the menu should be closer to the bottom`() {
-        val containerView = createMockViewWith(y = 0)
-        val anchor = createMockViewWith(y = 0)
-        val popupWindow = spy(PopupWindow())
-        val captor = argumentCaptor<Int>()
-        doReturn(Int.MAX_VALUE).`when`(containerView).measuredHeight
-        // Makes the availableHeightToBottom bigger than the availableHeightToTop
-        setScreenHeight(0)
-        doReturn(10).`when`(anchor).height
-
-        popupWindow.displayPopup(containerView, anchor, BrowserMenu.Orientation.DOWN)
-
-        verify(popupWindow).showAtLocation(any(), captor.capture(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())
-        assertNotEquals(0, captor.value and Gravity.BOTTOM)
-    }
-
-    @Test
-    fun `showAnchorAtLocation should show the menu with Gravity_TOP if the menu should be closer to the top`() {
-        val containerView = createMockViewWith(y = 0)
-        val anchor = createMockViewWith(y = 0)
-        val popupWindow = spy(PopupWindow())
-        val captor = argumentCaptor<Int>()
-        doReturn(Int.MAX_VALUE).`when`(containerView).measuredHeight
-        // Makes the availableHeightToBottom smaller than the availableHeightToTop
-        setScreenHeight(0)
-        doReturn(-10).`when`(anchor).height
-
-        popupWindow.displayPopup(containerView, anchor, BrowserMenu.Orientation.UP)
-
-        verify(popupWindow).showAtLocation(any(), captor.capture(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())
-        assertNotEquals(0, captor.value and Gravity.TOP)
-    }
-
     @Test
     fun `showAnchorAtLocation should use the OverflowMenuTop animation if the menu should be shown at the top`() {
         val containerView = createMockViewWith(y = 0)
@@ -498,18 +431,18 @@ class BrowserMenuTest {
         popupWindow.displayPopup(containerView, anchor, BrowserMenu.Orientation.UP)
 
         assertEquals(popupWindow.animationStyle, R.style.Mozac_Browser_Menu_Animation_OverflowMenuBottom)
-        verify(popupWindow).showAtLocation(anchor, Gravity.END or Gravity.BOTTOM, 0, 0)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, 0, 10)
     }
 
     @Test
     fun `displayPopup that don't fitUp neither fitDown`() {
         val containerView = createMockViewWith(y = 0)
-        val anchor = createMockViewWith(y = 0)
+        val anchor = createMockViewWith(y = 15)
         val popupWindow = spy(PopupWindow())
         doReturn(Int.MAX_VALUE).`when`(containerView).measuredHeight
 
         popupWindow.displayPopup(containerView, anchor, BrowserMenu.Orientation.DOWN)
-        verify(popupWindow).showAtLocation(anchor, Gravity.END or Gravity.TOP, 0, 0)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, 0, 15)
     }
 
     @Test


### PR DESCRIPTION

 Some devices would not display PopupWindow correctly at anchor location on PopupWindow.showAtAnchorLocation(). By using the anchor's absolute X, Y coords as offset for showAtLocation, and setting Gravity.NO_Gravity we can overcome this problem.


For https://github.com/mozilla-mobile/android-components/issues/9463 to address the Fenix issue https://github.com/mozilla-mobile/fenix/issues/17092
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR does not need a [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
