### PR TITLE
Closes #9754: add locale to browser state

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -93,6 +93,11 @@ sealed class LocaleAction : BrowserAction() {
      * @property locale the updated [Locale]
      */
     data class UpdateLocaleAction(val locale: Locale?) : LocaleAction()
+
+    /**
+     * Restores the [BrowserState.locale] state from storage.
+     */
+    object RestoreLocaleStateAction : LocaleAction()
 }
 
 /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -47,6 +47,7 @@ import mozilla.components.concept.engine.webextension.WebExtensionPageAction
 import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.lib.state.Action
 import mozilla.components.support.base.android.Clock
+import java.util.Locale
 
 /**
  * [Action] implementation related to [BrowserState].
@@ -81,6 +82,13 @@ sealed class SystemAction : BrowserAction() {
         val level: Int
     ) : SystemAction()
 }
+
+/**
+ * Updating the [BrowserState] to reflect app [Locale] changes.
+ *
+ * @property locale the updated [Locale]
+ */
+data class UpdateLocaleAction(val locale: Locale) : BrowserAction()
 
 /**
  * [BrowserAction] implementations related to updating the list of [ClosedTabSessionState] inside [BrowserState].

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -84,11 +84,16 @@ sealed class SystemAction : BrowserAction() {
 }
 
 /**
- * Updating the [BrowserState] to reflect app [Locale] changes.
- *
- * @property locale the updated [Locale]
+ * [BrowserAction] implementations related to updating the [Locale] inside [BrowserState].
  */
-data class UpdateLocaleAction(val locale: Locale) : BrowserAction()
+sealed class LocaleAction : BrowserAction() {
+    /**
+     * Updating the [BrowserState] to reflect app [Locale] changes.
+     *
+     * @property locale the updated [Locale]
+     */
+    data class UpdateLocaleAction(val locale: Locale?) : LocaleAction()
+}
 
 /**
  * [BrowserAction] implementations related to updating the list of [ClosedTabSessionState] inside [BrowserState].

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
@@ -24,6 +24,7 @@ import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
 import mozilla.components.browser.state.action.UndoAction
 import mozilla.components.browser.state.action.WebExtensionAction
+import mozilla.components.browser.state.action.UpdateLocaleAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.CustomTabSessionState
 import mozilla.components.browser.state.state.SessionState
@@ -59,6 +60,7 @@ internal object BrowserStateReducer {
             is LastAccessAction -> LastAccessReducer.reduce(state, action)
             is UndoAction -> UndoReducer.reduce(state, action)
             is ShareInternetResourceAction -> ShareInternetResourceStateReducer.reduce(state, action)
+            is UpdateLocaleAction -> state.copy(locale = action.locale)
         }
     }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
@@ -24,7 +24,7 @@ import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
 import mozilla.components.browser.state.action.UndoAction
 import mozilla.components.browser.state.action.WebExtensionAction
-import mozilla.components.browser.state.action.UpdateLocaleAction
+import mozilla.components.browser.state.action.LocaleAction.UpdateLocaleAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.CustomTabSessionState
 import mozilla.components.browser.state.state.SessionState

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.state.reducer
 
+import mozilla.components.browser.state.action.WebExtensionAction
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.ContainerAction
 import mozilla.components.browser.state.action.ContentAction
@@ -23,8 +24,7 @@ import mozilla.components.browser.state.action.SystemAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
 import mozilla.components.browser.state.action.UndoAction
-import mozilla.components.browser.state.action.WebExtensionAction
-import mozilla.components.browser.state.action.LocaleAction.UpdateLocaleAction
+import mozilla.components.browser.state.action.LocaleAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.CustomTabSessionState
 import mozilla.components.browser.state.state.SessionState
@@ -60,7 +60,7 @@ internal object BrowserStateReducer {
             is LastAccessAction -> LastAccessReducer.reduce(state, action)
             is UndoAction -> UndoReducer.reduce(state, action)
             is ShareInternetResourceAction -> ShareInternetResourceStateReducer.reduce(state, action)
-            is UpdateLocaleAction -> state.copy(locale = action.locale)
+            is LocaleAction -> LocaleStateReducer.reduce(state, action)
         }
     }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/DownloadStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/DownloadStateReducer.kt
@@ -39,5 +39,5 @@ internal object DownloadStateReducer {
     }
 
     private fun updateDownloads(state: BrowserState, download: DownloadState) =
-            state.copy(downloads = state.downloads + (download.id to download))
+        state.copy(downloads = state.downloads + (download.id to download))
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/LocaleStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/LocaleStateReducer.kt
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.reducer
+
+import mozilla.components.browser.state.action.LocaleAction
+import mozilla.components.browser.state.state.BrowserState
+
+internal object LocaleStateReducer {
+
+    /**
+     * [LocaleAction] Reducer function for modifying [BrowserState.locale].
+     */
+    fun reduce(state: BrowserState, action: LocaleAction): BrowserState {
+        return when (action) {
+            is LocaleAction.UpdateLocaleAction -> state.copy(locale = action.locale)
+            is LocaleAction.RestoreLocaleStateAction -> state
+        }
+    }
+}

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/BrowserState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/BrowserState.kt
@@ -28,7 +28,7 @@ import java.util.Locale
  * @property undoHistory History of recently closed tabs to support "undo" (Requires UndoMiddleware).
  * @property restoreComplete Whether or not restoring [BrowserState] has completed. This can be used
  * on application startup e.g. as an indicator that tabs have been restored.
- * @property locale The current locale of the app, defaults to null.
+ * @property locale The current locale of the app. Will be null when following the system default.
  */
 data class BrowserState(
     val tabs: List<TabSessionState> = emptyList(),

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/BrowserState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/BrowserState.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.state.state
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.state.recover.RecoverableTab
 import mozilla.components.lib.state.State
+import java.util.Locale
 
 /**
  * Value type that represents the complete state of the browser/engine.
@@ -27,6 +28,7 @@ import mozilla.components.lib.state.State
  * @property undoHistory History of recently closed tabs to support "undo" (Requires UndoMiddleware).
  * @property restoreComplete Whether or not restoring [BrowserState] has completed. This can be used
  * on application startup e.g. as an indicator that tabs have been restored.
+ * @property locale The current locale of the app, defaults to null.
  */
 data class BrowserState(
     val tabs: List<TabSessionState> = emptyList(),
@@ -39,5 +41,6 @@ data class BrowserState(
     val downloads: Map<String, DownloadState> = emptyMap(),
     val search: SearchState = SearchState(),
     val undoHistory: UndoHistoryState = UndoHistoryState(),
-    val restoreComplete: Boolean = false
+    val restoreComplete: Boolean = false,
+    val locale: Locale? = null
 ) : State

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/LocaleActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/LocaleActionTest.kt
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.action
+
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.support.test.ext.joinBlocking
+import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.Locale
+
+class LocaleActionTest {
+    @Test
+    fun `WHEN a new locale is selected THEN it is updated in the store`() {
+        val store = BrowserStore(BrowserState())
+        val locale1 = Locale("es")
+        store.dispatch(LocaleAction.UpdateLocaleAction(locale1)).joinBlocking()
+        assertEquals(locale1, store.state.locale)
+    }
+
+    @Test
+    fun `WHEN the state is restored from disk THEN the store receives the state`() {
+        val store = BrowserStore(BrowserState())
+
+        val state = store.state
+        store.dispatch(LocaleAction.RestoreLocaleStateAction).joinBlocking()
+        Assert.assertSame(store.state, state)
+    }
+}

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/LocaleActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/LocaleActionTest.kt
@@ -7,8 +7,8 @@ package mozilla.components.browser.state.action
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.test.ext.joinBlocking
-import org.junit.Assert
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Test
 import java.util.Locale
 
@@ -27,6 +27,6 @@ class LocaleActionTest {
 
         val state = store.state
         store.dispatch(LocaleAction.RestoreLocaleStateAction).joinBlocking()
-        Assert.assertSame(store.state, state)
+        assertSame(state, store.state)
     }
 }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/reducer/LocaleStateReducerTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/reducer/LocaleStateReducerTest.kt
@@ -12,9 +12,8 @@ import org.junit.Test
 import java.util.Locale
 
 class LocaleStateReducerTest {
-
     @Test
-    fun `WHEN updating locale action is called THEN the reducer updates locale state`() {
+    fun `WHEN updating locale action is called THEN the locale state is updated`() {
         val reducer = LocaleStateReducer
         val state = BrowserState()
         val locale = Locale("es")
@@ -28,7 +27,7 @@ class LocaleStateReducerTest {
     }
 
     @Test
-    fun `WHEN restoring locale action is called THEN the reducer persists state`() {
+    fun `WHEN restoring locale action is called THEN the locale state is persisted`() {
         val reducer = LocaleStateReducer
         val state = BrowserState()
         val action = LocaleAction.RestoreLocaleStateAction

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/reducer/LocaleStateReducerTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/reducer/LocaleStateReducerTest.kt
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.reducer
+
+import mozilla.components.browser.state.action.LocaleAction
+import mozilla.components.browser.state.state.BrowserState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.Locale
+
+class LocaleStateReducerTest {
+
+    @Test
+    fun `WHEN updating locale action is called THEN the reducer updates locale state`() {
+        val reducer = LocaleStateReducer
+        val state = BrowserState()
+        val locale = Locale("es")
+        val action = LocaleAction.UpdateLocaleAction(locale)
+
+        assertNull(state.locale)
+
+        val result = reducer.reduce(state, action)
+
+        assertEquals(result.locale, locale)
+    }
+
+    @Test
+    fun `WHEN restoring locale action is called THEN the reducer persists state`() {
+        val reducer = LocaleStateReducer
+        val state = BrowserState()
+        val action = LocaleAction.RestoreLocaleStateAction
+
+        assertNull(state.locale)
+
+        val result = reducer.reduce(state, action)
+
+        assertNull(result.locale)
+    }
+}

--- a/components/feature/privatemode/src/main/java/mozilla/components/feature/privatemode/notification/AbstractPrivateNotificationService.kt
+++ b/components/feature/privatemode/src/main/java/mozilla/components/feature/privatemode/notification/AbstractPrivateNotificationService.kt
@@ -31,7 +31,6 @@ import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.support.base.ids.SharedIdsHelper
 import mozilla.components.support.ktx.android.notification.ChannelData
 import mozilla.components.support.ktx.android.notification.ensureNotificationChannelExists
-import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 import java.util.Locale
 
@@ -131,9 +130,7 @@ abstract class AbstractPrivateNotificationService : Service() {
 
         localeScope = store.flowScoped { flow ->
             flow.mapNotNull { state -> state.locale }
-                .ifAnyChanged { locale ->
-                    arrayOf(locale)
-                }
+                .ifChanged()
                 .collect {
                     notifyLocaleChanged()
                 }

--- a/components/feature/privatemode/src/main/java/mozilla/components/feature/privatemode/notification/AbstractPrivateNotificationService.kt
+++ b/components/feature/privatemode/src/main/java/mozilla/components/feature/privatemode/notification/AbstractPrivateNotificationService.kt
@@ -89,17 +89,7 @@ abstract class AbstractPrivateNotificationService : Service() {
             }
         })
 
-        val notification = NotificationCompat.Builder(this, channelId)
-            .setOngoing(true)
-            .setVisibility(VISIBILITY_SECRET)
-            .setShowWhen(false)
-            .setLocalOnly(true)
-            .setContentIntent(Intent(ACTION_ERASE).let {
-                it.setClass(this, this::class.java)
-                PendingIntent.getService(this, 0, it, FLAG_ONE_SHOT)
-            })
-            .apply { buildNotification() }
-            .build()
+        val notification = createNotification(channelId)
 
         startForeground(id, notification)
 
@@ -123,6 +113,19 @@ abstract class AbstractPrivateNotificationService : Service() {
                 }
         }
     }
+
+    fun createNotification(channelId: String) =
+        NotificationCompat.Builder(this, channelId)
+            .setOngoing(true)
+            .setVisibility(VISIBILITY_SECRET)
+            .setShowWhen(false)
+            .setLocalOnly(true)
+            .setContentIntent(Intent(ACTION_ERASE).let {
+                it.setClass(this, this::class.java)
+                PendingIntent.getService(this, 0, it, FLAG_ONE_SHOT)
+            })
+            .apply { buildNotification() }
+            .build()
 
     final override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
         if (intent.action == ACTION_ERASE) {

--- a/components/feature/privatemode/src/test/java/mozilla/components/feature/privatemode/notification/AbstractPrivateNotificationServiceTest.kt
+++ b/components/feature/privatemode/src/test/java/mozilla/components/feature/privatemode/notification/AbstractPrivateNotificationServiceTest.kt
@@ -12,14 +12,24 @@ import android.content.SharedPreferences
 import androidx.core.app.NotificationCompat
 import androidx.core.content.getSystemService
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import mozilla.components.browser.state.action.LocaleAction
 import mozilla.components.browser.state.action.TabListAction
+import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.privatemode.notification.AbstractPrivateNotificationService.Companion.ACTION_ERASE
+import mozilla.components.support.ktx.android.notification.ensureNotificationChannelExists
 import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.eq
+import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.whenever
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -30,6 +40,7 @@ import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
+import java.util.Locale
 
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
@@ -37,9 +48,12 @@ class AbstractPrivateNotificationServiceTest {
 
     private lateinit var preferences: SharedPreferences
     private lateinit var notificationManager: NotificationManager
+    private val testDispatcher = TestCoroutineDispatcher()
 
     @Before
     fun setup() {
+        Dispatchers.setMain(testDispatcher)
+
         preferences = mock()
         notificationManager = mock()
         val editor = mock<SharedPreferences.Editor>()
@@ -48,11 +62,22 @@ class AbstractPrivateNotificationServiceTest {
         whenever(editor.putLong(anyString(), anyLong())).thenReturn(editor)
     }
 
+    @After
+    @ExperimentalCoroutinesApi
+    fun tearDown() {
+        Dispatchers.resetMain()
+        testDispatcher.cleanupTestCoroutines()
+    }
+
     @Test
-    fun `start foreground on create`() {
+    fun `WHEN the service is created THEN start foreground is called`() {
         val service = spy(object : MockService() {
             override fun NotificationCompat.Builder.buildNotification() {
                 setCategory(Notification.CATEGORY_STATUS)
+            }
+
+            override fun notifyLocaleChanged(notificationId: Int, channelId: String) {
+                // NOOP
             }
         })
         attachContext(service)
@@ -65,7 +90,7 @@ class AbstractPrivateNotificationServiceTest {
     }
 
     @Test
-    fun `remove all private tabs on erase intent`() {
+    fun `GIVEN an erase intent is received THEN remove all private tabs`() {
         val service = MockService()
         val result = service.onStartCommand(Intent(ACTION_ERASE), 0, 0)
 
@@ -74,7 +99,7 @@ class AbstractPrivateNotificationServiceTest {
     }
 
     @Test
-    fun `remove all private tabs on task removed`() {
+    fun `WHEN task is removed THEN all private tabs are removed`() {
         val service = spy(MockService())
         service.onTaskRemoved(mock())
 
@@ -86,6 +111,56 @@ class AbstractPrivateNotificationServiceTest {
     private open class MockService : AbstractPrivateNotificationService() {
         override val store: BrowserStore = mock()
         override fun NotificationCompat.Builder.buildNotification() = Unit
+        override fun notifyLocaleChanged(notificationId: Int, channelId: String) {
+            // NOOP
+        }
+    }
+
+
+    /*
+    val feature = spy(
+            PromptFeature(
+                fragment = mock(),
+                store = store,
+                fragmentManager = fragmentManager
+            ) { })
+        feature.start()
+
+        val promptRequest = SingleChoice(arrayOf()) {}
+        store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
+        testDispatcher.advanceUntilIdle()
+        verify(feature).onPromptRequested(store.state.tabs.first())
+     */
+
+
+    @Test
+    fun `WHEN a locale change is made in the browser store THEN the service should notify`() {
+        val service = spy(MockServiceWithStore())
+        attachContext(service)
+        service.onCreate()
+
+        val channelId = ensureNotificationChannelExists(
+            testContext,
+            AbstractPrivateNotificationService.NOTIFICATION_CHANNEL
+        )
+
+        val mockLocale = Locale("English")
+        service.store.dispatch(LocaleAction.UpdateLocaleAction(mockLocale)).joinBlocking()
+        testDispatcher.advanceUntilIdle()
+
+        verify(service).notifyLocaleChanged(anyInt(), eq(channelId))
+    }
+
+    private open class MockServiceWithStore : AbstractPrivateNotificationService() {
+        override val store = BrowserStore(
+            BrowserState(
+                locale = null
+            )
+        )
+        override fun NotificationCompat.Builder.buildNotification() = Unit
+        override fun notifyLocaleChanged(notificationId: Int, channelId: String) {
+            // NOOP
+        }
     }
 
     private fun attachContext(service: Service) {

--- a/components/support/locale/build.gradle
+++ b/components/support/locale/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_coroutines
+
+    androidTestImplementation Dependencies.testing_coroutines
 }
 
 apply from: '../../../publish.gradle'

--- a/components/support/locale/build.gradle
+++ b/components/support/locale/build.gradle
@@ -27,9 +27,11 @@ dependencies {
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.androidx_core
     implementation Dependencies.androidx_core_ktx
+    implementation Dependencies.kotlin_coroutines
 
     implementation project(':support-base')
     implementation project(':support-utils')
+    implementation project(':browser-state')
 
     testImplementation project(':support-test')
     testImplementation Dependencies.androidx_test_core

--- a/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleManager.kt
+++ b/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleManager.kt
@@ -11,15 +11,12 @@ import android.content.res.Resources
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.ConfigurationCompat
 import mozilla.components.support.base.R
-import mozilla.components.support.base.log.logger.Logger
 import java.util.Locale
 
 /**
  * Helper for apps that want to change locale defined by the system.
  */
 object LocaleManager {
-    private val logger = Logger("LocaleManager")
-
     /**
      * Change the system defined locale to the indicated in the [language] parameter.
      * This new [language] will be stored and will be the new current locale returned by [getCurrentLocale].

--- a/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleManager.kt
+++ b/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleManager.kt
@@ -28,12 +28,12 @@ object LocaleManager {
      *
      * @param context The [Context]
      * @param localeUseCase The [LocaleUseCases] used to notify [Locale] changes
-     * @param language The new language that has been selected
+     * @param language The new [Locale] that has been selected
      * @return A new Context object for whose resources are adjusted to match the new [language].
      */
-    fun setNewLocale(context: Context, localeUseCase: LocaleUseCases, language: String): Context {
-        Storage.save(context, language)
-        localeUseCase.notifyLocaleChanged(Locale(language))
+    fun setNewLocale(context: Context, localeUseCase: LocaleUseCases, locale: Locale?): Context {
+        Storage.save(context, locale?.language)
+        localeUseCase.notifyLocaleChanged(locale)
         return updateResources(context)
     }
 
@@ -113,7 +113,7 @@ object LocaleManager {
         }
 
         @Synchronized
-        fun save(context: Context, localeCode: String) {
+        fun save(context: Context, localeCode: String?) {
             val settings = getSharedPreferences(context)
             val key = context.getString(R.string.mozac_support_base_locale_preference_key_locale)
             settings.edit().putString(key, localeCode).apply()

--- a/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleManager.kt
+++ b/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleManager.kt
@@ -31,9 +31,13 @@ object LocaleManager {
      * @param language The new [Locale] that has been selected
      * @return A new Context object for whose resources are adjusted to match the new [language].
      */
-    fun setNewLocale(context: Context, localeUseCase: LocaleUseCases, locale: Locale?): Context {
+    fun setNewLocale(context: Context, localeUseCase: LocaleUseCases? = null, locale: Locale?): Context {
         Storage.save(context, locale?.language)
-        localeUseCase.notifyLocaleChanged(locale)
+
+        localeUseCase?.let { useCases ->
+            useCases.notifyLocaleChanged(locale)
+        }
+
         return updateResources(context)
     }
 

--- a/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleMiddleware.kt
+++ b/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleMiddleware.kt
@@ -25,8 +25,7 @@ import kotlin.coroutines.CoroutineContext
 class LocaleMiddleware(
     private val applicationContext: Context,
     coroutineContext: CoroutineContext = Dispatchers.IO,
-    private val localeManager: LocaleManager,
-    private val localeUseCases: LocaleUseCases
+    private val localeManager: LocaleManager
 ) : Middleware<BrowserState, BrowserAction> {
 
     private val logger = Logger("LocaleMiddleware")
@@ -53,12 +52,12 @@ class LocaleMiddleware(
                 "No recoverable locale has been set. Following device locale."
             )
         } else {
-            logger.debug("Locale restored from the storage ${localeHistory}")
+            logger.debug("Locale restored from the storage $localeHistory")
         }
         store.dispatch(LocaleAction.UpdateLocaleAction(localeHistory))
     }
 
     private fun updateLocale(locale: Locale?) {
-        localeManager.setNewLocale(applicationContext, localeUseCases, locale)
+        localeManager.setNewLocale(applicationContext, locale = locale)
     }
 }

--- a/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleMiddleware.kt
+++ b/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleMiddleware.kt
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.locale
+
+import android.content.Context
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.launch
+import mozilla.components.browser.state.action.BrowserAction
+import mozilla.components.browser.state.action.LocaleAction
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.lib.state.Middleware
+import mozilla.components.lib.state.MiddlewareContext
+import mozilla.components.lib.state.Store
+import mozilla.components.support.base.log.logger.Logger
+import java.util.Locale
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * [Middleware] implementation for updating [BrowserState.locale] state changes during restore.
+ */
+class LocaleMiddleware(
+    private val applicationContext: Context,
+    coroutineContext: CoroutineContext = Dispatchers.IO,
+    private val localeManager: LocaleManager,
+    private val localeUseCases: LocaleUseCases
+) : Middleware<BrowserState, BrowserAction> {
+
+    private val logger = Logger("LocaleMiddleware")
+    private var scope = CoroutineScope(coroutineContext)
+
+    @InternalCoroutinesApi
+    override fun invoke(
+        context: MiddlewareContext<BrowserState, BrowserAction>,
+        next: (BrowserAction) -> Unit,
+        action: BrowserAction
+    ) {
+        when (action) {
+            is LocaleAction.RestoreLocaleStateAction -> restoreLocale(context.store)
+            is LocaleAction.UpdateLocaleAction -> updateLocale(action.locale)
+        }
+
+        next(action)
+    }
+
+    private fun restoreLocale(store: Store<BrowserState, BrowserAction>) = scope.launch {
+        val localeHistory = localeManager.getCurrentLocale(applicationContext)
+        if (localeHistory == null) {
+            logger.debug(
+                "No recoverable locale has been set. Following device locale."
+            )
+        } else {
+            logger.debug("Locale restored from the storage ${localeHistory}")
+        }
+        store.dispatch(LocaleAction.UpdateLocaleAction(localeHistory))
+    }
+
+    private fun updateLocale(locale: Locale?) {
+        localeManager.setNewLocale(applicationContext, localeUseCases, locale)
+    }
+}

--- a/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleUseCases.kt
+++ b/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleUseCases.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.support.locale
 
+import mozilla.components.browser.state.action.LocaleAction
 import mozilla.components.browser.state.action.LocaleAction.UpdateLocaleAction
 import mozilla.components.browser.state.store.BrowserStore
 import java.util.Locale
@@ -28,7 +29,25 @@ class LocaleUseCases(browserStore: BrowserStore) {
         }
     }
 
+    /**
+     * Use case for restoring the [Locale].
+     */
+    class RestoreUseCase(
+        private val browserStore: BrowserStore
+    ) {
+        /**
+         * Restores the given [Locale] from storage.
+         */
+        operator fun invoke() {
+            browserStore.dispatch(LocaleAction.RestoreLocaleStateAction)
+        }
+    }
+
     val notifyLocaleChanged: UpdateLocaleUseCase by lazy {
         UpdateLocaleUseCase(browserStore)
+    }
+
+    val restore: RestoreUseCase by lazy {
+        RestoreUseCase(browserStore)
     }
 }

--- a/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleUseCases.kt
+++ b/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleUseCases.kt
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.locale
+
+import mozilla.components.browser.state.action.LocaleAction.UpdateLocaleAction
+import mozilla.components.browser.state.store.BrowserStore
+import java.util.Locale
+
+/**
+ * Contains use cases related to localization.
+ */
+class LocaleUseCases(browserStore: BrowserStore) {
+    /**
+     * Updates the [Locale] to the most recent user selection.
+     */
+    class UpdateLocaleUseCase internal constructor(
+        private val store: BrowserStore
+    ) {
+        /**
+         * Updates the locale for [BrowserStore] observers.
+         *
+         * @param locale The [Locale] that has been selected.
+         */
+        operator fun invoke(locale: Locale?) {
+            store.dispatch(UpdateLocaleAction(locale))
+        }
+    }
+
+    val notifyLocaleChanged: UpdateLocaleUseCase by lazy {
+        UpdateLocaleUseCase(browserStore)
+    }
+}

--- a/components/support/locale/src/test/java/mozilla/components/support/locale/LocaleManagerTest.kt
+++ b/components/support/locale/src/test/java/mozilla/components/support/locale/LocaleManagerTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.support.locale
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -18,9 +19,12 @@ import java.util.Locale
 @RunWith(AndroidJUnit4::class)
 class LocaleManagerTest {
 
+    private lateinit var localeUseCases: LocaleUseCases
+
     @Before
     fun setup() {
         LocaleManager.clear(testContext)
+        localeUseCases = LocaleUseCases(BrowserStore())
     }
 
     @Test
@@ -30,7 +34,7 @@ class LocaleManagerTest {
 
         assertNull(currentLocale)
 
-        val newContext = LocaleManager.setNewLocale(testContext, "es")
+        val newContext = LocaleManager.setNewLocale(testContext, localeUseCases, "es")
 
         assertNotEquals(testContext, newContext)
 
@@ -54,13 +58,13 @@ class LocaleManagerTest {
     fun `when resetting to system locale then the current locale will be the system one`() {
         assertEquals("en_US".toLocale(), Locale.getDefault())
 
-        LocaleManager.setNewLocale(testContext, "fr")
+        LocaleManager.setNewLocale(testContext, localeUseCases,"fr")
         val storedLocale = Locale.getDefault()
 
         assertEquals("fr".toLocale(), Locale.getDefault())
         assertEquals("fr".toLocale(), storedLocale)
 
-        LocaleManager.resetToSystemDefault(testContext)
+        LocaleManager.resetToSystemDefault(testContext, localeUseCases)
 
         assertEquals("en_US".toLocale(), Locale.getDefault())
         assertNull(LocaleManager.getCurrentLocale(testContext))
@@ -71,7 +75,7 @@ class LocaleManagerTest {
     fun `when setting a new locale then the current locale will be different than the system locale`() {
         assertEquals("en_US".toLocale(), Locale.getDefault())
 
-        LocaleManager.setNewLocale(testContext, "fr")
+        LocaleManager.setNewLocale(testContext, localeUseCases,"fr")
 
         assertEquals("en_US".toLocale(), LocaleManager.getSystemDefault())
         assertEquals("fr".toLocale(), LocaleManager.getCurrentLocale(testContext))

--- a/components/support/locale/src/test/java/mozilla/components/support/locale/LocaleManagerTest.kt
+++ b/components/support/locale/src/test/java/mozilla/components/support/locale/LocaleManagerTest.kt
@@ -16,6 +16,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.never
 import org.robolectric.annotation.Config
 import java.util.Locale
 
@@ -39,7 +40,7 @@ class LocaleManagerTest {
 
         assertNull(currentLocale)
 
-        val newContext = LocaleManager.setNewLocale(testContext, localeUseCases, "es")
+        val newContext = LocaleManager.setNewLocale(testContext, localeUseCases, "es".toLocale())
 
         assertNotEquals(testContext, newContext)
 
@@ -66,7 +67,7 @@ class LocaleManagerTest {
         LocaleManager.setNewLocale(
             testContext,
             localeUseCases,
-            "fr"
+            "fr".toLocale()
         )
 
         val storedLocale = Locale.getDefault()
@@ -85,7 +86,7 @@ class LocaleManagerTest {
     fun `when setting a new locale then the current locale will be different than the system locale`() {
         assertEquals("en_US".toLocale(), Locale.getDefault())
 
-        LocaleManager.setNewLocale(testContext, localeUseCases, "fr")
+        LocaleManager.setNewLocale(testContext, localeUseCases, "fr".toLocale())
 
         assertEquals("en_US".toLocale(), LocaleManager.getSystemDefault())
         assertEquals("fr".toLocale(), LocaleManager.getCurrentLocale(testContext))
@@ -97,21 +98,20 @@ class LocaleManagerTest {
     fun `when setting a new locale then the store is notified via use case`() {
         assertEquals("en_US".toLocale(), Locale.getDefault())
 
-        val newLanguage = "fr"
-        LocaleManager.setNewLocale(testContext, localeUseCases, newLanguage)
+        LocaleManager.setNewLocale(testContext, localeUseCases, "fr".toLocale())
 
         verify(localeUseCases, times(1)).notifyLocaleChanged
     }
 
     @Test
     @Config(qualifiers = "en-rUS")
-    fun `when resetting to system default locale then the store is notified via use case`() {
+    fun `GIVEN the locale use cases are defined WHEN resetting to system default locale THEN the store is notified via use case`() {
         assertEquals("en_US".toLocale(), Locale.getDefault())
 
         LocaleManager.setNewLocale(
             testContext,
             localeUseCases,
-            "fr"
+            "fr".toLocale()
         )
 
         verify(localeUseCases, times(1)).notifyLocaleChanged
@@ -124,5 +124,30 @@ class LocaleManagerTest {
         LocaleManager.resetToSystemDefault(testContext, localeUseCases)
 
         verify(localeUseCases, times(2)).notifyLocaleChanged
+    }
+
+    @Test
+    @Config(qualifiers = "en-rUS")
+    fun `WHEN setting a new locale THEN locale use cases are used only when defined`() {
+        assertEquals("en_US".toLocale(), Locale.getDefault())
+
+        val locale1 = "fr".toLocale()
+        LocaleManager.setNewLocale(
+            testContext,
+            locale = locale1
+        )
+
+        verify(localeUseCases, never()).notifyLocaleChanged
+        assertEquals(locale1, Locale.getDefault())
+
+        val locale2 = "es".toLocale()
+        LocaleManager.setNewLocale(
+            testContext,
+            localeUseCases,
+            locale2
+        )
+
+        verify(localeUseCases, times(1)).notifyLocaleChanged
+        assertEquals(locale2, Locale.getDefault())
     }
 }

--- a/components/support/locale/src/test/java/mozilla/components/support/locale/LocaleMiddlewareTest.kt
+++ b/components/support/locale/src/test/java/mozilla/components/support/locale/LocaleMiddlewareTest.kt
@@ -19,15 +19,15 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.After
-import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
-import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
 import org.mockito.Mockito.times
+import org.mockito.Mockito.spy
 import org.robolectric.annotation.Config
-import org.junit.Assert.assertEquals
 
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
@@ -59,7 +59,7 @@ class LocaleMiddlewareTest {
     fun `GIVEN a locale has been chosen in the app WHEN we restore state THEN locale is retrieved from storage`() = runBlockingTest {
         val localeManager = spy(LocaleManager)
         val currentLocale = localeManager.getCurrentLocale(testContext)
-        Assert.assertNull(currentLocale)
+        assertNull(currentLocale)
 
         val localeMiddleware = spy(
             LocaleMiddleware(
@@ -78,7 +78,7 @@ class LocaleMiddlewareTest {
 
         store.dispatch(LocaleAction.RestoreLocaleStateAction).joinBlocking()
 
-        Mockito.verify(localeManager, times(3)).getCurrentLocale(testContext)
+        verify(localeManager, times(3)).getCurrentLocale(testContext)
         assertEquals(store.state.locale, currentLocale)
     }
 
@@ -87,7 +87,7 @@ class LocaleMiddlewareTest {
     fun `WHEN we update the locale THEN the locale manager is updated`() = runBlockingTest {
         val localeManager = spy(LocaleManager)
         val currentLocale = localeManager.getCurrentLocale(testContext)
-        Assert.assertNull(currentLocale)
+        assertNull(currentLocale)
 
         val localeMiddleware = spy(
             LocaleMiddleware(
@@ -107,6 +107,6 @@ class LocaleMiddlewareTest {
         val newLocale = "es".toLocale()
         store.dispatch(LocaleAction.UpdateLocaleAction(newLocale)).joinBlocking()
 
-        Mockito.verify(localeManager).setNewLocale(testContext, locale = newLocale)
+        verify(localeManager).setNewLocale(testContext, locale = newLocale)
     }
 }

--- a/components/support/locale/src/test/java/mozilla/components/support/locale/LocaleMiddlewareTest.kt
+++ b/components/support/locale/src/test/java/mozilla/components/support/locale/LocaleMiddlewareTest.kt
@@ -1,0 +1,112 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.locale
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.setMain
+import mozilla.components.browser.state.action.LocaleAction
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
+import org.robolectric.annotation.Config
+import org.junit.Assert.assertEquals
+
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+class LocaleMiddlewareTest {
+
+    private lateinit var dispatcher: TestCoroutineDispatcher
+    private lateinit var scope: CoroutineScope
+
+    @Before
+    fun setUp() {
+        dispatcher = TestCoroutineDispatcher()
+        scope = CoroutineScope(dispatcher)
+
+        Dispatchers.setMain(dispatcher)
+
+        LocaleManager.clear(testContext)
+    }
+
+    @After
+    fun tearDown() {
+        dispatcher.cleanupTestCoroutines()
+        scope.cancel()
+
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    @Config(qualifiers = "en-rUS")
+    fun `GIVEN a locale has been chosen in the app WHEN we restore state THEN locale is retrieved from storage`() = runBlockingTest {
+        val localeManager = spy(LocaleManager)
+        val currentLocale = localeManager.getCurrentLocale(testContext)
+        Assert.assertNull(currentLocale)
+
+        val localeMiddleware = spy(
+            LocaleMiddleware(
+                testContext,
+                coroutineContext = dispatcher,
+                localeManager = localeManager
+            )
+        )
+
+        val store = BrowserStore(
+            initialState = BrowserState(),
+            middleware = listOf(localeMiddleware)
+        )
+
+        assertEquals(store.state.locale, null)
+
+        store.dispatch(LocaleAction.RestoreLocaleStateAction).joinBlocking()
+
+        Mockito.verify(localeManager, times(3)).getCurrentLocale(testContext)
+        assertEquals(store.state.locale, currentLocale)
+    }
+
+    @Test
+    @Config(qualifiers = "en-rUS")
+    fun `WHEN we update the locale THEN the locale manager is updated`() = runBlockingTest {
+        val localeManager = spy(LocaleManager)
+        val currentLocale = localeManager.getCurrentLocale(testContext)
+        Assert.assertNull(currentLocale)
+
+        val localeMiddleware = spy(
+            LocaleMiddleware(
+                testContext,
+                coroutineContext = dispatcher,
+                localeManager = localeManager
+            )
+        )
+
+        val store = BrowserStore(
+            initialState = BrowserState(),
+            middleware = listOf(localeMiddleware)
+        )
+
+        assertEquals(store.state.locale, null)
+
+        val newLocale = "es".toLocale()
+        store.dispatch(LocaleAction.UpdateLocaleAction(newLocale)).joinBlocking()
+
+        Mockito.verify(localeManager).setNewLocale(testContext, locale = newLocale)
+    }
+}

--- a/components/support/locale/src/test/java/mozilla/components/support/locale/LocaleUseCasesTest.kt
+++ b/components/support/locale/src/test/java/mozilla/components/support/locale/LocaleUseCasesTest.kt
@@ -5,13 +5,14 @@
 package mozilla.components.support.locale
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.browser.state.action.UpdateLocaleAction
+import mozilla.components.browser.state.action.LocaleAction
+import mozilla.components.browser.state.action.LocaleAction.UpdateLocaleAction
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.test.mock
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
+import org.mockito.Mockito.verify
 import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
@@ -25,12 +26,19 @@ class LocaleUseCasesTest {
     }
 
     @Test
-    fun `UpdateLocaleUseCase`() {
+    fun `WHEN the locale is updated THEN the browser state reflects the change`() {
         val useCases = LocaleUseCases(browserStore)
         val locale = Locale("MyFavoriteLanguage")
 
         useCases.notifyLocaleChanged(locale)
 
-        Mockito.verify(browserStore).dispatch(UpdateLocaleAction(locale))
+        verify(browserStore).dispatch(UpdateLocaleAction(locale))
+    }
+
+    @Test
+    fun `WHEN state is restored THEN the browser state locale is restored`() {
+        val useCases = LocaleUseCases(browserStore)
+        useCases.restore()
+        verify(browserStore).dispatch(LocaleAction.RestoreLocaleStateAction)
     }
 }

--- a/components/support/locale/src/test/java/mozilla/components/support/locale/LocaleUseCasesTest.kt
+++ b/components/support/locale/src/test/java/mozilla/components/support/locale/LocaleUseCasesTest.kt
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.locale
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.state.action.UpdateLocaleAction
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.support.test.mock
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import java.util.Locale
+
+@RunWith(AndroidJUnit4::class)
+class LocaleUseCasesTest {
+
+    private lateinit var browserStore: BrowserStore
+
+    @Before
+    fun setup() {
+        browserStore = mock()
+    }
+
+    @Test
+    fun `UpdateLocaleUseCase`() {
+        val useCases = LocaleUseCases(browserStore)
+        val locale = Locale("MyFavoriteLanguage")
+
+        useCases.notifyLocaleChanged(locale)
+
+        Mockito.verify(browserStore).dispatch(UpdateLocaleAction(locale))
+    }
+}

--- a/components/support/locale/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/support/locale/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,2 @@
+mock-maker-inline
+// This allows mocking final classes (classes are final by default in Kotlin)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,11 @@ permalink: /changelog/
 * **service-nimbus**
   * Added UI components for displaying a list of active Nimbus experiments.
 
+* **support-locale**
+  * ⚠️ **This is a breaking change**: Extended support for locale changes. The `LocaleManager` can now handle notifications about `Locale` changes through `LocaleUseCase`s, which are then reflected in the `BrowserStore`.
+  * 🚒 Bug fixed [issue #17190](https://github.com/mozilla-mobile/fenix/issues/17190) - Private browsing notifications are updated with the correct language when the app locale is changed.
+
+
 # 73.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v72.0.0...v73.0.0)


### PR DESCRIPTION
For #9754 
Related to Fenix https://github.com/mozilla-mobile/fenix/issues/18117

Allow private notifications to respond & update when a user changes the app language in Settings. 

- Add locale to the `BrowserStore`
- Create an action for updating the locale
- Create a use case so this action can be used wherever needed
- Restore action for locale use cases
- Tests for locale manager, locale use cases
- Middleware to handle locale updates and restoring from disk
- Tests for middleware

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
