### PR TITLE
Support querying all tab collections as a single list

### DIFF
--- a/components/feature/tab-collections/src/androidTest/java/mozilla/components/feature/tab/collections/TabCollectionStorageTest.kt
+++ b/components/feature/tab-collections/src/androidTest/java/mozilla/components/feature/tab/collections/TabCollectionStorageTest.kt
@@ -285,6 +285,90 @@ class TabCollectionStorageTest {
             assertEquals("https://www.firefox.com", tabs[0].url)
             assertEquals("Firefox", tabs[0].title)
         }
+
+        with(collections[4]) {
+            assertEquals("Articles", title)
+            assertEquals(1, tabs.size)
+
+            assertEquals("https://www.mozilla.org", tabs[0].url)
+            assertEquals("Mozilla", tabs[0].title)
+        }
+    }
+
+    @Test
+    @Suppress("ComplexMethod")
+    fun testGettingCollectionsList() = runBlocking {
+        storage.createCollection(
+            "Articles", listOf(
+            createTab("https://www.mozilla.org", title = "Mozilla")
+            )
+        )
+        storage.createCollection(
+            "Recipes", listOf(
+            createTab("https://www.firefox.com", title = "Firefox")
+            )
+        )
+        storage.createCollection(
+            "Books", listOf(
+            createTab("https://www.youtube.com", title = "YouTube"),
+            createTab("https://www.amazon.com", title = "Amazon")
+            )
+        )
+        storage.createCollection(
+            "News", listOf(
+            createTab("https://www.google.com", title = "Google"),
+            createTab("https://www.facebook.com", title = "Facebook")
+            )
+        )
+        storage.createCollection(
+            "Blogs", listOf(
+            createTab("https://www.wikipedia.org", title = "Wikipedia")
+            )
+        )
+
+        val collections = storage.getCollectionsList()
+        assertEquals(5, collections.size)
+
+        with(collections[0]) {
+            assertEquals("Blogs", title)
+            assertEquals(1, tabs.size)
+            assertEquals("https://www.wikipedia.org", tabs[0].url)
+            assertEquals("Wikipedia", tabs[0].title)
+        }
+
+        with(collections[1]) {
+            assertEquals("News", title)
+            assertEquals(2, tabs.size)
+            assertEquals("https://www.facebook.com", tabs[0].url)
+            assertEquals("Facebook", tabs[0].title)
+            assertEquals("https://www.google.com", tabs[1].url)
+            assertEquals("Google", tabs[1].title)
+        }
+
+        with(collections[2]) {
+            assertEquals("Books", title)
+            assertEquals(2, tabs.size)
+            assertEquals("https://www.amazon.com", tabs[0].url)
+            assertEquals("Amazon", tabs[0].title)
+            assertEquals("https://www.youtube.com", tabs[1].url)
+            assertEquals("YouTube", tabs[1].title)
+        }
+
+        with(collections[3]) {
+            assertEquals("Recipes", title)
+            assertEquals(1, tabs.size)
+
+            assertEquals("https://www.firefox.com", tabs[0].url)
+            assertEquals("Firefox", tabs[0].title)
+        }
+
+        with(collections[4]) {
+            assertEquals("Articles", title)
+            assertEquals(1, tabs.size)
+
+            assertEquals("https://www.mozilla.org", tabs[0].url)
+            assertEquals("Mozilla", tabs[0].title)
+        }
     }
 
     @Test

--- a/components/feature/tab-collections/src/androidTest/java/mozilla/components/feature/tab/collections/db/TabCollectionDaoTest.kt
+++ b/components/feature/tab-collections/src/androidTest/java/mozilla/components/feature/tab/collections/db/TabCollectionDaoTest.kt
@@ -135,6 +135,21 @@ class TabCollectionDaoTest {
     }
 
     @Test
+    fun testGettingCollectionsList() = runBlocking {
+        val collection1 = TabCollectionEntity(title = "Collection One", updatedAt = 10)
+        val collection2 = TabCollectionEntity(title = "Collection Two", updatedAt = 50)
+
+        collection1.id = tabCollectionDao.insertTabCollection(collection1)
+        collection2.id = tabCollectionDao.insertTabCollection(collection2)
+
+        val tabCollections = tabCollectionDao.getTabCollectionsList()
+
+        assertEquals(2, tabCollections.size)
+        assertEquals("Collection Two", tabCollections[1].collection.title)
+        assertEquals("Collection One", tabCollections[0].collection.title)
+    }
+
+    @Test
     fun testCountingTabCollections() {
         assertEquals(0, tabCollectionDao.countTabCollections())
 

--- a/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/TabCollectionStorage.kt
+++ b/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/TabCollectionStorage.kt
@@ -23,6 +23,7 @@ import java.util.UUID
 /**
  * A storage implementation that saves snapshots of tabs / sessions in named collections.
  */
+@Suppress("TooManyFunctions")
 class TabCollectionStorage(
     context: Context,
     private val reader: BrowserStateReader = BrowserStateReader(),
@@ -113,6 +114,15 @@ class TabCollectionStorage(
     fun getCollections(): Flow<List<TabCollection>> {
         return database.value.tabCollectionDao().getTabCollections().map { list ->
             list.map { entity -> TabCollectionAdapter(entity) }
+        }
+    }
+
+    /**
+    * Returns all [TabCollection] instances as a list.
+    */
+    suspend fun getCollectionsList(): List<TabCollection> {
+        return database.value.tabCollectionDao().getTabCollectionsList().map { e ->
+            TabCollectionAdapter(e)
         }
     }
 

--- a/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/db/TabCollectionDao.kt
+++ b/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/db/TabCollectionDao.kt
@@ -48,6 +48,15 @@ internal interface TabCollectionDao {
     )
     fun getTabCollections(): Flow<List<TabCollectionWithTabs>>
 
+    @Query(
+        """
+        SELECT *
+        FROM tab_collections
+        ORDER BY created_at DESC
+    """
+    )
+    suspend fun getTabCollectionsList(): List<TabCollectionWithTabs>
+
     @Query("SELECT COUNT(*) FROM tab_collections")
     fun countTabCollections(): Int
 }


### PR DESCRIPTION
Working on a few cases where querying the list a single time in a suspend function is much more convenient. Following the same pattern as in `Downloads` but interested in other naming suggestions :).