### PR TITLE
Add l10n.toml to list of auto-merge files.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,7 +21,7 @@ pull_request_rules:
     conditions:
       - author=mozilla-l10n-automation-bot
       - status-success=complete-pr
-      - files~=(strings.xml)
+      - files~=(strings.xml|l10n.toml)
     actions:
       review:
         type: APPROVE


### PR DESCRIPTION
Sometimes our L10N tooling does update `l10n.toml` and if that happens we do not auto-merge that PR since we only check for `strings.xml` files. This patch adds `l10n.toml` to the list. :)

(CC @Delphine)