### PR TITLE
For #9806 Close the download response before processing other actions

### DIFF
--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadMiddleware.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadMiddleware.kt
@@ -58,6 +58,7 @@ class DownloadMiddleware(
             is DownloadAction.RemoveAllDownloadsAction -> removeDownloads()
             is DownloadAction.UpdateDownloadAction -> updateDownload(action.download, context)
             is DownloadAction.RestoreDownloadsStateAction -> restoreDownloads(context.store)
+            is ContentAction.CancelDownloadAction -> closeDownloadResponse(context.store, action.sessionId)
             is DownloadAction.AddDownloadAction -> {
                 if (!action.download.private && !saveDownload(context.store, action.download)) {
                     // The download was already added before, so we are ignoring this request.
@@ -77,7 +78,6 @@ class DownloadMiddleware(
             is TabListAction.RemoveTabAction -> removePrivateNotifications(context.store, listOf(action.tabId))
             is DownloadAction.AddDownloadAction -> sendDownloadIntent(action.download)
             is DownloadAction.RestoreDownloadStateAction -> sendDownloadIntent(action.download)
-            is ContentAction.CancelDownloadAction -> closeDownloadResponse(context.store, action.sessionId)
         }
     }
 


### PR DESCRIPTION
I found a regression from my previous refactor, when I added [the combined action for closing the download and consuming it](https://github.com/mozilla-mobile/android-components/pull/9833#discussion_r589583002), the issue is due to the order in which the actions are processed. The order matters, and we have to make sure that we close the download before calling `next()` as it will trigger the download to be consumed  ([deleted](https://github.com/mozilla-mobile/android-components/blob/25226962ee6084e5d5a1cfbe6e93ac9880b4a400/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt#L72)) from the content, and if we get the order wrong we could be trying to find a download that [was already removed](https://github.com/mozilla-mobile/android-components/blob/25226962ee6084e5d5a1cfbe6e93ac9880b4a400/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadMiddleware.kt#L136), that is the exact issue that we have now. 

<img width="1346" alt="image" src="https://user-images.githubusercontent.com/773158/110727179-bf7d7c80-81e8-11eb-8f91-70fb3add427e.png">


I updated the tests to verify that we using the right order.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
