### PR TITLE
Closes #9605: Build optimization: Also follow 'testImplementation' dependencies.

### DIFF
--- a/taskcluster/ac_taskgraph/loader/build_config.py
+++ b/taskcluster/ac_taskgraph/loader/build_config.py
@@ -36,6 +36,7 @@ CONFIGURATIONS_WITH_DEPENDENCIES = (
 #    "geckoBetaImplementation",
 #    "geckoReleaseImplementation",
     "implementation",
+    "testImplementation"
 )
 ALL_COMPONENTS = object()
 


### PR DESCRIPTION
In theory I think we should also follow `androidTestImplementation` but not every module supports that and I think currently we expect the gradle command to always succeed.