### PR TITLE
Closes #9859: Detect media notification icon size is incorrect

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/mediasession/GeckoMediaSessionDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/mediasession/GeckoMediaSessionDelegate.kt
@@ -14,6 +14,7 @@ import org.mozilla.geckoview.MediaSession as GeckoViewMediaSession
 
 private const val ARTWORK_RETRIEVE_TIMEOUT = 1000L
 private const val ARTWORK_IMAGE_SIZE = 48
+private const val ARTWORK_ERROR_SIZE = 1
 
 internal class GeckoMediaSessionDelegate(
     private val engineSession: GeckoEngineSession
@@ -39,9 +40,17 @@ internal class GeckoMediaSessionDelegate(
         val getArtwork: (suspend () -> Bitmap?)? = metaData.artwork?.let {
             {
                 try {
-                    withTimeoutOrNull(ARTWORK_RETRIEVE_TIMEOUT) {
+                    var bitmap = withTimeoutOrNull(ARTWORK_RETRIEVE_TIMEOUT) {
                         it.getBitmap(ARTWORK_IMAGE_SIZE).await()
                     }
+
+                    /* workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1697255 */
+                    if (bitmap != null &&
+                        (bitmap.height <= ARTWORK_ERROR_SIZE || bitmap.width <= ARTWORK_ERROR_SIZE)) {
+                        bitmap = null
+                    }
+
+                    bitmap
                 } catch (e: IllegalArgumentException) {
                     null
                 }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
