### PR TITLE
Closes #9884: Catch SecurityException in GeckoSelectionActionDelegate when performing action

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/selection/GeckoSelectionActionDelegate.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/selection/GeckoSelectionActionDelegate.kt
@@ -58,8 +58,13 @@ open class GeckoSelectionActionDelegate(
     }
 
     override fun performAction(id: String, item: MenuItem): Boolean {
-        val selectedText = mSelection?.text ?: return super.performAction(id, item)
+        /* Temporary, removed once https://bugzilla.mozilla.org/show_bug.cgi?id=1694983 is fixed */
+        try {
+            val selectedText = mSelection?.text ?: return super.performAction(id, item)
 
-        return customDelegate.performAction(id, selectedText) || super.performAction(id, item)
+            return customDelegate.performAction(id, selectedText) || super.performAction(id, item)
+        } catch (e: SecurityException) {
+            return false
+        }
     }
 }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/selection/GeckoSelectionActionDelegateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/selection/GeckoSelectionActionDelegateTest.kt
@@ -7,9 +7,11 @@ package mozilla.components.browser.engine.gecko.selection
 import android.app.Activity
 import android.app.Application
 import android.app.Service
+import android.view.MenuItem
 import mozilla.components.concept.engine.selection.SelectionActionDelegate
 import mozilla.components.support.test.mock
 import org.junit.Assert
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -55,6 +57,25 @@ class GeckoSelectionActionDelegateTest {
             Assert.assertTrue(actualActions.contains(it))
         }
     }
+
+    @Test
+    fun `WHEN perform action triggers a security exception THEN false is returned`() {
+        val customActions = arrayOf("1", "2", "3")
+        val customDelegate = object : SelectionActionDelegate {
+            override fun getAllActions(): Array<String> = customActions
+            override fun isActionAvailable(id: String, selectedText: String): Boolean = false
+            override fun getActionTitle(id: String): CharSequence? = ""
+            override fun performAction(id: String, selectedText: String): Boolean {
+                throw SecurityException("test")
+            }
+            override fun sortedActions(actions: Array<String>): Array<String> {
+                return actions
+            }
+        }
+
+        val geckoDelegate = TestGeckoSelectionActionDelegate(mock(), customDelegate)
+        assertFalse(geckoDelegate.performAction("test", mock()))
+    }
 }
 
 /**
@@ -65,4 +86,7 @@ class TestGeckoSelectionActionDelegate(
     customDelegate: SelectionActionDelegate
 ) : GeckoSelectionActionDelegate(activity, customDelegate) {
     public override fun getAllActions() = super.getAllActions()
+    public override fun performAction(id: String, item: MenuItem): Boolean {
+        return super.performAction(id, item)
+    }
 }


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
