### PR TITLE
Add ability to reset Nimbus telemetry identifiers.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -30,7 +30,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "2.4"
 
-    const val mozilla_appservices = "69.0.0"
+    const val mozilla_appservices = "70.0.0"
 
     const val mozilla_glean = "33.1.2"
 


### PR DESCRIPTION
This should be called when the user opts out of telemetry. In the future we may also need to call it when they opt back in, so that we can provide the updated `AvailableRandomizationUnits`.

The corresponding SDK method was added in https://github.com/mozilla/nimbus-sdk/pull/80, and is currently waiting for a new release of nimbus-sdk and application-services before we can merge this PR.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- ~~[ ] **Tests**: This PR includes thorough tests or an explanation of why it does not~~
  - Like other methods of the `NimbusClient` class, this is a thin pass-through wrapper to the underlying SDK that doesn't have any interesting behaviours to test.
- ~~[ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
  - Covered by the Nimbus SDK changelog.
- ~~[ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~
  - No user facing features.

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
