### PR TITLE
Closes #9654: Rework MediaSession Service foreground notification behaviour

### DIFF
--- a/components/feature/media/src/main/java/mozilla/components/feature/media/notification/MediaNotification.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/notification/MediaNotification.kt
@@ -56,6 +56,10 @@ internal class MediaNotification(
         return buildNotification(data, mediaSessionCompat, sessionState !is CustomTabSessionState)
     }
 
+    fun createDummy(mediaSessionCompat: MediaSessionCompat): Notification {
+        return buildNotification(NotificationData(), mediaSessionCompat, false)
+    }
+
     private fun buildNotification(
         data: NotificationData,
         mediaSession: MediaSessionCompat,

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/notification/MediaNotificationTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/notification/MediaNotificationTest.kt
@@ -46,6 +46,16 @@ class MediaNotificationTest {
     }
 
     @Test
+    fun `media session notification for dummy state`() {
+        val notification =
+            MediaNotification(context, AbstractMediaSessionService::class.java).createDummy(mock())
+
+        assertEquals("", notification.text)
+        assertEquals("", notification.title)
+        assertEquals(R.drawable.mozac_feature_media_playing, notification.iconResource)
+    }
+
+    @Test
     fun `media notification for playing state`() {
         val state = BrowserState(
             tabs = listOf(

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/service/MediaSessionServiceDelegateTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/service/MediaSessionServiceDelegateTest.kt
@@ -44,6 +44,7 @@ class MediaSessionServiceDelegateTest {
         delegate.onCreate()
 
         verify(service).startForeground(ArgumentMatchers.anyInt(), any())
+        assert(delegate.isForegroundService)
 
         delegate.onDestroy()
     }
@@ -64,6 +65,7 @@ class MediaSessionServiceDelegateTest {
 
         verify(service).startForeground(ArgumentMatchers.anyInt(), any())
         verify(service, never()).stopSelf()
+        assert(delegate.isForegroundService)
 
         store.dispatch(MediaSessionAction.DeactivatedMediaSessionAction(store.state.tabs[0].id))
 
@@ -92,6 +94,7 @@ class MediaSessionServiceDelegateTest {
         verify(service).startForeground(ArgumentMatchers.anyInt(), any())
         verify(service, never()).stopSelf()
         verify(delegate, never()).shutdown()
+        assert(delegate.isForegroundService)
 
         store.dispatch(MediaSessionAction.DeactivatedMediaSessionAction(store.state.customTabs[0].id))
 
@@ -126,6 +129,7 @@ class MediaSessionServiceDelegateTest {
         verify(service, never()).stopSelf()
         verify(delegate, never()).shutdown()
         verify(controller, never()).pause()
+        assert(delegate.isForegroundService)
 
         delegate.onStartCommand(AbstractMediaSessionService.pauseIntent(
             testContext,
@@ -157,6 +161,8 @@ class MediaSessionServiceDelegateTest {
         verify(service, never()).stopSelf()
         verify(delegate, never()).shutdown()
         verify(controller, never()).pause()
+        verify(service).stopForeground(false)
+        assert(!delegate.isForegroundService)
 
         delegate.onStartCommand(AbstractMediaSessionService.playIntent(
             testContext,
@@ -190,6 +196,8 @@ class MediaSessionServiceDelegateTest {
         verify(service).startForeground(ArgumentMatchers.anyInt(), any())
         verify(service, never()).stopSelf()
         verify(controller, never()).pause()
+        verify(service).stopForeground(false)
+        assert(!delegate.isForegroundService)
 
         delegate.onStartCommand(AbstractMediaSessionService.playIntent(
             testContext,
@@ -238,6 +246,7 @@ class MediaSessionServiceDelegateTest {
         verify(delegate, never()).shutdown()
         verify(controller, never()).pause()
         verify(controller, never()).play()
+        assert(delegate.isForegroundService)
 
         mediaSessionCallback.onPause()
         verify(controller).pause()


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
