### PR TITLE
Continue to remove JCenter

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,7 +7,16 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
+
+    if (project.hasProperty("centralRepo")) {
+        maven {
+            name "MavenCentral"
+            url project.property("centralRepo")
+        }
+    } else {
+        mavenCentral()
+    }
 }
 
 dependencies {

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,14 @@ import org.yaml.snakeyaml.Yaml
 
 buildscript {
     repositories {
-        jcenter()
+        if (hasProperty("centralRepo")) {
+            maven {
+                name "MavenCentral"
+                url property("centralRepo")
+            }
+        } else {
+            mavenCentral()
+        }
     }
 
     dependencies {


### PR DESCRIPTION
* `buildSrc` and `settings.gradle` were still referencing JCenter. They now use Maven Central. That seems to just work.
* Both did not use our artifact cache and always pulled everything from an external repository. This is now fixed and with that we will hopefully see less intermittent failures caused by us being unable to pull in Gradle plugins.