### PR TITLE
For #9606 - Adds defaultSettings when creating a new GeckoEngineSession

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -88,7 +88,8 @@ class GeckoEngine(
         }
 
         override fun onToggleActionPopup(extension: WebExtension, action: Action): EngineSession? {
-            return webExtensionDelegate?.onToggleActionPopup(extension, GeckoEngineSession(runtime), action)
+            return webExtensionDelegate?.onToggleActionPopup(extension, GeckoEngineSession(runtime,
+                defaultSettings = defaultSettings), action)
         }
     }
     private val webExtensionTabHandler = object : TabHandler {
@@ -214,7 +215,7 @@ class GeckoEngine(
             val installedExtension = GeckoWebExtension(it, runtime)
             webExtensionDelegate?.onInstalled(installedExtension)
             installedExtension.registerActionHandler(webExtensionActionHandler)
-            installedExtension.registerTabHandler(webExtensionTabHandler)
+            installedExtension.registerTabHandler(webExtensionTabHandler, defaultSettings)
             onSuccess(installedExtension)
         }
 
@@ -272,7 +273,7 @@ class GeckoEngine(
             val updatedExtension = if (geckoExtension != null) {
                 GeckoWebExtension(geckoExtension, runtime).also {
                     it.registerActionHandler(webExtensionActionHandler)
-                    it.registerTabHandler(webExtensionTabHandler)
+                    it.registerTabHandler(webExtensionTabHandler, defaultSettings)
                 }
             } else {
                 null
@@ -343,7 +344,7 @@ class GeckoEngine(
 
             extensions.forEach { extension ->
                 extension.registerActionHandler(webExtensionActionHandler)
-                extension.registerTabHandler(webExtensionTabHandler)
+                extension.registerTabHandler(webExtensionTabHandler, defaultSettings)
             }
 
             onSuccess(extensions)

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -9,6 +9,7 @@ import androidx.annotation.VisibleForTesting
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.browser.engine.gecko.await
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.DisabledFlags
@@ -239,16 +240,18 @@ class GeckoWebExtension(
     /**
      * See [WebExtension.registerTabHandler].
      */
-    override fun registerTabHandler(tabHandler: TabHandler) {
-
+    override fun registerTabHandler(tabHandler: TabHandler, defaultSettings: Settings?) {
         val tabDelegate = object : GeckoNativeWebExtension.TabDelegate {
 
             override fun onNewTab(
                 ext: GeckoNativeWebExtension,
                 tabDetails: GeckoNativeWebExtension.CreateTabDetails
             ): GeckoResult<GeckoSession>? {
-                val geckoEngineSession = GeckoEngineSession(runtime, openGeckoSession = false)
-
+                val geckoEngineSession = GeckoEngineSession(
+                    runtime,
+                    defaultSettings = defaultSettings,
+                    openGeckoSession = false
+                )
                 tabHandler.onNewTab(
                     this@GeckoWebExtension,
                     geckoEngineSession,
@@ -262,7 +265,7 @@ class GeckoWebExtension(
                 ext.metaData.optionsPageUrl?.let { optionsPageUrl ->
                     tabHandler.onNewTab(
                         this@GeckoWebExtension,
-                        GeckoEngineSession(runtime),
+                        GeckoEngineSession(runtime, defaultSettings = defaultSettings),
                         false,
                         optionsPageUrl
                     )

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.engine.gecko.webextension
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.DisabledFlags
@@ -318,7 +319,9 @@ class GeckoWebExtensionTest {
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
-        extension.registerTabHandler(tabHandler)
+        val defaultSettings: DefaultSettings = mock()
+
+        extension.registerTabHandler(tabHandler, defaultSettings)
         verify(nativeGeckoWebExt).tabDelegate = tabDelegateCaptor.capture()
 
         // Verify that tab methods are forwarded to the handler

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -88,7 +88,8 @@ class GeckoEngine(
         }
 
         override fun onToggleActionPopup(extension: WebExtension, action: Action): EngineSession? {
-            return webExtensionDelegate?.onToggleActionPopup(extension, GeckoEngineSession(runtime), action)
+            return webExtensionDelegate?.onToggleActionPopup(extension, GeckoEngineSession(runtime,
+                defaultSettings = defaultSettings), action)
         }
     }
     private val webExtensionTabHandler = object : TabHandler {
@@ -214,7 +215,7 @@ class GeckoEngine(
             val installedExtension = GeckoWebExtension(it, runtime)
             webExtensionDelegate?.onInstalled(installedExtension)
             installedExtension.registerActionHandler(webExtensionActionHandler)
-            installedExtension.registerTabHandler(webExtensionTabHandler)
+            installedExtension.registerTabHandler(webExtensionTabHandler, defaultSettings)
             onSuccess(installedExtension)
         }
 
@@ -272,7 +273,7 @@ class GeckoEngine(
             val updatedExtension = if (geckoExtension != null) {
                 GeckoWebExtension(geckoExtension, runtime).also {
                     it.registerActionHandler(webExtensionActionHandler)
-                    it.registerTabHandler(webExtensionTabHandler)
+                    it.registerTabHandler(webExtensionTabHandler, defaultSettings)
                 }
             } else {
                 null
@@ -343,7 +344,7 @@ class GeckoEngine(
 
             extensions.forEach { extension ->
                 extension.registerActionHandler(webExtensionActionHandler)
-                extension.registerTabHandler(webExtensionTabHandler)
+                extension.registerTabHandler(webExtensionTabHandler, defaultSettings)
             }
 
             onSuccess(extensions)

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -9,6 +9,7 @@ import androidx.annotation.VisibleForTesting
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.browser.engine.gecko.await
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.DisabledFlags
@@ -244,7 +245,7 @@ class GeckoWebExtension(
     /**
      * See [WebExtension.registerTabHandler].
      */
-    override fun registerTabHandler(tabHandler: TabHandler) {
+    override fun registerTabHandler(tabHandler: TabHandler, defaultSettings: Settings?) {
 
         val tabDelegate = object : GeckoNativeWebExtension.TabDelegate {
 
@@ -252,7 +253,11 @@ class GeckoWebExtension(
                 ext: GeckoNativeWebExtension,
                 tabDetails: GeckoNativeWebExtension.CreateTabDetails
             ): GeckoResult<GeckoSession>? {
-                val geckoEngineSession = GeckoEngineSession(runtime, openGeckoSession = false)
+                val geckoEngineSession = GeckoEngineSession(
+                    runtime,
+                    defaultSettings = defaultSettings,
+                    openGeckoSession = false
+                )
 
                 tabHandler.onNewTab(
                     this@GeckoWebExtension,
@@ -267,7 +272,8 @@ class GeckoWebExtension(
                 ext.metaData.optionsPageUrl?.let { optionsPageUrl ->
                     tabHandler.onNewTab(
                         this@GeckoWebExtension,
-                        GeckoEngineSession(runtime),
+                        GeckoEngineSession(runtime,
+                            defaultSettings = defaultSettings),
                         false,
                         optionsPageUrl
                     )

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.engine.gecko.webextension
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.DisabledFlags
@@ -324,7 +325,9 @@ class GeckoWebExtensionTest {
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
-        extension.registerTabHandler(tabHandler)
+        val defaultSettings: DefaultSettings = mock()
+
+        extension.registerTabHandler(tabHandler, defaultSettings)
         verify(nativeGeckoWebExt).tabDelegate = tabDelegateCaptor.capture()
 
         // Verify that tab methods are forwarded to the handler

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -85,7 +85,8 @@ class GeckoEngine(
         }
 
         override fun onToggleActionPopup(extension: WebExtension, action: Action): EngineSession? {
-            return webExtensionDelegate?.onToggleActionPopup(extension, GeckoEngineSession(runtime), action)
+            return webExtensionDelegate?.onToggleActionPopup(extension, GeckoEngineSession(runtime,
+                defaultSettings = defaultSettings), action)
         }
     }
     private val webExtensionTabHandler = object : TabHandler {
@@ -211,7 +212,7 @@ class GeckoEngine(
             val installedExtension = GeckoWebExtension(it, runtime)
             webExtensionDelegate?.onInstalled(installedExtension)
             installedExtension.registerActionHandler(webExtensionActionHandler)
-            installedExtension.registerTabHandler(webExtensionTabHandler)
+            installedExtension.registerTabHandler(webExtensionTabHandler, defaultSettings)
             onSuccess(installedExtension)
         }
 
@@ -269,7 +270,7 @@ class GeckoEngine(
             val updatedExtension = if (geckoExtension != null) {
                 GeckoWebExtension(geckoExtension, runtime).also {
                     it.registerActionHandler(webExtensionActionHandler)
-                    it.registerTabHandler(webExtensionTabHandler)
+                    it.registerTabHandler(webExtensionTabHandler, defaultSettings)
                 }
             } else {
                 null
@@ -340,7 +341,7 @@ class GeckoEngine(
 
             extensions.forEach { extension ->
                 extension.registerActionHandler(webExtensionActionHandler)
-                extension.registerTabHandler(webExtensionTabHandler)
+                extension.registerTabHandler(webExtensionTabHandler, defaultSettings)
             }
 
             onSuccess(extensions)

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -9,6 +9,7 @@ import androidx.annotation.VisibleForTesting
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.browser.engine.gecko.await
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.DisabledFlags
@@ -239,7 +240,7 @@ class GeckoWebExtension(
     /**
      * See [WebExtension.registerTabHandler].
      */
-    override fun registerTabHandler(tabHandler: TabHandler) {
+    override fun registerTabHandler(tabHandler: TabHandler, defaultSettings: Settings?) {
 
         val tabDelegate = object : GeckoNativeWebExtension.TabDelegate {
 
@@ -247,7 +248,11 @@ class GeckoWebExtension(
                 ext: GeckoNativeWebExtension,
                 tabDetails: GeckoNativeWebExtension.CreateTabDetails
             ): GeckoResult<GeckoSession>? {
-                val geckoEngineSession = GeckoEngineSession(runtime, openGeckoSession = false)
+                val geckoEngineSession = GeckoEngineSession(
+                    runtime,
+                    defaultSettings = defaultSettings,
+                    openGeckoSession = false
+                )
 
                 tabHandler.onNewTab(
                     this@GeckoWebExtension,
@@ -262,7 +267,7 @@ class GeckoWebExtension(
                 ext.metaData.optionsPageUrl?.let { optionsPageUrl ->
                     tabHandler.onNewTab(
                         this@GeckoWebExtension,
-                        GeckoEngineSession(runtime),
+                        GeckoEngineSession(runtime, defaultSettings = defaultSettings),
                         false,
                         optionsPageUrl
                     )

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.engine.gecko.webextension
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.DisabledFlags
@@ -318,7 +319,9 @@ class GeckoWebExtensionTest {
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
-        extension.registerTabHandler(tabHandler)
+        val defaultSettings: DefaultSettings = mock()
+
+        extension.registerTabHandler(tabHandler, defaultSettings)
         verify(nativeGeckoWebExt).tabDelegate = tabDelegateCaptor.capture()
 
         // Verify that tab methods are forwarded to the handler

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -7,6 +7,7 @@ package mozilla.components.concept.engine.webextension
 import android.graphics.Bitmap
 import android.net.Uri
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.Settings
 import org.json.JSONObject
 
 /**
@@ -127,8 +128,10 @@ abstract class WebExtension(
      *
      * @param tabHandler the [TabHandler] to be invoked when the web extension
      * wants to open a new tab.
+     * @param defaultSettings used to pass default tab settings to any tabs opened by
+     * a web extension.
      */
-    abstract fun registerTabHandler(tabHandler: TabHandler)
+    abstract fun registerTabHandler(tabHandler: TabHandler, defaultSettings: Settings?)
 
     /**
      * Registers a [TabHandler] for the provided [EngineSession]. The handler

--- a/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
+++ b/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
@@ -545,7 +545,8 @@ class WebExtensionSupportTest {
         val actionHandlerCaptor = argumentCaptor<ActionHandler>()
         val tabHandlerCaptor = argumentCaptor<TabHandler>()
         verify(ext, never()).registerActionHandler(any(), any())
-        verify(ext, never()).registerTabHandler(any(), any())
+        verify(ext, never()).registerTabHandler(session = any(),
+            tabHandler = any())
 
         val engineSession1: EngineSession = mock()
         store.dispatch(EngineAction.LinkEngineSessionAction(tab.id, engineSession1)).joinBlocking()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,6 +33,10 @@ permalink: /changelog/
 * **feature-webauthn**
   * 🆕 New component to enable support for WebAuthn specification with `WebAuthnFeature`.
 
+* **concept-engine**
+  * Added `defaultSettings: Settings?` parameter to registerTabHandler to supply a default Tracking Policy when opening a new extension tab.
+  * When calling `onNewTab` in `registerTabHandler` from `GeckoWebExtension.kt` a default `TrackingProtectionPolicy.strict()` is supplied to the new `GeckoEngineSession`. This was added in to avoid WebExtension tabs without any ETP settings.
+
 * **concept-storage**
   * Introduced `CreditCardsAddressesStorage` interface for describing credit card and address storage.
 


### PR DESCRIPTION
 This fixes the issue where some new WebExtension tabs would have no ETP setting in Fenix.

For https://github.com/mozilla-mobile/android-components/issues/9606
and -> https://github.com/mozilla-mobile/fenix/issues/12848
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR  does not include any user facing features.

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
