### PR TITLE
Issue #9793: Remove setting the "uniffi.component.autofill.libraryOverride" property in AutofillCreditCardsAddressesStorage

### DIFF
--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/AutofillCreditCardsAddressesStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/AutofillCreditCardsAddressesStorage.kt
@@ -35,16 +35,6 @@ class AutofillCreditCardsAddressesStorage(
         AutofillStorageConnection
     }
 
-    init {
-        // Set the name of the native library so that we use the appservices megazord for
-        // compiled code.
-        // TODO remove this when https://github.com/mozilla/application-services/issues/3874 lands
-        System.setProperty(
-            "uniffi.component.autofill.libraryOverride",
-            System.getProperty("mozilla.appservices.megazord.library", "megazord")
-        )
-    }
-
     override suspend fun addCreditCard(creditCardFields: UpdatableCreditCardFields): CreditCard =
         withContext(coroutineContext) {
             conn.getStorage().addCreditCard(creditCardFields.into()).into()


### PR DESCRIPTION
Fixes #9793

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
