### PR TITLE
Re-land: "Closes #8693: Integrate GeckoWebExecutor#FETCH_FLAG_PRIVATE."

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchClient.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchClient.kt
@@ -54,14 +54,7 @@ class GeckoViewFetchClient(
         }
 
         return try {
-            var fetchFlags = 0
-            if (request.cookiePolicy == Request.CookiePolicy.OMIT) {
-                fetchFlags += GeckoWebExecutor.FETCH_FLAGS_ANONYMOUS
-            }
-            if (request.redirect == Request.Redirect.MANUAL) {
-                fetchFlags += GeckoWebExecutor.FETCH_FLAGS_NO_REDIRECTS
-            }
-            val webResponse = executor.fetch(webRequest, fetchFlags).poll(readTimeOutMillis)
+            val webResponse = executor.fetch(webRequest, request.fetchFlags).poll(readTimeOutMillis)
             webResponse?.toResponse() ?: throw IOException("Fetch failed with null response")
         } catch (e: TimeoutException) {
             throw SocketTimeoutException()
@@ -69,6 +62,21 @@ class GeckoViewFetchClient(
             throw IOException(e)
         }
     }
+
+    private val Request.fetchFlags: Int
+        get() {
+            var fetchFlags = 0
+            if (cookiePolicy == Request.CookiePolicy.OMIT) {
+                fetchFlags += GeckoWebExecutor.FETCH_FLAGS_ANONYMOUS
+            }
+            if (private) {
+                fetchFlags += GeckoWebExecutor.FETCH_FLAGS_PRIVATE
+            }
+            if (redirect == Request.Redirect.MANUAL) {
+                fetchFlags += GeckoWebExecutor.FETCH_FLAGS_NO_REDIRECTS
+            }
+            return fetchFlags
+        }
 
     companion object {
         const val MAX_READ_TIMEOUT_MINUTES = 5L

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
@@ -223,6 +223,19 @@ class GeckoViewFetchUnitTestCases : FetchTestCases() {
     }
 
     @Test
+    fun performPrivateRequest() {
+        mockResponse(200)
+
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
+        whenever(request.private).thenReturn(true)
+        createNewClient().fetch(request)
+
+        verify(geckoWebExecutor)!!.fetch(any(), eq(GeckoWebExecutor.FETCH_FLAGS_PRIVATE))
+    }
+
+    @Test
     override fun get200WithContentTypeCharset() {
         val request = mock<Request>()
         whenever(request.url).thenReturn("https://mozilla.org")

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchClient.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchClient.kt
@@ -54,14 +54,7 @@ class GeckoViewFetchClient(
         }
 
         return try {
-            var fetchFlags = 0
-            if (request.cookiePolicy == Request.CookiePolicy.OMIT) {
-                fetchFlags += GeckoWebExecutor.FETCH_FLAGS_ANONYMOUS
-            }
-            if (request.redirect == Request.Redirect.MANUAL) {
-                fetchFlags += GeckoWebExecutor.FETCH_FLAGS_NO_REDIRECTS
-            }
-            val webResponse = executor.fetch(webRequest, fetchFlags).poll(readTimeOutMillis)
+            val webResponse = executor.fetch(webRequest, request.fetchFlags).poll(readTimeOutMillis)
             webResponse?.toResponse() ?: throw IOException("Fetch failed with null response")
         } catch (e: TimeoutException) {
             throw SocketTimeoutException()
@@ -69,6 +62,21 @@ class GeckoViewFetchClient(
             throw IOException(e)
         }
     }
+
+    private val Request.fetchFlags: Int
+        get() {
+            var fetchFlags = 0
+            if (cookiePolicy == Request.CookiePolicy.OMIT) {
+                fetchFlags += GeckoWebExecutor.FETCH_FLAGS_ANONYMOUS
+            }
+            if (private) {
+                fetchFlags += GeckoWebExecutor.FETCH_FLAGS_PRIVATE
+            }
+            if (redirect == Request.Redirect.MANUAL) {
+                fetchFlags += GeckoWebExecutor.FETCH_FLAGS_NO_REDIRECTS
+            }
+            return fetchFlags
+        }
 
     companion object {
         const val MAX_READ_TIMEOUT_MINUTES = 5L

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
@@ -223,6 +223,19 @@ class GeckoViewFetchUnitTestCases : FetchTestCases() {
     }
 
     @Test
+    fun performPrivateRequest() {
+        mockResponse(200)
+
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
+        whenever(request.private).thenReturn(true)
+        createNewClient().fetch(request)
+
+        verify(geckoWebExecutor)!!.fetch(any(), eq(GeckoWebExecutor.FETCH_FLAGS_PRIVATE))
+    }
+
+    @Test
     override fun get200WithContentTypeCharset() {
         val request = mock<Request>()
         whenever(request.url).thenReturn("https://mozilla.org")

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchClient.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchClient.kt
@@ -54,14 +54,7 @@ class GeckoViewFetchClient(
         }
 
         return try {
-            var fetchFlags = 0
-            if (request.cookiePolicy == Request.CookiePolicy.OMIT) {
-                fetchFlags += GeckoWebExecutor.FETCH_FLAGS_ANONYMOUS
-            }
-            if (request.redirect == Request.Redirect.MANUAL) {
-                fetchFlags += GeckoWebExecutor.FETCH_FLAGS_NO_REDIRECTS
-            }
-            val webResponse = executor.fetch(webRequest, fetchFlags).poll(readTimeOutMillis)
+            val webResponse = executor.fetch(webRequest, request.fetchFlags).poll(readTimeOutMillis)
             webResponse?.toResponse() ?: throw IOException("Fetch failed with null response")
         } catch (e: TimeoutException) {
             throw SocketTimeoutException()
@@ -69,6 +62,21 @@ class GeckoViewFetchClient(
             throw IOException(e)
         }
     }
+
+    private val Request.fetchFlags: Int
+        get() {
+            var fetchFlags = 0
+            if (cookiePolicy == Request.CookiePolicy.OMIT) {
+                fetchFlags += GeckoWebExecutor.FETCH_FLAGS_ANONYMOUS
+            }
+            if (private) {
+                fetchFlags += GeckoWebExecutor.FETCH_FLAGS_PRIVATE
+            }
+            if (redirect == Request.Redirect.MANUAL) {
+                fetchFlags += GeckoWebExecutor.FETCH_FLAGS_NO_REDIRECTS
+            }
+            return fetchFlags
+        }
 
     companion object {
         const val MAX_READ_TIMEOUT_MINUTES = 5L

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
@@ -223,6 +223,19 @@ class GeckoViewFetchUnitTestCases : FetchTestCases() {
     }
 
     @Test
+    fun performPrivateRequest() {
+        mockResponse(200)
+
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
+        whenever(request.private).thenReturn(true)
+        createNewClient().fetch(request)
+
+        verify(geckoWebExecutor)!!.fetch(any(), eq(GeckoWebExecutor.FETCH_FLAGS_PRIVATE))
+    }
+
+    @Test
     override fun get200WithContentTypeCharset() {
         val request = mock<Request>()
         whenever(request.url).thenReturn("https://mozilla.org")

--- a/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Request.kt
+++ b/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Request.kt
@@ -33,7 +33,8 @@ import java.util.concurrent.TimeUnit
  * sent with the request, defaults to [CookiePolicy.INCLUDE]
  * @property useCaches Whether caches should be used or a network request
  * should be forced, defaults to true (use caches).
- *
+* @property private Whether the request should be performed in a private context, defaults to false.
+ * The feature is not support in all [Client]s, check support before using.
  * @see [Headers.Names]
  * @see [Headers.Values]
  */
@@ -46,7 +47,8 @@ data class Request(
     val body: Body? = null,
     val redirect: Redirect = Redirect.FOLLOW,
     val cookiePolicy: CookiePolicy = CookiePolicy.INCLUDE,
-    val useCaches: Boolean = true
+    val useCaches: Boolean = true,
+    val private: Boolean = false
 ) {
     /**
      * A [Body] to be send with the [Request].

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
@@ -643,14 +643,12 @@ abstract class AbstractFetchDownloadService : Service() {
             headers.append(RANGE, "bytes=${currentDownloadJobState.currentBytesCopied}-")
         }
 
-        val cookiePolicy = if (download.private) {
-            Request.CookiePolicy.OMIT
-        } else {
-            Request.CookiePolicy.INCLUDE
-        }
-
         var isUsingHttpClient = false
-        val request = Request(download.url.sanitizeURL(), headers = headers, cookiePolicy = cookiePolicy)
+        val request = Request(
+            download.url.sanitizeURL(),
+            headers = headers,
+            private = download.private
+        )
         // When resuming a download we need to use the httpClient as
         // download.response doesn't support adding headers.
         val response = if (isResumingDownload || useHttpClient || download.response == null) {

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
@@ -1062,7 +1062,7 @@ class AbstractFetchDownloadServiceTest {
     }
 
     @Test
-    fun `WHEN a download is from a private session the client must include the correct CookiePolicy`() = runBlocking {
+    fun `WHEN a download is from a private session the request must be private`() = runBlocking {
         val response = Response(
             "https://example.com/file.txt",
             200,
@@ -1076,15 +1076,14 @@ class AbstractFetchDownloadServiceTest {
 
         service.performDownload(downloadJob)
         verify(client).fetch(providedRequest.capture())
-
-        assertEquals(Request.CookiePolicy.OMIT, providedRequest.value.cookiePolicy)
+        assertTrue(providedRequest.value.private)
 
         downloadJob.state = download.copy(private = false)
         service.performDownload(downloadJob)
 
         verify(client, times(2)).fetch(providedRequest.capture())
 
-        assertEquals(Request.CookiePolicy.INCLUDE, providedRequest.value.cookiePolicy)
+        assertFalse(providedRequest.value.private)
     }
 
     @Test

--- a/components/lib/fetch-httpurlconnection/src/main/java/mozilla/components/lib/fetch/httpurlconnection/HttpURLConnectionClient.kt
+++ b/components/lib/fetch-httpurlconnection/src/main/java/mozilla/components/lib/fetch/httpurlconnection/HttpURLConnectionClient.kt
@@ -32,6 +32,9 @@ class HttpURLConnectionClient : Client() {
 
     @Throws(IOException::class)
     override fun fetch(request: Request): Response {
+        if (request.private) {
+            throw IllegalArgumentException("Client doesn't support private request")
+        }
         if (request.isDataUri()) {
             return fetchDataUri(request)
         }

--- a/components/lib/fetch-okhttp/src/main/java/mozilla/components/lib/fetch/okhttp/OkHttpClient.kt
+++ b/components/lib/fetch-okhttp/src/main/java/mozilla/components/lib/fetch/okhttp/OkHttpClient.kt
@@ -37,6 +37,10 @@ class OkHttpClient(
     )
 
     override fun fetch(request: Request): Response {
+        if (request.private) {
+            throw IllegalArgumentException("Client doesn't support private request")
+        }
+
         if (request.isDataUri()) {
             return fetchDataUri(request)
         }


### PR DESCRIPTION
This re-lands commit 2d1842df117dc7e42543207bb62ed872eab5cd86.

This change was already added to the changelog in the last release.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
