### PR TITLE
Closes #9757 remove downloads notification when private tabs are closed

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -963,6 +963,11 @@ sealed class DownloadAction : BrowserAction() {
     data class UpdateDownloadAction(val download: DownloadState) : DownloadAction()
 
     /**
+     * Mark the download notification of the provided [downloadId] as removed from the status bar.
+     */
+    data class DismissDownloadNotificationAction(val downloadId: String) : DownloadAction()
+
+    /**
      * Restores the [BrowserState.downloads] state from the storage.
      */
     object RestoreDownloadsStateAction : DownloadAction()

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/DownloadStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/DownloadStateReducer.kt
@@ -19,6 +19,14 @@ internal object DownloadStateReducer {
             is DownloadAction.UpdateDownloadAction -> {
                 updateDownloads(state, action.download)
             }
+            is DownloadAction.DismissDownloadNotificationAction -> {
+                val download = state.downloads[action.downloadId]
+                if (download != null) {
+                    updateDownloads(state, download.copy(notificationId = null))
+                } else {
+                    state
+                }
+            }
             is DownloadAction.RemoveDownloadAction -> {
                 state.copy(downloads = state.downloads - action.downloadId)
             }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadState.kt
@@ -28,6 +28,8 @@ import java.util.UUID
  * @property createdTime A timestamp when the download was created.
  * @property response A response object associated with this request, when provided can be
  * used instead of performing a manual a download.
+ * @property notificationId Identifies the download notification in the status bar, if this
+ * [DownloadState] has one otherwise null.
  */
 @Suppress("Deprecation")
 data class DownloadState(
@@ -45,7 +47,8 @@ data class DownloadState(
     val sessionId: String? = null,
     val private: Boolean = false,
     val createdTime: Long = System.currentTimeMillis(),
-    val response: Response? = null
+    val response: Response? = null,
+    val notificationId: Int? = null
 ) {
     val filePath: String get() =
         Environment.getExternalStoragePublicDirectory(destinationDirectory).path + File.separatorChar + fileName

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/DownloadActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/DownloadActionTest.kt
@@ -10,6 +10,8 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.test.ext.joinBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertSame
 import org.junit.Test
@@ -29,6 +31,32 @@ class DownloadActionTest {
         store.dispatch(DownloadAction.AddDownloadAction(download2)).joinBlocking()
         assertEquals(download2, store.state.downloads[download2.id])
         assertEquals(2, store.state.downloads.size)
+    }
+
+    @Test
+    fun `WHEN DismissDownloadNotificationAction is dispatched THEN notificationId is set to null`() {
+        val store = BrowserStore(BrowserState())
+
+        val download = DownloadState("https://mozilla.org/download1", destinationDirectory = "", notificationId = 100)
+        store.dispatch(DownloadAction.AddDownloadAction(download)).joinBlocking()
+        assertNotNull(store.state.downloads[download.id]!!.notificationId)
+
+        store.dispatch(DownloadAction.DismissDownloadNotificationAction(download.id)).joinBlocking()
+        assertNull(store.state.downloads[download.id]!!.notificationId)
+    }
+
+    @Test
+    fun `WHEN DismissDownloadNotificationAction is dispatched with an invalid downloadId THEN the state must not change`() {
+        val store = BrowserStore(BrowserState())
+
+        val download = DownloadState("https://mozilla.org/download1", destinationDirectory = "", notificationId = 100)
+        store.dispatch(DownloadAction.AddDownloadAction(download)).joinBlocking()
+        assertNotNull(store.state.downloads[download.id]!!.notificationId)
+        assertEquals(1, store.state.downloads.size)
+
+        store.dispatch(DownloadAction.DismissDownloadNotificationAction("-1")).joinBlocking()
+        assertNotNull(store.state.downloads[download.id]!!.notificationId)
+        assertEquals(download, store.state.downloads[download.id])
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **feature-downloads**:
+  * 🚒 Bug fixed [issue #9757](https://github.com/mozilla-mobile/android-components/issues/9757) - Remove downloads notification when private tabs are closed.
+
 * **feature-push**
   * ⚠️ **This is a breaking change**: Removed `databasePath` from `RustPushConnection` constructor and added `context`. The file path is now queries lazily.
 


### PR DESCRIPTION
We want to observe any actions that remove tabs, to verify if there are private downloads associated with it if so we want to remove their notifications from the status bar.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
