### PR TITLE
Closes #9531: Stop retrieving metadata artwork when in private tabs

### DIFF
--- a/components/feature/media/src/main/java/mozilla/components/feature/media/ext/SessionState.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/ext/SessionState.kt
@@ -6,10 +6,14 @@ package mozilla.components.feature.media.ext
 
 import android.content.Context
 import android.graphics.Bitmap
+import kotlinx.coroutines.withTimeoutOrNull
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.concept.engine.mediasession.MediaSession
 import mozilla.components.feature.media.R
+
+private const val ARTWORK_RETRIEVE_TIMEOUT = 1000L
+private const val ARTWORK_IMAGE_SIZE = 48
 
 internal fun SessionState?.getTitleOrUrl(context: Context, title: String? = null): String = when {
     this == null -> context.getString(R.string.mozac_feature_media_notification_private_mode)
@@ -19,10 +23,13 @@ internal fun SessionState?.getTitleOrUrl(context: Context, title: String? = null
     else -> content.url
 }
 
-internal fun SessionState?.getNonPrivateIcon(artwork: Bitmap?): Bitmap? = when {
+internal suspend fun SessionState?.getNonPrivateIcon(getArtwork: (suspend (Int) -> Bitmap?)?): Bitmap? = when {
     this == null -> null
     content.private -> null
-    artwork != null -> artwork
+    getArtwork != null ->
+        withTimeoutOrNull(ARTWORK_RETRIEVE_TIMEOUT) {
+            getArtwork(ARTWORK_IMAGE_SIZE)
+        }
     else -> content.icon
 }
 

--- a/components/feature/media/src/main/java/mozilla/components/feature/media/notification/MediaNotification.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/notification/MediaNotification.kt
@@ -13,7 +13,6 @@ import android.support.v4.media.session.MediaSessionCompat
 import androidx.annotation.DrawableRes
 import androidx.core.app.NotificationCompat
 import androidx.media.app.NotificationCompat.MediaStyle
-import kotlinx.coroutines.withTimeoutOrNull
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.CustomTabSessionState
 import mozilla.components.browser.state.state.MediaState
@@ -30,9 +29,6 @@ import mozilla.components.feature.media.service.AbstractMediaService
 import mozilla.components.feature.media.service.AbstractMediaSessionService
 import mozilla.components.support.base.ids.SharedIdsHelper
 import java.util.Locale
-
-private const val ARTWORK_RETRIEVE_TIMEOUT = 1000L
-private const val ARTWORK_IMAGE_SIZE = 48
 
 /**
  * Helper to display a notification for web content playing media.
@@ -167,16 +163,13 @@ private suspend fun SessionState.toNotificationData(
     val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)?.also {
         it.action = AbstractMediaSessionService.ACTION_SWITCH_TAB
     }
-    val artwork = withTimeoutOrNull(ARTWORK_RETRIEVE_TIMEOUT) {
-        mediaSessionState?.metadata?.getArtwork?.invoke(ARTWORK_IMAGE_SIZE)
-    }
 
     return when (mediaSessionState?.playbackState) {
         MediaSession.PlaybackState.PLAYING -> NotificationData(
             title = getTitleOrUrl(context, mediaSessionState?.metadata?.title),
             description = nonPrivateUrl,
             icon = R.drawable.mozac_feature_media_playing,
-            largeIcon = getNonPrivateIcon(artwork),
+            largeIcon = getNonPrivateIcon(mediaSessionState?.metadata?.getArtwork),
             action = NotificationCompat.Action.Builder(
                 R.drawable.mozac_feature_media_action_pause,
                 context.getString(R.string.mozac_feature_media_notification_action_pause),
@@ -197,7 +190,7 @@ private suspend fun SessionState.toNotificationData(
             title = getTitleOrUrl(context, mediaSessionState?.metadata?.title),
             description = nonPrivateUrl,
             icon = R.drawable.mozac_feature_media_paused,
-            largeIcon = getNonPrivateIcon(artwork),
+            largeIcon = getNonPrivateIcon(mediaSessionState?.metadata?.getArtwork),
             action = NotificationCompat.Action.Builder(
                 R.drawable.mozac_feature_media_action_play,
                 context.getString(R.string.mozac_feature_media_notification_action_play),

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/ext/SessionStateKtTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/ext/SessionStateKtTest.kt
@@ -1,0 +1,189 @@
+package mozilla.components.feature.media.ext
+
+import android.graphics.Bitmap
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.state.state.ContentState
+import mozilla.components.browser.state.state.SessionState
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SessionStateKtTest {
+    private val bitmap: Bitmap = mock()
+    private val getArtwork: (suspend (Int) -> Bitmap?) = { bitmap }
+
+    @Test
+    fun `getNonPrivateIcon returns null when in private mode`() {
+        val sessionState: SessionState = mock()
+        val contentState: ContentState = mock()
+
+        whenever(sessionState.content).thenReturn(contentState)
+        whenever(contentState.private).thenReturn(true)
+
+        var result: Bitmap?
+        runBlocking {
+            result = sessionState.getNonPrivateIcon(getArtwork)
+        }
+
+        assertEquals(result, null)
+    }
+
+    @Test
+    fun `getNonPrivateIcon returns bitmap when not in private mode`() {
+        val sessionState: SessionState = mock()
+        val contentState: ContentState = mock()
+
+        whenever(sessionState.content).thenReturn(contentState)
+        whenever(contentState.private).thenReturn(false)
+
+        var result: Bitmap?
+        runBlocking {
+            result = sessionState.getNonPrivateIcon(getArtwork)
+        }
+
+        assertEquals(result, bitmap)
+    }
+
+    @Test
+    fun `getNonPrivateIcon returns content icon when not in private mode`() {
+        val sessionState: SessionState = mock()
+        val contentState: ContentState = mock()
+        val icon: Bitmap = mock()
+
+        whenever(sessionState.content).thenReturn(contentState)
+        whenever(contentState.private).thenReturn(false)
+        whenever(contentState.icon).thenReturn(icon)
+
+        var result: Bitmap?
+        runBlocking {
+            result = sessionState.getNonPrivateIcon(null)
+        }
+
+        assertEquals(result, icon)
+    }
+
+    @Test
+    fun `getTitleOrUrl returns null when in private mode`() {
+        val sessionState: SessionState = mock()
+        val contentState: ContentState = mock()
+
+        whenever(sessionState.content).thenReturn(contentState)
+        whenever(contentState.private).thenReturn(true)
+
+        val result = sessionState.getTitleOrUrl(testContext, "test")
+
+        assertEquals(result, "A site is playing media")
+    }
+
+    @Test
+    fun `getTitleOrUrl returns metadata title when not in private mode`() {
+        val sessionState: SessionState = mock()
+        val contentState: ContentState = mock()
+
+        whenever(sessionState.content).thenReturn(contentState)
+        whenever(contentState.private).thenReturn(false)
+
+        val result = sessionState.getTitleOrUrl(testContext, "test")
+
+        assertEquals(result, "test")
+    }
+
+    @Test
+    fun `getTitleOrUrl returns title when not in private mode`() {
+        val sessionState: SessionState = mock()
+        val contentState: ContentState = mock()
+        val contentTitle = "content title"
+        val contentUrl = "content url"
+
+        whenever(sessionState.content).thenReturn(contentState)
+        whenever(contentState.private).thenReturn(false)
+        whenever(contentState.title).thenReturn(contentTitle)
+        whenever(contentState.url).thenReturn(contentUrl)
+
+        val result = sessionState.getTitleOrUrl(testContext, null)
+
+        assertEquals(result, contentTitle)
+    }
+
+    @Test
+    fun `getTitleOrUrl returns url when not in private mode`() {
+        val sessionState: SessionState = mock()
+        val contentState: ContentState = mock()
+        val contentTitle = ""
+        val contentUrl = "content url"
+
+        whenever(sessionState.content).thenReturn(contentState)
+        whenever(contentState.private).thenReturn(false)
+        whenever(contentState.title).thenReturn(contentTitle)
+        whenever(contentState.url).thenReturn(contentUrl)
+
+        val result = sessionState.getTitleOrUrl(testContext, null)
+
+        assertEquals(result, contentUrl)
+    }
+
+    @Test
+    fun `getNotPrivateUrl returns null when in private mode`() {
+        val sessionState: SessionState = mock()
+        val contentState: ContentState = mock()
+        val contentUrl = "content url"
+
+        whenever(sessionState.content).thenReturn(contentState)
+        whenever(contentState.private).thenReturn(true)
+        whenever(contentState.url).thenReturn(contentUrl)
+
+        val result = sessionState.nonPrivateUrl
+
+        assertEquals(result, "")
+    }
+
+    @Test
+    fun `nonPrivateUrl returns null when not in private mode`() {
+        val sessionState: SessionState = mock()
+        val contentState: ContentState = mock()
+        val contentUrl = "content url"
+
+        whenever(sessionState.content).thenReturn(contentState)
+        whenever(contentState.private).thenReturn(false)
+        whenever(contentState.url).thenReturn(contentUrl)
+
+        val result = sessionState.nonPrivateUrl
+
+        assertEquals(result, contentUrl)
+    }
+
+    @Test
+    fun `nonPrivateIcon returns null when in private mode`() {
+        val sessionState: SessionState = mock()
+        val contentState: ContentState = mock()
+        val icon: Bitmap = mock()
+
+        whenever(sessionState.content).thenReturn(contentState)
+        whenever(contentState.private).thenReturn(true)
+        whenever(contentState.icon).thenReturn(icon)
+
+        val result = sessionState.nonPrivateIcon
+
+        assertEquals(result, null)
+    }
+
+    @Test
+    fun `nonPrivateIcon returns null when not in private mode`() {
+        val sessionState: SessionState = mock()
+        val contentState: ContentState = mock()
+        val icon: Bitmap = mock()
+
+        whenever(sessionState.content).thenReturn(contentState)
+        whenever(contentState.private).thenReturn(false)
+        whenever(contentState.icon).thenReturn(icon)
+
+        val result = sessionState.nonPrivateIcon
+
+        assertEquals(result, icon)
+    }
+}

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/notification/MediaNotificationTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/notification/MediaNotificationTest.kt
@@ -21,6 +21,7 @@ import mozilla.components.feature.media.service.AbstractMediaService
 import mozilla.components.feature.media.service.AbstractMediaSessionService
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -273,6 +274,54 @@ class MediaNotificationTest {
                 createTab("https://www.mozilla.org", id = "test-tab", title = "Mozilla", private = true,
                     mediaSessionState = MediaSessionState(mock(), playbackState = MediaSession.PlaybackState.PAUSED)
                 ))
+        )
+
+        val notification = runBlocking {
+            MediaNotification(context, AbstractMediaSessionService::class.java).create(state.tabs[0], mock())
+        }
+
+        assertEquals("", notification.text)
+        assertEquals("A site is playing media", notification.title)
+        assertEquals(R.drawable.mozac_feature_media_paused, notification.iconResource)
+    }
+
+    @Test
+    fun `media session notification with metadata in non private mode`() {
+        val mediaSessionState: MediaSessionState = mock()
+        val metadata: MediaSession.Metadata = mock()
+        whenever(mediaSessionState.metadata).thenReturn(metadata)
+        whenever(mediaSessionState.playbackState).thenReturn(MediaSession.PlaybackState.PAUSED)
+        whenever(metadata.title).thenReturn("test title")
+
+        val state = BrowserState(
+            tabs = listOf(
+                createTab("https://www.mozilla.org", id = "test-tab", title = "Mozilla", private = false,
+                    mediaSessionState = mediaSessionState)
+            )
+        )
+
+        val notification = runBlocking {
+            MediaNotification(context, AbstractMediaSessionService::class.java).create(state.tabs[0], mock())
+        }
+
+        assertEquals("https://www.mozilla.org", notification.text)
+        assertEquals("test title", notification.title)
+        assertEquals(R.drawable.mozac_feature_media_paused, notification.iconResource)
+    }
+
+    @Test
+    fun `media session notification with metadata in private mode`() {
+        val mediaSessionState: MediaSessionState = mock()
+        val metadata: MediaSession.Metadata = mock()
+        whenever(mediaSessionState.metadata).thenReturn(metadata)
+        whenever(mediaSessionState.playbackState).thenReturn(MediaSession.PlaybackState.PAUSED)
+        whenever(metadata.title).thenReturn("test title")
+
+        val state = BrowserState(
+            tabs = listOf(
+                createTab("https://www.mozilla.org", id = "test-tab", title = "Mozilla", private = true,
+                    mediaSessionState = mediaSessionState)
+            )
         )
 
         val notification = runBlocking {


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
