### PR TITLE
For #9869 - Verify bitmap is not blank before setting it as notification icon

### DIFF
--- a/components/feature/media/src/main/java/mozilla/components/feature/media/notification/MediaNotification.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/notification/MediaNotification.kt
@@ -11,6 +11,7 @@ import android.graphics.Bitmap
 import android.os.Build
 import android.support.v4.media.session.MediaSessionCompat
 import androidx.annotation.DrawableRes
+import androidx.annotation.VisibleForTesting
 import androidx.core.app.NotificationCompat
 import androidx.media.app.NotificationCompat.MediaStyle
 import mozilla.components.browser.state.state.CustomTabSessionState
@@ -55,9 +56,10 @@ internal class MediaNotification(
             .setSmallIcon(data.icon)
             .setContentTitle(data.title)
             .setContentText(data.description)
-            .setLargeIcon(data.largeIcon)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+
+        if (!data.largeIcon.isEmpty()) builder.setLargeIcon(data.largeIcon)
 
         if (data.action != null) {
             builder.addAction(data.action)
@@ -84,6 +86,20 @@ internal class MediaNotification(
         return builder.build()
     }
 }
+
+/**
+ * Creates an empty bitmap with the same size and config as the provided one, than compares
+ * them using sameAs() to determine if their pixel data is different.
+ * @returns true if provided bitmap contains no pixel data
+ * */
+@VisibleForTesting
+internal fun Bitmap?.isEmpty() =
+    if (this == null) {
+        true
+    } else {
+        val emptyBitmap = Bitmap.createBitmap(width, height, config)
+        sameAs(emptyBitmap)
+    }
 
 private suspend fun SessionState.toNotificationData(
     context: Context,

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/notification/MediaNotificationTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/notification/MediaNotificationTest.kt
@@ -8,6 +8,8 @@ import android.app.Notification
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.Color
 import androidx.core.app.NotificationCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
@@ -186,6 +188,33 @@ class MediaNotificationTest {
         assertEquals("", notification.text)
         assertEquals("A site is playing media", notification.title)
         assertEquals(R.drawable.mozac_feature_media_paused, notification.iconResource)
+    }
+
+    @Test
+    fun `given an empty bitmap when calling isEmpty() then return true`() {
+        // given
+        val emptyBitmap: Bitmap? = Bitmap.createBitmap(400, 400, Bitmap.Config.ARGB_8888)
+
+        // when
+        val result = emptyBitmap.isEmpty()
+
+        // then
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `given a non-empty bitmap when calling isEmpty() then return false`() {
+        // given
+        val bitmap: Bitmap? = Bitmap.createBitmap(400, 400, Bitmap.Config.ARGB_8888)
+            .apply {
+                setPixel(1, 1, Color.RED)
+            }
+
+        // when
+        val result = bitmap.isEmpty()
+
+        // then
+        assertEquals(false, result)
     }
 }
 


### PR DESCRIPTION
For https://github.com/mozilla-mobile/android-components/issues/9869

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR does not need [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR does not include any user facing features.

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
