### PR TITLE
Closes #9528: Exposes BrowserMenu dismiss through BrowserToolbarMenu

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -312,6 +312,13 @@ class BrowserToolbar @JvmOverloads constructor(
         updateState(State.DISPLAY)
     }
 
+    /**
+     * Dismisses the display toolbar popup menu.
+     */
+    override fun dismissMenu() {
+        display.views.menu.dismissMenu()
+    }
+
     internal fun onUrlEntered(url: String) {
         if (urlCommitListener?.invoke(url) != false) {
             // Return to display mode if there's no urlCommitListener or if it returned true. This lets

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -17,6 +17,8 @@ import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.toolbar.display.DisplayToolbar
+import mozilla.components.browser.toolbar.display.DisplayToolbarViews
+import mozilla.components.browser.toolbar.display.MenuButton
 import mozilla.components.browser.toolbar.edit.EditToolbar
 import mozilla.components.concept.toolbar.AutocompleteDelegate
 import mozilla.components.concept.toolbar.Toolbar
@@ -25,6 +27,7 @@ import mozilla.components.concept.toolbar.Toolbar.SiteTrackingProtection
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -711,5 +714,19 @@ class BrowserToolbarTest {
         toolbar.onStop()
 
         verify(toolbar.display).onStop()
+    }
+
+    @Test
+    fun `dismiss menu is forwarded to display toolbar`() {
+        val toolbar = BrowserToolbar(testContext)
+        toolbar.display = mock()
+        val displayToolbarViews: DisplayToolbarViews = mock()
+        val menuButton: MenuButton = mock()
+
+        whenever(toolbar.display.views).thenReturn(displayToolbarViews)
+        whenever(displayToolbarViews.menu).thenReturn(menuButton)
+
+        toolbar.dismissMenu()
+        verify(menuButton).dismissMenu()
     }
 }

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -168,6 +168,11 @@ interface Toolbar {
     fun editMode()
 
     /**
+     * Dismisses the display toolbar popup menu
+     */
+    fun dismissMenu()
+
+    /**
      * Listener to be invoked when the user edits the URL.
      */
     interface OnEditListener {

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/CustomTabSessionTitleObserverTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/CustomTabSessionTitleObserverTest.kt
@@ -91,6 +91,7 @@ class CustomTabSessionTitleObserverTest {
         override fun setOnEditListener(listener: Toolbar.OnEditListener) = Unit
         override fun displayMode() = Unit
         override fun editMode() = Unit
+        override fun dismissMenu() = Unit
     }
 }
 

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
@@ -109,6 +109,10 @@ class ToolbarAutocompleteFeatureTest {
         override fun invalidateActions() {
             fail()
         }
+
+        override fun dismissMenu() {
+            fail()
+        }
     }
 
     @Test

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
@@ -92,6 +92,10 @@ class ToolbarInteractorTest {
         override fun invalidateActions() {
             fail()
         }
+
+        override fun dismissMenu() {
+            fail()
+        }
     }
 
     @Test


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
