### PR TITLE
Revert "Update to Kotlin 1.4.30."

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -7,7 +7,7 @@
 
 // Synchronized version numbers for dependencies used by (some) modules
 object Versions {
-    const val kotlin = "1.4.30"
+    const val kotlin = "1.4.21"
     const val coroutines = "1.4.2"
 
     const val junit = "4.12"


### PR DESCRIPTION
This reverts commit 4641e44c389501c0c9b9513009b18e3488a3750e.

Fixes #9640.