### PR TITLE
Revert GV as a temporary workaround for a Fenix keyboard issue

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -6,7 +6,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Nightly Version.
      */
-    const val nightly_version = "88.0.20210309094921"
+    const val nightly_version = "88.0.20210302034602"
 
     /**
      * GeckoView Beta Version.


### PR DESCRIPTION
Temporary quick fix for https://github.com/mozilla-mobile/fenix/issues/18416

Don't immediately see the connection but thanks to @csadilek who tested that reverting to a previous GV version fixes that issue.