### PR TITLE
Strings to uplift releases/73

### DIFF
--- a/components/browser/awesomebar/src/main/res/values-iw/strings.xml
+++ b/components/browser/awesomebar/src/main/res/values-iw/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Description for the button to accept the search suggestion and continue editing the search. -->
+    <string name="mozac_browser_awesomebar_edit_suggestion">לקבל ולערוך את ההצעה</string>
+</resources>

--- a/components/browser/awesomebar/src/main/res/values-mix/strings.xml
+++ b/components/browser/awesomebar/src/main/res/values-mix/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Description for the button to accept the search suggestion and continue editing the search. -->
+    <string name="mozac_browser_awesomebar_edit_suggestion">Aceptar y editar sugerencia</string>
+</resources>

--- a/components/browser/engine-system/src/main/res/values-mix/strings.xml
+++ b/components/browser/engine-system/src/main/res/values-mix/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the title of an alert dialog displayed by a web page. %1$s will be replaced with the URL of the current page (displaying the dialog). -->
+    <string name="mozac_browser_engine_system_alert_title">Página nu %1$s katyi:</string>
+    <!-- Text for the message of an auth dialog displayed by a web page.
+    %1$s will be replaced by the hostname or a description of the protected area/site, %2$s will be replaced with the URL of the current page (displaying the dialog). -->
+    <string name="mozac_browser_engine_system_auth_message">%2$s tsiki sivi tsi tu un se e. Ndaka tu in: “%1$s”</string>
+    <!-- Text for the message of an auth dialog displayed by a web page. %1$s will be replaced with the URL of the current page (displaying the dialog). -->
+    <string name="mozac_browser_engine_system_auth_no_realm_message">%1$s tsiki sivi tsi tu un se e.</string>
+</resources>

--- a/components/browser/errorpages/src/main/res/values-kmr/strings.xml
+++ b/components/browser/errorpages/src/main/res/values-kmr/strings.xml
@@ -106,8 +106,22 @@
     <!-- The document title and heading of the error page shown when a website cannot be loaded because the browser is in offline mode. -->
     <string name="mozac_browser_errorpages_offline_title">Moda derhêl</string>
 
+    <!-- The error message shown when a website cannot be loaded because the browser is in offline mode. -->
+    <string name="mozac_browser_errorpages_offline_message"><![CDATA[
+      <p>Gerok di moda xwe ya negirêdayî de dixebite û nikare xwe bigihîne hêmana daxwazkirî.</p>
+      <ul>
+        <li>Gelo amûr bi toreke çalak ve girêdayî ye?</li>
+        <li>Li ser "Dîsa Biceribîne"yê bitikîne ku derbasî moda girêdayî bibî û rûpelê bar bikî.</li>
+      </ul>
+    ]]></string>
+
     <!-- The document title and heading of the error page shown when the browser prevents loading a website on a restricted port. -->
     <string name="mozac_browser_errorpages_port_blocked_title">Port ji ber sedemên ewlehiyê hatiye sînordarkirin</string>
+
+    <!-- The error message shown when the browser prevents loading a website on a restricted port. -->
+    <string name="mozac_browser_errorpages_port_blocked_message"><![CDATA[
+      <p>Navnîşana hatî xwestin porteke diyarkirî ye (mînak, <q>mozilla.org:80</q> ji bo potra 80 li ser mozilla.orgê) ku di rewşa asayî de ji bilî gera webê ji bo armancên <em>din</em> tê bikaranîn. Gerokê daxwaz ji bo parastin û ewlekariya te betal kir..</p>
+    ]]></string>
 
     <!-- The document title and heading of the error page shown when the Internet connection is disrupted while loading a website. -->
     <string name="mozac_browser_errorpages_net_reset_title">Girêdan hate resetkirin</string>

--- a/components/browser/errorpages/src/main/res/values-mix/strings.xml
+++ b/components/browser/errorpages/src/main/res/values-mix/strings.xml
@@ -1,6 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <!-- The button that appears at the bottom of an error page. -->
+    <string name="mozac_browser_errorpages_page_refresh">Ki’tsàa tuku</string>
+
+    <!-- The document title and heading of the error page shown when a website sends back unusual and incorrect credentials for an SSL certificate. -->
+    <string name="mozac_browser_errorpages_security_ssl_title">Mani^ku tyiitai^ña</string>
+
+    <!-- The text shown inside the advanced button used to expand the advanced options. It's only shown when a website has an invalid SSL certificate. -->
+    <string name="mozac_browser_errorpages_security_bad_cert_advanced">Ntyityí</string>
+
+    <!-- Text that will show up on the button at the bottom of the error page -->
+    <string name="mozac_browser_errorpages_no_internet_refresh_button">Kitsa tuku</string>
+
+    <!-- The document title and heading of an error page. -->
+    <string name="mozac_browser_errorpages_malformed_uri_title">Va^a dirección</string>
+
     <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_file_not_found_title">Kòo tutu ndukuku</string>
 

--- a/components/browser/menu/src/main/res/values-iw/strings.xml
+++ b/components/browser/menu/src/main/res/values-iw/strings.xml
@@ -2,6 +2,8 @@
 <resources>
     <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
     <string name="mozac_browser_menu_button">תפריט</string>
+    <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
+    <string name="mozac_browser_menu_highlighted">מודגש</string>
     <!-- Label for add-ons submenu section -->
     <string name="mozac_browser_menu_addons">תוספות</string>
     <!-- Label for add-ons sub menu item for add-ons manager -->

--- a/components/browser/menu/src/main/res/values-mix/strings.xml
+++ b/components/browser/menu/src/main/res/values-mix/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
+    <string name="mozac_browser_menu_button">Katsi</string>
+    <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
+    <string name="mozac_browser_menu_highlighted">Tu^un nchichi</string>
+    <!-- Label for add-ons submenu section -->
+    <string name="mozac_browser_menu_addons">Add-ons</string>
+    <!-- Label for add-ons sub menu item for add-ons manager -->
+    <string name="mozac_browser_menu_addons_manager">Komplementos</string>
+</resources>

--- a/components/browser/menu/src/main/res/values-mr/strings.xml
+++ b/components/browser/menu/src/main/res/values-mr/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
+    <string name="mozac_browser_menu_button">मेनू</string>
+    <!-- Label for add-ons submenu section -->
+    <string name="mozac_browser_menu_addons">ॲड-ऑन</string>
+    <!-- Label for add-ons sub menu item for add-ons manager -->
+    <string name="mozac_browser_menu_addons_manager">अ‍ॅड-ऑन व्यवस्थापक</string>
+</resources>

--- a/components/browser/menu2/src/main/res/values-iw/strings.xml
+++ b/components/browser/menu2/src/main/res/values-iw/strings.xml
@@ -2,4 +2,6 @@
 <resources>
     <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
     <string name="mozac_browser_menu2_button">תפריט</string>
-    </resources>
+    <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
+    <string name="mozac_browser_menu2_highlighted">מודגש</string>
+</resources>

--- a/components/browser/menu2/src/main/res/values-mix/strings.xml
+++ b/components/browser/menu2/src/main/res/values-mix/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
+    <string name="mozac_browser_menu2_button">Katsi</string>
+    <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
+    <string name="mozac_browser_menu2_highlighted">Tu^un nchichi</string>
+</resources>

--- a/components/browser/toolbar/src/main/res/values-mix/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-mix/strings.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
+    <string name="mozac_browser_toolbar_menu_button">Katsi</string>
+    <string name="mozac_clear_button_description">Ku^un</string>
+    <!-- Content description: For the tracking protection toolbar icon, it is set when the site has tracking protection enabled, but none trackers have been blocked or detected. -->
+    <string name="mozac_browser_toolbar_content_description_tracking_protection_on_no_trackers_blocked">Chika va^a ña sau</string>
+    <!-- Content description: For the tracking protection toolbar icon, it is set when the site has tracking protection enabled, and trackers have been blocked or detected.-->
+    <string name="mozac_browser_toolbar_content_description_tracking_protection_on_trackers_blocked1">Chika va^a ña sau</string>
+    <!-- Content description: For the tracking protection toolbar icon, it is set when the site has tracking protection disabled.-->
+    <string name="mozac_browser_toolbar_content_description_tracking_protection_off_for_a_site1">Chika va^a ña sau nu pagina yo^o </string>
+    <!-- Content description: For the site security information icon (the site security icon).-->
+    <string name="mozac_browser_toolbar_content_description_site_info">Tu^tu sitio yo^o</string>
+    <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
+    <string name="mozac_browser_toolbar_progress_loading">Sachuin</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">Ma ku kunu ña ku reproducción automática</string>
+</resources>

--- a/components/browser/toolbar/src/main/res/values-ur/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-ur/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_toolbar_content_description_site_info">سائٹ کی معلومات</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
     <string name="mozac_browser_toolbar_progress_loading">لوڈ کر رہا ہے</string>
+    <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
+    <string name="mozac_browser_toolbar_content_description_autoplay_blocked">کچھ مشمولات کو آٹو پلے سیٹنگ سے مسدود کردیا گیا ہے</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-zh-rCN/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-zh-rCN/strings.xml
@@ -12,7 +12,7 @@
     <!-- Content description: For the site security information icon (the site security icon).-->
     <string name="mozac_browser_toolbar_content_description_site_info">网站信息</string>
     <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
-    <string name="mozac_browser_toolbar_progress_loading">载入中</string>
+    <string name="mozac_browser_toolbar_progress_loading">正在载入</string>
     <!-- Content description: For the autoplay toolbar icon, it is set when the auto play permission is blocking content playing.-->
     <string name="mozac_browser_toolbar_content_description_autoplay_blocked">某些内容已被自动播放设置阻止</string>
 </resources>

--- a/components/feature/addons/src/main/res/values-co/strings.xml
+++ b/components/feature/addons/src/main/res/values-co/strings.xml
@@ -51,7 +51,7 @@
     <!-- Description for management permission. -->
     <string name="mozac_feature_addons_permissions_management_description">Cuttighjà l’impiegu di l’estensioni è urganizà i temi</string>
     <!-- Description for native_messaging permission. -->
-    <string name="mozac_feature_addons_permissions_native_messaging_description">Scambià messaghji cù parechje altre appiecazioni</string>
+    <string name="mozac_feature_addons_permissions_native_messaging_description">Scambià messaghji cù d’altre appiecazioni chì quessa</string>
     <!-- Description for notifications permission. -->
     <string name="mozac_feature_addons_permissions_notifications_description">Affissavvi nutificazioni</string>
     <!-- Description for pkcs11 permission. -->

--- a/components/feature/addons/src/main/res/values-iw/strings.xml
+++ b/components/feature/addons/src/main/res/values-iw/strings.xml
@@ -45,7 +45,7 @@
     <!-- Description for find permission. -->
     <string name="mozac_feature_addons_permissions_find_description">קריאת הטקסט של כל הלשוניות הפתוחות</string>
     <!-- Description for geolocation permission. -->
-    <string name="mozac_feature_addons_permissions_geolocation_description">גישה למיקום שלך</string>
+    <string name="mozac_feature_addons_permissions_geolocation_description">גישה לנתוני המיקום שלך</string>
     <!-- Description for history permission. -->
     <string name="mozac_feature_addons_permissions_history_description">גישה להיסטוריית הגלישה</string>
     <!-- Description for management permission. -->

--- a/components/feature/addons/src/main/res/values-kmr/strings.xml
+++ b/components/feature/addons/src/main/res/values-kmr/strings.xml
@@ -3,11 +3,11 @@
     <!-- Description for privacy add-on permission. -->
     <string name="mozac_feature_addons_permissions_privacy_description">Sazkariyên nihêniyê bixwîne û biguherîne</string>
     <!-- Description for all_urls add-on permission. -->
-    <string name="mozac_feature_addons_permissions_all_urls_description">Ji bo hemû malperan xwe bigihîne daneyên xwe</string>
+    <string name="mozac_feature_addons_permissions_all_urls_description">Ji bo hemû malperan xwe bigihîne daneyên te</string>
     <!-- Description for giving an add-on access to users's data on one site. %1$s  will be replaced by the DNS host name for which a web extension is requesting access (e.g., www.mozilla.org). -->
     <string name="mozac_feature_addons_permissions_one_site_description">Ji bo %1$s’ê xwe bigihîne daneyên xwe</string>
     <!-- Description for giving an add-on access to users's data in multiple sites in the domain %1$s. %1$s will be replaced by the DNS domain for which a web extension is requesting access (e.g., mozilla.org). -->
-    <string name="mozac_feature_addons_permissions_sites_in_domain_description">Ji bo malperên di domaîna %1$s’ê de xwe bigihîne daneyên xwe</string>
+    <string name="mozac_feature_addons_permissions_sites_in_domain_description">Xwe bigihîne daneyên malperên te yên aîdî domaîna %1$s’ê</string>
     <!-- When an add-on requires access to more than 4 sites, for example the add-on requires access for 5 sites. We will show the first 4 sites in individual entries, as in mozac_feature_addons_permissions_one_site_description,
      then we will show another collapsed entry saying "Access your data on 1 other site". This entry it's for the singular case, when the add-on is only accessing one extra site. -->
     <string name="mozac_feature_addons_permissions_one_extra_site_description" tools:ignore="PluralsCandidate">Li ser malpereke din xwe bigihîne daneyên xwe</string>
@@ -35,11 +35,11 @@
     <!-- Description for browser_data permission. -->
     <string name="mozac_feature_addons_permissions_browser_data_description">Paqijkirina raboriya gerînê, kûkî û daneyên têkildar</string>
     <!-- Description for clipboard_read permission. -->
-    <string name="mozac_feature_addons_permissions_clipboard_read_description">Wergirtina daneyan ji panoyê</string>
+    <string name="mozac_feature_addons_permissions_clipboard_read_description">Daneyan ji panoyê bistîne</string>
     <!-- Description for clipboard_write permission. -->
-    <string name="mozac_feature_addons_permissions_clipboard_write_description">Şandina daneyan li panoyê</string>
+    <string name="mozac_feature_addons_permissions_clipboard_write_description">Daneyan bişîne panoyê</string>
     <!-- Description for downloads permission. -->
-    <string name="mozac_feature_addons_permissions_downloads_description">Daxistina dosyeyan, xwendin û gihertina raboriya gerokê</string>
+    <string name="mozac_feature_addons_permissions_downloads_description">Dosyeyan daxîne, raboriya gerokê bixwîne û biguherîne</string>
     <!-- Description for downloads_open permission. -->
     <string name="mozac_feature_addons_permissions_downloads_open_description">Vekirina dosyeyên li cîhaza te barkirî</string>
     <!-- Description for find permission. -->
@@ -53,7 +53,7 @@
     <!-- Description for native_messaging permission. -->
     <string name="mozac_feature_addons_permissions_native_messaging_description">Şandina/stendina peyaman bi sepanên din ên Ji bilî vê</string>
     <!-- Description for notifications permission. -->
-    <string name="mozac_feature_addons_permissions_notifications_description">Nîşandana danezanan ji bo te</string>
+    <string name="mozac_feature_addons_permissions_notifications_description">Danezanan ji te re nîşan bide</string>
     <!-- Description for pkcs11 permission. -->
     <string name="mozac_feature_addons_permissions_pkcs11_description">Dabînkirina xizmetên rastandinê ji bo nasnameya krîptografîkî</string>
     <!-- Description for proxy permission. -->
@@ -95,7 +95,7 @@
     <!-- This is displayed in a page where the user can see the installed and recommended(not installed yet) add-ons, this string indicates the installed section. -->
     <string name="mozac_feature_addons_installed_section">Sazkirî</string>
     <!-- This is displayed in a page where the user can see the installed and recommended(not installed yet) add-ons, this string indicates the recommended section. -->
-    <string name="mozac_feature_addons_recommended_section">Yên pêşniyarkirî</string>
+    <string name="mozac_feature_addons_recommended_section">Yên pêşniyar</string>
     <!-- This is displayed in a page where the user can see the installed and recommended(not installed yet) add-ons, this string indicates the not yet supported section. -->
     <string name="mozac_feature_addons_unsupported_section">Hîn nayê piştgirîkirin</string>
     <!-- This is displayed in a page where the user can see the installed and recommended(not installed yet) add-ons, this string indicates the not yet available section. -->

--- a/components/feature/addons/src/main/res/values-mix/strings.xml
+++ b/components/feature/addons/src/main/res/values-mix/strings.xml
@@ -2,8 +2,42 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- The version on of add-on. -->
     <string name="mozac_feature_addons_version">Versión</string>
+    <!-- The rating of the add-on. -->
+    <string name="mozac_feature_addons_rating">Calificación</string>
+    <!-- Indicates the add-on is enabled. -->
+    <string name="mozac_feature_addons_settings_on">Kuna</string>
+    <!-- Indicates the add-on is disabled. -->
+    <string name="mozac_feature_addons_settings_off">Kasi</string>
+    <!-- Indicates the add-on is enabled. -->
+    <string name="mozac_feature_addons_enabled">Kuna</string>
+    <!-- Indicates the add-on is disabled. -->
+    <string name="mozac_feature_addons_disabled">Kasi</string>
+    <!-- This is displayed in a page where the user can see the installed and recommended(not installed yet) add-ons, this string indicates the disabled section. -->
+    <string name="mozac_feature_addons_disabled_section">Kasi</string>
+    <!-- This is button that remove (uninstall an add-on). -->
+    <string name="mozac_feature_addons_remove">Xitaá</string>
+    <!-- This is the title of a dialog that asks the users if they to install or not an add-on. %1$s is the add-on name. -->
+    <string name="mozac_feature_addons_permissions_dialog_title">¿Chika %1$s?</string>
+    <!-- This is the subtitle of a dialog that asks the users if they want to install or not an add-on, the subtitle lists the permissions that this add-on requires, the permissions will dynamically be listed after the ":". -->
+    <string name="mozac_feature_addons_permissions_dialog_subtitle">Se necesita permiso para:</string>
+    <!-- This is a button to add (install) an add-on . -->
+    <string name="mozac_feature_addons_permissions_dialog_add">Chika</string>
+    <!-- This is a button to cancel the add-on installation . -->
+    <string name="mozac_feature_addons_permissions_dialog_cancel">Kunchatu</string>
+    <!-- This is the label of a button to cancel an ongoing add-on installation. -->
+    <string name="mozac_feature_addons_install_addon_dialog_cancel">Kunchatu</string>
+    <!-- Accessibility content description for the amount of stars that add-on has, where %1$.02f will be the amount of stars and / separator and 5 the maximum number of stars e.g (2/5, 4.5/5 or 5/5)  . -->
+    <string name="mozac_feature_addons_rating_content_description">%1$.02f / 5</string>
+    <!-- This is the title of page where all the add-ons are listed-->
+    <string name="mozac_feature_addons_addons">Komplementos</string>
+    <!-- Label for add-ons sub menu item for add-ons manager-->
+    <string name="mozac_feature_addons_addons_manager">Komplementos</string>
+    <!-- The label of the allow button, this will be shown to the user when an add-on needs new permissions, with the button the user will indicate that they want to accept the new permissions and update the add-on-->
+    <string name="mozac_feature_addons_updater_notification_allow_button">Va’a</string>
     <!-- Text shown in not yet supported add-ons section in AddonsManagerAdapter. -->
     <string name="mozac_feature_addons_unsupported_caption">1 complemento</string>
     <!-- Text shown in not yet supported add-ons section in AddonsManagerAdapter - plural. %1$s is the number of unsupported add-ons -->
     <string name="mozac_feature_addons_unsupported_caption_plural">%1$s complementos</string>
+    <!-- Displayed in the "Status" field for the updater when there was an error during the add-on update. -->
+    <string name="mozac_feature_addons_updater_status_error">Vaá</string>
     </resources>

--- a/components/feature/addons/src/main/res/values-mr/strings.xml
+++ b/components/feature/addons/src/main/res/values-mr/strings.xml
@@ -4,6 +4,8 @@
     <string name="mozac_feature_addons_permissions_privacy_description">गोपनीयता सेटिंग वाचा व बदला</string>
     <!-- Description for all_urls add-on permission. -->
     <string name="mozac_feature_addons_permissions_all_urls_description">सर्व संकेतस्थळांची आपली माहिती पहा</string>
+    <!-- Description for giving an add-on access to users's data on one site. %1$s  will be replaced by the DNS host name for which a web extension is requesting access (e.g., www.mozilla.org). -->
+    <string name="mozac_feature_addons_permissions_one_site_description">%1$s साठी आपली माहिती पहा</string>
     <!-- Description for tabs add-on permission. -->
     <string name="mozac_feature_addons_permissions_tabs_description">ब्राउझरचे टॅब पहा</string>
     <!-- Description for unlimited_storage permission. -->
@@ -102,12 +104,12 @@
     <string name="mozac_feature_addons_install_addon_content_description">ॲड-ऑन प्रतिष्ठापीत करा</string>
     <!-- This is the label of a button to cancel an ongoing add-on installation. -->
     <string name="mozac_feature_addons_install_addon_dialog_cancel">रद्द करा</string>
-    <!-- Indicates how many users have rated an add-on. %1$s will be replaced with number of users -->
-    <string name="mozac_feature_addons_user_rating_count">वापरकर्ते: %1$s</string>
     <!-- Accessibility content description for the amount of stars that add-on has, where %1$.02f will be the amount of stars and / separator and 5 the maximum number of stars e.g (2/5, 4.5/5 or 5/5)  . -->
     <string name="mozac_feature_addons_rating_content_description">%1$.02f/5</string>
     <!-- This is the title of page where all the add-ons are listed-->
     <string name="mozac_feature_addons_addons">ॲड-ऑन</string>
+    <!-- Label for add-ons sub menu item for add-ons manager-->
+    <string name="mozac_feature_addons_addons_manager">अ‍ॅड-ऑन व्यवस्थापक</string>
     <!-- The label of the allow button, this will be shown to the user when an add-on needs new permissions, with the button the user will indicate that they want to accept the new permissions and update the add-on-->
     <string name="mozac_feature_addons_updater_notification_allow_button">परवानगी द्या</string>
     <!-- The label of the deny button on a notification, this will be shown to the user when an add-on needs new permissions. Indicates the user denies the new permissions and prevents the add-on from be updated-->

--- a/components/feature/app-links/src/main/res/values-mix/strings.xml
+++ b/components/feature/app-links/src/main/res/values-mix/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- The tile for the list of external apps to open the link in -->
+    <string name="mozac_feature_applinks_open_in">Kuna tsi…</string>
+    <!-- The description to warn users that their private browsing session changes  -->
+    <string name="mozac_feature_applinks_confirm_dialog_title">¿Kuna nu aplicación? ntyina ni ku kuntye^e ña sau.</string>
+    <!-- Opens the selected time -->
+    <string name="mozac_feature_applinks_confirm_dialog_confirm">Kuna</string>
+    <!-- Cancels the prompt -->
+    <string name="mozac_feature_applinks_confirm_dialog_deny">Kunchatu</string>
+</resources>

--- a/components/feature/autofill/src/main/res/values-be/strings.xml
+++ b/components/feature/autofill/src/main/res/values-be/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Разблакаваць %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Без імя карыстальніка)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Пароль для %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-br/strings.xml
+++ b/components/feature/autofill/src/main/res/values-br/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
+     a username or password can be autofilled for the highlighted text field. %1$s will be replaced
+     with the name of the browser application (e.g. Firefox) -->
+    <string name="mozac_feature_autofill_popup_unlock_application">Dibrennañ %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(anv arveriad ebet)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Ger-tremen evit %1$s</string>
+</resources>

--- a/components/feature/autofill/src/main/res/values-ca/strings.xml
+++ b/components/feature/autofill/src/main/res/values-ca/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
+     a username or password can be autofilled for the highlighted text field. %1$s will be replaced
+     with the name of the browser application (e.g. Firefox) -->
+    <string name="mozac_feature_autofill_popup_unlock_application">Desbloca el %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Cap nom d’usuari)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Contrasenya per a %1$s</string>
+</resources>

--- a/components/feature/autofill/src/main/res/values-cak/strings.xml
+++ b/components/feature/autofill/src/main/res/values-cak/strings.xml
@@ -13,4 +13,24 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">Ewan tzij richin %1$s</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">Xsach jikib\'anïk</string>
+
+    <!-- Autofill: Text shown in dialog asking the user to confirm before autofilling credentials into a
+    third-party app where we could not verify the authenticity (e.g. we determined that this app is
+    a twitter client and we could autofill twitter credentials, but according to the "Digital Asset
+    Links" this application is not the official Twitter application for twitter.com credentials.
+    %1$s will be replaced with the name of the browser application (e.g. Firefox).
+    -->
+    <string name="mozac_feature_autofill_confirmation_authenticity">%1$s man xtikïr ta xnik\'öx ri rujikib\'axik chokoy. ¿La nawajo\' chi ruyon ketz\'aqatisäx ri taq ruwujil echa\'on?</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Ja\'</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">Mani</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-cak/strings.xml
+++ b/components/feature/autofill/src/main/res/values-cak/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Timeq\'at %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Majun rub\'i\' okisanel)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Ewan tzij richin %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-co/strings.xml
+++ b/components/feature/autofill/src/main/res/values-co/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Spalancà %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Nisunu nome d’utilizatore)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Parolla d’entrata per %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-co/strings.xml
+++ b/components/feature/autofill/src/main/res/values-co/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
+     a username or password can be autofilled for the highlighted text field. %1$s will be replaced
+     with the name of the browser application (e.g. Firefox) -->
+    <string name="mozac_feature_autofill_popup_unlock_application">Spalancà %1$s</string>
+</resources>

--- a/components/feature/autofill/src/main/res/values-cs/strings.xml
+++ b/components/feature/autofill/src/main/res/values-cs/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Odemknout aplikaci %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Žádné uživatelské jméno)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Heslo pro účet %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-cy/strings.xml
+++ b/components/feature/autofill/src/main/res/values-cy/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
+     a username or password can be autofilled for the highlighted text field. %1$s will be replaced
+     with the name of the browser application (e.g. Firefox) -->
+    <string name="mozac_feature_autofill_popup_unlock_application">Datgloi %1$s</string>
+</resources>

--- a/components/feature/autofill/src/main/res/values-cy/strings.xml
+++ b/components/feature/autofill/src/main/res/values-cy/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Datgloi %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(dim enw defnyddiwr)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Cyfrinair %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-de/strings.xml
+++ b/components/feature/autofill/src/main/res/values-de/strings.xml
@@ -13,4 +13,24 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">Passwort für %1$s</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">Verifizierung fehlgeschlagen</string>
+
+    <!-- Autofill: Text shown in dialog asking the user to confirm before autofilling credentials into a
+    third-party app where we could not verify the authenticity (e.g. we determined that this app is
+    a twitter client and we could autofill twitter credentials, but according to the "Digital Asset
+    Links" this application is not the official Twitter application for twitter.com credentials.
+    %1$s will be replaced with the name of the browser application (e.g. Firefox).
+    -->
+    <string name="mozac_feature_autofill_confirmation_authenticity">%1$s konnte die Authentizität der Anwendung nicht überprüfen. Möchten Sie mit der Autovervollständigung der ausgewählten Anmeldeinformationen fortfahren?</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Ja</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">Nein</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-de/strings.xml
+++ b/components/feature/autofill/src/main/res/values-de/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">%1$s entsperren</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Kein Benutzername)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Passwort für %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-dsb/strings.xml
+++ b/components/feature/autofill/src/main/res/values-dsb/strings.xml
@@ -13,4 +13,24 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">Gronidło za %1$s</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">Pśeglědanje njejo se raźiło</string>
+
+    <!-- Autofill: Text shown in dialog asking the user to confirm before autofilling credentials into a
+    third-party app where we could not verify the authenticity (e.g. we determined that this app is
+    a twitter client and we could autofill twitter credentials, but according to the "Digital Asset
+    Links" this application is not the official Twitter application for twitter.com credentials.
+    %1$s will be replaced with the name of the browser application (e.g. Firefox).
+    -->
+    <string name="mozac_feature_autofill_confirmation_authenticity">%1$s njejo mógał awtentiskosć nałoženja pśespytowaś. Cośo z awtomatiskim wupołnjowanim wubranych pśizjawjeńskich datow pókšacowaś?</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Jo</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">Ně</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-dsb/strings.xml
+++ b/components/feature/autofill/src/main/res/values-dsb/strings.xml
@@ -3,14 +3,14 @@
     <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
-    <string name="mozac_feature_autofill_popup_unlock_application">A %1$s feloldása</string>
+    <string name="mozac_feature_autofill_popup_unlock_application">%1$s wěcej njeblokěrowaś</string>
 
     <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
     username is saved (e.g. we only have a password). This text will be shown in place where otherwise
     the username would be displayed. -->
-    <string name="mozac_feature_autofill_popup_no_username">(Nincs felhasználónév)</string>
+    <string name="mozac_feature_autofill_popup_no_username">(Žedno wužywaŕske mě)</string>
 
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
-    <string name="mozac_feature_autofill_popup_password">Jelszó a következőhöz: %1$s</string>
+    <string name="mozac_feature_autofill_popup_password">Gronidło za %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-el/strings.xml
+++ b/components/feature/autofill/src/main/res/values-el/strings.xml
@@ -13,4 +13,16 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">Κωδικός πρόσβασης για %1$s</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">Αποτυχία επαλήθευσης</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Ναι</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">Όχι</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-el/strings.xml
+++ b/components/feature/autofill/src/main/res/values-el/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Ξεκλείδωμα %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Χωρίς όνομα χρήστη)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Κωδικός πρόσβασης για %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-en-rCA/strings.xml
+++ b/components/feature/autofill/src/main/res/values-en-rCA/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Unlock %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(No username)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Password for %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-eo/strings.xml
+++ b/components/feature/autofill/src/main/res/values-eo/strings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
+     a username or password can be autofilled for the highlighted text field. %1$s will be replaced
+     with the name of the browser application (e.g. Firefox) -->
+    <string name="mozac_feature_autofill_popup_unlock_application">Malbloki %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(sen nomo de uzanto)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Pasvorto por %1$s</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">Malsukcesa kontrolo</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Jes</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">Ne</string>
+</resources>

--- a/components/feature/autofill/src/main/res/values-es-rAR/strings.xml
+++ b/components/feature/autofill/src/main/res/values-es-rAR/strings.xml
@@ -13,4 +13,24 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">Contraseña para %s</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">Falló la verificación</string>
+
+    <!-- Autofill: Text shown in dialog asking the user to confirm before autofilling credentials into a
+    third-party app where we could not verify the authenticity (e.g. we determined that this app is
+    a twitter client and we could autofill twitter credentials, but according to the "Digital Asset
+    Links" this application is not the official Twitter application for twitter.com credentials.
+    %1$s will be replaced with the name of the browser application (e.g. Firefox).
+    -->
+    <string name="mozac_feature_autofill_confirmation_authenticity">%1$s no pudo verificar la autenticidad de la aplicación. ¿Desea continuar autocompletando las credenciales seleccionadas?</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Sí</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">No</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-es-rAR/strings.xml
+++ b/components/feature/autofill/src/main/res/values-es-rAR/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Desbloquear %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Sin nombre de usuario)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Contraseña para %s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-es-rCL/strings.xml
+++ b/components/feature/autofill/src/main/res/values-es-rCL/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Desbloquear %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Sin nombre de usuario)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Contraseña para %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-es-rES/strings.xml
+++ b/components/feature/autofill/src/main/res/values-es-rES/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Desbloquear %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Sin nombre de usuario)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Contraseña para %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-es/strings.xml
+++ b/components/feature/autofill/src/main/res/values-es/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
+     a username or password can be autofilled for the highlighted text field. %1$s will be replaced
+     with the name of the browser application (e.g. Firefox) -->
+    <string name="mozac_feature_autofill_popup_unlock_application">Desbloquear %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Sin nombre de usuario)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Contraseña para %1$s</string>
+</resources>

--- a/components/feature/autofill/src/main/res/values-eu/strings.xml
+++ b/components/feature/autofill/src/main/res/values-eu/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
+     a username or password can be autofilled for the highlighted text field. %1$s will be replaced
+     with the name of the browser application (e.g. Firefox) -->
+    <string name="mozac_feature_autofill_popup_unlock_application">Desblokeatu %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Erabiltzaile-izenik ez)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">%1$s kontuaren pasahitza</string>
+</resources>

--- a/components/feature/autofill/src/main/res/values-fa/strings.xml
+++ b/components/feature/autofill/src/main/res/values-fa/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
+     a username or password can be autofilled for the highlighted text field. %1$s will be replaced
+     with the name of the browser application (e.g. Firefox) -->
+    <string name="mozac_feature_autofill_popup_unlock_application">بازکردن %1$s</string>
+</resources>

--- a/components/feature/autofill/src/main/res/values-fa/strings.xml
+++ b/components/feature/autofill/src/main/res/values-fa/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">بازکردن %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(بدون نام‌کاربری)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">گذرواژه برای %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-fi/strings.xml
+++ b/components/feature/autofill/src/main/res/values-fi/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Avaa %1$sin lukitus</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(ei käyttäjätunnusta)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Salasana tilille %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-fr/strings.xml
+++ b/components/feature/autofill/src/main/res/values-fr/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Déverrouiller %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Aucun nom d’utilisateur)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Mot de passe pour %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-fy-rNL/strings.xml
+++ b/components/feature/autofill/src/main/res/values-fy-rNL/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">%1$s ûntskoattelje</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Gjin brûkersnamme)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Wachtwurd foar %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-gn/strings.xml
+++ b/components/feature/autofill/src/main/res/values-gn/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Emyandyjey %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Puruhára hera’ỹva)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">%1$s ñe’ẽñemi</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-hr/strings.xml
+++ b/components/feature/autofill/src/main/res/values-hr/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
+     a username or password can be autofilled for the highlighted text field. %1$s will be replaced
+     with the name of the browser application (e.g. Firefox) -->
+    <string name="mozac_feature_autofill_popup_unlock_application">Otključaj %1$s</string>
+</resources>

--- a/components/feature/autofill/src/main/res/values-hr/strings.xml
+++ b/components/feature/autofill/src/main/res/values-hr/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Otključaj %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(nema korisničkog imena)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Lozinka za %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-hsb/strings.xml
+++ b/components/feature/autofill/src/main/res/values-hsb/strings.xml
@@ -13,4 +13,24 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">Hesło za %1$s</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">Přepruwowanje je so nimokuliło</string>
+
+    <!-- Autofill: Text shown in dialog asking the user to confirm before autofilling credentials into a
+    third-party app where we could not verify the authenticity (e.g. we determined that this app is
+    a twitter client and we could autofill twitter credentials, but according to the "Digital Asset
+    Links" this application is not the official Twitter application for twitter.com credentials.
+    %1$s will be replaced with the name of the browser application (e.g. Firefox).
+    -->
+    <string name="mozac_feature_autofill_confirmation_authenticity">%1$s njemóžeše awtentiskosć nałoženja přepruwować. Chceće z awtomatiskim wupjelnjenjom wubranych přizjewjenskich datow pokročować?</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Haj</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">Ně</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-hsb/strings.xml
+++ b/components/feature/autofill/src/main/res/values-hsb/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">%1$s hižo njeblokować</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Žane wužiwarske mjeno)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Hesło za %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-hu/strings.xml
+++ b/components/feature/autofill/src/main/res/values-hu/strings.xml
@@ -13,4 +13,24 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">Jelszó a következőhöz: %1$s</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">Az ellenőrzés sikertelen</string>
+
+    <!-- Autofill: Text shown in dialog asking the user to confirm before autofilling credentials into a
+    third-party app where we could not verify the authenticity (e.g. we determined that this app is
+    a twitter client and we could autofill twitter credentials, but according to the "Digital Asset
+    Links" this application is not the official Twitter application for twitter.com credentials.
+    %1$s will be replaced with the name of the browser application (e.g. Firefox).
+    -->
+    <string name="mozac_feature_autofill_confirmation_authenticity">A(z) %1$s nem tudta ellenőrizni az alkalmazás hitelességét. Folytatja a kiválasztott hitelesítő adatok automatikus kitöltését?</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Igen</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">Nem</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-hu/strings.xml
+++ b/components/feature/autofill/src/main/res/values-hu/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
+     a username or password can be autofilled for the highlighted text field. %1$s will be replaced
+     with the name of the browser application (e.g. Firefox) -->
+    <string name="mozac_feature_autofill_popup_unlock_application">A %1$s feloldása</string>
+</resources>

--- a/components/feature/autofill/src/main/res/values-in/strings.xml
+++ b/components/feature/autofill/src/main/res/values-in/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
+     a username or password can be autofilled for the highlighted text field. %1$s will be replaced
+     with the name of the browser application (e.g. Firefox) -->
+    <string name="mozac_feature_autofill_popup_unlock_application">Buka %1$s</string>
+</resources>

--- a/components/feature/autofill/src/main/res/values-it/strings.xml
+++ b/components/feature/autofill/src/main/res/values-it/strings.xml
@@ -13,4 +13,24 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">Password per %1$s</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">Verifica non riuscita</string>
+
+    <!-- Autofill: Text shown in dialog asking the user to confirm before autofilling credentials into a
+    third-party app where we could not verify the authenticity (e.g. we determined that this app is
+    a twitter client and we could autofill twitter credentials, but according to the "Digital Asset
+    Links" this application is not the official Twitter application for twitter.com credentials.
+    %1$s will be replaced with the name of the browser application (e.g. Firefox).
+    -->
+    <string name="mozac_feature_autofill_confirmation_authenticity">%1$s non ha potuto verificare l’autenticità dell’applicazione. Procedere con la compilazione automatica usando le credenziali selezionate?</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Sì</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">No</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-it/strings.xml
+++ b/components/feature/autofill/src/main/res/values-it/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Sblocca %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(nessun nome utente)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Password per %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-iw/strings.xml
+++ b/components/feature/autofill/src/main/res/values-iw/strings.xml
@@ -13,4 +13,16 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">ססמה עבור %1$s</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">האימות נכשל</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">כן</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">לא</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-iw/strings.xml
+++ b/components/feature/autofill/src/main/res/values-iw/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">שחרור נעילת %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(אין שם משתמש)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">ססמה עבור %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-ja/strings.xml
+++ b/components/feature/autofill/src/main/res/values-ja/strings.xml
@@ -3,14 +3,14 @@
     <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
-    <string name="mozac_feature_autofill_popup_unlock_application">Desbloquear %1$s</string>
+    <string name="mozac_feature_autofill_popup_unlock_application">%1$s のロックを解除</string>
 
     <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
     username is saved (e.g. we only have a password). This text will be shown in place where otherwise
     the username would be displayed. -->
-    <string name="mozac_feature_autofill_popup_no_username">(Sem nome de utilizador)</string>
+    <string name="mozac_feature_autofill_popup_no_username">(ユーザー名なし)</string>
 
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
-    <string name="mozac_feature_autofill_popup_password">Palavra-passe para %1$s</string>
+    <string name="mozac_feature_autofill_popup_password">%1$s のパスワード</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-ka/strings.xml
+++ b/components/feature/autofill/src/main/res/values-ka/strings.xml
@@ -13,4 +13,24 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">პაროლი ანგარიშისთვის %1$s</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">დამოწმება ვერ მოხერხდა</string>
+
+    <!-- Autofill: Text shown in dialog asking the user to confirm before autofilling credentials into a
+    third-party app where we could not verify the authenticity (e.g. we determined that this app is
+    a twitter client and we could autofill twitter credentials, but according to the "Digital Asset
+    Links" this application is not the official Twitter application for twitter.com credentials.
+    %1$s will be replaced with the name of the browser application (e.g. Firefox).
+    -->
+    <string name="mozac_feature_autofill_confirmation_authenticity">%1$s ვერ ადასტურებს აპლიკაციის ნამდვილობას. გსურთ, განაგრძოთ შერჩეული მონაცემებით თვითშევსება?</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">დიახ</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">არა</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-ka/strings.xml
+++ b/components/feature/autofill/src/main/res/values-ka/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">გაიხსნას %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(სახელის გარეშე)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">პაროლი ანგარიშისთვის %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-kab/strings.xml
+++ b/components/feature/autofill/src/main/res/values-kab/strings.xml
@@ -13,4 +13,16 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">Awal uffir i %1$s</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">Asenqed ur yeddi ara</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Ih</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">Ala</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-kab/strings.xml
+++ b/components/feature/autofill/src/main/res/values-kab/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Serreḥ i %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Ulac isem n useqdac)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Awal uffir i %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-kk/strings.xml
+++ b/components/feature/autofill/src/main/res/values-kk/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
+     a username or password can be autofilled for the highlighted text field. %1$s will be replaced
+     with the name of the browser application (e.g. Firefox) -->
+    <string name="mozac_feature_autofill_popup_unlock_application">%1$s босату</string>
+</resources>

--- a/components/feature/autofill/src/main/res/values-kk/strings.xml
+++ b/components/feature/autofill/src/main/res/values-kk/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">%1$s босату</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Пайдаланушы аты жоқ)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">%1$s үшін пароль</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-kmr/strings.xml
+++ b/components/feature/autofill/src/main/res/values-kmr/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Kilîda %1$s’ê veke</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Navê bikarhêner tune)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Pêborîna %1$s’ê</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-ko/strings.xml
+++ b/components/feature/autofill/src/main/res/values-ko/strings.xml
@@ -13,4 +13,24 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">%1$s 비밀번호</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">확인 실패</string>
+
+    <!-- Autofill: Text shown in dialog asking the user to confirm before autofilling credentials into a
+    third-party app where we could not verify the authenticity (e.g. we determined that this app is
+    a twitter client and we could autofill twitter credentials, but according to the "Digital Asset
+    Links" this application is not the official Twitter application for twitter.com credentials.
+    %1$s will be replaced with the name of the browser application (e.g. Firefox).
+    -->
+    <string name="mozac_feature_autofill_confirmation_authenticity">%1$s가 응용 프로그램의 신뢰성을 확인할 수 없습니다. 선택한 자격 증명을 자동으로 채우시겠습니까?</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">예</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">아니오</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-ko/strings.xml
+++ b/components/feature/autofill/src/main/res/values-ko/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">%1$s 잠금 해제</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(사용자 이름 없음)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">%1$s 비밀번호</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-lt/strings.xml
+++ b/components/feature/autofill/src/main/res/values-lt/strings.xml
@@ -13,4 +13,24 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">Paskyros „%1$s“ slaptažodis</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">Patvirtinimas nepavyko</string>
+
+    <!-- Autofill: Text shown in dialog asking the user to confirm before autofilling credentials into a
+    third-party app where we could not verify the authenticity (e.g. we determined that this app is
+    a twitter client and we could autofill twitter credentials, but according to the "Digital Asset
+    Links" this application is not the official Twitter application for twitter.com credentials.
+    %1$s will be replaced with the name of the browser application (e.g. Firefox).
+    -->
+    <string name="mozac_feature_autofill_confirmation_authenticity">„%1$s“ nepavyko patvirtinti programos autentiškumo. Ar norite automatiškai užpildyti prisijungimo duomenis?</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Taip</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">Ne</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-lt/strings.xml
+++ b/components/feature/autofill/src/main/res/values-lt/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Atrakinti „%1$s“</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(nėra naudotojo vardo)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Paskyros „%1$s“ slaptažodis</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-mix/strings.xml
+++ b/components/feature/autofill/src/main/res/values-mix/strings.xml
@@ -3,14 +3,14 @@
     <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
-    <string name="mozac_feature_autofill_popup_unlock_application">Unlock %1$s</string>
+    <string name="mozac_feature_autofill_popup_unlock_application">Kuna %1$s</string>
 
     <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
     username is saved (e.g. we only have a password). This text will be shown in place where otherwise
     the username would be displayed. -->
-    <string name="mozac_feature_autofill_popup_no_username">(No username)</string>
+    <string name="mozac_feature_autofill_popup_no_username">(Koo sivi)</string>
 
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
-    <string name="mozac_feature_autofill_popup_password">Password for %1$s</string>
+    <string name="mozac_feature_autofill_popup_password">Tu^un se^e %s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-nb-rNO/strings.xml
+++ b/components/feature/autofill/src/main/res/values-nb-rNO/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Lås opp %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Uten brukernavn)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Passord for %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-nl/strings.xml
+++ b/components/feature/autofill/src/main/res/values-nl/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">%1$s ontgrendelen</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Geen gebruikersnaam)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Wachtwoord voor %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-nn-rNO/strings.xml
+++ b/components/feature/autofill/src/main/res/values-nn-rNO/strings.xml
@@ -13,4 +13,12 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">Passord for %1$s</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Ja</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">Nei</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-nn-rNO/strings.xml
+++ b/components/feature/autofill/src/main/res/values-nn-rNO/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Lås opp %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(ikkje noko brukarnamn)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Passord for %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-nn-rNO/strings.xml
+++ b/components/feature/autofill/src/main/res/values-nn-rNO/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
+     a username or password can be autofilled for the highlighted text field. %1$s will be replaced
+     with the name of the browser application (e.g. Firefox) -->
+    <string name="mozac_feature_autofill_popup_unlock_application">Lås opp %1$s</string>
+</resources>

--- a/components/feature/autofill/src/main/res/values-pa-rIN/strings.xml
+++ b/components/feature/autofill/src/main/res/values-pa-rIN/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
+     a username or password can be autofilled for the highlighted text field. %1$s will be replaced
+     with the name of the browser application (e.g. Firefox) -->
+    <string name="mozac_feature_autofill_popup_unlock_application">%1$s ਅਣ-ਲਾਕ ਕਰੋ</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(ਕੋਈ ਵਰਤੋਂਕਾਰ ਨਾਂ ਨਹੀਂ)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">%1$s ਲਈ ਪਾਸਵਰਡ</string>
+</resources>

--- a/components/feature/autofill/src/main/res/values-pl/strings.xml
+++ b/components/feature/autofill/src/main/res/values-pl/strings.xml
@@ -13,4 +13,24 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">Hasło dla konta %1$s</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">Weryfikacja się nie powiodła</string>
+
+    <!-- Autofill: Text shown in dialog asking the user to confirm before autofilling credentials into a
+    third-party app where we could not verify the authenticity (e.g. we determined that this app is
+    a twitter client and we could autofill twitter credentials, but according to the "Digital Asset
+    Links" this application is not the official Twitter application for twitter.com credentials.
+    %1$s will be replaced with the name of the browser application (e.g. Firefox).
+    -->
+    <string name="mozac_feature_autofill_confirmation_authenticity">%1$s nie może zweryfikować autentyczności aplikacji. Czy kontynuować automatyczne wypełnianie wybranych danych logowania?</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Tak</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">Nie</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-pl/strings.xml
+++ b/components/feature/autofill/src/main/res/values-pl/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Odblokuj program %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Bez nazwy użytkownika)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Hasło dla konta %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-pt-rBR/strings.xml
+++ b/components/feature/autofill/src/main/res/values-pt-rBR/strings.xml
@@ -13,4 +13,24 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">Senha de %1$s</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">Falha na verificação</string>
+
+    <!-- Autofill: Text shown in dialog asking the user to confirm before autofilling credentials into a
+    third-party app where we could not verify the authenticity (e.g. we determined that this app is
+    a twitter client and we could autofill twitter credentials, but according to the "Digital Asset
+    Links" this application is not the official Twitter application for twitter.com credentials.
+    %1$s will be replaced with the name of the browser application (e.g. Firefox).
+    -->
+    <string name="mozac_feature_autofill_confirmation_authenticity">O %1$s não conseguiu verificar a autenticidade do aplicativo. Quer prosseguir com o preenchimento automático das credenciais selecionadas?</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Sim</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">Não</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-pt-rBR/strings.xml
+++ b/components/feature/autofill/src/main/res/values-pt-rBR/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Desbloquear %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(sem nome de usuário)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Senha de %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-rm/strings.xml
+++ b/components/feature/autofill/src/main/res/values-rm/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Debloccar %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Nagin num d\'utilisader)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Pled-clav per %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-ru/strings.xml
+++ b/components/feature/autofill/src/main/res/values-ru/strings.xml
@@ -13,4 +13,12 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">Пароль для %1$s</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Да</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">Нет</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-ru/strings.xml
+++ b/components/feature/autofill/src/main/res/values-ru/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Разблокировать %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Нет имени пользователя)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Пароль для %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-sat/strings.xml
+++ b/components/feature/autofill/src/main/res/values-sat/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
+     a username or password can be autofilled for the highlighted text field. %1$s will be replaced
+     with the name of the browser application (e.g. Firefox) -->
+    <string name="mozac_feature_autofill_popup_unlock_application">%1$s ᱠᱷᱩᱞᱟᱹᱭ ᱢᱮ</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(ᱵᱮᱵᱷᱟᱨᱤᱭᱟᱹ ᱧᱩᱛᱩᱢ ᱵᱟᱹᱱᱩᱜᱼᱟ)</string>
+
+    </resources>

--- a/components/feature/autofill/src/main/res/values-sk/strings.xml
+++ b/components/feature/autofill/src/main/res/values-sk/strings.xml
@@ -3,11 +3,14 @@
     <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
-    <string name="mozac_feature_autofill_popup_unlock_application">Desbloquiar %1$s</string>
+    <string name="mozac_feature_autofill_popup_unlock_application">Odomknúť %1$s</string>
 
     <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
     username is saved (e.g. we only have a password). This text will be shown in place where otherwise
     the username would be displayed. -->
-    <string name="mozac_feature_autofill_popup_no_username">(Ensin nome d\'usuariu)</string>
+    <string name="mozac_feature_autofill_popup_no_username">(Žiadne používateľské meno)</string>
 
-    </resources>
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Heslo pre účet %1$s</string>
+</resources>

--- a/components/feature/autofill/src/main/res/values-sl/strings.xml
+++ b/components/feature/autofill/src/main/res/values-sl/strings.xml
@@ -4,4 +4,8 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Odkleni %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Geslo za %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-sl/strings.xml
+++ b/components/feature/autofill/src/main/res/values-sl/strings.xml
@@ -5,6 +5,11 @@
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Odkleni %1$s</string>
 
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(brez uporabniškega imena)</string>
+
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">Geslo za %1$s</string>

--- a/components/feature/autofill/src/main/res/values-sr/strings.xml
+++ b/components/feature/autofill/src/main/res/values-sr/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Откључај %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(без корисничког имена)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Лозинка за %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-su/strings.xml
+++ b/components/feature/autofill/src/main/res/values-su/strings.xml
@@ -3,11 +3,14 @@
     <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
-    <string name="mozac_feature_autofill_popup_unlock_application">Desbloquiar %1$s</string>
+    <string name="mozac_feature_autofill_popup_unlock_application">Buka konci %1$s</string>
 
     <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
     username is saved (e.g. we only have a password). This text will be shown in place where otherwise
     the username would be displayed. -->
-    <string name="mozac_feature_autofill_popup_no_username">(Ensin nome d\'usuariu)</string>
+    <string name="mozac_feature_autofill_popup_no_username">(Taya sandiasma)</string>
 
-    </resources>
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Kecap sandi pikeun %1$s</string>
+</resources>

--- a/components/feature/autofill/src/main/res/values-sv-rSE/strings.xml
+++ b/components/feature/autofill/src/main/res/values-sv-rSE/strings.xml
@@ -13,4 +13,24 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">Lösenord för %1$s</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">Verifieringen misslyckades</string>
+
+    <!-- Autofill: Text shown in dialog asking the user to confirm before autofilling credentials into a
+    third-party app where we could not verify the authenticity (e.g. we determined that this app is
+    a twitter client and we could autofill twitter credentials, but according to the "Digital Asset
+    Links" this application is not the official Twitter application for twitter.com credentials.
+    %1$s will be replaced with the name of the browser application (e.g. Firefox).
+    -->
+    <string name="mozac_feature_autofill_confirmation_authenticity">%1$s kunde inte verifiera programmets äkthet. Vill du fortsätta med att automatiskt fylla i de valda uppgifterna?</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Ja</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">Nej</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-sv-rSE/strings.xml
+++ b/components/feature/autofill/src/main/res/values-sv-rSE/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Lås upp %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Inget användarnamn)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Lösenord för %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-te/strings.xml
+++ b/components/feature/autofill/src/main/res/values-te/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(వాడుకరి పేరు లేదు)</string>
+
+    </resources>

--- a/components/feature/autofill/src/main/res/values-tg/strings.xml
+++ b/components/feature/autofill/src/main/res/values-tg/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Кушодани қулфи %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Номи корбар нест)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Ниҳонвожа барои %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-tl/strings.xml
+++ b/components/feature/autofill/src/main/res/values-tl/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">i-Unlock ang %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(No username)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Password para sa %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-tr/strings.xml
+++ b/components/feature/autofill/src/main/res/values-tr/strings.xml
@@ -13,4 +13,24 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">%1$s parolası</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">Doğrulama başarısız</string>
+
+    <!-- Autofill: Text shown in dialog asking the user to confirm before autofilling credentials into a
+    third-party app where we could not verify the authenticity (e.g. we determined that this app is
+    a twitter client and we could autofill twitter credentials, but according to the "Digital Asset
+    Links" this application is not the official Twitter application for twitter.com credentials.
+    %1$s will be replaced with the name of the browser application (e.g. Firefox).
+    -->
+    <string name="mozac_feature_autofill_confirmation_authenticity">%1$s, uygulamanın yetkinliğini doğrulayamadı. Seçili hesap bilgilerini otomatik olarak doldurmaya devam etmek istiyor musunuz?</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Evet</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">Hayır</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-tr/strings.xml
+++ b/components/feature/autofill/src/main/res/values-tr/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">%1$s kilidini aç</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Kullanıcı adı yok)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">%1$s parolası</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-uk/strings.xml
+++ b/components/feature/autofill/src/main/res/values-uk/strings.xml
@@ -13,4 +13,24 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">Пароль для %1$s</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">Помилка перевірки</string>
+
+    <!-- Autofill: Text shown in dialog asking the user to confirm before autofilling credentials into a
+    third-party app where we could not verify the authenticity (e.g. we determined that this app is
+    a twitter client and we could autofill twitter credentials, but according to the "Digital Asset
+    Links" this application is not the official Twitter application for twitter.com credentials.
+    %1$s will be replaced with the name of the browser application (e.g. Firefox).
+    -->
+    <string name="mozac_feature_autofill_confirmation_authenticity">%1$s не вдалося перевірити справжність програми. Продовжити автозаповнення вибраних облікових даних?</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Так</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">Ні</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-uk/strings.xml
+++ b/components/feature/autofill/src/main/res/values-uk/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Розблокувати %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Без імені користувача)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Пароль для %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-ur/strings.xml
+++ b/components/feature/autofill/src/main/res/values-ur/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Autofill: Text shown in popup in third-party app if the browser app needs to be unlocked before
+     a username or password can be autofilled for the highlighted text field. %1$s will be replaced
+     with the name of the browser application (e.g. Firefox) -->
+    <string name="mozac_feature_autofill_popup_unlock_application">%1$s ان لاک کریں</string>
+</resources>

--- a/components/feature/autofill/src/main/res/values-vi/strings.xml
+++ b/components/feature/autofill/src/main/res/values-vi/strings.xml
@@ -13,4 +13,24 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">Mật khẩu cho %1$s</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">Xác minh thất bại</string>
+
+    <!-- Autofill: Text shown in dialog asking the user to confirm before autofilling credentials into a
+    third-party app where we could not verify the authenticity (e.g. we determined that this app is
+    a twitter client and we could autofill twitter credentials, but according to the "Digital Asset
+    Links" this application is not the official Twitter application for twitter.com credentials.
+    %1$s will be replaced with the name of the browser application (e.g. Firefox).
+    -->
+    <string name="mozac_feature_autofill_confirmation_authenticity">%1$s không thể xác minh tính xác thực của ứng dụng. Bạn có muốn tiếp tục tự động điền thông tin đăng nhập đã chọn không?</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">Có</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">Không</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-vi/strings.xml
+++ b/components/feature/autofill/src/main/res/values-vi/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">Mở khóa %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">(Không có tên người dùng)</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">Mật khẩu cho %1$s</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-zh-rCN/strings.xml
+++ b/components/feature/autofill/src/main/res/values-zh-rCN/strings.xml
@@ -13,4 +13,24 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">%1$s 的密码</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">验证失败</string>
+
+    <!-- Autofill: Text shown in dialog asking the user to confirm before autofilling credentials into a
+    third-party app where we could not verify the authenticity (e.g. we determined that this app is
+    a twitter client and we could autofill twitter credentials, but according to the "Digital Asset
+    Links" this application is not the official Twitter application for twitter.com credentials.
+    %1$s will be replaced with the name of the browser application (e.g. Firefox).
+    -->
+    <string name="mozac_feature_autofill_confirmation_authenticity">%1$s 无法验证此应用程序的真实性，您确定要自动填充选择的登录信息吗？</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">是</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">否</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-zh-rCN/strings.xml
+++ b/components/feature/autofill/src/main/res/values-zh-rCN/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">解锁 %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">（无用户名）</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">%1$s 的密码</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-zh-rTW/strings.xml
+++ b/components/feature/autofill/src/main/res/values-zh-rTW/strings.xml
@@ -13,4 +13,24 @@
     <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
     %1$s will be replaced with the login/username of the account. -->
     <string name="mozac_feature_autofill_popup_password">%1$s 的密碼</string>
+
+    <!-- Autofill: Title of a dialog asking the user to confirm before autofilling credentials into
+    a third-party app after the authenticity verification failed. -->
+    <string name="mozac_feature_autofill_confirmation_title">驗證失敗</string>
+
+    <!-- Autofill: Text shown in dialog asking the user to confirm before autofilling credentials into a
+    third-party app where we could not verify the authenticity (e.g. we determined that this app is
+    a twitter client and we could autofill twitter credentials, but according to the "Digital Asset
+    Links" this application is not the official Twitter application for twitter.com credentials.
+    %1$s will be replaced with the name of the browser application (e.g. Firefox).
+    -->
+    <string name="mozac_feature_autofill_confirmation_authenticity">%1$s 無法驗證此應用程式的真實性，您確定要自動填入選擇的登入資訊嗎？</string>
+
+    <!-- Autofill: Positive button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_yes">要填入</string>
+
+    <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
+    credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
+    <string name="mozac_feature_autofill_confirmation_no">不要填入</string>
 </resources>

--- a/components/feature/autofill/src/main/res/values-zh-rTW/strings.xml
+++ b/components/feature/autofill/src/main/res/values-zh-rTW/strings.xml
@@ -4,4 +4,13 @@
      a username or password can be autofilled for the highlighted text field. %1$s will be replaced
      with the name of the browser application (e.g. Firefox) -->
     <string name="mozac_feature_autofill_popup_unlock_application">解鎖 %1$s</string>
+
+    <!-- Autofill: Text shown in popup in third-party app if we found a matching account, but no
+    username is saved (e.g. we only have a password). This text will be shown in place where otherwise
+    the username would be displayed. -->
+    <string name="mozac_feature_autofill_popup_no_username">（無使用者名稱）</string>
+
+    <!-- Autofill: Text shown in popup in third-party app to autofill the password for an account.
+    %1$s will be replaced with the login/username of the account. -->
+    <string name="mozac_feature_autofill_popup_password">%1$s 的密碼</string>
 </resources>

--- a/components/feature/awesomebar/src/main/res/values-mix/strings.xml
+++ b/components/feature/awesomebar/src/main/res/values-mix/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- The description for a suggestion that represents an opened tab.
+    Used to distinguish between History search suggestions from your
+    browsing history and your open tabs -->
+    <string name="switch_to_tab_description">Sama xikua</string>
+</resources>

--- a/components/feature/contextmenu/src/main/res/values-mr/strings.xml
+++ b/components/feature/contextmenu/src/main/res/values-mr/strings.xml
@@ -30,10 +30,20 @@
     <string name="mozac_feature_contextmenu_snackbar_action_switch">बदला</string>
     <!-- Text for context menu item to open the link in an external app. -->
     <string name="mozac_feature_contextmenu_open_link_in_external_app">बाहेरील अॅपमध्ये दुवा उघडा</string>
-    <!-- Action shown in a text selection context menu. This will prompt a search using the selected text. The first parameter is the name of the application (For example: Fenix)-->
-    <string name="mozac_selection_context_menu_search">%s शोध</string>
-    <!-- Action shown in a text selection context menu. This will prompt a search in a private tab using the selected text The first parameter is the name of the application (For example: Fenix) -->
-    <string name="mozac_selection_context_menu_search_privately">%s खाजगी शोध</string>
+    <!-- Text for context menu item to share the email with another app. -->
+    <string name="mozac_feature_contextmenu_share_email_address">ईमेल पत्ता शेअर करा</string>
+    <!-- Text for context menu item to copy the email address to the clipboard. -->
+    <string name="mozac_feature_contextmenu_copy_email_address">ईमेल पत्त्याची प्रत बनवा</string>
+    <!-- Text for context menu item to add to a contact. -->
+    <string name="mozac_feature_contextmenu_add_to_contact">संपर्कांत समावेश करा</string>
+    <!-- Action shown in a text selection context menu. This will prompt a search using the selected text.-->
+    <string name="mozac_selection_context_menu_search_2">शोधा</string>
+    <!-- Action shown in a text selection context menu. This will prompt a search in a private tab using the selected text-->
+    <string name="mozac_selection_context_menu_search_privately_2">खाजगी शोध</string>
     <!-- Action shown in a text selection context menu. This will prompt a share of the selected text. -->
     <string name="mozac_selection_context_menu_share">शेअर करा</string>
+    <!-- Action shown in a text selection context menu. This will prompt a new email from the selected text. -->
+    <string name="mozac_selection_context_menu_email">ईमेल</string>
+    <!-- Action shown in a text selection context menu. This will prompt a new call from the selected text. -->
+    <string name="mozac_selection_context_menu_call">कॉल करा</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-cak/strings.xml
+++ b/components/feature/downloads/src/main/res/values-cak/strings.xml
@@ -43,4 +43,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Titz\'aqatisäïx rub\'anik rik\'in</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Man tikirel ta nijaq %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">K\'o chi niya\' q\'ij richin ye\'ok chi kipam ri taq yakb\'äl chuqa\' taq k\'ïy k\'oxom richin yeqasäx taq yakb\'äl. Tib\'an b\'enam pa runuk\'ulem Android, tapitz\'a\' ya\'oj q\'ij chuqa\' tipitz\' ri tiya\' q\'ij.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-cy/strings.xml
+++ b/components/feature/downloads/src/main/res/values-cy/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Cwblhau’r weithred gyda</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Methu agor %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Mae angen caniatâd mynedid i ffeiliau a chyfryngau i lwytho ffeiliau i lawr. Ewch i osodiadau Android, tapiwch caniatâd, a thapio caniatáu.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-de/strings.xml
+++ b/components/feature/downloads/src/main/res/values-de/strings.xml
@@ -44,4 +44,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Aktion abschließen mittels</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">%1$s kann nicht geöffnet werden</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Berechtigung für Datei- und Medienzugriff erforderlich, um Dateien herunterzuladen. Öffnen Sie die Android-Einstellungen, tippen Sie auf Berechtigungen und tippen Sie auf Erlauben.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-dsb/strings.xml
+++ b/components/feature/downloads/src/main/res/values-dsb/strings.xml
@@ -43,4 +43,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Akciju skóńcyś z pomocu</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">%1$s njedajo se wócyniś</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Pśistup k datajam a medijam jo trjebny, aby dataje ześěgnuł. Pśejźćo k nastajenjam Android, pótusniśo pšawa a pón Dowóliś.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-en-rCA/strings.xml
+++ b/components/feature/downloads/src/main/res/values-en-rCA/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Complete action using</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Unable to open %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Files and media permission access needed to download files. Go to Android settings, tap permissions, and tap allow.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-en-rGB/strings.xml
+++ b/components/feature/downloads/src/main/res/values-en-rGB/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Complete action using</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Unable to open %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Files and media permission access needed to download files. Go to Android settings, tap permissions, and tap allow.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-es-rAR/strings.xml
+++ b/components/feature/downloads/src/main/res/values-es-rAR/strings.xml
@@ -43,4 +43,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Completar acción usando</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">No se puede abrir %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Se necesita permiso de acceso a archivos y medios para descargar archivos. Ir a la configuración de Android, tocar permisos y tocar permitir.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-eu/strings.xml
+++ b/components/feature/downloads/src/main/res/values-eu/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Burutu ekintza honekin</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Ezin da %1$s ireki</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Fitxategiak deskargatzeko, fitxategi eta multimediaren sarbide-baimenak behar dira. Zoaz Android-en ezarpenetara, sakatu baimenak eta sakatu baimendu.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-fr/strings.xml
+++ b/components/feature/downloads/src/main/res/values-fr/strings.xml
@@ -44,4 +44,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Continuer avec</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Impossible d’ouvrir %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Les autorisations d’accès au stockage de fichiers et de médias sont nécessaires pour télécharger des fichiers. Rendez-vous dans les paramètres d’Android, sélectionnez Autorisations puis Autoriser.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-fy-rNL/strings.xml
+++ b/components/feature/downloads/src/main/res/values-fy-rNL/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Hanneling foltôgje mei</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Kin %1$s net iepenje</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Tagong ta bestannen en media fereaske om bestannen te downloaden. Gean nei Android-ynstellingen, tik op machtigingen en tik op tastean.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-gn/strings.xml
+++ b/components/feature/downloads/src/main/res/values-gn/strings.xml
@@ -44,4 +44,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Emoĩmba tembiapo rupi</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Ndaikatúi ijuruja %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Oñeikotevẽ marandurendápe jeike ha ñemoneĩ emboguejy hag̃ua marandurenda. Eho Android ñembohekópe, eikutu ñemoneĩ ha eikutu moneĩ.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-hr/strings.xml
+++ b/components/feature/downloads/src/main/res/values-hr/strings.xml
@@ -43,4 +43,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Završi radnju koristeći</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Nije moguće otvoriti %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Za preuzimanje datoteka potrebna je dozvola za pristup datotekama i medijima. Idi u postavke sustava Android, odaberi dozvole i odaberi &quot;Dopusti&quot;.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-hsb/strings.xml
+++ b/components/feature/downloads/src/main/res/values-hsb/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Akciju skónčić z pomocu</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">%1$s njeda so wočinić</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Přistup k datajam a medijam je trěbny, zo byšće dataje sćahnył. Přeńdźće k nastajenjam Android, podótkńće so prawow a potom Dowolić.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-hu/strings.xml
+++ b/components/feature/downloads/src/main/res/values-hu/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Művelet befejezése ezzel:</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">A(z) %1$s nem nyitható meg</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">A fájlok letöltéséhez fájl és média engedély hozzáférés szükséges. Nyissa meg az Android beállításokat, koppintson az engedélyekre, és koppintson az engedélyezésre.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-it/strings.xml
+++ b/components/feature/downloads/src/main/res/values-it/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Completa azione con</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Impossibile aprire %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Per scaricare i file è richiesto il permesso di accedere a file e contenuti multimediali. Vai alle impostazioni di Android, tocca Autorizzazioni e successivamente Consenti.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-iw/strings.xml
+++ b/components/feature/downloads/src/main/res/values-iw/strings.xml
@@ -43,4 +43,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">השלמת הפעולה באמצעות</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">לא ניתן לפתוח את %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">יש צורך בגישה להרשאה לקבצים ומדיה על מנת להוריד קבצים. יש לעבור אל ההגדרות של Android, להקיש על הרשאות ולהקיש על ״לאפשר״.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-ka/strings.xml
+++ b/components/feature/downloads/src/main/res/values-ka/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">მოქმედების შესასრულებლად გამოიყენება</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">ვერ გაიხსნა %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">ფაილების ნებართვებთან წვდომაა საჭირო, ჩამოსატვირთად. გადადით Android-ის პარამეტრებში, შეეხეთ ნებართვებს და შემდეგ დაშვებას.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-kk/strings.xml
+++ b/components/feature/downloads/src/main/res/values-kk/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Әрекетті келесіні қолданып аяқтау</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">%1$s ашу мүмкін емес</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Файлдарды жүктеп алу үшін файлдар мен медиа рұқсаты қажет. Android баптауларына өтіп, рұқсаттарды шертіңіз және рұқсат етуді таңдаңыз.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-ko/strings.xml
+++ b/components/feature/downloads/src/main/res/values-ko/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">다음 앱을 사용하여 작업 완료</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">%1$s 앱을 열 수 없음</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">파일을 다운로드하려면 파일 및 미디어 권한 액세스가 필요합니다. Android 설정으로 이동하여 권한을 누르고 허용을 누르세요.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-lt/strings.xml
+++ b/components/feature/downloads/src/main/res/values-lt/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Užbaigti veiksmą naudojant</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Nepavyko atverti „%1$s“</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Norint parsiųsti failus, reikia leidimo prie failų ir medijos. Eikite į „Android“ nustatymus, bakstelėkite leidimus, ir bakstelėkite leisti.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-mr/strings.xml
+++ b/components/feature/downloads/src/main/res/values-mr/strings.xml
@@ -39,4 +39,8 @@
 
     <!-- Content description for close button -->
     <string name="mozac_feature_downloads_button_close">बंद करा</string>
+    <!-- Title for the third party download app chooser dialog -->
+    <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">वापरून कृती पूर्ण करा</string>
+    <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
+    <string name="mozac_feature_downloads_unable_to_open_third_party_app">%1$s उघडण्यात अक्षम</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-nb-rNO/strings.xml
+++ b/components/feature/downloads/src/main/res/values-nb-rNO/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Fullfør handling med</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Kan ikke å åpne %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Tilgang til filer og media er nødvendig for å laste ned filer. Gå til Android-innstillinger, trykk på tillatelser og trykk på tillat.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-nb-rNO/strings.xml
+++ b/components/feature/downloads/src/main/res/values-nb-rNO/strings.xml
@@ -43,5 +43,5 @@
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Kan ikke å åpne %1$s</string>
     <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
-    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Tilgang til filer og media er nødvendig for å laste ned filer. Gå til Android-innstillinger, trykk på tillatelser og trykk på tillat.</string>
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Tilgang til filer og medier er nødvendig for å laste ned filer. Gå til Android-innstillinger, trykk på tillatelser og trykk på tillat.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-nl/strings.xml
+++ b/components/feature/downloads/src/main/res/values-nl/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Handeling voltooien met</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Kan %1$s niet openen</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Toegang tot bestanden en media vereist om bestanden te downloaden. Ga naar Android-instellingen, tik op machtigingen en tik op toestaan.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-nn-rNO/strings.xml
+++ b/components/feature/downloads/src/main/res/values-nn-rNO/strings.xml
@@ -43,4 +43,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Fullfør handlinga med</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Klarte ikkje å opne %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Tilgang til filer og media er nødvendig for å laste ned filer. Gå til Android-innstillingar, trykk på løyve (tillatelser) og trykk på tillat.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-pl/strings.xml
+++ b/components/feature/downloads/src/main/res/values-pl/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Dokończ za pomocą aplikacji</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Nie można otworzyć aplikacji %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Do pobierania plików wymagany jest dostęp do plików i multimediów. Przejdź do ustawień Androida, stuknij „Uprawnienia” i stuknij „Zezwól”.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-pt-rBR/strings.xml
+++ b/components/feature/downloads/src/main/res/values-pt-rBR/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Completar ação usando</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Não foi possível abrir %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">É necessário ter permissão de acesso a arquivos e mídia para baixar arquivos. Abra a configuração do Android, toque em permissões e toque em permitir.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-pt-rPT/strings.xml
+++ b/components/feature/downloads/src/main/res/values-pt-rPT/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Concluir ação utilizando</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Não foi possível abrir %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">A permissão de acesso a ficheiros e media é necessária para transferir ficheiros. Aceda às configurações do Android, toque em permissões e toque em permitir.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-rm/strings.xml
+++ b/components/feature/downloads/src/main/res/values-rm/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Cumplettar l\'acziun cun</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Impussibel d\'avrir %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Per pudair telechargiar datotecas è la permissiun da pudair acceder a datotecas e medias necessaria. Va als parameters dad Android, smatga sin permissiuns e lura sin permetter.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-sl/strings.xml
+++ b/components/feature/downloads/src/main/res/values-sl/strings.xml
@@ -43,4 +43,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Dokončaj dejanje z</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Ni mogoče odpreti %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Za prenašanje datotek so potrebna dovoljenja za dostop do datotek in predstavnosti. V nastavitvah sistema Android tapnite Dovoljenja in Dovoli.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-sv-rSE/strings.xml
+++ b/components/feature/downloads/src/main/res/values-sv-rSE/strings.xml
@@ -43,4 +43,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Slutför åtgärden med</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Kunde inte öppna %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Åtkomst till filer och media krävs för att ladda ner filer. Gå till Android-inställningar, tryck på behörigheter och tryck på tillåt.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-tg/strings.xml
+++ b/components/feature/downloads/src/main/res/values-tg/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Иҷро кардани амал ба воситаи</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">%1$s кушода намешавад</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Барои боргирӣ кардани файлҳо иҷозати дастрасӣ ба файлҳо ва расонаҳо лозим аст. Ба танзимоти Android гузаред, иҷозатҳоро ламс кунед ва иҷозат диҳед.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-tr/strings.xml
+++ b/components/feature/downloads/src/main/res/values-tr/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Eylemi şununla tamamla</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">%1$s açılamıyor</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Dosya indirmek için dosyalar ve medya erişimine izin vermeniz gerekiyor. Android ayarlarından izinlere girerek izin verin.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-uk/strings.xml
+++ b/components/feature/downloads/src/main/res/values-uk/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Завершити дію за допомогою</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Не вдалося відкрити %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Доступ до файлів та медіафайлів необхідний для завантаження файлів. Перейдіть до налаштувань Android, торкніться дозволів і торкніться дозволити.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-vi/strings.xml
+++ b/components/feature/downloads/src/main/res/values-vi/strings.xml
@@ -42,4 +42,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">Hoàn thành hành động bằng</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">Không thể mở %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">Cần có quyền truy cập vào tập tin và phương tiện để tải tập tin xuống. Đi tới cài đặt Android, nhấn vào quyền và nhấn cho phép.</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-zh-rCN/strings.xml
+++ b/components/feature/downloads/src/main/res/values-zh-rCN/strings.xml
@@ -44,4 +44,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">使用下列应用完成操作</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">无法打开 %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">下载文件需要文件和媒体访问权限。请前往 Android 设置，点按“权限”，并选择“允许”。</string>
 </resources>

--- a/components/feature/downloads/src/main/res/values-zh-rTW/strings.xml
+++ b/components/feature/downloads/src/main/res/values-zh-rTW/strings.xml
@@ -44,4 +44,6 @@
     <string name="mozac_feature_downloads_third_party_app_chooser_dialog_title">使用下列軟體完成操作</string>
     <!-- Message that appears when trying to download with an external app fails. %1$s will be replaced with the name the external app. -->--&gt;
     <string name="mozac_feature_downloads_unable_to_open_third_party_app">無法開啟 %1$s</string>
+    <!-- Text for the info dialog when write to storage permissions have been denied but user tries to download a file. -->
+    <string name="mozac_feature_downloads_write_external_storage_permissions_needed_message">需要有檔案與媒體存取權限才能下載檔案。請到 Android 設定當中的「權限」點擊「允許」。</string>
 </resources>

--- a/components/feature/privatemode/src/main/res/values-mr/strings.xml
+++ b/components/feature/privatemode/src/main/res/values-mr/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- The user visible name of the "notification channel" (Android 8+ feature) for the ongoing notification shown while a browsing session is active. -->
+    <string name="mozac_feature_privatemode_notification_channel_name">खाजगी ब्राऊझिंग सत्र</string>
+</resources>

--- a/components/feature/prompts/src/main/res/values-mr/strings.xml
+++ b/components/feature/prompts/src/main/res/values-mr/strings.xml
@@ -18,6 +18,8 @@
     <string name="mozac_feature_prompt_password_hint">पासवर्ड</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save">जतन करू नका</string>
+    <!-- Negative confirmation that we should never save a login for this site -->
+    <string name="mozac_feature_prompt_never_save">कधीही जतन करू नका</string>
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">जतन करा</string>
     <!-- Negative confirmation that we should not save the updated login -->
@@ -77,4 +79,19 @@
     <string name="mozac_feature_prompts_nov">नोव्हें</string>
     <!-- December month of the year (short description), used on the month chooser dialog. -->
     <string name="mozac_feature_prompts_dec">डिसें</string>
+    <!-- Option in expanded select login prompt that links to login settings -->
+    <string name="mozac_feature_prompts_manage_logins">लॉगिन व्यवस्थापित करा</string>
+    <!-- Content description for expanding the saved logins options in the select login prompt -->
+    <string name="mozac_feature_prompts_expand_logins_content_description">सूचित लॉगिन विस्तृत करा</string>
+    <!-- Content description for collapsing the saved logins options in the select login prompt -->
+    <string name="mozac_feature_prompts_collapse_logins_content_description">सूचित लॉगिन संकुचित करा</string>
+    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
+    <string name="mozac_feature_prompts_saved_logins">सूचित लॉगिन</string>
+
+    <!-- Strings shown in a dialog that appear when users try to refresh a certain kind of webpages -->
+    <string name="mozac_feature_prompt_repost_title">या साइटवर डेटा पुन्हा पाठवायचा?</string>
+    <!-- Pressing this will dismiss the dialog and reload the page sending again the previous data -->
+    <string name="mozac_feature_prompt_repost_positive_button_text">डेटा पुन्हा पाठवा</string>
+    <!-- Pressing this will dismiss the dialog and not refresh the webpage -->
+    <string name="mozac_feature_prompt_repost_negative_button_text">रद्द करा</string>
 </resources>

--- a/components/feature/pwa/src/main/res/values-mr/strings.xml
+++ b/components/feature/pwa/src/main/res/values-mr/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Default shortcut label used if website has no title -->
+    <string name="mozac_feature_pwa_default_shortcut_label">संकेतस्थळ</string>
+
+    <!-- Refresh button in site controls notification. -->
+    <string name="mozac_feature_pwa_site_controls_refresh">पुनःदाखल करा</string>
+    <!-- Toast displayed when the website URL is copied. -->
+    <string name="mozac_feature_pwa_copy_success">URL ची प्रत बनवली.</string>
+</resources>

--- a/components/feature/qr/src/main/res/values-kmr/strings.xml
+++ b/components/feature/qr/src/main/res/values-kmr/strings.xml
@@ -2,7 +2,7 @@
 <resources>
 
     <!-- Content description (not visible, for screen readers etc.): Description of an image view. -->
-    <string name="mozac_feature_qr_scanner">Pişkînera QR</string>
+    <string name="mozac_feature_qr_scanner">Xwînera QR</string>
 
     <!-- Text shown if no camera is available on the device and the QR scanner cannot be displayed. -->
     <string name="mozac_feature_qr_scanner_no_camera">Di cîhazê de kamera tune</string>

--- a/components/feature/qr/src/main/res/values-mr/strings.xml
+++ b/components/feature/qr/src/main/res/values-mr/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Content description (not visible, for screen readers etc.): Description of an image view. -->
+    <string name="mozac_feature_qr_scanner">QR स्कॅनर</string>
+
+    <!-- Text shown if no camera is available on the device and the QR scanner cannot be displayed. -->
+    <string name="mozac_feature_qr_scanner_no_camera">उपकरणावर कोणताही कॅमेरा उपलब्ध नाही</string>
+
+</resources>

--- a/components/feature/webnotifications/src/main/res/values-mr/strings.xml
+++ b/components/feature/webnotifications/src/main/res/values-mr/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Default Web Notification Channel Name. -->
+    <string name="mozac_feature_notification_channel_name">साइट सुचना</string>
+</resources>

--- a/components/support/base/src/main/res/values-cak/strings.xml
+++ b/components/support/base/src/main/res/values-cak/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Tib\'e pa taq nuk\'ulem</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Tewäx</string>
+</resources>

--- a/components/support/base/src/main/res/values-co/strings.xml
+++ b/components/support/base/src/main/res/values-co/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Andà à e preferenze</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Ricusà</string>
+</resources>

--- a/components/support/base/src/main/res/values-cy/strings.xml
+++ b/components/support/base/src/main/res/values-cy/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Mynd i gosodiadau</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Cau</string>
+</resources>

--- a/components/support/base/src/main/res/values-de/strings.xml
+++ b/components/support/base/src/main/res/values-de/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Einstellungen öffnen</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Schließen</string>
+</resources>

--- a/components/support/base/src/main/res/values-dsb/strings.xml
+++ b/components/support/base/src/main/res/values-dsb/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">K nastajenjam</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Zachyśiś</string>
+</resources>

--- a/components/support/base/src/main/res/values-el/strings.xml
+++ b/components/support/base/src/main/res/values-el/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Απόρριψη</string>
+</resources>

--- a/components/support/base/src/main/res/values-en-rCA/strings.xml
+++ b/components/support/base/src/main/res/values-en-rCA/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Go to settings</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Dismiss</string>
+</resources>

--- a/components/support/base/src/main/res/values-en-rGB/strings.xml
+++ b/components/support/base/src/main/res/values-en-rGB/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Go to settings</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Dismiss</string>
+</resources>

--- a/components/support/base/src/main/res/values-eo/strings.xml
+++ b/components/support/base/src/main/res/values-eo/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Ignori</string>
+</resources>

--- a/components/support/base/src/main/res/values-es-rAR/strings.xml
+++ b/components/support/base/src/main/res/values-es-rAR/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Ir a Ajustes</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Descartar</string>
+</resources>

--- a/components/support/base/src/main/res/values-eu/strings.xml
+++ b/components/support/base/src/main/res/values-eu/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Joan ezarpenetara</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Baztertu</string>
+</resources>

--- a/components/support/base/src/main/res/values-fi/strings.xml
+++ b/components/support/base/src/main/res/values-fi/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Siirry asetuksiin</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Hylkää</string>
+</resources>

--- a/components/support/base/src/main/res/values-fr/strings.xml
+++ b/components/support/base/src/main/res/values-fr/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Ouvrir les paramètres</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Ignorer</string>
+</resources>

--- a/components/support/base/src/main/res/values-fy-rNL/strings.xml
+++ b/components/support/base/src/main/res/values-fy-rNL/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Nei ynstellingen</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Slute</string>
+</resources>

--- a/components/support/base/src/main/res/values-gn/strings.xml
+++ b/components/support/base/src/main/res/values-gn/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Eho ñembohekópe</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Mosẽ</string>
+</resources>

--- a/components/support/base/src/main/res/values-hr/strings.xml
+++ b/components/support/base/src/main/res/values-hr/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Idi u postavke</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Odbaci</string>
+</resources>

--- a/components/support/base/src/main/res/values-hsb/strings.xml
+++ b/components/support/base/src/main/res/values-hsb/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">K nastajenjam</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Zaćisnyć</string>
+</resources>

--- a/components/support/base/src/main/res/values-hu/strings.xml
+++ b/components/support/base/src/main/res/values-hu/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Ugrás a beállításokhoz</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Elvetés</string>
+</resources>

--- a/components/support/base/src/main/res/values-it/strings.xml
+++ b/components/support/base/src/main/res/values-it/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Vai alle impostazioni</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Annulla</string>
+</resources>

--- a/components/support/base/src/main/res/values-iw/strings.xml
+++ b/components/support/base/src/main/res/values-iw/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">מעבר להגדרות</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">סגירה</string>
+</resources>

--- a/components/support/base/src/main/res/values-ka/strings.xml
+++ b/components/support/base/src/main/res/values-ka/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">პარამეტრებზე გადასვლა</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">დახურვა</string>
+</resources>

--- a/components/support/base/src/main/res/values-kab/strings.xml
+++ b/components/support/base/src/main/res/values-kab/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Ddu ɣer iɣewwaṛen</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Zgel</string>
+</resources>

--- a/components/support/base/src/main/res/values-kk/strings.xml
+++ b/components/support/base/src/main/res/values-kk/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Баптауларға өту</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Тайдыру</string>
+</resources>

--- a/components/support/base/src/main/res/values-kmr/strings.xml
+++ b/components/support/base/src/main/res/values-kmr/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Here sazkariyan</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Bigire</string>
+</resources>

--- a/components/support/base/src/main/res/values-ko/strings.xml
+++ b/components/support/base/src/main/res/values-ko/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">설정으로 이동</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">닫기</string>
+</resources>

--- a/components/support/base/src/main/res/values-lt/strings.xml
+++ b/components/support/base/src/main/res/values-lt/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Eiti į nustatymus</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Paslėpti</string>
+</resources>

--- a/components/support/base/src/main/res/values-nb-rNO/strings.xml
+++ b/components/support/base/src/main/res/values-nb-rNO/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Gå til innstillinger</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Avvis</string>
+</resources>

--- a/components/support/base/src/main/res/values-nl/strings.xml
+++ b/components/support/base/src/main/res/values-nl/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Naar instellingen</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Sluiten</string>
+</resources>

--- a/components/support/base/src/main/res/values-nn-rNO/strings.xml
+++ b/components/support/base/src/main/res/values-nn-rNO/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Gå til Innstillingar</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Avvis</string>
+</resources>

--- a/components/support/base/src/main/res/values-pl/strings.xml
+++ b/components/support/base/src/main/res/values-pl/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Przejdź do ustawień</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Zamknij</string>
+</resources>

--- a/components/support/base/src/main/res/values-pt-rBR/strings.xml
+++ b/components/support/base/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Ir para configurações</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Descartar</string>
+</resources>

--- a/components/support/base/src/main/res/values-pt-rPT/strings.xml
+++ b/components/support/base/src/main/res/values-pt-rPT/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Ir para as definições</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Dispensar</string>
+</resources>

--- a/components/support/base/src/main/res/values-rm/strings.xml
+++ b/components/support/base/src/main/res/values-rm/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Ir als parameters</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Ignorar</string>
+</resources>

--- a/components/support/base/src/main/res/values-ru/strings.xml
+++ b/components/support/base/src/main/res/values-ru/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Перейти в настройки</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Закрыть</string>
+</resources>

--- a/components/support/base/src/main/res/values-sk/strings.xml
+++ b/components/support/base/src/main/res/values-sk/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Prejsť do nastavení</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Zavrieť</string>
+</resources>

--- a/components/support/base/src/main/res/values-sl/strings.xml
+++ b/components/support/base/src/main/res/values-sl/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Pojdi v nastavitve</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Skrij</string>
+</resources>

--- a/components/support/base/src/main/res/values-sv-rSE/strings.xml
+++ b/components/support/base/src/main/res/values-sv-rSE/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Gå till Inställningar</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Ignorera</string>
+</resources>

--- a/components/support/base/src/main/res/values-tg/strings.xml
+++ b/components/support/base/src/main/res/values-tg/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Гузариш ба танзимот</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Нодида гузарондан</string>
+</resources>

--- a/components/support/base/src/main/res/values-tl/strings.xml
+++ b/components/support/base/src/main/res/values-tl/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Pumunta sa mga setting</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Paalisin</string>
+</resources>

--- a/components/support/base/src/main/res/values-tr/strings.xml
+++ b/components/support/base/src/main/res/values-tr/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Ayarlara git</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Kapat</string>
+</resources>

--- a/components/support/base/src/main/res/values-uk/strings.xml
+++ b/components/support/base/src/main/res/values-uk/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Перейти до налаштувань</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Відхилити</string>
+</resources>

--- a/components/support/base/src/main/res/values-vi/strings.xml
+++ b/components/support/base/src/main/res/values-vi/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">Đi đến cài đặt</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">Bỏ qua</string>
+</resources>

--- a/components/support/base/src/main/res/values-zh-rCN/strings.xml
+++ b/components/support/base/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">转至“设置”</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">隐藏</string>
+</resources>

--- a/components/support/base/src/main/res/values-zh-rTW/strings.xml
+++ b/components/support/base/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for the positive action button, that will take the user to the settings page -->
+    <string name="mozac_support_base_permissions_needed_positive_button">開啟設定</string>
+    <!-- Text for the negative action button to dismiss the dialog. -->
+    <string name="mozac_support_base_permissions_needed_negative_button">隱藏</string>
+</resources>

--- a/components/support/ktx/src/main/res/values-mr/strings.xml
+++ b/components/support/ktx/src/main/res/values-mr/strings.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Text displayed when choosing which app to call with after selecting a phone number-->
+    <string name="mozac_support_ktx_menu_call_with">यासह कॉल करा…</string>
     <string name="mozac_support_ktx_menu_share_with">यासह शेअर करा…</string>
     <string name="mozac_support_ktx_share_dialog_title">याद्वारे शेअर करा</string>
 </resources>

--- a/components/ui/tabcounter/src/main/res/values-kmr/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-kmr/strings.xml
@@ -11,5 +11,5 @@
     <!-- Browser menu button to close tab. Closes the current session when pressed. -->
     <string name="mozac_close_tab">Hilpekînê bigire</string>
     <!-- Content description of the tab counter toolbar button -->
-    <string name="mozac_tab_counter_content_description">Bişkoka darika amûran a jimarkera hilpekînan.</string>
+    <string name="mozac_tab_counter_content_description">Bişkoka darikê amûran a jimarkera hilpekînan.</string>
 </resources>


### PR DESCRIPTION
This patch uplifts strings to `releases/73.0`. I used the following commands:

```
git clone git@github.com:mozilla-mobile/android-components.git
cd android-components
git checkout releases/73.0
git pull
git checkout -b st3fan/strings-uplift
./l10n-uplift.py st3fan/strings-uplift --uplift --verbose
git push --set-upstream origin st3fan/strings-uplift
```


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
