### PR TITLE
Revert "Update to Glean v34.0.0"

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -32,7 +32,7 @@ object Versions {
 
     const val mozilla_appservices = "70.0.0"
 
-    const val mozilla_glean = "34.0.0"
+    const val mozilla_glean = "33.1.2"
 
     const val material = "1.2.1"
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,9 +49,6 @@ permalink: /changelog/
 * **lib-state**
   * Add `threadNamePrefix` parameter to `Store` to give threads created by the `Store` a specific name.
 
-* **service-glean**
-  * 🆙 Updated Glean to version 34.0.0 ([changelog](https://github.com/mozilla/glean/releases/tag/v34.0.0))
-
 # 72.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v71.0.0...v72.0.0)

--- a/samples/sync/src/main/res/layout/activity_main.xml
+++ b/samples/sync/src/main/res/layout/activity_main.xml
@@ -130,7 +130,7 @@
                 style="?android:attr/listSeparatorTextViewStyle"
                 android:text="@string/devices" />
 
-            <FragmentContainerView android:name="org.mozilla.samples.sync.DeviceFragment"
+            <fragment android:name="org.mozilla.samples.sync.DeviceFragment"
                 android:id="@+id/devices_fragment"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
Reverts mozilla-mobile/android-components#9549. We see a failing test in Fenix with this: https://github.com/mozilla-mobile/fenix/pull/17977#issuecomment-778420282

Let's revert and figure this out next week...so we don't have to block A-C upgrades.