### PR TITLE
Update to GeckoView Nightly 88.0.20210303094110

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -6,7 +6,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Nightly Version.
      */
-    const val nightly_version = "88.0.20210302034602"
+    const val nightly_version = "88.0.20210303094110"
 
     /**
      * GeckoView Beta Version.

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
@@ -119,6 +119,8 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
 
     @VisibleForTesting
     internal fun updateInputResult(event: MotionEvent) {
+        @Suppress("Deprecation")
+        // Deprecation to be replaced in https://github.com/mozilla-mobile/android-components/issues/9614
         super.onTouchEventForResult(event)
             .accept {
                 // This should never be null.


### PR DESCRIPTION
Suppress a new deprecation until we'll migrate to the new API in
https://github.com/mozilla-mobile/android-components/issues/9614