### PR TITLE
Revert "For #9101 - Show BrowserMenu at the right location on Android <=23"

### DIFF
--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
@@ -20,17 +20,14 @@ import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.browser.menu.view.DynamicWidthRecyclerView
 import mozilla.components.concept.menu.MenuStyle
 import mozilla.components.support.test.any
-import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
 import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.doNothing
@@ -381,126 +378,6 @@ class BrowserMenuTest {
         verify(popupWindow).showAsDropDown(anchor, 0, screenHeight - contentHeight)
     }
 
-    @Config(qualifiers = "ldltr")
-    @Test
-    fun `showAnchorAtLocation should show the menu with Gravity_START if LTR`() {
-        val containerView = createMockViewWith(y = 0)
-        val anchor = createMockViewWith(y = 0)
-        val popupWindow = spy(PopupWindow())
-        doReturn(Int.MAX_VALUE).`when`(containerView).measuredHeight
-        val captor = argumentCaptor<Int>()
-
-        popupWindow.displayPopup(containerView, anchor, BrowserMenu.Orientation.DOWN)
-
-        verify(popupWindow).showAtLocation(any(), captor.capture(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())
-        assertNotEquals(0, captor.value and Gravity.START)
-    }
-
-    @Config(qualifiers = "ldrtl")
-    @Test
-    fun `showAnchorAtLocation should show the menu with Gravity_END if RTL`() {
-        val containerView = createMockViewWith(y = 0)
-        val anchor = createMockViewWith(y = 0)
-        val popupWindow = spy(PopupWindow())
-        doReturn(Int.MAX_VALUE).`when`(containerView).measuredHeight
-        val captor = argumentCaptor<Int>()
-
-        popupWindow.displayPopup(containerView, anchor, BrowserMenu.Orientation.DOWN)
-
-        verify(popupWindow).showAtLocation(any(), captor.capture(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())
-        assertNotEquals(0, captor.value and Gravity.END)
-    }
-
-    @Test
-    fun `showAnchorAtLocation should show the menu with Gravity_BOTTOM if the menu should be closer to the bottom`() {
-        val containerView = createMockViewWith(y = 0)
-        val anchor = createMockViewWith(y = 0)
-        val popupWindow = spy(PopupWindow())
-        val captor = argumentCaptor<Int>()
-        doReturn(Int.MAX_VALUE).`when`(containerView).measuredHeight
-        // Makes the availableHeightToBottom bigger than the availableHeightToTop
-        setScreenHeight(0)
-        doReturn(10).`when`(anchor).height
-
-        popupWindow.displayPopup(containerView, anchor, BrowserMenu.Orientation.DOWN)
-
-        verify(popupWindow).showAtLocation(any(), captor.capture(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())
-        assertNotEquals(0, captor.value and Gravity.BOTTOM)
-    }
-
-    @Test
-    fun `showAnchorAtLocation should show the menu with Gravity_TOP if the menu should be closer to the top`() {
-        val containerView = createMockViewWith(y = 0)
-        val anchor = createMockViewWith(y = 0)
-        val popupWindow = spy(PopupWindow())
-        val captor = argumentCaptor<Int>()
-        doReturn(Int.MAX_VALUE).`when`(containerView).measuredHeight
-        // Makes the availableHeightToBottom smaller than the availableHeightToTop
-        setScreenHeight(0)
-        doReturn(-10).`when`(anchor).height
-
-        popupWindow.displayPopup(containerView, anchor, BrowserMenu.Orientation.UP)
-
-        verify(popupWindow).showAtLocation(any(), captor.capture(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())
-        assertNotEquals(0, captor.value and Gravity.TOP)
-    }
-
-    @Test
-    fun `showAnchorAtLocation should use the OverflowMenuTop animation if the menu should be shown at the top`() {
-        val containerView = createMockViewWith(y = 0)
-        val anchor = createMockViewWith(y = 0)
-        val popupWindow = spy(PopupWindow())
-        doReturn(Int.MAX_VALUE).`when`(containerView).measuredHeight
-        // Makes the availableHeightToBottom smaller than the availableHeightToTop
-        setScreenHeight(0)
-        doReturn(-10).`when`(anchor).height
-
-        popupWindow.displayPopup(containerView, anchor, BrowserMenu.Orientation.UP)
-
-        assertEquals(popupWindow.animationStyle, R.style.Mozac_Browser_Menu_Animation_OverflowMenuTop)
-    }
-
-    @Test
-    fun `showAnchorAtLocation should use the OverflowMenuBottom animation if the menu should be shown at the bottom`() {
-        val containerView = createMockViewWith(y = 0)
-        val anchor = createMockViewWith(y = 0)
-        val popupWindow = spy(PopupWindow())
-        doReturn(Int.MAX_VALUE).`when`(containerView).measuredHeight
-        // Makes the availableHeightToBottom bigger than the availableHeightToTop
-        setScreenHeight(0)
-        doReturn(10).`when`(anchor).height
-
-        popupWindow.displayPopup(containerView, anchor, BrowserMenu.Orientation.DOWN)
-
-        assertEquals(popupWindow.animationStyle, R.style.Mozac_Browser_Menu_Animation_OverflowMenuBottom)
-    }
-
-    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP, Build.VERSION_CODES.LOLLIPOP_MR1, Build.VERSION_CODES.M])
-    @Test
-    fun `displayPopup on lower Android versions should directly call showAtAnchorLocation even if it fits`() {
-        // Constructing the test the same as the above one.
-        // The only difference is the Android SDK based on which another PopupWindow method should be used.
-
-        val containerView = createMockViewWith(y = 0)
-        // Makes the availableHeightToTop 10
-        val anchor = createMockViewWith(y = 10)
-        val popupWindow = spy(PopupWindow())
-        val screenHeight = -1
-        val contentHeight = -9
-
-        // Makes the availableHeightToBottom smaller than the availableHeightToTop
-        setScreenHeight(screenHeight)
-        doReturn(-10).`when`(anchor).height
-
-        // Makes the content of the menu smaller than the availableHeightToTop
-        doReturn(contentHeight).`when`(containerView).measuredHeight
-
-        popupWindow.displayPopup(containerView, anchor, BrowserMenu.Orientation.UP)
-
-        assertEquals(popupWindow.animationStyle, R.style.Mozac_Browser_Menu_Animation_OverflowMenuBottom)
-        verify(popupWindow).showAtLocation(anchor, Gravity.END or Gravity.BOTTOM, 0, 0)
-    }
-
     @Test
     fun `displayPopup that don't fitUp neither fitDown`() {
         val containerView = createMockViewWith(y = 0)
@@ -509,7 +386,7 @@ class BrowserMenuTest {
         doReturn(Int.MAX_VALUE).`when`(containerView).measuredHeight
 
         popupWindow.displayPopup(containerView, anchor, BrowserMenu.Orientation.DOWN)
-        verify(popupWindow).showAtLocation(anchor, Gravity.END or Gravity.TOP, 0, 0)
+        verify(popupWindow).showAtLocation(anchor, Gravity.START or Gravity.TOP, 0, 0)
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -180,9 +180,6 @@ permalink: /changelog/
 * **support-test-libstate**
   * Added `CaptureActionsMiddleware`: A `Middleware` implementation for unit tests that want to inspect actions dispatched on a `Store`.
 
-* **browser-menu**:
-  * 🚒 Bug fixed [issue #9101](https://github.com/mozilla-mobile/android-components/issues/9101) - Fix BrowserMenu position after rotating the screen on Android <=23
-
 * **feature-sitepermissions**
   * ⚠️ **This is a breaking change**: The `SitePermissionsRules` constructor, now requires a new parameter `mediaKeySystemAccess`.
   * 🌟 Added support for EME permission prompts, see [#7121](https://github.com/mozilla-mobile/android-components/issues/7121).


### PR DESCRIPTION
This reverts commit 506d2c9100ef5e4ca6060b4b228444fe1a34bf26.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
