### PR TITLE
Make NimbusClient field immutable/thread-safe

### DIFF
--- a/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/Nimbus.kt
+++ b/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/Nimbus.kt
@@ -189,7 +189,7 @@ class Nimbus(
     private val fetchScope: CoroutineScope =
         CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
 
-    private var nimbus: NimbusClientInterface
+    private val nimbus: NimbusClientInterface
 
     override var globalUserParticipation: Boolean
         get() = nimbus.getGlobalUserParticipation()


### PR DESCRIPTION
This field doesn't need to be mutable and making it final addresses my concern in https://github.com/mozilla-mobile/fenix/pull/17834#discussion_r570492699