### PR TITLE
Closes #9507: Separate addons facts for enabled and installed

### DIFF
--- a/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
+++ b/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
@@ -35,7 +35,8 @@ import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.kotlin.isExtensionUrl
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.filterChanged
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
-import mozilla.components.support.webextensions.facts.emitWebExtensionsInitializedFact
+import mozilla.components.support.webextensions.facts.emitWebExtensionInstalledFact
+import mozilla.components.support.webextensions.facts.emitWebExtensionEnabledFact
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -243,6 +244,7 @@ object WebExtensionSupport {
             override fun onEnabled(extension: WebExtension) {
                 installedExtensions[extension.id] = extension
                 store.dispatch(WebExtensionAction.UpdateWebExtensionEnabledAction(extension.id, true))
+                emitWebExtensionEnabledFact(extension)
             }
 
             override fun onDisabled(extension: WebExtension) {
@@ -299,7 +301,6 @@ object WebExtensionSupport {
         runtime.listInstalledWebExtensions(
             onSuccess = {
                 extensions -> extensions.forEach { registerInstalledExtension(store, it) }
-                emitWebExtensionsInitializedFact(extensions)
                 closeUnsupportedTabs(store, extensions)
                 initializationResult.complete(Unit)
                 onExtensionsLoaded?.invoke(extensions.filter { !it.isBuiltIn() })
@@ -317,6 +318,10 @@ object WebExtensionSupport {
     private fun registerInstalledExtension(store: BrowserStore, webExtension: WebExtension) {
         installedExtensions[webExtension.id] = webExtension
         store.dispatch(WebExtensionAction.InstallWebExtensionAction(webExtension.toState()))
+
+        if (!webExtension.isBuiltIn()) {
+            emitWebExtensionInstalledFact(webExtension)
+        }
 
         // Register action handler for all existing engine sessions on the new extension,
         // an issue was filed to get us an API, so we don't have to do this per extension:

--- a/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/facts/WebExtensionFacts.kt
+++ b/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/facts/WebExtensionFacts.kt
@@ -18,7 +18,8 @@ class WebExtensionFacts {
      * Items that specify which portion of the web extension events were invoked.
      */
     object Items {
-        const val WEB_EXTENSIONS_INITIALIZED = "web_extensions_initialized"
+        const val WEB_EXTENSION_ENABLED = "web_extension_enabled"
+        const val WEB_EXTENSION_INSTALLED = "web_extension_installed"
     }
 }
 
@@ -37,15 +38,22 @@ private fun emitWebExtensionFact(
     ).collect()
 }
 
-internal fun emitWebExtensionsInitializedFact(extensions: List<WebExtension>) {
-    val installedAddons = extensions.filter { !it.isBuiltIn() }
-    val enabledAddons = installedAddons.filter { it.isEnabled() }
+internal fun emitWebExtensionEnabledFact(extension: WebExtension) {
     emitWebExtensionFact(
         Action.INTERACTION,
-        WebExtensionFacts.Items.WEB_EXTENSIONS_INITIALIZED,
+        WebExtensionFacts.Items.WEB_EXTENSION_ENABLED,
         metadata = mapOf(
-            "installed" to installedAddons.map { it.id },
-            "enabled" to enabledAddons.map { it.id }
+            "enabled" to extension.id
+        )
+    )
+}
+
+internal fun emitWebExtensionInstalledFact(extension: WebExtension) {
+    emitWebExtensionFact(
+        Action.INTERACTION,
+        WebExtensionFacts.Items.WEB_EXTENSION_INSTALLED,
+        metadata = mapOf(
+            "installed" to extension.id
         )
     )
 }

--- a/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
+++ b/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
@@ -115,12 +115,10 @@ class WebExtensionSupportTest {
             val interactionFact = facts[0]
             assertEquals(FactsAction.INTERACTION, interactionFact.action)
             assertEquals(Component.SUPPORT_WEBEXTENSIONS, interactionFact.component)
-            assertEquals(WEB_EXTENSIONS_INITIALIZED, interactionFact.item)
-            assertEquals(2, interactionFact.metadata?.size)
+            assertEquals(WEB_EXTENSION_INSTALLED, interactionFact.item)
+            assertEquals(1, interactionFact.metadata?.size)
             assertTrue(interactionFact.metadata?.containsKey("installed")!!)
-            assertTrue(interactionFact.metadata?.containsKey("enabled")!!)
-            assertEquals(listOf(ext1.id, ext2.id), interactionFact.metadata?.get("installed"))
-            assertEquals(listOf(ext1.id), interactionFact.metadata?.get("enabled"))
+            assertEquals(ext1.id, interactionFact.metadata?.get("installed"))
         }
         assertEquals(ext1, WebExtensionSupport.installedExtensions[ext1.id])
         assertEquals(ext2, WebExtensionSupport.installedExtensions[ext2.id])


### PR DESCRIPTION
For [Fenix #16832](https://github.com/mozilla-mobile/fenix/issues/16832)
Fenix PR: https://github.com/mozilla-mobile/fenix/pull/17445

The old implementation does not track for a user manually enabling an addon (which is what DS wants). This PR separates the single fact into two discrete facts, so we can track when an addon is _installed_, and when a user has manually _enabled_ an addon.

The original PR for this was reverted (see [comment](https://github.com/mozilla-mobile/android-components/pull/9201#discussion_r564113145)). This PR will fix our "broken" metrics data, and answer the correct product questions around addons.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
