### PR TITLE
Search: Remember and restore order of search engine list for user's region

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -1035,7 +1035,8 @@ sealed class SearchAction : BrowserAction() {
         val additionalAvailableSearchEngines: List<SearchEngine>,
         val userSelectedSearchEngineId: String?,
         val userSelectedSearchEngineName: String?,
-        val regionDefaultSearchEngineId: String
+        val regionDefaultSearchEngineId: String,
+        val regionSearchEnginesOrder: List<String>
     ) : SearchAction()
 
     /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/SearchReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/SearchReducer.kt
@@ -39,6 +39,7 @@ private fun BrowserState.setSearchEngines(
         hiddenSearchEngines = action.hiddenSearchEngines,
         additionalSearchEngines = action.additionalSearchEngines,
         additionalAvailableSearchEngines = action.additionalAvailableSearchEngines,
+        regionSearchEnginesOrder = action.regionSearchEnginesOrder,
         complete = true
     ))
 }
@@ -95,7 +96,9 @@ private fun BrowserState.showSearchEngine(
     return if (searchEngine != null) {
         copy(search = search.copy(
             hiddenSearchEngines = search.hiddenSearchEngines - searchEngine,
-            regionSearchEngines = search.regionSearchEngines + searchEngine
+            regionSearchEngines = (search.regionSearchEngines + searchEngine).sortedBy {
+                search.regionSearchEnginesOrder.indexOf(it.id)
+            }
         ))
     } else {
         this

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/SearchState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/SearchState.kt
@@ -24,6 +24,8 @@ import mozilla.components.browser.state.search.SearchEngine
  * Or `null` if the user hasn't made an explicit choice.
  * @property regionDefaultSearchEngineId The ID of the default [SearchEngine] of the "home" region
  * of the user.
+ * @property regionSearchEnginesOrder Ordered list of [SearchEngine] IDs in the preferred order for
+ * this region. Can be used when [regionSearchEngines] needs to be reordered.
  * @property complete Flag that indicates whether loading the list of search engines has completed.
  * This can be used for waiting for specific values (e.g. the default search engine) to be available.
  */
@@ -37,6 +39,7 @@ data class SearchState(
     val userSelectedSearchEngineId: String? = null,
     val userSelectedSearchEngineName: String? = null,
     val regionDefaultSearchEngineId: String? = null,
+    val regionSearchEnginesOrder: List<String> = emptyList(),
     val complete: Boolean = false
 )
 

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/SearchActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/SearchActionTest.kt
@@ -46,7 +46,8 @@ class SearchActionTest {
             userSelectedSearchEngineName = null,
             hiddenSearchEngines = emptyList(),
             additionalSearchEngines = emptyList(),
-            additionalAvailableSearchEngines = emptyList()
+            additionalAvailableSearchEngines = emptyList(),
+            regionSearchEnginesOrder = listOf("id1", "id2")
         )).joinBlocking()
 
         val searchEngines = store.state.search.regionSearchEngines
@@ -83,7 +84,8 @@ class SearchActionTest {
             userSelectedSearchEngineName = null,
             hiddenSearchEngines = emptyList(),
             additionalSearchEngines = emptyList(),
-            additionalAvailableSearchEngines = emptyList()
+            additionalAvailableSearchEngines = emptyList(),
+            regionSearchEnginesOrder = emptyList()
         )).joinBlocking()
 
         val searchEngines = store.state.search.customSearchEngines

--- a/components/feature/search/src/main/java/mozilla/components/feature/search/middleware/SearchMiddleware.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/middleware/SearchMiddleware.kt
@@ -119,7 +119,8 @@ class SearchMiddleware(
             customSearchEngines = customSearchEngines.await(),
             hiddenSearchEngines = hiddenSearchEngines,
             additionalSearchEngines = additionalSearchEngines,
-            additionalAvailableSearchEngines = additionalAvailableSearchEngines
+            additionalAvailableSearchEngines = additionalAvailableSearchEngines,
+            regionSearchEnginesOrder = regionSearchEngineIds
         )
 
         store.dispatch(action)

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/ext/BrowserStoreKtTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/ext/BrowserStoreKtTest.kt
@@ -76,7 +76,8 @@ class BrowserStoreKtTest {
             customSearchEngines = emptyList(),
             hiddenSearchEngines = emptyList(),
             additionalAvailableSearchEngines = emptyList(),
-            additionalSearchEngines = emptyList()
+            additionalSearchEngines = emptyList(),
+            regionSearchEnginesOrder = listOf("google")
         ))
 
         assertTrue(latch.await(10, TimeUnit.SECONDS))
@@ -101,7 +102,8 @@ class BrowserStoreKtTest {
             customSearchEngines = emptyList(),
             hiddenSearchEngines = emptyList(),
             additionalAvailableSearchEngines = emptyList(),
-            additionalSearchEngines = emptyList()
+            additionalSearchEngines = emptyList(),
+            regionSearchEnginesOrder = listOf("google")
         ))
 
         assertTrue(latch.await(10, TimeUnit.SECONDS))

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/middleware/SearchMiddlewareTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/middleware/SearchMiddlewareTest.kt
@@ -862,6 +862,85 @@ class SearchMiddlewareTest {
             assertTrue(selectedSearchEngine.resultUrls[0].startsWith("https://www.amazon.com/"))
         }
     }
+
+    @Test
+    fun `Reorders list of region search engines after adding previously removed search engines`() {
+        val searchMiddleware = SearchMiddleware(
+            testContext,
+            ioDispatcher = dispatcher,
+            customStorage = CustomSearchEngineStorage(testContext, dispatcher)
+        )
+
+        val store = BrowserStore(
+            middleware = listOf(searchMiddleware)
+        )
+
+        assertTrue(store.state.search.regionSearchEngines.isEmpty())
+
+        store.dispatch(SearchAction.SetRegionAction(
+            RegionState("US", "US")
+        )).joinBlocking()
+
+        wait(store, dispatcher)
+
+        // ///////////////////////////////////////////////////////////////////////////////////////////
+        // Verify initial state
+        // ///////////////////////////////////////////////////////////////////////////////////////////
+
+        assertEquals(5, store.state.search.regionSearchEngines.size)
+
+        assertEquals("Google", store.state.search.regionSearchEngines[0].name)
+        assertEquals("Bing", store.state.search.regionSearchEngines[1].name)
+        assertEquals("Amazon.com", store.state.search.regionSearchEngines[2].name)
+        assertEquals("DuckDuckGo", store.state.search.regionSearchEngines[3].name)
+        assertEquals("Wikipedia", store.state.search.regionSearchEngines[4].name)
+
+        assertEquals("Google", store.state.search.selectedOrDefaultSearchEngine!!.name)
+
+        store.dispatch(SearchAction.HideSearchEngineAction(
+            "google-b-1-m"
+        )).joinBlocking()
+
+        store.dispatch(SearchAction.HideSearchEngineAction(
+            "ddg"
+        )).joinBlocking()
+
+        // ///////////////////////////////////////////////////////////////////////////////////////////
+        // Verify after hiding search engines
+        // ///////////////////////////////////////////////////////////////////////////////////////////
+
+        assertEquals(3, store.state.search.regionSearchEngines.size)
+
+        assertEquals("Bing", store.state.search.regionSearchEngines[0].name)
+        assertEquals("Amazon.com", store.state.search.regionSearchEngines[1].name)
+        assertEquals("Wikipedia", store.state.search.regionSearchEngines[2].name)
+
+        assertEquals("Bing", store.state.search.selectedOrDefaultSearchEngine!!.name)
+
+        println(store.state.search.regionSearchEngines)
+
+        store.dispatch(
+            SearchAction.ShowSearchEngineAction("google-b-1-m")
+        ).joinBlocking()
+
+        store.dispatch(
+            SearchAction.ShowSearchEngineAction("ddg")
+        ).joinBlocking()
+
+        // ///////////////////////////////////////////////////////////////////////////////////////////
+        // Verify state after adding search engines back
+        // ///////////////////////////////////////////////////////////////////////////////////////////
+
+        assertEquals(5, store.state.search.regionSearchEngines.size)
+
+        assertEquals("Google", store.state.search.regionSearchEngines[0].name)
+        assertEquals("Bing", store.state.search.regionSearchEngines[1].name)
+        assertEquals("Amazon.com", store.state.search.regionSearchEngines[2].name)
+        assertEquals("DuckDuckGo", store.state.search.regionSearchEngines[3].name)
+        assertEquals("Wikipedia", store.state.search.regionSearchEngines[4].name)
+
+        assertEquals("Google", store.state.search.selectedOrDefaultSearchEngine!!.name)
+    }
 }
 
 private fun wait(store: BrowserStore, dispatcher: TestCoroutineDispatcher) {


### PR DESCRIPTION
When user's add and remove search engines from the region list then this will make sure that the search engines are still in the order as dictated by the configuration for the region.