### PR TITLE
Closes #9864: Remove authorizeOAuthCode from the FirefoxAccount API

### DIFF
--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
@@ -8,17 +8,6 @@ import kotlinx.coroutines.Deferred
 import org.json.JSONObject
 
 /**
- * The access-type determines whether the code can be exchanged for a refresh token for
- * offline use or not.
- *
- * @property msg string value of the access-type
- */
-enum class AccessType(val msg: String) {
-    ONLINE("online"),
-    OFFLINE("offline")
-}
-
-/**
  * An object that represents a login flow initiated by [OAuthAccount].
  * @property state OAuth state parameter, identifying a specific authentication flow.
  * This string is randomly generated during [OAuthAccount.beginOAuthFlow] and [OAuthAccount.beginPairingFlow].
@@ -100,23 +89,6 @@ interface OAuthAccount : AutoCloseable {
      * @return Current account's session token, if available. `null` otherwise.
      */
     fun getSessionToken(): String?
-
-    /**
-     * Provisions a scoped OAuth code for a given [clientId] and the passed [scopes].
-     *
-     * @param clientId the client id string
-     * @param scopes the list of scopes to request access to
-     * @param state the state token string
-     * @param accessType the accessType method to be used by the returned code, determines whether
-     * the code can be exchanged for a refresh token to be used offline or not
-     * @return Deferred authorized auth code string, or `null` in case of failure.
-     */
-    suspend fun authorizeOAuthCode(
-        clientId: String,
-        scopes: Array<String>,
-        state: String,
-        accessType: AccessType = AccessType.ONLINE
-    ): String?
 
     /**
      * Fetches the profile object for the current client either from the existing cached state

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
@@ -9,10 +9,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.plus
-import mozilla.appservices.fxaclient.AuthorizationParameters
 import kotlinx.coroutines.withContext
 import mozilla.appservices.fxaclient.PersistedFirefoxAccount as InternalFxAcct
-import mozilla.components.concept.sync.AccessType
 import mozilla.components.concept.sync.AuthFlowUrl
 import mozilla.components.concept.sync.MigratingAccountInfo
 import mozilla.components.concept.sync.DeviceConstellation
@@ -134,18 +132,6 @@ class FirefoxAccount internal constructor(
             throw e
         } catch (e: FxaException) {
             null
-        }
-    }
-
-    override suspend fun authorizeOAuthCode(
-        clientId: String,
-        scopes: Array<String>,
-        state: String,
-        accessType: AccessType
-    ) = withContext(scope.coroutineContext) {
-        handleFxaExceptions(logger, "authorizeOAuthCode", { null }) {
-            val params = AuthorizationParameters(clientId, scopes.toList(), state, accessType.msg, null, null, null)
-            inner.authorizeOAuthCode(params)
         }
     }
 

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.sync.AccessTokenInfo
-import mozilla.components.concept.sync.AccessType
 import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.AuthFlowUrl
 import mozilla.components.concept.sync.MigratingAccountInfo
@@ -703,10 +702,6 @@ class FxaAccountManagerTest {
 
         override suspend fun getProfile(ignoreCache: Boolean): Profile? {
             return profile
-        }
-
-        override suspend fun authorizeOAuthCode(clientId: String, scopes: Array<String>, state: String, accessType: AccessType): String? {
-            return "123abc"
         }
 
         override fun getCurrentDeviceId(): String? {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -43,6 +43,9 @@ permalink: /changelog/
   possible to run some service-related unittests on a Windows host. [#9731](https://github.com/mozilla-mobile/android-components/pull/9731)
     * Work on restoring this capability will be tracked in [application-services#3917](https://github.com/mozilla/application-services/issues/3917).
 
+* **service-firefox-accounts**
+  * ⚠️ **This is a breaking change**: Removed the currently unused `authorizeOAuthCode` from FirefoxAccount API surface.
+
 # 73.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v72.0.0...v73.0.0)


### PR DESCRIPTION
I'll wait for https://github.com/mozilla-mobile/android-components/pull/9731 to land to avoid conflicts there.

cc @rfk 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
