### PR TITLE
[RELENG-169] support staging release promotion projects

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,7 +7,7 @@ tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: 32c7e914db92719dc1c508f4c08a02ac75e94105
+              revision: a458418ef7cdd6778f1283926c6116966255bc24
           trustDomain: mobile
       in:
           $let:
@@ -175,7 +175,7 @@ tasks:
                             routes:
                                 $flattenDeep:
                                     - checks
-                                    - $if: 'level == "3"'
+                                    - $if: 'level == "3" || repoUrl == "https://github.com/mozilla-releng/staging-android-components"'
                                       then:
                                           - tc-treeherder.v2.${project}.${head_sha}
                                           - $if: 'tasks_for == "github-push"'

--- a/taskcluster/ac_taskgraph/release_promotion.py
+++ b/taskcluster/ac_taskgraph/release_promotion.py
@@ -16,7 +16,7 @@ from taskgraph.parameters import Parameters
 from taskgraph.util.taskgraph import find_decision_task, find_existing_tasks_from_previous_kinds
 
 RELEASE_PROMOTION_PROJECTS = (
-    "https://github.com/mozilla-mobile/android-components", "https://github.com/escapewindow/android-components"
+    "https://github.com/mozilla-mobile/android-components", "https://github.com/mozilla-releng/staging-android-components"
 )
 
 

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -133,7 +133,10 @@ treeherder:
         samples-browser-system: samples-browser-system
 
 
-task-priority: highest
+task-priority:
+    by-project:
+        "android-components": highest
+        "staging-android-components": low
 
 taskgraph:
     register: ac_taskgraph:register


### PR DESCRIPTION
Let's make mozilla-releng/staging-android-components the official
staging repository. By supporting it in the automation, we no longer
need to maintain a staging patchset to test things properly.