### PR TITLE
Closes #9531: Return content icon if get artwork fails

### DIFF
--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/mediasession/MediaSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/mediasession/MediaSession.kt
@@ -45,7 +45,7 @@ class MediaSession {
         val title: String? = null,
         val artist: String? = null,
         val album: String? = null,
-        val getArtwork: (suspend (Int) -> Bitmap?)?
+        val getArtwork: (suspend () -> Bitmap?)?
     )
 
     /**

--- a/components/feature/media/src/main/java/mozilla/components/feature/media/ext/SessionState.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/ext/SessionState.kt
@@ -6,14 +6,10 @@ package mozilla.components.feature.media.ext
 
 import android.content.Context
 import android.graphics.Bitmap
-import kotlinx.coroutines.withTimeoutOrNull
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.concept.engine.mediasession.MediaSession
 import mozilla.components.feature.media.R
-
-private const val ARTWORK_RETRIEVE_TIMEOUT = 1000L
-private const val ARTWORK_IMAGE_SIZE = 48
 
 internal fun SessionState?.getTitleOrUrl(context: Context, title: String? = null): String = when {
     this == null -> context.getString(R.string.mozac_feature_media_notification_private_mode)
@@ -23,13 +19,13 @@ internal fun SessionState?.getTitleOrUrl(context: Context, title: String? = null
     else -> content.url
 }
 
-internal suspend fun SessionState?.getNonPrivateIcon(getArtwork: (suspend (Int) -> Bitmap?)?): Bitmap? = when {
+@Suppress("TooGenericExceptionCaught")
+internal suspend fun SessionState?.getNonPrivateIcon(
+    getArtwork: (suspend () -> Bitmap?)?
+): Bitmap? = when {
     this == null -> null
     content.private -> null
-    getArtwork != null ->
-        withTimeoutOrNull(ARTWORK_RETRIEVE_TIMEOUT) {
-            getArtwork(ARTWORK_IMAGE_SIZE)
-        }
+    getArtwork != null -> getArtwork() ?: content.icon
     else -> content.icon
 }
 

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/ext/SessionStateKtTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/ext/SessionStateKtTest.kt
@@ -15,7 +15,8 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class SessionStateKtTest {
     private val bitmap: Bitmap = mock()
-    private val getArtwork: (suspend (Int) -> Bitmap?) = { bitmap }
+    private val getArtwork: (suspend () -> Bitmap?) = { bitmap }
+    private val getArtworkNull: (suspend () -> Bitmap?) = { null }
 
     @Test
     fun `getNonPrivateIcon returns null when in private mode`() {
@@ -62,6 +63,24 @@ class SessionStateKtTest {
         var result: Bitmap?
         runBlocking {
             result = sessionState.getNonPrivateIcon(null)
+        }
+
+        assertEquals(result, icon)
+    }
+
+    @Test
+    fun `getNonPrivateIcon returns content icon when getArtwork return null`() {
+        val sessionState: SessionState = mock()
+        val contentState: ContentState = mock()
+        val icon: Bitmap = mock()
+
+        whenever(sessionState.content).thenReturn(contentState)
+        whenever(contentState.private).thenReturn(false)
+        whenever(contentState.icon).thenReturn(icon)
+
+        var result: Bitmap?
+        runBlocking {
+            result = sessionState.getNonPrivateIcon(getArtworkNull)
         }
 
         assertEquals(result, icon)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
