### PR TITLE
Remove unneeded/unused browser session fields

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -10,8 +10,6 @@ import android.graphics.Bitmap
 import mozilla.components.browser.session.ext.syncDispatch
 import mozilla.components.browser.session.ext.toSecurityInfoState
 import mozilla.components.browser.state.action.ContentAction.RemoveWebAppManifestAction
-import mozilla.components.browser.state.action.ContentAction.UpdateBackNavigationStateAction
-import mozilla.components.browser.state.action.ContentAction.UpdateForwardNavigationStateAction
 import mozilla.components.browser.state.action.ContentAction.UpdateLoadingStateAction
 import mozilla.components.browser.state.action.ContentAction.UpdateProgressAction
 import mozilla.components.browser.state.action.ContentAction.UpdateSecurityInfoAction
@@ -63,14 +61,12 @@ class Session(
         fun onTitleChanged(session: Session, title: String) = Unit
         fun onProgress(session: Session, progress: Int) = Unit
         fun onLoadingStateChanged(session: Session, loading: Boolean) = Unit
-        fun onNavigationStateChanged(session: Session, canGoBack: Boolean, canGoForward: Boolean) = Unit
         fun onLoadRequest(
             session: Session,
             url: String,
             triggeredByRedirect: Boolean,
             triggeredByWebContent: Boolean
         ) = Unit
-        fun onSearch(session: Session, searchTerms: String) = Unit
         fun onSecurityChanged(session: Session, securityInfo: SecurityInfo) = Unit
         fun onCustomTabConfigChanged(session: Session, customTabConfig: CustomTabConfig?) = Unit
         fun onWebAppManifestChanged(session: Session, manifest: WebAppManifest?) = Unit
@@ -78,7 +74,6 @@ class Session(
         fun onTrackerBlocked(session: Session, tracker: Tracker, all: List<Tracker>) = Unit
         fun onTrackerLoaded(session: Session, tracker: Tracker, all: List<Tracker>) = Unit
         fun onContentPermissionRequested(session: Session, permissionRequest: PermissionRequest): Boolean = false
-        fun onAppPermissionRequested(session: Session, permissionRequest: PermissionRequest): Boolean = false
         fun onRecordingDevicesChanged(session: Session, devices: List<RecordingDevice>) = Unit
     }
 
@@ -126,22 +121,6 @@ class Session(
         if (notifyObservers(old, new) { onLoadingStateChanged(this@Session, new) }) {
             store?.syncDispatch(UpdateLoadingStateAction(id, new))
         }
-    }
-
-    /**
-     * Navigation state, true if there's an history item to go back to, otherwise false.
-     */
-    var canGoBack: Boolean by Delegates.observable(false) { _, old, new ->
-        notifyObservers(old, new) { onNavigationStateChanged(this@Session, new, canGoForward) }
-        store?.syncDispatch(UpdateBackNavigationStateAction(id, canGoBack))
-    }
-
-    /**
-     * Navigation state, true if there's an history item to go forward to, otherwise false.
-     */
-    var canGoForward: Boolean by Delegates.observable(false) { _, old, new ->
-        notifyObservers(old, new) { onNavigationStateChanged(this@Session, canGoBack, new) }
-        store?.syncDispatch(UpdateForwardNavigationStateAction(id, canGoForward))
     }
 
     /**

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -10,6 +10,7 @@ import android.net.Uri
 import android.os.Environment
 import androidx.core.net.toUri
 import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.ext.syncDispatch
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.CrashAction
@@ -140,8 +141,12 @@ internal class EngineObserver(
     }
 
     override fun onNavigationStateChange(canGoBack: Boolean?, canGoForward: Boolean?) {
-        canGoBack?.let { session.canGoBack = canGoBack }
-        canGoForward?.let { session.canGoForward = canGoForward }
+        canGoBack?.let {
+            store?.syncDispatch(ContentAction.UpdateBackNavigationStateAction(session.id, canGoBack))
+        }
+        canGoForward?.let {
+            store?.syncDispatch(ContentAction.UpdateForwardNavigationStateAction(session.id, canGoForward))
+        }
     }
 
     override fun onSecurityChange(secure: Boolean, host: String?, issuer: String?) {

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/ext/BrowserStoreExtensions.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/ext/BrowserStoreExtensions.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.lib.state.Store
 
 /**
  * Dispatches [action] on [BrowserStore] and blocks the current thread until the [action] was processed and a new
@@ -16,7 +17,7 @@ import mozilla.components.browser.state.state.BrowserState
  * This is helpful for the migration phase where we want to keep `SessionManager` / `Session` and `BrowserState` in
  * sync when a legacy method returns.
  */
-internal fun BrowserStore.syncDispatch(action: BrowserAction) {
+internal fun Store<BrowserState, BrowserAction>.syncDispatch(action: BrowserAction) {
     runBlocking {
         dispatch(action).join()
     }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -34,7 +34,6 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.reset
-import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 
@@ -153,24 +152,6 @@ class SessionTest {
 
         verify(store).dispatch(ContentAction.UpdateLoadingStateAction(session.id, session.loading))
         verifyNoMoreInteractions(store)
-    }
-
-    @Test
-    fun `observer is notified when navigation state changes`() {
-        val observer = mock(Session.Observer::class.java)
-
-        val session = Session("https://www.mozilla.org")
-        session.register(observer)
-
-        session.canGoBack = true
-        assertEquals(true, session.canGoBack)
-        verify(observer).onNavigationStateChanged(eq(session), eq(true), eq(false))
-
-        session.canGoForward = true
-        assertEquals(true, session.canGoForward)
-        verify(observer).onNavigationStateChanged(eq(session), eq(true), eq(true))
-
-        verifyNoMoreInteractions(observer)
     }
 
     @Test
@@ -500,21 +481,17 @@ class SessionTest {
         val session = Session("")
         val defaultObserver = object : Session.Observer {}
         val contentPermissionRequest: PermissionRequest = mock()
-        val appPermissionRequest: PermissionRequest = mock()
 
         defaultObserver.onUrlChanged(session, "")
         defaultObserver.onTitleChanged(session, "")
         defaultObserver.onProgress(session, 0)
         defaultObserver.onLoadingStateChanged(session, true)
-        defaultObserver.onNavigationStateChanged(session, true, true)
         defaultObserver.onLoadRequest(session, "https://www.mozilla.org", true, true)
-        defaultObserver.onSearch(session, "")
         defaultObserver.onSecurityChanged(session, Session.SecurityInfo())
         defaultObserver.onCustomTabConfigChanged(session, null)
         defaultObserver.onTrackerBlockingEnabledChanged(session, true)
         defaultObserver.onTrackerBlocked(session, mock(), emptyList())
         defaultObserver.onContentPermissionRequested(session, contentPermissionRequest)
-        defaultObserver.onAppPermissionRequested(session, appPermissionRequest)
         defaultObserver.onWebAppManifestChanged(session, mock())
         defaultObserver.onRecordingDevicesChanged(session, emptyList())
     }
@@ -601,37 +578,5 @@ class SessionTest {
 
         assertFalse(parentSession.hasParentSession)
         assertTrue(session.hasParentSession)
-    }
-
-    @Test
-    fun `action is dispatched when back navigation state changes`() {
-        val store: BrowserStore = mock()
-        `when`(store.dispatch(any())).thenReturn(mock())
-
-        val session = Session("https://www.mozilla.org")
-        session.store = store
-        session.canGoBack = true
-        verify(store).dispatch(ContentAction.UpdateBackNavigationStateAction(session.id, true))
-
-        session.canGoBack = false
-        verify(store).dispatch(ContentAction.UpdateBackNavigationStateAction(session.id, false))
-
-        verifyNoMoreInteractions(store)
-    }
-
-    @Test
-    fun `action is dispatched when forward navigation state changes`() {
-        val store: BrowserStore = mock()
-        `when`(store.dispatch(any())).thenReturn(mock())
-
-        val session = Session("https://www.mozilla.org")
-        session.store = store
-        session.canGoForward = true
-        verify(store).dispatch(ContentAction.UpdateForwardNavigationStateAction(session.id, true))
-
-        session.canGoForward = false
-        verify(store).dispatch(ContentAction.UpdateForwardNavigationStateAction(session.id, false))
-
-        verifyNoMoreInteractions(store)
     }
 }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -361,7 +361,7 @@ open class DefaultComponents(private val applicationContext: Context) {
             primaryImageTintResource = R.color.photonBlue90,
             primaryContentDescription = "Back",
             isInPrimaryState = {
-                sessionManager.selectedSession?.canGoBack ?: true
+                store.state.selectedTab?.content?.canGoBack ?: true
             },
             disableInSecondaryState = true,
             secondaryImageTintResource = R.color.photonGrey40
@@ -374,7 +374,7 @@ open class DefaultComponents(private val applicationContext: Context) {
             primaryContentDescription = "Forward",
             primaryImageTintResource = R.color.photonBlue90,
             isInPrimaryState = {
-                sessionManager.selectedSession?.canGoForward ?: true
+                store.state.selectedTab?.content?.canGoForward ?: true
             },
             disableInSecondaryState = true,
             secondaryImageTintResource = R.color.photonGrey40


### PR DESCRIPTION
On the lookout for some low hanging fruit :). These should have been unneeded for a while and there's probably more here we could remove but let's do it incrementally.