### PR TITLE
Limit usage of JCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,26 @@ allprojects {
                 url project.property("jcenterRepo")
             }
         } else {
-            jcenter()
+            jcenter() {
+                content {
+                    ////////////////////////////////////////////////////////////////////////////////
+                    // JCenter is going away. Please do not add any new dependencies here.
+                    // https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
+                    ////////////////////////////////////////////////////////////////////////////////
+
+                    // Used by Android Gradle Plugin
+                    // Issue for publishing to maven central: https://youtrack.jetbrains.com/issue/IDEA-261387
+                    // Related plugin issue: https://issuetracker.google.com/issues/179291081
+                    // Other option: Update to Android Gradle Plugin 7+ (still in Alpha currently)
+                    includeVersion("org.jetbrains.trove4j", "trove4j", "20160824")
+
+                    // Used by detekt
+                    // Issue for publishing to maven central: https://github.com/Kotlin/kotlinx.html/issues/173
+                    // Related detekt issue: https://github.com/detekt/detekt/issues/3461
+                    includeVersion("org.jetbrains.kotlinx", "kotlinx-html-jvm", "0.7.1")
+                    includeVersion("org.jetbrains.kotlinx", "kotlinx-html-common", "0.7.1")
+                }
+            }
         }
 
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -23,15 +23,6 @@ buildscript {
         } else {
             mavenCentral()
         }
-
-        if (project.hasProperty("jcenterRepo")) {
-            maven {
-                name "BintrayJCenter"
-                url project.property("jcenterRepo")
-            }
-        } else {
-            jcenter()
-        }
     }
 
     dependencies {


### PR DESCRIPTION
This doesn't get rid of JCenter yet. But at least starts to limit its usage to the bare minimum.

Locally I can run `assemble`, `detekt`, `ktlint`, `lint` with this. Let's see if taskcluster finds any issues.