### PR TITLE
TabsUseCases: Remove methods that take a Session object.

### DIFF
--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
@@ -34,11 +34,6 @@ class TabsUseCases(
      */
     interface SelectTabUseCase {
         /**
-         * Select given [session].
-         */
-        operator fun invoke(session: Session)
-
-        /**
          * Select [Session] with the given [tabId].
          */
         operator fun invoke(tabId: String)
@@ -47,16 +42,6 @@ class TabsUseCases(
     class DefaultSelectTabUseCase internal constructor(
         private val sessionManager: SessionManager
     ) : SelectTabUseCase {
-
-        /**
-         * Marks the provided session as selected.
-         *
-         * @param session The session to select.
-         */
-        override operator fun invoke(session: Session) {
-            sessionManager.select(session)
-        }
-
         /**
          * Marks the tab with the provided [tabId] as selected.
          */
@@ -93,13 +78,6 @@ class TabsUseCases(
          * should be removed together with invoke(Session).
          */
         operator fun invoke(sessionId: String, selectParentIfExists: Boolean) = invoke(sessionId)
-
-        /**
-         * Removes the provided session.
-         *
-         * @param session The session to remove.
-         */
-        operator fun invoke(session: Session)
     }
 
     /**
@@ -119,7 +97,7 @@ class TabsUseCases(
         override operator fun invoke(sessionId: String) {
             val session = sessionManager.findSessionById(sessionId)
             if (session != null) {
-                invoke(session)
+                sessionManager.remove(session)
             }
         }
 
@@ -137,15 +115,6 @@ class TabsUseCases(
                 sessionManager.remove(session, selectParentIfExists)
             }
         }
-
-        /**
-         * Removes the provided session.
-         *
-         * @param session The session to remove.
-         */
-        override operator fun invoke(session: Session) {
-            sessionManager.remove(session)
-        }
     }
 
     class AddNewTabUseCase internal constructor(
@@ -160,7 +129,7 @@ class TabsUseCases(
          * @param flags the [LoadUrlFlags] to use when loading the provided URL.
          */
         override fun invoke(url: String, flags: LoadUrlFlags, additionalHeaders: Map<String, String>?) {
-            this.invoke(url, true, true, null, flags)
+            this.invoke(url, selectTab = true, startLoading = true, parentId = null, flags = flags)
         }
 
         /**
@@ -222,7 +191,7 @@ class TabsUseCases(
          * @param flags the [LoadUrlFlags] to use when loading the provided URL.
          */
         override fun invoke(url: String, flags: LoadUrlFlags, additionalHeaders: Map<String, String>?) {
-            this.invoke(url, true, true, null, flags)
+            this.invoke(url, selectTab = true, startLoading = true, parentId = null, flags = flags)
         }
 
         /**
@@ -335,7 +304,7 @@ class TabsUseCases(
     class RestoreUseCase(
         private val store: BrowserStore,
         private val sessionManager: SessionManager,
-        private val selectTab: TabsUseCases.SelectTabUseCase
+        private val selectTab: SelectTabUseCase
     ) {
         /**
          * Restores the given list of [RecoverableTab]s.

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
@@ -28,6 +28,7 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
@@ -46,7 +47,9 @@ class TabsUseCasesTest {
         val useCases = TabsUseCases(BrowserStore(), sessionManager)
 
         val session = Session("A")
-        useCases.selectTab(session)
+        doReturn(session).`when`(sessionManager).findSessionById(session.id)
+
+        useCases.selectTab(session.id)
 
         verify(sessionManager).select(session)
     }
@@ -57,7 +60,9 @@ class TabsUseCasesTest {
         val useCases = TabsUseCases(BrowserStore(), sessionManager)
 
         val session = Session("A")
-        useCases.removeTab(session)
+        doReturn(session).`when`(sessionManager).findSessionById(session.id)
+
+        useCases.removeTab(session.id)
 
         verify(sessionManager).remove(session, false)
     }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/TabsTrayFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/TabsTrayFragment.kt
@@ -13,7 +13,6 @@ import androidx.recyclerview.widget.GridLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_tabstray.tabsTray
 import kotlinx.android.synthetic.main.fragment_tabstray.toolbar
-import mozilla.components.browser.session.Session
 import mozilla.components.browser.tabstray.TabsAdapter
 import mozilla.components.browser.thumbnails.loader.ThumbnailLoader
 import mozilla.components.feature.tabs.TabsUseCases
@@ -96,11 +95,6 @@ private class RemoveTabWithUndoUseCase(
 ) : TabsUseCases.RemoveTabUseCase {
     override fun invoke(sessionId: String) {
         actual.invoke(sessionId)
-        showSnackbar()
-    }
-
-    override fun invoke(session: Session) {
-        actual.invoke(session)
         showSnackbar()
     }
 


### PR DESCRIPTION
We have counterparts that take the tab ID instead. Removing them allows us to remove some of the overrides in
Fenix, which reduces the amount of `Session` usage.