### PR TITLE
Close #9564: Fix intermittent failing test in feature-app-links

### DIFF
--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksFeatureTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksFeatureTest.kt
@@ -111,10 +111,11 @@ class AppLinksFeatureTest {
         val intent: Intent = mock()
         val appIntent = AppIntentState(intentUrl, intent)
         store.dispatch(ContentAction.UpdateAppIntentAction(tab.id, appIntent)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
 
         val tabWithPendingAppIntent = store.state.findTab(tab.id)!!
         assertNotNull(tabWithPendingAppIntent.content.appIntent)
+
+        testDispatcher.advanceUntilIdle()
         verify(feature).handleAppIntent(tabWithPendingAppIntent, intentUrl, intent)
 
         store.waitUntilIdle()


### PR DESCRIPTION
We should advance the test dispatcher after we have made our assertion
on BrowserState in cases where the advancing the test dispatcher may
consume the intent action.

I _think_ this is the right way to fix #9564 , but I'm not completely sure how other parts of app links works.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
