### PR TITLE
Issue #9857: Add first test cases for FillRequestHandler.

### DIFF
--- a/components/feature/autofill/build.gradle
+++ b/components/feature/autofill/build.gradle
@@ -44,12 +44,14 @@ dependencies {
     implementation Dependencies.kotlin_coroutines
 
     testImplementation project(':support-test')
+    testImplementation project(':lib-fetch-okhttp')
 
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_coroutines
+    testImplementation Dependencies.testing_mockwebserver
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/handler/FillRequestHandler.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/handler/FillRequestHandler.kt
@@ -5,22 +5,19 @@
 package mozilla.components.feature.autofill.handler
 
 import android.annotation.SuppressLint
-import android.app.PendingIntent
 import android.app.assist.AssistStructure
 import android.content.Context
-import android.content.Intent
-import android.content.IntentSender
 import android.os.Build
-import android.service.autofill.Dataset
 import android.service.autofill.FillRequest
 import android.service.autofill.FillResponse
-import android.view.autofill.AutofillValue
-import android.widget.RemoteViews
 import androidx.annotation.RequiresApi
-import mozilla.components.concept.storage.Login
 import mozilla.components.feature.autofill.AutofillConfiguration
-import mozilla.components.feature.autofill.R
-import mozilla.components.feature.autofill.structure.ParsedStructure
+import mozilla.components.feature.autofill.response.dataset.DatasetBuilder
+import mozilla.components.feature.autofill.response.dataset.LoginDatasetBuilder
+import mozilla.components.feature.autofill.response.fill.AuthFillResponseBuilder
+import mozilla.components.feature.autofill.response.fill.FillResponseBuilder
+import mozilla.components.feature.autofill.response.fill.LoginFillResponseBuilder
+import mozilla.components.feature.autofill.structure.RawStructure
 import mozilla.components.feature.autofill.structure.getLookupDomain
 import mozilla.components.feature.autofill.structure.parseStructure
 
@@ -35,23 +32,15 @@ internal class FillRequestHandler(
     private val configuration: AutofillConfiguration
 ) {
     /**
-     * Handles the given [FillRequest] and returns a matching [FillResponse] or `null` if this
-     * request could not be handled.
-     */
-    suspend fun handle(request: FillRequest, forceUnlock: Boolean = false): FillResponse? {
-        return handle(request.fillContexts.last().structure, forceUnlock)
-    }
-
-    /**
      * Handles a fill request for the given [AssistStructure] and returns a matching [FillResponse]
      * or `null` if the request could not be handled or the passed in [AssistStructure] is `null`.
      */
     @SuppressLint("InlinedApi")
     @Suppress("ReturnCount")
     suspend fun handle(
-        structure: AssistStructure?,
+        structure: RawStructure?,
         forceUnlock: Boolean = false
-    ): FillResponse? {
+    ): FillResponseBuilder? {
         if (structure == null) {
             return null
         }
@@ -70,25 +59,19 @@ internal class FillRequestHandler(
         }
 
         return if (!configuration.lock.keepUnlocked() && !forceUnlock) {
-            createAuthResponse(context, configuration, parsedStructure)
+            AuthFillResponseBuilder(parsedStructure)
         } else {
-            createLoginsResponse(
-                context,
-                configuration,
-                parsedStructure,
-                logins,
-                needsConfirmation
-            )
+            LoginFillResponseBuilder(parsedStructure, logins, needsConfirmation)
         }
     }
 
     /**
-     * Handles a fill request for the given [AssistStructure] and returns only a [Dataset] for the
-     * given [loginId] -  or `null` if the request could not be handled or the passed in
-     * [AssistStructure] is `null`
+     * Handles a fill request for the given [RawStructure] and returns only a [DatasetBuilder] for
+     * the given [loginId] -  or `null` if the request could not be handled or the passed in
+     * [RawStructure] is `null`
      */
     @Suppress("ReturnCount")
-    suspend fun handleConfirmation(structure: AssistStructure?, loginId: String): Dataset? {
+    suspend fun handleConfirmation(structure: RawStructure?, loginId: String): DatasetBuilder? {
         if (structure == null) {
             return null
         }
@@ -103,133 +86,6 @@ internal class FillRequestHandler(
 
         val login = logins.firstOrNull { login -> login.guid == loginId } ?: return null
 
-        return createDataSetResponse(
-            context,
-            configuration,
-            login,
-            parsedStructure,
-            needsConfirmation = false
-        )
+        return LoginDatasetBuilder(parsedStructure, login, needsConfirmation = false)
     }
-}
-
-@RequiresApi(Build.VERSION_CODES.O)
-private fun createAuthResponse(
-    context: Context,
-    configuration: AutofillConfiguration,
-    parsedStructure: ParsedStructure
-): FillResponse {
-    val builder = FillResponse.Builder()
-
-    val autofillIds = listOfNotNull(parsedStructure.usernameId, parsedStructure.passwordId)
-
-    val authPresentation = RemoteViews(context.packageName, android.R.layout.simple_list_item_1).apply {
-        setTextViewText(
-            android.R.id.text1,
-            context.getString(R.string.mozac_feature_autofill_popup_unlock_application, configuration.applicationName)
-        )
-    }
-
-    val authIntent = Intent(context, configuration.unlockActivity)
-
-    val intentSender: IntentSender = PendingIntent.getActivity(
-        context,
-        configuration.activityRequestCode,
-        authIntent,
-        PendingIntent.FLAG_CANCEL_CURRENT
-    ).intentSender
-
-    builder.setAuthentication(autofillIds.toTypedArray(), intentSender, authPresentation)
-
-    return builder.build()
-}
-
-@RequiresApi(Build.VERSION_CODES.O)
-private fun createLoginsResponse(
-    context: Context,
-    configuration: AutofillConfiguration,
-    parsedStructure: ParsedStructure,
-    logins: List<Login>,
-    needsConfirmation: Boolean
-): FillResponse {
-    val builder = FillResponse.Builder()
-
-    logins.forEachIndexed { index, login ->
-        val dataset = createDataSetResponse(
-            context,
-            configuration,
-            login,
-            parsedStructure,
-            needsConfirmation,
-            requestOffset = index
-        )
-        builder.addDataset(dataset)
-    }
-
-    return builder.build()
-}
-
-@RequiresApi(Build.VERSION_CODES.O)
-@Suppress("LongParameterList")
-private fun createDataSetResponse(
-    context: Context,
-    configuration: AutofillConfiguration,
-    login: Login,
-    parsedStructure: ParsedStructure,
-    needsConfirmation: Boolean,
-    requestOffset: Int = 0
-): Dataset {
-    val dataset = Dataset.Builder()
-
-    val usernamePresentation = RemoteViews(context.packageName, android.R.layout.simple_list_item_1)
-    usernamePresentation.setTextViewText(android.R.id.text1, login.usernamePresentationOrFallback(context))
-    val passwordPresentation = RemoteViews(context.packageName, android.R.layout.simple_list_item_1)
-    passwordPresentation.setTextViewText(android.R.id.text1, login.passwordPresentation(context))
-
-    parsedStructure.usernameId?.let { id ->
-        dataset.setValue(
-            id,
-            if (needsConfirmation) null else AutofillValue.forText(login.username),
-            usernamePresentation
-        )
-    }
-
-    parsedStructure.passwordId?.let { id ->
-        dataset.setValue(
-            id,
-            if (needsConfirmation) null else AutofillValue.forText(login.password),
-            passwordPresentation
-        )
-    }
-
-    if (needsConfirmation) {
-        val confirmIntent = Intent(context, configuration.confirmActivity)
-        confirmIntent.putExtra(EXTRA_LOGIN_ID, login.guid)
-
-        val intentSender: IntentSender = PendingIntent.getActivity(
-            context,
-            configuration.activityRequestCode + requestOffset,
-            confirmIntent,
-            PendingIntent.FLAG_CANCEL_CURRENT
-        ).intentSender
-
-        dataset.setAuthentication(intentSender)
-    }
-
-    return dataset.build()
-}
-
-private fun Login.usernamePresentationOrFallback(context: Context): String {
-    return if (username.isNotEmpty()) {
-        username
-    } else {
-        context.getString(R.string.mozac_feature_autofill_popup_no_username)
-    }
-}
-
-private fun Login.passwordPresentation(context: Context): String {
-    return context.getString(
-        R.string.mozac_feature_autofill_popup_password,
-        usernamePresentationOrFallback(context)
-    )
 }

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/dataset/DatasetBuilder.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/dataset/DatasetBuilder.kt
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.autofill.response.dataset
+
+import android.content.Context
+import android.service.autofill.Dataset
+import mozilla.components.feature.autofill.AutofillConfiguration
+
+internal interface DatasetBuilder {
+    fun build(
+        context: Context,
+        configuration: AutofillConfiguration
+    ): Dataset
+}

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/dataset/LoginDatasetBuilder.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/dataset/LoginDatasetBuilder.kt
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.autofill.response.dataset
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.IntentSender
+import android.os.Build
+import android.service.autofill.Dataset
+import android.view.autofill.AutofillValue
+import android.widget.RemoteViews
+import androidx.annotation.RequiresApi
+import mozilla.components.concept.storage.Login
+import mozilla.components.feature.autofill.AutofillConfiguration
+import mozilla.components.feature.autofill.handler.EXTRA_LOGIN_ID
+import mozilla.components.feature.autofill.structure.ParsedStructure
+
+@RequiresApi(Build.VERSION_CODES.O)
+internal data class LoginDatasetBuilder(
+    val parsedStructure: ParsedStructure,
+    val login: Login,
+    val needsConfirmation: Boolean,
+    val requestOffset: Int = 0
+) : DatasetBuilder {
+    override fun build(
+        context: Context,
+        configuration: AutofillConfiguration
+    ): Dataset {
+        val dataset = Dataset.Builder()
+
+        val usernamePresentation = RemoteViews(context.packageName, android.R.layout.simple_list_item_1)
+        usernamePresentation.setTextViewText(android.R.id.text1, login.usernamePresentationOrFallback(context))
+        val passwordPresentation = RemoteViews(context.packageName, android.R.layout.simple_list_item_1)
+        passwordPresentation.setTextViewText(android.R.id.text1, login.passwordPresentation(context))
+
+        parsedStructure.usernameId?.let { id ->
+            dataset.setValue(
+                id,
+                if (needsConfirmation) null else AutofillValue.forText(login.username),
+                usernamePresentation
+            )
+        }
+
+        parsedStructure.passwordId?.let { id ->
+            dataset.setValue(
+                id,
+                if (needsConfirmation) null else AutofillValue.forText(login.password),
+                passwordPresentation
+            )
+        }
+
+        if (needsConfirmation) {
+            val confirmIntent = Intent(context, configuration.confirmActivity)
+            confirmIntent.putExtra(EXTRA_LOGIN_ID, login.guid)
+
+            val intentSender: IntentSender = PendingIntent.getActivity(
+                context,
+                configuration.activityRequestCode + requestOffset,
+                confirmIntent,
+                PendingIntent.FLAG_CANCEL_CURRENT
+            ).intentSender
+
+            dataset.setAuthentication(intentSender)
+        }
+
+        return dataset.build()
+    }
+}
+
+private fun Login.usernamePresentationOrFallback(context: Context): String {
+    return if (username.isNotEmpty()) {
+        username
+    } else {
+        context.getString(mozilla.components.feature.autofill.R.string.mozac_feature_autofill_popup_no_username)
+    }
+}
+
+private fun Login.passwordPresentation(context: Context): String {
+    return context.getString(
+        mozilla.components.feature.autofill.R.string.mozac_feature_autofill_popup_password,
+        usernamePresentationOrFallback(context)
+    )
+}

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/fill/AuthFillResponseBuilder.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/fill/AuthFillResponseBuilder.kt
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.autofill.response.fill
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.IntentSender
+import android.os.Build
+import android.service.autofill.FillResponse
+import android.widget.RemoteViews
+import androidx.annotation.RequiresApi
+import mozilla.components.feature.autofill.AutofillConfiguration
+import mozilla.components.feature.autofill.R
+import mozilla.components.feature.autofill.structure.ParsedStructure
+
+internal data class AuthFillResponseBuilder(
+    private val parsedStructure: ParsedStructure
+) : FillResponseBuilder {
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    override fun build(
+        context: Context,
+        configuration: AutofillConfiguration
+    ): FillResponse {
+        val builder = FillResponse.Builder()
+
+        val autofillIds = listOfNotNull(parsedStructure.usernameId, parsedStructure.passwordId)
+
+        val authPresentation = RemoteViews(context.packageName, android.R.layout.simple_list_item_1).apply {
+            setTextViewText(
+                android.R.id.text1,
+                context.getString(
+                    R.string.mozac_feature_autofill_popup_unlock_application,
+                    configuration.applicationName
+                )
+            )
+        }
+
+        val authIntent = Intent(context, configuration.unlockActivity)
+
+        val intentSender: IntentSender = PendingIntent.getActivity(
+            context,
+            configuration.activityRequestCode,
+            authIntent,
+            PendingIntent.FLAG_CANCEL_CURRENT
+        ).intentSender
+
+        builder.setAuthentication(autofillIds.toTypedArray(), intentSender, authPresentation)
+
+        return builder.build()
+    }
+}

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/fill/FillResponseBuilder.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/fill/FillResponseBuilder.kt
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.autofill.response.fill
+
+import android.content.Context
+import android.service.autofill.FillResponse
+import mozilla.components.feature.autofill.AutofillConfiguration
+
+internal interface FillResponseBuilder {
+    fun build(
+        context: Context,
+        configuration: AutofillConfiguration
+    ): FillResponse
+}

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/fill/LoginFillResponseBuilder.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/fill/LoginFillResponseBuilder.kt
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.autofill.response.fill
+
+import android.content.Context
+import android.os.Build
+import android.service.autofill.FillResponse
+import androidx.annotation.RequiresApi
+import mozilla.components.concept.storage.Login
+import mozilla.components.feature.autofill.AutofillConfiguration
+import mozilla.components.feature.autofill.response.dataset.LoginDatasetBuilder
+import mozilla.components.feature.autofill.structure.ParsedStructure
+
+/**
+ * [FillResponseBuilder] implementation that creates a [FillResponse] containing logins for
+ * autofilling.
+ */
+@RequiresApi(Build.VERSION_CODES.O)
+internal data class LoginFillResponseBuilder(
+    val parsedStructure: ParsedStructure,
+    val logins: List<Login>,
+    val needsConfirmation: Boolean
+) : FillResponseBuilder {
+    override fun build(
+        context: Context,
+        configuration: AutofillConfiguration
+    ): FillResponse {
+        val builder = FillResponse.Builder()
+
+        logins.forEachIndexed { index, login ->
+            val datasetBuilder = LoginDatasetBuilder(
+                parsedStructure,
+                login,
+                needsConfirmation,
+                requestOffset = index
+            )
+
+            val dataset = datasetBuilder.build(
+                context,
+                configuration
+            )
+
+            builder.addDataset(dataset)
+        }
+
+        return builder.build()
+    }
+}

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/structure/RawStructure.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/structure/RawStructure.kt
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.autofill.structure
+
+import android.app.assist.AssistStructure
+import android.os.Build
+import android.view.autofill.AutofillId
+import androidx.annotation.RequiresApi
+
+/**
+ * A raw view structure provided by an application - to be parsed into a [ParsedStructure].
+ */
+internal interface RawStructure {
+    val activityPackageName: String
+
+    fun createNavigator(): AutofillNodeNavigator<*, AutofillId>
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+internal fun AssistStructure.toRawStructure(): RawStructure {
+    return AssistStructureWrapper(this)
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+private class AssistStructureWrapper(
+    private val actual: AssistStructure
+) : RawStructure {
+    override val activityPackageName: String
+        get() = actual.activityComponent.packageName
+
+    override fun createNavigator(): AutofillNodeNavigator<*, AutofillId> {
+        return ViewNodeNavigator(actual, activityPackageName)
+    }
+}

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/ui/AbstractAutofillConfirmActivity.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/ui/AbstractAutofillConfirmActivity.kt
@@ -24,6 +24,7 @@ import mozilla.components.feature.autofill.AutofillConfiguration
 import mozilla.components.feature.autofill.R
 import mozilla.components.feature.autofill.handler.EXTRA_LOGIN_ID
 import mozilla.components.feature.autofill.handler.FillRequestHandler
+import mozilla.components.feature.autofill.structure.toRawStructure
 
 /**
  * Activity responsible for asking the user to confirm before autofilling a third-party app. It is
@@ -48,8 +49,12 @@ abstract class AbstractAutofillConfirmActivity : FragmentActivity() {
         }
 
         // While the user is asked to confirm, we already try to build the fill response asynchronously.
-        dataset = lifecycleScope.async(Dispatchers.IO) {
-            fillHandler.handleConfirmation(structure, loginId)
+        val rawStructure = structure?.toRawStructure()
+        if (rawStructure != null) {
+            dataset = lifecycleScope.async(Dispatchers.IO) {
+                val builder = fillHandler.handleConfirmation(rawStructure, loginId)
+                builder?.build(this@AbstractAutofillConfirmActivity, configuration)
+            }
         }
 
         if (savedInstanceState == null) {

--- a/components/feature/autofill/src/test/java/mozilla/components/feature/autofill/handler/FillRequestHandlerTest.kt
+++ b/components/feature/autofill/src/test/java/mozilla/components/feature/autofill/handler/FillRequestHandlerTest.kt
@@ -1,0 +1,197 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.autofill.handler
+
+import kotlinx.coroutines.runBlocking
+import mozilla.components.concept.storage.Login
+import mozilla.components.concept.storage.LoginsStorage
+import mozilla.components.feature.autofill.AutofillConfiguration
+import mozilla.components.feature.autofill.response.fill.FillResponseBuilder
+import mozilla.components.feature.autofill.response.fill.LoginFillResponseBuilder
+import mozilla.components.feature.autofill.test.createMockStructure
+import mozilla.components.feature.autofill.ui.AbstractAutofillConfirmActivity
+import mozilla.components.feature.autofill.ui.AbstractAutofillUnlockActivity
+import mozilla.components.feature.autofill.verify.CredentialAccessVerifier
+import mozilla.components.lib.publicsuffixlist.PublicSuffixList
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.doReturn
+import org.robolectric.RobolectricTestRunner
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+internal class FillRequestHandlerTest {
+    @Test
+    fun `App - Twitter - With credentials`() {
+        val credentials = generateRandomLoginFor("twitter.com")
+        createTestCase<LoginFillResponseBuilder>(
+            filename = "fixtures/app_twitter.xml",
+            packageName = "com.twitter.android",
+            logins = mapOf(credentials),
+            assertThat = { builder ->
+                assertNotNull(builder!!)
+                assertEquals(1, builder.logins.size)
+                assertEquals(credentials.second, builder.logins[0])
+                assertEquals(false, builder.needsConfirmation)
+            }
+        )
+    }
+
+    @Test
+    fun `App - Twitter - Without credentials`() {
+        createTestCase<LoginFillResponseBuilder>(
+            filename = "fixtures/app_twitter.xml",
+            packageName = "com.twitter.android",
+            logins = emptyMap(),
+            assertThat = { builder ->
+                assertNull(builder)
+            }
+        )
+    }
+
+    @Test
+    fun `App - Expensify`() {
+        createTestCase<LoginFillResponseBuilder>(
+            filename = "fixtures/app_expensify.xml",
+            packageName = "org.me.mobiexpensifyg",
+            logins = mapOf(
+                generateRandomLoginFor("expensify.com")
+            ),
+            assertThat = { builder ->
+                // Unfortunately we are not able to link the app and the website yet.
+                assertNull(builder)
+            }
+        )
+    }
+
+    @Test
+    fun `App - Facebook`() {
+        val credentials = generateRandomLoginFor("facebook.com")
+        createTestCase<LoginFillResponseBuilder>(
+            filename = "fixtures/app_facebook.xml",
+            packageName = "com.facebook.katana",
+            logins = mapOf(credentials),
+            assertThat = { builder ->
+                assertNotNull(builder!!)
+                assertEquals(1, builder.logins.size)
+                assertEquals(credentials.second, builder.logins[0])
+            }
+        )
+    }
+
+    @Test
+    fun `App - Facebook Lite`() {
+        val credentials = generateRandomLoginFor("facebook.com")
+        createTestCase<LoginFillResponseBuilder>(
+            filename = "fixtures/app_facebook_lite.xml",
+            packageName = "com.facebook.lite",
+            logins = mapOf(credentials),
+            assertThat = { builder ->
+                assertNotNull(builder!!)
+                assertEquals(1, builder.logins.size)
+                assertEquals(credentials.second, builder.logins[0])
+            }
+        )
+    }
+
+    @Test
+    fun `App - Messenger Lite`() {
+        val credentials = generateRandomLoginFor("facebook.com")
+        createTestCase<LoginFillResponseBuilder>(
+            filename = "fixtures/app_messenger_lite.xml",
+            packageName = "com.facebook.mlite",
+            logins = mapOf(credentials),
+            assertThat = { builder ->
+                assertNotNull(builder!!)
+                assertEquals(1, builder.logins.size)
+                assertEquals(credentials.second, builder.logins[0])
+            }
+        )
+    }
+
+    @Test
+    fun `Browser - Fenix Nightly - amazon-co-uk`() {
+        val credentials = generateRandomLoginFor("amazon.co.uk")
+        createTestCase<LoginFillResponseBuilder>(
+            filename = "fixtures/browser_fenix_amazon.co.uk.xml",
+            packageName = "org.mozilla.fenix",
+            logins = mapOf(credentials),
+            assertThat = { builder ->
+                assertNotNull(builder!!)
+                assertEquals(1, builder.logins.size)
+                assertEquals(credentials.second, builder.logins[0])
+            }
+        )
+    }
+
+    @Test
+    fun `Browser - WebView - gmail`() {
+        val credentials = generateRandomLoginFor("accounts.google.com")
+        createTestCase<LoginFillResponseBuilder>(
+            filename = "fixtures/browser_webview_gmail.xml",
+            packageName = "org.chromium.webview_shell",
+            logins = mapOf(credentials),
+            assertThat = { builder ->
+                assertNull(builder)
+            }
+        )
+    }
+}
+
+private fun <B : FillResponseBuilder> FillRequestHandlerTest.createTestCase(
+    filename: String,
+    packageName: String,
+    logins: Map<String, Login>,
+    assertThat: (B?) -> Unit,
+    canVerifyRelationship: Boolean = true
+) = runBlocking {
+    val structure = createMockStructure(filename, packageName)
+
+    val storage: LoginsStorage = mock()
+    `when`(storage.getByBaseDomain(anyString())).thenAnswer { invocation ->
+        val origin = invocation.getArgument(0) as String
+        println("MockStorage: Query password for $origin")
+        logins[origin]?.let { listOf(it) } ?: emptyList<Login>()
+    }
+
+    val verifier: CredentialAccessVerifier = mock()
+    doReturn(canVerifyRelationship).`when`(verifier).hasCredentialRelationship(any(), any(), any())
+
+    val configuration = AutofillConfiguration(
+        storage = storage,
+        publicSuffixList = PublicSuffixList(testContext),
+        unlockActivity = AbstractAutofillUnlockActivity::class.java,
+        confirmActivity = AbstractAutofillConfirmActivity::class.java,
+        applicationName = "Test",
+        httpClient = mock(),
+        verifier = verifier
+    )
+
+    val handler = FillRequestHandler(
+        testContext,
+        configuration
+    )
+
+    val builder = handler.handle(structure)
+    @Suppress("UNCHECKED_CAST")
+    assertThat(builder as? B)
+}
+
+private fun generateRandomLoginFor(origin: String): Pair<String, Login> {
+    return origin to Login(
+        guid = UUID.randomUUID().toString(),
+        origin = origin,
+        username = "user" + UUID.randomUUID().toString(),
+        password = "password" + UUID.randomUUID().toString()
+    )
+}

--- a/components/feature/autofill/src/test/java/mozilla/components/feature/autofill/test/DOMNavigator.kt
+++ b/components/feature/autofill/src/test/java/mozilla/components/feature/autofill/test/DOMNavigator.kt
@@ -1,0 +1,133 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.autofill.test
+
+import android.view.autofill.AutofillId
+import mozilla.components.feature.autofill.structure.AutofillNodeNavigator
+import mozilla.components.feature.autofill.structure.ParsedStructure
+import mozilla.components.support.test.mock
+import org.w3c.dom.Document
+import org.w3c.dom.Element
+import java.io.File
+import java.util.WeakHashMap
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * Alternative [AutofillNodeNavigator] implementation for reading a captured view structure from an
+ * XML file for testing purposes.
+ */
+internal class DOMNavigator(
+    file: File,
+    override val activityPackageName: String
+) : AutofillNodeNavigator<Element, AutofillId> {
+
+    override fun currentText(node: Element): String? {
+        return node.getAttribute("autofillValue")
+    }
+
+    private val document: Document
+
+    init {
+        val db = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+        file.inputStream().use {
+            document = db.parse(it)
+        }
+    }
+
+    override val rootNodes: List<Element>
+        get() = listOf(document.documentElement)
+
+    override fun childNodes(node: Element): List<Element> {
+        val children = node.childNodes
+        return (0 until children.length)
+            .map { children.item(it) }
+            .filter { it is Element }
+            .map { it as Element }
+    }
+
+    override fun clues(node: Element): Iterable<CharSequence> {
+        val attributes = node.attributes
+        return (0 until attributes.length)
+            .map { attributes.item(it) }
+            .mapNotNull { if (it.nodeName != "hint") it.nodeValue else null }
+    }
+
+    override fun autofillId(node: Element): AutofillId? {
+        val rawId = if (isEditText(node) || isHtmlInputField(node)) {
+            attr(node, "autofillId") ?: clues(node).joinToString("|")
+        } else {
+            null
+        }
+
+        return rawId?.let { getOrCreateAutofillIdMock(it) }
+    }
+
+    override fun isEditText(node: Element): Boolean =
+        tagName(node) == "EditText" || (inputType(node) and AutofillNodeNavigator.editTextMask) > 0
+
+    override fun isHtmlInputField(node: Element) = tagName(node) == "input"
+
+    private fun tagName(node: Element) = node.tagName
+
+    override fun isHtmlForm(node: Element): Boolean = node.tagName == "form"
+
+    fun attr(node: Element, name: String) = node.attributes.getNamedItem(name)?.nodeValue
+
+    override fun isFocused(node: Element) = attr(node, "focus") == "true"
+
+    override fun isVisible(node: Element) = attr(node, "visibility")?.let { it == "0" } ?: true
+
+    override fun packageName(node: Element) = attr(node, "idPackage")
+
+    override fun webDomain(node: Element) = attr(node, "webDomain")
+
+    override fun isButton(node: Element): Boolean {
+        when (node.tagName) {
+            "Button" -> return true
+            "button" -> return true
+        }
+
+        return when (attr(node, "type")) {
+            "submit" -> true
+            "button" -> true
+            else -> false
+        }
+    }
+
+    override fun inputType(node: Element): Int =
+        attr(node, "inputType")?.let {
+            Integer.parseInt(it, 16)
+        } ?: 0
+
+    override fun build(
+        usernameId: AutofillId?,
+        passwordId: AutofillId?,
+        webDomain: String?,
+        packageName: String
+    ): ParsedStructure {
+        return ParsedStructure(
+            usernameId,
+            passwordId,
+            webDomain,
+            packageName
+        )
+    }
+}
+
+private val autofillIdMapping = WeakHashMap<AutofillId, String>()
+
+private fun getOrCreateAutofillIdMock(id: String): AutofillId {
+    val existingEntry = autofillIdMapping.entries.firstOrNull { entry -> entry.value == id }
+    if (existingEntry != null) {
+        return existingEntry.key
+    }
+
+    val autofillId: AutofillId = mock()
+    autofillIdMapping[autofillId] = id
+    return autofillId
+}
+
+internal val AutofillId.originalId: String
+    get() = autofillIdMapping[this] ?: throw AssertionError("Unknown AutofillId instance")

--- a/components/feature/autofill/src/test/java/mozilla/components/feature/autofill/test/MockStructure.kt
+++ b/components/feature/autofill/src/test/java/mozilla/components/feature/autofill/test/MockStructure.kt
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.autofill.test
+
+import android.view.autofill.AutofillId
+import mozilla.components.feature.autofill.handler.FillRequestHandlerTest
+import mozilla.components.feature.autofill.structure.AutofillNodeNavigator
+import mozilla.components.feature.autofill.structure.RawStructure
+import java.io.File
+
+internal fun FillRequestHandlerTest.createMockStructure(filename: String, packageName: String): RawStructure {
+    val classLoader = javaClass.classLoader ?: throw RuntimeException("No class loader")
+    val resource = classLoader.getResource(filename) ?: throw RuntimeException("Resource not found")
+    val file = File(resource.path)
+
+    return MockStructure(packageName, file)
+}
+
+private class MockStructure(
+    private val packageName: String,
+    private val file: File
+) : RawStructure {
+    override val activityPackageName: String = packageName
+
+    override fun createNavigator(): AutofillNodeNavigator<*, AutofillId> {
+        return DOMNavigator(file, packageName)
+    }
+}

--- a/components/feature/autofill/src/test/resources/fixtures/app_expensify.xml
+++ b/components/feature/autofill/src/test/resources/fixtures/app_expensify.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<FrameLayout>
+    <LinearLayout idEntry="action_bar_root" idPackage="org.me.mobiexpensifyg" idType="id">
+        <View idEntry="action_mode_bar_stub" idPackage="org.me.mobiexpensifyg" idType="id"/>
+        <RelativeLayout idEntry="content" idPackage="org.me.mobiexpensifyg" idType="id">
+            <ImageSwitcher idEntry="background_image_view" idPackage="org.me.mobiexpensifyg" idType="id"/>
+            <FrameLayout idEntry="form_container" idPackage="org.me.mobiexpensifyg" idType="id">
+                <LinearLayout idEntry="text_input_layout" idPackage="org.me.mobiexpensifyg" idType="id">
+                    <EditText idEntry="edit_text" idPackage="org.me.mobiexpensifyg" idType="id" hint="Email" inputType="21"/>
+                </LinearLayout>
+                <View idEntry="underline_view" idPackage="org.me.mobiexpensifyg" idType="id"/>
+                <TextView idEntry="error_text" idPackage="org.me.mobiexpensifyg" idType="id"/>
+                <TextView idEntry="cancel_text" idPackage="org.me.mobiexpensifyg" idType="id"/>
+                <FrameLayout idEntry="submit_button" idPackage="org.me.mobiexpensifyg" idType="id">
+                    <FrameLayout idEntry="container" idPackage="org.me.mobiexpensifyg" idType="id">
+                        <TextView idEntry="title_text" idPackage="org.me.mobiexpensifyg" idType="id"/>
+                        <ProgressBar idEntry="progress_bar" idPackage="org.me.mobiexpensifyg" idType="id"/>
+                    </FrameLayout>
+                </FrameLayout>
+            </FrameLayout>
+            <LinearLayout idEntry="navigation_element_container" idPackage="org.me.mobiexpensifyg" idType="id">
+                <TextSwitcher idEntry="navigation_element_switcher" idPackage="org.me.mobiexpensifyg" idType="id">
+                    <TextView idEntry="navigation_element_text1" idPackage="org.me.mobiexpensifyg" idType="id"/>
+                    <TextView idEntry="navigation_element_text2" idPackage="org.me.mobiexpensifyg" idType="id"/>
+                </TextSwitcher>
+            </LinearLayout>
+            <TextSwitcher idEntry="expensify_motto_switcher" idPackage="org.me.mobiexpensifyg" idType="id">
+                <TextView/>
+                <TextView/>
+            </TextSwitcher>
+            <View idEntry="footer_separator" idPackage="org.me.mobiexpensifyg" idType="id"/>
+            <TextSwitcher idEntry="expensify_ambassador_name_switcher" idPackage="org.me.mobiexpensifyg" idType="id">
+                <TextView/>
+                <TextView/>
+            </TextSwitcher>
+            <TextSwitcher idEntry="expensify_customer_since_switcher" idPackage="org.me.mobiexpensifyg" idType="id">
+                <TextView/>
+                <TextView/>
+            </TextSwitcher>
+            <TextView idEntry="privacy_policy_text" idPackage="org.me.mobiexpensifyg" idType="id"/>
+        </RelativeLayout>
+    </LinearLayout>
+</FrameLayout>

--- a/components/feature/autofill/src/test/resources/fixtures/app_facebook.xml
+++ b/components/feature/autofill/src/test/resources/fixtures/app_facebook.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<FrameLayout>
+    <LinearLayout idEntry="(name removed)" idPackage="com.facebook.katana" idType="id">
+        <FrameLayout idEntry="(name removed)" idPackage="com.facebook.katana" idType="id">
+            <FrameLayout idEntry="(name removed)" idPackage="com.facebook.katana" idType="id">
+                <EditText inputType="21" autofillId="autofillId-username"/>
+                <EditText inputType="81"/>
+            </FrameLayout>
+        </FrameLayout>
+    </LinearLayout>
+</FrameLayout>

--- a/components/feature/autofill/src/test/resources/fixtures/app_facebook_lite.xml
+++ b/components/feature/autofill/src/test/resources/fixtures/app_facebook_lite.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<FrameLayout>
+    <LinearLayout>
+        <View idEntry="action_mode_bar_stub" idPackage="android" idType="id"/>
+        <FrameLayout idEntry="content" idPackage="android" idType="id">
+            <FrameLayout idEntry="main_layout" idPackage="com.facebook.lite" idType="id">
+                <ImageView idEntry="image_overlay_under_content" idPackage="com.facebook.lite" idType="id"/>
+                <ViewGroup>
+                    <ViewGroup/>
+                    <ViewGroup/>
+                    <MultiAutoCompleteTextView autofillValue="" inputType="80001" autofillId="autofillId-username"/>
+                    <ViewGroup/>
+                    <MultiAutoCompleteTextView inputType="80081"/>
+                    <ViewGroup>
+                        <ViewGroup/>
+                    </ViewGroup>
+                    <ViewGroup>
+                        <ViewGroup/>
+                    </ViewGroup>
+                    <ViewGroup/>
+                    <ViewGroup>
+                        <ViewGroup/>
+                    </ViewGroup>
+                    <ViewGroup>
+                        <ViewGroup/>
+                    </ViewGroup>
+                    <ViewGroup/>
+                    <ViewGroup/>
+                    <ViewGroup>
+                        <ViewGroup/>
+                    </ViewGroup>
+                    <ViewGroup>
+                        <ViewGroup/>
+                    </ViewGroup>
+                    <ViewGroup>
+                        <ViewGroup/>
+                    </ViewGroup>
+                    <View/>
+                    <View/>
+                </ViewGroup>
+                <ImageView idEntry="image_overlay_over_content" idPackage="com.facebook.lite" idType="id"/>
+                <View idEntry="webview_stub" idPackage="com.facebook.lite" idType="id"/>
+                <View idEntry="inline_textbox_stub" idPackage="com.facebook.lite" idType="id"/>
+                <View idEntry="floating_textbox_stub" idPackage="com.facebook.lite" idType="id"/>
+                <View idEntry="screen_transition_loading_view_stub" idPackage="com.facebook.lite" idType="id"/>
+                <View idEntry="zoomview_stub" idPackage="com.facebook.lite" idType="id"/>
+                <View idEntry="videoview_stub" idPackage="com.facebook.lite" idType="id"/>
+                <View idEntry="dummy_surfaceview" idPackage="com.facebook.lite" idType="id"/>
+                <View idEntry="livestreamingview_stub" idPackage="com.facebook.lite" idType="id"/>
+                <View idEntry="snack_bar_view_stub" idPackage="com.facebook.lite" idType="id"/>
+            </FrameLayout>
+        </FrameLayout>
+    </LinearLayout>
+    <View idEntry="navigationBarBackground" idPackage="android" idType="id"/>
+    <View idEntry="statusBarBackground" idPackage="android" idType="id"/>
+</FrameLayout>

--- a/components/feature/autofill/src/test/resources/fixtures/app_messenger_lite.xml
+++ b/components/feature/autofill/src/test/resources/fixtures/app_messenger_lite.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<FrameLayout>
+    <LinearLayout idEntry="action_bar_root" idPackage="com.facebook.mlite" idType="id">
+        <View idEntry="action_mode_bar_stub" idPackage="com.facebook.mlite" idType="id"/>
+        <ScrollView idEntry="content_view" idPackage="com.facebook.mlite" idType="id">
+            <LinearLayout idEntry="root_view" idPackage="com.facebook.mlite" idType="id">
+                <LinearLayout idEntry="sso_confirmation_form" idPackage="com.facebook.mlite" idType="id"/>
+                <LinearLayout idEntry="username_password_form" idPackage="com.facebook.mlite" idType="id">
+                    <TextView idEntry="login_message" idPackage="com.facebook.mlite" idType="id"/>
+                    <LinearLayout idEntry="login_username_text" idPackage="com.facebook.mlite" idType="id">
+                        <EditText inputType="1" autofillId="autofillId-username"/>
+                    </LinearLayout>
+                    <LinearLayout idEntry="login_password_edit_text" idPackage="com.facebook.mlite" idType="id">
+                        <EditText inputType="81"/>
+                    </LinearLayout>
+                    <TextView idEntry="login_login_button" idPackage="com.facebook.mlite" idType="id"/>
+                    <TextView idEntry="create_account_button" idPackage="com.facebook.mlite" idType="id"/>
+                    <TextView idEntry="bottom_create_account_message" idPackage="com.facebook.mlite" idType="id"/>
+                    <TextView idEntry="login_forgot_password_button" idPackage="com.facebook.mlite" idType="id"/>
+                </LinearLayout>
+                <LinearLayout idEntry="login_approval_form" idPackage="com.facebook.mlite" idType="id"/>
+                <FrameLayout idEntry="progress_screen" idPackage="com.facebook.mlite" idType="id"/>
+            </LinearLayout>
+        </ScrollView>
+    </LinearLayout>
+</FrameLayout>

--- a/components/feature/autofill/src/test/resources/fixtures/app_twitter.xml
+++ b/components/feature/autofill/src/test/resources/fixtures/app_twitter.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<FrameLayout>
+    <LinearLayout>
+        <View idEntry="action_mode_bar_stub" idPackage="android" idType="id" />
+        <FrameLayout>
+            <FrameLayout idEntry="action_bar_root" idPackage="com.twitter.android" idType="id">
+                <FrameLayout idEntry="content" idPackage="android" idType="id">
+                    <LinearLayout>
+                        <LinearLayout idEntry="toolbar_container" idPackage="com.twitter.android" idType="id">
+                            <FrameLayout idEntry="status_message_container" idPackage="com.twitter.android" idType="id" />
+                            <ViewGroup idEntry="toolbar" idPackage="com.twitter.android" idType="id">
+                                <ViewGroup>
+                                    <ImageView />
+                                </ViewGroup>
+                                <TextView />
+                                <RelativeLayout>
+                                    <ImageView />
+                                    <Button idEntry="signup" idPackage="com.twitter.android" idType="id" />
+                                </RelativeLayout>
+                            </ViewGroup>
+                        </LinearLayout>
+                        <ScrollView>
+                            <LinearLayout>
+                                <LinearLayout idEntry="signup_header" idPackage="com.twitter.android" idType="id">
+                                    <TextView idEntry="header_title" idPackage="com.twitter.android" idType="id" />
+                                    <TextView idEntry="header_subtitle" idPackage="com.twitter.android" idType="id" />
+                                </LinearLayout>
+                                <LinearLayout idEntry="login_form" idPackage="com.twitter.android" idType="id">
+                                    <EditText idEntry="login_identifier" idPackage="com.twitter.android" idType="id" autofillValue="" autofillId="autofillId-username" />
+                                    <EditText idEntry="login_password" idPackage="com.twitter.android" idType="id" />
+                                    <TextView idEntry="password_reset" idPackage="com.twitter.android" idType="id" />
+                                </LinearLayout>
+                            </LinearLayout>
+                        </ScrollView>
+                        <FrameLayout>
+                            <View />
+                            <Button idEntry="login_login" idPackage="com.twitter.android" idType="id" />
+                        </FrameLayout>
+                        <WebView idEntry="js_inst" idPackage="com.twitter.android" idType="id" />
+                    </LinearLayout>
+                </FrameLayout>
+                <View idEntry="action_mode_bar_stub" idPackage="com.twitter.android" idType="id" />
+            </FrameLayout>
+        </FrameLayout>
+    </LinearLayout>
+    <View idEntry="navigationBarBackground" idPackage="android" idType="id" />
+    <View idEntry="statusBarBackground" idPackage="android" idType="id" />
+</FrameLayout>

--- a/components/feature/autofill/src/test/resources/fixtures/browser_fenix_amazon.co.uk.xml
+++ b/components/feature/autofill/src/test/resources/fixtures/browser_fenix_amazon.co.uk.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<FrameLayout>
+    <LinearLayout idEntry="action_bar_root" idPackage="org.mozilla.firefox" idType="id">
+        <View idEntry="action_mode_bar_stub" idPackage="org.mozilla.firefox" idType="id"/>
+        <FrameLayout idEntry="container" idPackage="org.mozilla.firefox" idType="id">
+            <ViewGroup idEntry="browserLayout" idPackage="org.mozilla.firefox" idType="id">
+                <ViewGroup idEntry="swipeRefresh" idPackage="org.mozilla.firefox" idType="id">
+                    <FrameLayout idEntry="engineView" idPackage="org.mozilla.firefox" idType="id">
+                        <form webDomain="www.amazon.co.uk" data-enable-mobile-account-js="true" action="https://www.amazon.co.uk/ap/register" method="post" data-fwcim-id="369de96d" novalidate="" id="ap_register_form" name="register" class="ap_ango_default fwcim-form auth-validate-form auth-clearable-form">
+                            <input webDomain="www.amazon.co.uk" name="appActionToken" type="hidden"/>
+                            <input webDomain="www.amazon.co.uk" name="appAction" type="hidden"/>
+                            <input webDomain="www.amazon.co.uk" name="openid.return_to" type="hidden"/>
+                            <input webDomain="www.amazon.co.uk" name="prevRID" type="hidden"/>
+                            <input webDomain="www.amazon.co.uk" name="workflowState" type="hidden"/>
+                            <input webDomain="www.amazon.co.uk" id="auth-country-picker" name="countryCode" type="hidden" class="auth-country-picker" disabled="disabled"/>
+                            <input webDomain="www.amazon.co.uk" autofillHints="emailAddress" inputType="21" autocorrect="off" id="ap_email" name="email" type="email" maxlength="64" placeholder="Mobile number or email" autocapitalize="off"/>
+                            <input webDomain="www.amazon.co.uk" autofillHints="password" inputType="e1" autocorrect="off" autocomplete="off" id="ap_password" name="password" type="password" maxlength="1024" placeholder="Create a password" autocapitalize="off"/>
+                            <input webDomain="www.amazon.co.uk" id="ap_show_password_checked" name="showPasswordChecked" type="hidden"/>
+                            <input webDomain="www.amazon.co.uk" id="auth-register-show-password-checkbox" name="" type="checkbox" checked=""/>
+                            <input webDomain="www.amazon.co.uk" id="continue" type="submit" class="a-button-input" aria-labelledby="auth-continue-announce"/>
+                        </form>
+                        <form webDomain="www.amazon.co.uk" action="https://www.amazon.co.uk/ap/signin" method="post" data-fwcim-id="4a0d320d" novalidate="" id="ap_login_form" name="signIn" class="auth-validate-form fwcim-form auth-clearable-form">
+                            <input webDomain="www.amazon.co.uk" name="appActionToken" type="hidden"/>
+                            <input webDomain="www.amazon.co.uk" name="appAction" type="hidden"/>
+                            <input webDomain="www.amazon.co.uk" name="openid.return_to" type="hidden"/>
+                            <input webDomain="www.amazon.co.uk" name="prevRID" type="hidden"/>
+                            <input webDomain="www.amazon.co.uk" name="workflowState" type="hidden"/>
+                            <input webDomain="www.amazon.co.uk" autofillHints="emailAddress" inputType="21" autocorrect="off" id="ap_email_login" name="email" type="email" maxlength="128" placeholder="Email (phone for mobile accounts)" autocapitalize="off" focus="true" autofillId="autofillId-username"/>
+                            <input webDomain="www.amazon.co.uk" autofillHints="password" inputType="e1" id="ap-credential-autofill-hint" name="password" type="password" maxlength="1024" autofillId="autofillId-password"/>
+                            <input webDomain="www.amazon.co.uk" id="continue" type="submit" class="a-button-input" aria-labelledby="continue-announce"/>
+                        </form>
+                    </FrameLayout>
+                </ViewGroup>
+                <FrameLayout idEntry="nestedScrollQuickAction" idPackage="org.mozilla.firefox" idType="id">
+                    <ViewGroup idEntry="quick_action_sheet" idPackage="org.mozilla.firefox" idType="id">
+                        <ViewGroup idEntry="quick_action_sheet" idPackage="org.mozilla.firefox" idType="id">
+                            <View idEntry="quick_action_sheet_faded_handle" idPackage="org.mozilla.firefox" idType="id"/>
+                            <LinearLayout idEntry="quick_action_buttons_layout" idPackage="org.mozilla.firefox" idType="id">
+                                <Button idEntry="quick_action_share" idPackage="org.mozilla.firefox" idType="id"/>
+                                <Button idEntry="quick_action_downloads" idPackage="org.mozilla.firefox" idType="id"/>
+                                <Button idEntry="quick_action_bookmark" idPackage="org.mozilla.firefox" idType="id"/>
+                                <Button idEntry="quick_action_appearance" idPackage="org.mozilla.firefox" idType="id"/>
+                                <Button idEntry="quick_action_open_app_link" idPackage="org.mozilla.firefox" idType="id"/>
+                                <Button idEntry="quick_action_read" idPackage="org.mozilla.firefox" idType="id"/>
+                            </LinearLayout>
+                            <View idEntry="quick_action_overlay" idPackage="org.mozilla.firefox" idType="id"/>
+                        </ViewGroup>
+                    </ViewGroup>
+                </FrameLayout>
+                <View idEntry="stubFindInPage" idPackage="org.mozilla.firefox" idType="id"/>
+                <ViewGroup idEntry="toolbar" idPackage="org.mozilla.firefox" idType="id">
+                    <TextView idEntry="mozac_browser_toolbar_title_view" idPackage="org.mozilla.firefox" idType="id"/>
+                    <TextView idEntry="mozac_browser_toolbar_url_view" idPackage="org.mozilla.firefox" idType="id" hint="Search or enter address"/>
+                    <FrameLayout idEntry="counter_root" idPackage="org.mozilla.firefox" idType="id">
+                        <TextView idEntry="counter_text" idPackage="org.mozilla.firefox" idType="id"/>
+                    </FrameLayout>
+                    <EditText idEntry="mozac_browser_toolbar_edit_url_view" idPackage="org.mozilla.firefox" idType="id" hint="Search or enter address" inputType="11"/>
+                    <ImageView idEntry="mozac_browser_toolbar_clear_view" idPackage="org.mozilla.firefox" idType="id"/>
+                </ViewGroup>
+                <ViewGroup idEntry="readerViewControlsBar" idPackage="org.mozilla.firefox" idType="id"/>
+            </ViewGroup>
+        </FrameLayout>
+        <ViewGroup idEntry="navigationToolbar" idPackage="org.mozilla.firefox" idType="id"/>
+    </LinearLayout>
+</FrameLayout>

--- a/components/feature/autofill/src/test/resources/fixtures/browser_webview_gmail.xml
+++ b/components/feature/autofill/src/test/resources/fixtures/browser_webview_gmail.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<FrameLayout>
+    <TextView idEntry="title" idPackage="android" idType="id" />
+    <LinearLayout idEntry="container" idPackage="org.chromium.webview_shell" idType="id">
+        <EditText idEntry="url_field" idPackage="org.chromium.webview_shell" idType="id" />
+        <form webDomain="accounts.google.com">
+            <input autofillHints="username" name="identifier" type="email" label="Forgot email?" id="identifierId" autofillId="autofillId-username"/>
+            <input name="hiddenPassword" type="password" label="Forgot email?" />
+            <input autofillHints="off" name="ca" type="text" label="Forgot email?" />
+        </form>
+    </LinearLayout>
+</FrameLayout>


### PR DESCRIPTION
Okay, here are the first tests for our Android Autofill implementation. Unfortunately the Autofill API classes can't be constructed or inspected. So I had to create this intermediate representation that we translate between. The Lockwise team already built this great XML representation that we can use in tests and I took a bunch of that code.

I haven't written tests for all XML files from the Lockwise repository yet. In addition to that I would like to collect some more samples from apps. However this is already good to go and there's no need to wait for more tests.