### PR TITLE
For #9922 - Calculate menu width only once, before layout

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/DynamicWidthRecyclerView.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/DynamicWidthRecyclerView.kt
@@ -19,6 +19,11 @@ class DynamicWidthRecyclerView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null
 ) : RecyclerView(context, attrs) {
+    @VisibleForTesting
+    @Px internal var maxWidthOfAllChildren: Int = 0
+        set(value) {
+            if (field == 0) field = value
+        }
 
     @Px var minWidth: Int = -1
     @Px var maxWidth: Int = -1
@@ -29,8 +34,13 @@ class DynamicWidthRecyclerView @JvmOverloads constructor(
             // Ignore any bounds set in xml. Allow for children to expand entirely.
             callParentOnMeasure(MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED), heightSpec)
 
+            // First measure will report the width/height for the entire list
+            // The first layout pass will actually remove child views that do not fit the screen
+            // so future onMeasure calls will report skewed values.
+            maxWidthOfAllChildren = measuredWidth
+
             // Children now have "unspecified" width. Let's set some bounds.
-            setReconciledDimensions(measuredWidth, measuredHeight)
+            setReconciledDimensions(maxWidthOfAllChildren, measuredHeight)
         } else {
             // Default behavior. layout_width / layout_height properties will be used for measuring.
             callParentOnMeasure(widthSpec, heightSpec)

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/view/DynamicWidthRecyclerViewTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/view/DynamicWidthRecyclerViewTest.kt
@@ -11,6 +11,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
@@ -184,6 +185,34 @@ class DynamicWidthRecyclerViewTest {
         dynamicRecyclerView.setReconciledDimensions(childrenWidth, 100)
 
         verify(dynamicRecyclerView).callSetMeasuredDimension(materialMaxWidth, 100)
+    }
+
+    @Test
+    fun `maxWidthOfAllChildren can only be initialized once with a positive value`() {
+        val dynamicRecyclerView = DynamicWidthRecyclerView(testContext)
+
+        assertEquals(0, dynamicRecyclerView.maxWidthOfAllChildren)
+
+        dynamicRecyclerView.maxWidthOfAllChildren = 42
+        assertEquals(42, dynamicRecyclerView.maxWidthOfAllChildren)
+
+        dynamicRecyclerView.maxWidthOfAllChildren = 24
+        assertEquals(42, dynamicRecyclerView.maxWidthOfAllChildren)
+    }
+
+    @Test
+    fun `onMeasure will call setReconciledDimensions with maxWidthOfAllChildren`() {
+        val dynamicRecyclerView = spy(DynamicWidthRecyclerView(testContext))
+        doReturn(100).`when`(dynamicRecyclerView).measuredHeight
+        doReturn(100).`when`(dynamicRecyclerView).measuredWidth
+        doReturn(100).`when`(dynamicRecyclerView).height
+        dynamicRecyclerView.maxWidthOfAllChildren = 42
+        dynamicRecyclerView.minWidth = 10
+        dynamicRecyclerView.maxWidth = Int.MAX_VALUE
+
+        dynamicRecyclerView.measure(0, 0)
+
+        verify(dynamicRecyclerView).setReconciledDimensions(42, 100)
     }
 
     private fun buildRecyclerView(layoutWidth: Int): DynamicWidthRecyclerView {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **browser-menu**:
+  * 🚒 Bug fixed [issue #](https://github.com/mozilla-mobile/android-components/issues/9922) - The browser menu will have it's dynamic width calculated only once, before the first layout.
+
 * **browser-menu**
   * 🌟️ BrowserMenu support a bottom collapsed/expandable layout through a new ExpandableLayout that will wrap a menu layout before being used in a PopupWindow and automatically allow the collapse/expand behaviors.
   * To use this set `isCollapsingMenuLimit = true` for any menu item of a bottom anchored menu.


### PR DESCRIPTION
Previously the width could've change while the menu was scrolled or the width
may have been too small / big for the entire list when a larger / narrower
would be initially off screen, waiting for a scroll to be laid out.


https://user-images.githubusercontent.com/11428869/111498027-43d08200-874a-11eb-9902-0986db03c71c.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
