### PR TITLE
Update feature-recentlyclosed dependencies to fix failing RecentlyClosedMiddlewareTest.

### DIFF
--- a/components/feature/recentlyclosed/build.gradle
+++ b/components/feature/recentlyclosed/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     kapt Dependencies.androidx_room_compiler
 
     testImplementation project(':browser-session')
+    testImplementation project(':feature-session')
     testImplementation project(':support-test')
     testImplementation project(':support-test-libstate')
 

--- a/components/feature/recentlyclosed/src/test/java/mozilla/components/feature/recentlyclosed/RecentlyClosedMiddlewareTest.kt
+++ b/components/feature/recentlyclosed/src/test/java/mozilla/components/feature/recentlyclosed/RecentlyClosedMiddlewareTest.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
-import mozilla.components.browser.session.undo.UndoMiddleware
+import mozilla.components.feature.session.middleware.undo.UndoMiddleware
 import mozilla.components.browser.state.action.RecentlyClosedAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.action.UndoAction


### PR DESCRIPTION
Additionally filed https://github.com/mozilla-mobile/android-components/issues/9605. It looks like our "build optimization" didn't see this dependency and therefore didn't build this and the PR went green. Then on `master` it exploded...