### PR TITLE
Add proof of concept component to translate between concept-fetch and ktor

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -379,6 +379,10 @@ projects:
     path: components/lib/fetch-okhttp
     description: 'An implementation of lib-fetch based on OkHttp.'
     publish: true
+  lib-ktor-fetch:
+    path: components/lib/ktor-fetch
+    description: 'A component that can translate between concept-fetch and Ktor.'
+    publish: true
   lib-jexl:
     path: components/lib/jexl
     description: 'Javascript Expression Language: Powerful context-based expression parser and evaluator.'

--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ _Supporting components with generic helper code._
 
 * ⚪ [**JEXL**](components/lib/jexl/README.md) - Javascript Expression Language: Context-based expression parser and evaluator.
 
+* 🔴 [**Ktor-Fetch**](components/lib/ktor-fetch/README.md) - A component that can translate between `concept-fetch` and [Ktor]()(https://ktor.io/).
+
 * 🔵 [**Public Suffix List**](components/lib/publicsuffixlist/README.md) - A library for reading and using the [public suffix list](https://publicsuffix.org/).
 
 * 🔵 [**Push-Firebase**](components/lib/push-firebase/README.md) - A [concept-push](concept/push/README.md) implementation using [Firebase Cloud Messaging](https://firebase.google.com/products/cloud-messaging/).

--- a/build.gradle
+++ b/build.gradle
@@ -206,6 +206,8 @@ subprojects {
                     exclude 'META-INF/atomicfu.kotlin_module'
                     exclude 'META-INF/AL2.0'
                     exclude 'META-INF/LGPL2.1'
+                    exclude "META-INF/io.netty.versions.properties"
+                    exclude "META-INF/INDEX.LIST"
                 }
 
                 aaptOptions {

--- a/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Request.kt
+++ b/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Request.kt
@@ -68,6 +68,11 @@ data class Request(
             fun fromFile(file: File): Body = Body(file.inputStream())
 
             /**
+             * Create a [Body] from the provided [ByteArray].
+             */
+            fun fromByteArray(array: ByteArray) = Body(array.inputStream())
+
+            /**
              * Create a [Body] from the provided [unencodedParams] in the format of Content-Type
              * "application/x-www-form-urlencoded". Parameters are formatted as "key1=value1&key2=value2..."
              * and values are percent-encoded. If the given map is empty, the response body will contain the

--- a/components/lib/ktor-fetch/README.md
+++ b/components/lib/ktor-fetch/README.md
@@ -1,0 +1,28 @@
+# [Android Components](../../../README.md) > Libraries > Ktor-Fetch
+
+A component that can translate between `concept-fetch` and [Ktor]()(https://ktor.io/).
+
+## Usage
+
+### Setting up the dependency
+
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) ([Setup repository](../../../README.md#maven-repository)):
+
+```Groovy
+implementation "org.mozilla.components:lib-fetch-okhttp:{latest-version}"
+```
+
+### Creating a `HttpClientEngine` (Ktor) from a `Client` (`concept-fetch`)
+
+```Kotlin
+val client = ...
+HttpClient(client.toKtorEngine()).use {
+    // ...
+}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/lib/ktor-fetch/build.gradle
+++ b/components/lib/ktor-fetch/build.gradle
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion config.minSdkVersion
+        targetSdkVersion config.targetSdkVersion
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions.freeCompilerArgs += [
+            "-Xopt-in=kotlin.RequiresOptIn"
+    ]
+}
+
+
+dependencies {
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
+
+    implementation project(':concept-fetch')
+    implementation "io.ktor:ktor-client-core:1.5.0"
+
+    androidTestImplementation project(":browser-engine-gecko-nightly")
+
+    androidTestImplementation "io.ktor:ktor-client-tests:1.5.0"
+    androidTestImplementation "io.ktor:ktor-client-tests-jvm:1.5.0"
+
+    androidTestImplementation Dependencies.testing_mockwebserver
+    androidTestImplementation Dependencies.testing_junit
+
+    androidTestImplementation Dependencies.androidx_test_core
+    androidTestImplementation Dependencies.androidx_test_runner
+    androidTestImplementation Dependencies.androidx_test_rules
+    androidTestImplementation project(':tooling-fetch-tests')
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/components/lib/ktor-fetch/proguard-rules.pro
+++ b/components/lib/ktor-fetch/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/lib/ktor-fetch/src/androidTest/java/mozilla/components/lib/ktor/fetch/ClientTests.kt
+++ b/components/lib/ktor-fetch/src/androidTest/java/mozilla/components/lib/ktor/fetch/ClientTests.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.lib.ktor.fetch
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ClientTests {
+    @Test
+    fun simpleGet() {
+        val server = MockWebServer()
+        server.enqueue(MockResponse()
+            .setResponseCode(200)
+            .setBody("Hello World!"))
+
+        HttpClient(Gecko).use { client ->
+            val content = runBlocking { client.get<String>(server.url("/").toString()) }
+            assertEquals("Hello World!", content)
+        }
+    }
+}

--- a/components/lib/ktor-fetch/src/androidTest/java/mozilla/components/lib/ktor/fetch/Gecko.kt
+++ b/components/lib/ktor-fetch/src/androidTest/java/mozilla/components/lib/ktor/fetch/Gecko.kt
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.lib.ktor.fetch
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.HttpClientEngineFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.engine.gecko.fetch.GeckoViewFetchClient
+import mozilla.components.lib.ktor.fetch.ext.toKtorEngine
+
+/**
+ * Factory for creating an [HttpClientEngine] using GeckoView running in the test context.
+ */
+object Gecko : HttpClientEngineFactory<FetchEngineConfig> {
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    override fun create(block: FetchEngineConfig.() -> Unit): HttpClientEngine {
+        val client = runBlocking(Dispatchers.Main) { GeckoViewFetchClient(context) }
+        return client.toKtorEngine()
+    }
+}

--- a/components/lib/ktor-fetch/src/main/AndroidManifest.xml
+++ b/components/lib/ktor-fetch/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.lib.ktor.fetch" />

--- a/components/lib/ktor-fetch/src/main/java/mozilla/components/lib/ktor/fetch/FetchEngine.kt
+++ b/components/lib/ktor-fetch/src/main/java/mozilla/components/lib/ktor/fetch/FetchEngine.kt
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.lib.ktor.fetch
+
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.HttpClientEngineBase
+import io.ktor.client.engine.callContext
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.HttpResponseData
+import io.ktor.http.Headers
+import io.ktor.http.HeadersBuilder
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpProtocolVersion
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
+import io.ktor.util.InternalAPI
+import io.ktor.util.KtorExperimentalAPI
+import io.ktor.util.date.GMTDate
+import io.ktor.utils.io.jvm.javaio.toInputStream
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
+import mozilla.components.concept.fetch.Client
+import mozilla.components.concept.fetch.MutableHeaders
+import mozilla.components.concept.fetch.Request
+import mozilla.components.concept.fetch.Response
+import java.util.concurrent.Executors
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * A [HttpClientEngine] implementation that uses the given [Client] implementing `concept-fetch`.
+ */
+class FetchEngine(
+    private val client: Client,
+    override val config: FetchEngineConfig
+) : HttpClientEngineBase("ktor-fetch-${client.javaClass.simpleName}") {
+    @OptIn(KtorExperimentalAPI::class) // config.threadsCount is experimental
+    override val dispatcher: CoroutineDispatcher by lazy {
+        Executors.newFixedThreadPool(
+            config.threadsCount
+        ).asCoroutineDispatcher()
+    }
+
+    @InternalAPI
+    @Suppress("BlockingMethodInNonBlockingContext")
+    override suspend fun execute(data: HttpRequestData): HttpResponseData {
+        val request = data.toFetchRequest()
+        val response = client.fetch(request)
+        return response.toKtorResponse()
+    }
+}
+
+private fun HttpRequestData.toFetchRequest(): Request {
+    return Request(
+        url.toString(),
+        method = method.toFetchMethod(),
+        headers = toFetchHeaders(),
+        body = body.toFetchRequestBody()
+    )
+}
+
+private fun HttpMethod.toFetchMethod(): Request.Method {
+    return when (this) {
+        HttpMethod.Get -> Request.Method.GET
+        HttpMethod.Delete -> Request.Method.DELETE
+        HttpMethod.Head -> Request.Method.HEAD
+        HttpMethod.Post -> Request.Method.POST
+        HttpMethod.Put -> Request.Method.PUT
+        HttpMethod.Options -> Request.Method.OPTIONS
+        else -> throw NotImplementedError("Unsupported method: ${this.value}")
+    }
+}
+
+private fun OutgoingContent.toFetchRequestBody(): Request.Body? {
+    return when (this) {
+        is OutgoingContent.NoContent -> null
+        is OutgoingContent.ByteArrayContent -> Request.Body.fromByteArray(bytes())
+        is OutgoingContent.ReadChannelContent -> Request.Body(readFrom().toInputStream())
+        is OutgoingContent.WriteChannelContent -> throw NotImplementedError()
+        is OutgoingContent.ProtocolUpgrade -> throw NotImplementedError()
+    }
+}
+
+private fun HttpRequestData.toFetchHeaders(): MutableHeaders {
+    val fetchHeaders = MutableHeaders()
+
+    headers.forEach { name, values ->
+        values.forEach { value ->
+            fetchHeaders.append(name, value)
+        }
+    }
+
+    return fetchHeaders
+}
+
+private suspend fun Response.toKtorResponse(): HttpResponseData {
+    return HttpResponseData(
+        statusCode = HttpStatusCode.fromValue(status),
+        requestTime = GMTDate(),
+        headers = toKtorHeaders(),
+        version = toHttpProtocolVersion(),
+        body = body.toKtorBody(),
+        callContext = getCallContext()
+    )
+}
+
+private fun Response.Body.toKtorBody(): Any {
+    return string()
+}
+
+private fun Response.toKtorHeaders(): Headers {
+    val builder = HeadersBuilder()
+
+    headers.forEach { header ->
+        builder.append(header.name, header.value)
+    }
+
+    return builder.build()
+}
+
+private fun Response.toHttpProtocolVersion(): HttpProtocolVersion {
+    return HttpProtocolVersion.HTTP_1_1
+}
+
+@OptIn(InternalAPI::class)
+private suspend fun getCallContext(): CoroutineContext {
+    return callContext()
+}

--- a/components/lib/ktor-fetch/src/main/java/mozilla/components/lib/ktor/fetch/FetchEngineConfig.kt
+++ b/components/lib/ktor-fetch/src/main/java/mozilla/components/lib/ktor/fetch/FetchEngineConfig.kt
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.lib.ktor.fetch
+
+import io.ktor.client.engine.HttpClientEngineConfig
+
+/**
+ * Configuration for [FetchEngine].
+ */
+class FetchEngineConfig : HttpClientEngineConfig()

--- a/components/lib/ktor-fetch/src/main/java/mozilla/components/lib/ktor/fetch/ext/Client.kt
+++ b/components/lib/ktor-fetch/src/main/java/mozilla/components/lib/ktor/fetch/ext/Client.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.lib.ktor.fetch.ext
+
+import io.ktor.client.engine.HttpClientEngine
+import mozilla.components.concept.fetch.Client
+import mozilla.components.lib.ktor.fetch.FetchEngineConfig
+import mozilla.components.lib.ktor.fetch.FetchEngine
+
+/**
+ * Creates a [HttpClientEngine] (Ktor) from this [Client] (`concept-fetch`).
+ */
+fun Client.toKtorEngine(
+    block: FetchEngineConfig.() -> Unit = {}
+) = FetchEngine(
+    client = this,
+    config = FetchEngineConfig().apply(block)
+)


### PR DESCRIPTION
In a multiplatform library that does network requests we would need to abstract the http client away. In our components we already do this with `concept-fetch`. JetBrains did the same for Kotlin multiplatform with [ktor](https://ktor.io/). Instead of making `concept-fetch` work on iOS, we can use ktor in our multiplatform libraries. This proof of concept implementation of `ktor-fetch` translates between the two worlds. With that you can use any `concept-fetch` `Client` (primarily GeckoView) as a `HttpClientEngine` in ktor.