### PR TITLE
Closes #9526 guessFileName handle generic content types

### DIFF
--- a/components/support/utils/src/main/java/mozilla/components/support/utils/DownloadUtils.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/DownloadUtils.kt
@@ -126,6 +126,16 @@ object DownloadUtils {
     private val encodedSymbolPattern = Pattern.compile("%[0-9a-f]{2}|[0-9a-z!#$&+-.^_`|~]", Pattern.CASE_INSENSITIVE)
 
     /**
+     * Keep aligned with desktop generic content types:
+     * https://searchfox.org/mozilla-central/source/browser/components/downloads/DownloadsCommon.jsm#208
+     */
+    private val GENERIC_CONTENT_TYPES = arrayOf(
+        "application/octet-stream",
+        "binary/octet-stream",
+        "application/unknown"
+    )
+
+    /**
      * Guess the name of the file that should be downloaded.
      *
      * This method is largely identical to [android.webkit.URLUtil.guessFileName]
@@ -146,7 +156,11 @@ object DownloadUtils {
         val sanitizedMimeType = sanitizeMimeType(mimeType)
 
         val fileName = if (extractedFileName.contains('.')) {
-            changeExtension(extractedFileName, sanitizedMimeType)
+            if (GENERIC_CONTENT_TYPES.contains(mimeType)) {
+                extractedFileName
+            } else {
+                changeExtension(extractedFileName, sanitizedMimeType)
+            }
         } else {
             extractedFileName + createExtension(sanitizedMimeType)
         }

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt
@@ -107,6 +107,9 @@ class DownloadUtilsTest {
         assertEquals("file.html", DownloadUtils.guessFileName(null, null, "http://example.com/file", "text/html"))
         assertEquals("file.html", DownloadUtils.guessFileName(null, null, "http://example.com/file", "text/html; charset=utf-8"))
         assertEquals("file.txt", DownloadUtils.guessFileName(null, null, "http://example.com/file.txt", "text/html"))
+        assertEquals("file.data", DownloadUtils.guessFileName(null, null, "http://example.com/file.data", "application/octet-stream"))
+        assertEquals("file.data", DownloadUtils.guessFileName(null, null, "http://example.com/file.data", "binary/octet-stream"))
+        assertEquals("file.data", DownloadUtils.guessFileName(null, null, "http://example.com/file.data", "application/unknown"))
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **feature-downloads**:
+  * 🚒 Bug fixed [issue #9441](https://github.com/mozilla-mobile/android-components/issues/9441) - Don't ask for redundant system files permission if not required.
+  * 🚒 Bug fixed [issue #9526](https://github.com/mozilla-mobile/android-components/issues/9526) - Downloads with generic content types use the correct file extension.
+
 # 72.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v71.0.0...v72.0.0)
@@ -25,9 +29,6 @@ permalink: /changelog/
 
 * **support-base**
   * ⚠️ **This is a breaking change**: Update the signature of `ActivityResultHandler.onActivityResult` to avoid conflict with internal Android APIs.
-
-* **feature-downloads**:
-  * 🚒 Bug fixed [issue #9441](https://github.com/mozilla-mobile/android-components/issues/9441) - Don't ask for redundant system files permission if not required.
 
 * **feature-addons**
   * 🚒 Bug fixed [issue #9484] https://github.com/mozilla-mobile/android-components/issues/9484) - Handle multiple add-ons update that require new permissions.


### PR DESCRIPTION
> application/octet-stream is the default value for all other cases. An unknown file type should use this type. Browsers pay a particular care when manipulating these files, attempting to safeguard the user to prevent dangerous behaviors.

From https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
and also similar implementation on desktop https://searchfox.org/mozilla-central/source/browser/components/downloads/DownloadsCommon.jsm#208

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
