### PR TITLE
Close issue #9823 Make users aware that download was not performed because of a denied permission

### DIFF
--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
@@ -33,6 +33,7 @@ import mozilla.components.feature.downloads.manager.onDownloadStopped
 import mozilla.components.feature.downloads.ui.DownloaderApp
 import mozilla.components.feature.downloads.ui.DownloadAppChooserDialog
 import mozilla.components.lib.state.ext.flowScoped
+import mozilla.components.support.base.dialog.DeniedPermissionDialogFragment
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.base.feature.OnNeedToRequestPermissions
 import mozilla.components.support.base.feature.PermissionsFeature
@@ -213,6 +214,7 @@ class DownloadsFeature(
             } else {
                 closeDownloadResponse(tab.id)
                 useCases.consumeDownload(tab.id, download.id)
+                showPermissionDeniedDialog()
             }
         }
     }
@@ -394,6 +396,16 @@ class DownloadsFeature(
         val positiveButtonTextColor: Int? = null,
         val positiveButtonRadius: Float? = null
     )
+
+    @VisibleForTesting
+    internal fun showPermissionDeniedDialog() {
+        fragmentManager?.let {
+            val dialog = DeniedPermissionDialogFragment.newInstance(
+                R.string.mozac_feature_downloads_write_external_storage_permissions_needed_message
+            )
+            dialog.showNow(fragmentManager, DeniedPermissionDialogFragment.FRAGMENT_TAG)
+        }
+    }
 }
 
 @VisibleForTesting

--- a/components/feature/downloads/src/main/res/values/strings.xml
+++ b/components/feature/downloads/src/main/res/values/strings.xml
@@ -45,4 +45,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Complete action using</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->-->
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Unable to open %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Files and media permission access needed to download files. Go to Android settings, tap permissions, and tap allow.</string>
 </resources>

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
@@ -403,6 +403,7 @@ class DownloadsFeatureTest {
 
         verify(downloadManager, never()).download(any(), anyString())
         verify(feature).closeDownloadResponse("test-tab")
+        verify(feature).showPermissionDeniedDialog()
     }
 
     @Test

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/AlertDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/AlertDialogFragmentTest.kt
@@ -14,7 +14,7 @@ import mozilla.components.feature.prompts.PromptFeature
 import mozilla.components.feature.prompts.R
 import mozilla.components.feature.prompts.R.id
 import mozilla.components.support.test.mock
-import mozilla.ext.appCompatContext
+import mozilla.components.support.test.ext.appCompatContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/AuthenticationDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/AuthenticationDialogFragmentTest.kt
@@ -11,7 +11,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.feature.prompts.R.id
 import mozilla.components.support.test.mock
-import mozilla.ext.appCompatContext
+import mozilla.components.support.test.ext.appCompatContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/ChoiceDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/ChoiceDialogFragmentTest.kt
@@ -29,8 +29,8 @@ import mozilla.components.feature.prompts.dialog.ChoiceDialogFragment.Companion.
 import mozilla.components.feature.prompts.dialog.ChoiceDialogFragment.Companion.MULTIPLE_CHOICE_DIALOG_TYPE
 import mozilla.components.feature.prompts.dialog.ChoiceDialogFragment.Companion.SINGLE_CHOICE_DIALOG_TYPE
 import mozilla.components.feature.prompts.dialog.ChoiceDialogFragment.Companion.newInstance
+import mozilla.components.support.test.ext.appCompatContext
 import mozilla.components.support.test.robolectric.testContext
-import mozilla.ext.appCompatContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/ColorPickerDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/ColorPickerDialogFragmentTest.kt
@@ -12,8 +12,8 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.feature.prompts.R
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.ext.appCompatContext
 import mozilla.components.support.test.robolectric.testContext
-import mozilla.ext.appCompatContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/ConfirmDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/ConfirmDialogFragmentTest.kt
@@ -8,7 +8,7 @@ import android.content.DialogInterface
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.ext.appCompatContext
+import mozilla.components.support.test.ext.appCompatContext
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Before

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/MultiButtonDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/MultiButtonDialogFragmentTest.kt
@@ -14,7 +14,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.feature.prompts.R
 import mozilla.components.feature.prompts.R.id
 import mozilla.components.support.test.mock
-import mozilla.ext.appCompatContext
+import mozilla.components.support.test.ext.appCompatContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/SaveLoginDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/SaveLoginDialogFragmentTest.kt
@@ -14,8 +14,8 @@ import junit.framework.TestCase
 import mozilla.components.concept.storage.Login
 import mozilla.components.feature.prompts.R
 import mozilla.components.support.test.any
+import mozilla.components.support.test.ext.appCompatContext
 import mozilla.components.support.test.mock
-import mozilla.ext.appCompatContext
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/TextPromptDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/TextPromptDialogFragmentTest.kt
@@ -12,7 +12,7 @@ import androidx.core.view.isVisible
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.feature.prompts.R.id
 import mozilla.components.support.test.mock
-import mozilla.ext.appCompatContext
+import mozilla.components.support.test.ext.appCompatContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/TimePickerDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/TimePickerDialogFragmentTest.kt
@@ -24,9 +24,9 @@ import mozilla.components.feature.prompts.ext.year
 import mozilla.components.support.ktx.kotlin.toDate
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
+import mozilla.components.support.test.ext.appCompatContext
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
-import mozilla.ext.appCompatContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/login/LoginSelectBarTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/login/LoginSelectBarTest.kt
@@ -12,9 +12,9 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.storage.Login
 import mozilla.components.feature.prompts.R
+import mozilla.components.support.test.ext.appCompatContext
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
-import mozilla.ext.appCompatContext
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue

--- a/components/support/base/src/main/java/mozilla/components/support/base/dialog/DeniedPermissionDialogFragment.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/dialog/DeniedPermissionDialogFragment.kt
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.base.dialog
+
+import android.app.Dialog
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.provider.Settings
+import androidx.annotation.StringRes
+import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import mozilla.components.support.base.R
+
+internal const val KEY_MESSAGE = "KEY_MESSAGE"
+
+/**
+ * A dialog to be displayed when the Android permission is denied,
+ * users should be notified and offered a way activate it on the app settings.
+ * The dialog will have two buttons: One "Go to settings" and another for "Dismissing".
+ */
+class DeniedPermissionDialogFragment : DialogFragment() {
+    internal val message: Int by lazy { safeArguments.getInt(KEY_MESSAGE) }
+    val safeArguments get() = requireNotNull(arguments)
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val builder = AlertDialog.Builder(requireContext())
+            .setMessage(message)
+            .setCancelable(true)
+            .setNegativeButton(R.string.mozac_support_base_permissions_needed_negative_button) { _, _ ->
+                dismiss()
+            }
+            .setPositiveButton(R.string.mozac_support_base_permissions_needed_positive_button) { _, _ ->
+                openSettingsPage()
+            }
+        return builder.create()
+    }
+
+    @VisibleForTesting
+    internal fun openSettingsPage() {
+        dismiss()
+        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+        val uri = Uri.fromParts("package", requireContext().packageName, null)
+        intent.data = uri
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        requireContext().startActivity(intent)
+    }
+
+    companion object {
+        /**
+         * A builder method for creating a [DeniedPermissionDialogFragment]
+         * @param message the message of the dialog.
+         **/
+        fun newInstance(
+            @StringRes message: Int
+        ): DeniedPermissionDialogFragment {
+
+            val fragment = DeniedPermissionDialogFragment()
+            val arguments = fragment.arguments ?: Bundle()
+
+            with(arguments) {
+                putInt(KEY_MESSAGE, message)
+            }
+
+            fragment.arguments = arguments
+            return fragment
+        }
+
+        const val FRAGMENT_TAG = "DENIED_DOWNLOAD_PERMISSION_PROMPT_DIALOG"
+    }
+}

--- a/components/support/base/src/main/res/values/strings.xml
+++ b/components/support/base/src/main/res/values/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Go to settings</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Dismiss</string>
+</resources>

--- a/components/support/base/src/test/java/mozilla/components/support/base/dialog/DeniedPermissionDialogFragmentTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/dialog/DeniedPermissionDialogFragmentTest.kt
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.base.dialog
+
+import android.content.DialogInterface.BUTTON_POSITIVE
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.base.R
+import mozilla.components.support.test.ext.appCompatContext
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class DeniedPermissionDialogFragmentTest {
+
+    @Test
+    fun `WHEN showing the dialog THEN it has the provided message`() {
+        val messageId = R.string.mozac_support_base_permissions_needed_negative_button
+        val fragment = spy(
+            DeniedPermissionDialogFragment.newInstance(messageId)
+        )
+
+        doReturn(appCompatContext).`when`(fragment).requireContext()
+
+        val dialog = fragment.onCreateDialog(null)
+
+        dialog.show()
+
+        val messageTextView = dialog.findViewById<TextView>(android.R.id.message)
+
+        assertEquals(fragment.message, messageId)
+        assertEquals(messageTextView.text.toString(), testContext.getString(messageId))
+    }
+
+    @Test
+    fun `WHEN clicking the positive button THEN the settings page will show`() {
+        val messageId = R.string.mozac_support_base_permissions_needed_negative_button
+
+        val fragment = spy(
+            DeniedPermissionDialogFragment.newInstance(messageId)
+        )
+
+        doNothing().`when`(fragment).dismiss()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
+
+        val dialog = fragment.onCreateDialog(null)
+        dialog.show()
+
+        val positiveButton = (dialog as AlertDialog).getButton(BUTTON_POSITIVE)
+        positiveButton.performClick()
+
+        verify(fragment).openSettingsPage()
+    }
+}

--- a/components/support/test/src/main/java/mozilla/components/support/test/ext/Context.kt
+++ b/components/support/test/src/main/java/mozilla/components/support/test/ext/Context.kt
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.ext
+package mozilla.components.support.test.ext
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.R
 import androidx.appcompat.view.ContextThemeWrapper
 import mozilla.components.support.test.robolectric.testContext
@@ -14,5 +15,5 @@ import mozilla.components.support.test.robolectric.testContext
  *
  * Useful for views that uses theme attributes, for example.
  */
-internal val appCompatContext: Context
+@VisibleForTesting val appCompatContext: Context
     get() = ContextThemeWrapper(testContext, R.style.Theme_AppCompat)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,7 @@ permalink: /changelog/
 * **feature-downloads**:
   * 🚒 Bug fixed [issue #9757](https://github.com/mozilla-mobile/android-components/issues/9757) - Remove downloads notification when private tabs are closed.
   * 🚒 Bug fixed [issue #9789](https://github.com/mozilla-mobile/android-components/issues/9789) - Canceled first PDF download prevents following attempts from downloading.
+  * 🚒 Bug fixed [issue #9823](https://github.com/mozilla-mobile/android-components/issues/9823) - Downloads prompts do not show again when a user denies system permission twice.
 
 * **concept-engine**,**browser-engine-gecko**, **browser-engine-gecko-beta**, **browser-engine-gecko-nightly**, **browser-engine-system**
   * ⚠️ **This is a breaking change**: `EngineSession`.`enableTrackingProtection()` and `EngineSession`.`disableTrackingProtection()` have been removed, please use `EngineSession`.`updateTrackingProtection()` instead , for more details see [issue #9787](https://github.com/mozilla-mobile/android-components/issues/9787).


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
