### PR TITLE
Update to Application Services v73.0.1

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -30,7 +30,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "2.4"
 
-    const val mozilla_appservices = "72.1.0"
+    const val mozilla_appservices = "73.0.1"
 
     const val mozilla_glean = "35.0.0"
 

--- a/components/service/firefox-accounts/README.md
+++ b/components/service/firefox-accounts/README.md
@@ -173,7 +173,7 @@ val accountEventsObserver = object : AccountEventsObserver {
     override fun onEvents(event: List<AccountEvent>) {
         // device received some commands; for example, here's how you can process incoming Send Tab commands:
         commands
-            .filter { it is AccountEvent.IncomingDeviceCommand }
+            .filter { it is AccountEvent.CommandReceived }
             .map { it.command }
             .filter { it is DeviceCommandIncoming.TabReceived }
             .forEach {

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Exceptions.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Exceptions.kt
@@ -7,28 +7,28 @@ package mozilla.components.service.fxa
 /**
  * High-level exception class for the exceptions thrown in the Rust library.
  */
-typealias FxaException = mozilla.appservices.fxaclient.FxaException
+typealias FxaException = mozilla.appservices.fxaclient.FxaErrorException
 
 /**
  * Thrown on a network error.
  */
-typealias FxaNetworkException = mozilla.appservices.fxaclient.FxaException.Network
+typealias FxaNetworkException = mozilla.appservices.fxaclient.FxaErrorException.Network
 
 /**
  * Thrown when the Rust library hits an assertion or panic (this is always a bug).
  */
-typealias FxaPanicException = mozilla.appservices.fxaclient.FxaException.Panic
+typealias FxaPanicException = mozilla.appservices.fxaclient.FxaErrorException.Panic
 
 /**
  * Thrown when the operation requires additional authorization.
  */
-typealias FxaUnauthorizedException = mozilla.appservices.fxaclient.FxaException.Unauthorized
+typealias FxaUnauthorizedException = mozilla.appservices.fxaclient.FxaErrorException.Authentication
 
 /**
  * Thrown when the Rust library hits an unexpected error that isn't a panic.
  * This may indicate library misuse, network errors, etc.
  */
-typealias FxaUnspecifiedException = mozilla.appservices.fxaclient.FxaException.Unspecified
+typealias FxaUnspecifiedException = mozilla.appservices.fxaclient.FxaErrorException.Other
 
 /**
  * @return 'true' if this exception should be re-thrown and eventually crash the app.

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
@@ -9,9 +9,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.plus
-import mozilla.appservices.fxaclient.AuthorizationParams
+import mozilla.appservices.fxaclient.AuthorizationParameters
 import kotlinx.coroutines.withContext
-import mozilla.appservices.fxaclient.FirefoxAccount as InternalFxAcct
+import mozilla.appservices.fxaclient.PersistedFirefoxAccount as InternalFxAcct
 import mozilla.components.concept.sync.AccessType
 import mozilla.components.concept.sync.AuthFlowUrl
 import mozilla.components.concept.sync.MigratingAccountInfo
@@ -21,7 +21,7 @@ import mozilla.components.concept.sync.StatePersistenceCallback
 import mozilla.components.concept.base.crash.CrashReporting
 import mozilla.components.support.base.log.logger.Logger
 
-typealias PersistCallback = mozilla.appservices.fxaclient.FirefoxAccount.PersistCallback
+typealias PersistCallback = mozilla.appservices.fxaclient.PersistedFirefoxAccount.PersistCallback
 
 /**
  * FirefoxAccount represents the authentication state of a client.
@@ -144,7 +144,7 @@ class FirefoxAccount internal constructor(
         accessType: AccessType
     ) = withContext(scope.coroutineContext) {
         handleFxaExceptions(logger, "authorizeOAuthCode", { null }) {
-            val params = AuthorizationParams(clientId, scopes, state, accessType.msg)
+            val params = AuthorizationParameters(clientId, scopes.toList(), state, accessType.msg, null, null, null)
             inner.authorizeOAuthCode(params)
         }
     }

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
@@ -9,8 +9,8 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withContext
-import mozilla.appservices.fxaclient.FirefoxAccount
-import mozilla.appservices.fxaclient.FxaException
+import mozilla.appservices.fxaclient.PersistedFirefoxAccount as FirefoxAccount
+import mozilla.appservices.fxaclient.FxaErrorException as FxaException
 import mozilla.components.concept.sync.ConstellationState
 import mozilla.components.concept.sync.Device
 import mozilla.components.concept.sync.DeviceConstellation

--- a/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/Nimbus.kt
+++ b/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/Nimbus.kt
@@ -29,7 +29,7 @@ import org.mozilla.experiments.nimbus.AvailableRandomizationUnits
 import org.mozilla.experiments.nimbus.EnrolledExperiment
 import org.mozilla.experiments.nimbus.EnrollmentChangeEvent
 import org.mozilla.experiments.nimbus.EnrollmentChangeEventType
-import org.mozilla.experiments.nimbus.ErrorException
+import org.mozilla.experiments.nimbus.NimbusErrorException
 import org.mozilla.experiments.nimbus.NimbusClient
 import org.mozilla.experiments.nimbus.NimbusClientInterface
 import org.mozilla.experiments.nimbus.RemoteSettingsConfig
@@ -298,9 +298,9 @@ class Nimbus(
         try {
             nimbus.fetchExperiments()
             notifyObservers { onExperimentsFetched() }
-        } catch (e: ErrorException.RequestError) {
+        } catch (e: NimbusErrorException.RequestError) {
             logger.info("Error fetching experiments from endpoint: $e")
-        } catch (e: ErrorException.ResponseError) {
+        } catch (e: NimbusErrorException.ResponseError) {
             logger.info("Error fetching experiments from endpoint: $e")
         }
     }
@@ -318,7 +318,7 @@ class Nimbus(
             nimbus.applyPendingExperiments().also(::recordExperimentTelemetryEvents)
             // Get the experiments to record in telemetry
             postEnrolmentCalculation()
-        } catch (e: ErrorException.InvalidExperimentFormat) {
+        } catch (e: NimbusErrorException.InvalidExperimentFormat) {
             logger.info("Invalid experiment format: $e")
         }
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,11 @@ permalink: /changelog/
 * **service-sync-autofill**
   * Refactors `AutofillCreditCardsAddressesStorage` from **browser-storage-sync** into its own component. [#9801](https://github.com/mozilla-mobile/android-components/issues/9801)
 
+* **service-firefox-accounts**,**browser-storage-sync**,**service-nimbus**,**service-sync-logins**
+  * Due to a temporary build issue in the Application Services project, it is not currently
+  possible to run some service-related unittests on a Windows host. [#9731](https://github.com/mozilla-mobile/android-components/pull/9731)
+    * Work on restoring this capability will be tracked in [application-services#3917](https://github.com/mozilla/application-services/issues/3917).
+
 # 73.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v72.0.0...v73.0.0)


### PR DESCRIPTION
*Update:* The new version of Application Services has been released and it includes auto-generated bindings for the fxaclient component. This PR updates the appservices version and provides the necessary tweaks for API changes.

I've tested this manually in a local build of Fenix and account- and send-tab-related functionality seems to be working well.

--
Over in https://github.com/mozilla/application-services/pull/3876 I'm working on a significant restructure of the `fxa-client` Rust component, aiming to use our new bindings-generation tool to replace a bunch of hand-written code. This PR captures the corresponding a-c changes to adapt to the minor API differences between authgenerated and hand-written code.

~~It's not appropriate to merge yet, but I wanted to push it for early visible and feedback, particularly if any of the changes here seem like the sort of thing we should not be doing. /cc @grigoryk @jonalmeida~~