### PR TITLE
Fixes #9708: Remove extraneous entity.id assignments in LoginExceptionStorage and PinnedSiteStorage

### DIFF
--- a/components/feature/logins/src/main/java/mozilla/components/feature/logins/exceptions/LoginExceptionStorage.kt
+++ b/components/feature/logins/src/main/java/mozilla/components/feature/logins/exceptions/LoginExceptionStorage.kt
@@ -31,7 +31,7 @@ class LoginExceptionStorage(
         LoginExceptionEntity(
             origin = origin
         ).also { entity ->
-            entity.id = database.value.loginExceptionDao().insertLoginException(entity)
+            database.value.loginExceptionDao().insertLoginException(entity)
         }
     }
 

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/PinnedSiteStorage.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/PinnedSiteStorage.kt
@@ -61,7 +61,7 @@ class PinnedSiteStorage(context: Context) {
                 isDefault = isDefault,
                 createdAt = currentTimeMillis()
             )
-            entity.id = pinnedSiteDao.insertPinnedSite(entity)
+            pinnedSiteDao.insertPinnedSite(entity)
         }
 
     /**

--- a/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/PinnedSitesStorageTest.kt
+++ b/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/PinnedSitesStorageTest.kt
@@ -53,11 +53,8 @@ class PinnedSitesStorageTest {
         storage.addPinnedSite("Mozilla", "https://www.mozilla.org")
         storage.addPinnedSite("Firefox", "https://www.firefox.com", isDefault = true)
 
-        // PinnedSiteDao.insertPinnedSite is actually called with "id = null", but due to an
-        // extraneous assignment ("entity.id = ") in PinnedSiteStorage.addPinnedSite we can for now
-        // only verify the call with "id = 0". See issue #9708.
-        verify(dao).insertPinnedSite(PinnedSiteEntity(id = 0, title = "Mozilla", url = "https://www.mozilla.org", isDefault = false, createdAt = 3))
-        verify(dao).insertPinnedSite(PinnedSiteEntity(id = 0, title = "Firefox", url = "https://www.firefox.com", isDefault = true, createdAt = 3))
+        verify(dao).insertPinnedSite(PinnedSiteEntity(title = "Mozilla", url = "https://www.mozilla.org", isDefault = false, createdAt = 3))
+        verify(dao).insertPinnedSite(PinnedSiteEntity(title = "Firefox", url = "https://www.firefox.com", isDefault = true, createdAt = 3))
 
         Unit
     }

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
@@ -312,6 +312,8 @@ class FennecMigratorTest {
             "Internet for people, not profit — Mozilla",
             "https://www.mozilla.org/en-US/"
         )
+
+        Unit
     }
 
     @Test


### PR DESCRIPTION
Just a small (and hopefully wanted) cleanup PR, see #9708 for my explanation.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
