### PR TITLE
Uplift: Closes #9668: feature-tab-collections: Pass restored tab ID back to caller

### DIFF
--- a/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/ext/TabsUseCases.kt
+++ b/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/ext/TabsUseCases.kt
@@ -18,7 +18,7 @@ operator fun TabsUseCases.RestoreUseCase.invoke(
     context: Context,
     engine: Engine,
     tab: Tab,
-    onTabRestored: () -> Unit,
+    onTabRestored: (String) -> Unit,
     onFailure: () -> Unit
 ) {
     val item = tab.restore(
@@ -32,8 +32,7 @@ operator fun TabsUseCases.RestoreUseCase.invoke(
         onFailure()
     } else {
         invoke(listOf(item), item.id)
-
-        onTabRestored()
+        onTabRestored(item.id)
     }
 }
 


### PR DESCRIPTION
See #9668. We need this to address a regression Fenix 86: https://github.com/mozilla-mobile/fenix/issues/17889