### PR TITLE
Adjust detekt TooManyFunctions threshold

### DIFF
--- a/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/BrowserAwesomeBar.kt
+++ b/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/BrowserAwesomeBar.kt
@@ -33,7 +33,7 @@ internal const val INITIAL_NUMBER_OF_PROVIDERS = 5
 /**
  * A customizable [AwesomeBar] implementation.
  */
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("LargeClass")
 class BrowserAwesomeBar @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,

--- a/components/browser/engine-gecko-beta/src/androidTest/java/mozilla/components/browser/engine/gecko/fetch/geckoview/GeckoViewFetchTestCases.kt
+++ b/components/browser/engine-gecko-beta/src/androidTest/java/mozilla/components/browser/engine/gecko/fetch/geckoview/GeckoViewFetchTestCases.kt
@@ -13,7 +13,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 @MediumTest
-@Suppress("TooManyFunctions")
 class GeckoViewFetchTestCases : mozilla.components.tooling.fetch.tests.FetchTestCases() {
     override fun createNewClient(): Client = GeckoViewFetchClient(ApplicationProvider.getApplicationContext())
 

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -65,7 +65,7 @@ import java.lang.ref.WeakReference
 /**
  * Gecko-based implementation of Engine interface.
  */
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("LargeClass")
 class GeckoEngine(
     context: Context,
     private val defaultSettings: Settings? = null,

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -24,7 +24,6 @@ import org.mozilla.geckoview.GeckoSession
 /**
  * Gecko-based EngineView implementation.
  */
-@Suppress("TooManyFunctions")
 class GeckoEngineView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
@@ -26,7 +26,7 @@ import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_UNHANDLED
  * https://github.com/takahirom/webview-in-coordinatorlayout
  */
 
-@Suppress("TooManyFunctions", "ClickableViewAccessibility")
+@Suppress("ClickableViewAccessibility")
 open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrollingChild {
 
     @VisibleForTesting

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -54,7 +54,6 @@ typealias AC_FILE_FACING_MODE = PromptRequest.File.FacingMode
 /**
  * Gecko-based PromptDelegate implementation.
  */
-@Suppress("TooManyFunctions")
 internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSession) :
     PromptDelegate {
 

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -31,7 +31,6 @@ import org.mozilla.geckoview.WebExtension.Action as GeckoNativeWebExtensionActio
  * Gecko-based implementation of [WebExtension], wrapping the native web
  * extension object provided by GeckoView.
  */
-@Suppress("TooManyFunctions")
 class GeckoWebExtension(
     val nativeExtension: GeckoNativeWebExtension,
     val runtime: GeckoRuntime

--- a/components/browser/engine-gecko-nightly/src/androidTest/java/mozilla/components/browser/engine/gecko/fetch/geckoview/GeckoViewFetchTestCases.kt
+++ b/components/browser/engine-gecko-nightly/src/androidTest/java/mozilla/components/browser/engine/gecko/fetch/geckoview/GeckoViewFetchTestCases.kt
@@ -13,7 +13,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 @MediumTest
-@Suppress("TooManyFunctions")
 class GeckoViewFetchTestCases : mozilla.components.tooling.fetch.tests.FetchTestCases() {
     override fun createNewClient(): Client = GeckoViewFetchClient(ApplicationProvider.getApplicationContext())
 

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -65,7 +65,7 @@ import java.lang.ref.WeakReference
 /**
  * Gecko-based implementation of Engine interface.
  */
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("LargeClass")
 class GeckoEngine(
     context: Context,
     private val defaultSettings: Settings? = null,

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -24,7 +24,6 @@ import org.mozilla.geckoview.GeckoSession
 /**
  * Gecko-based EngineView implementation.
  */
-@Suppress("TooManyFunctions")
 class GeckoEngineView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
@@ -26,7 +26,7 @@ import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_UNHANDLED
  * https://github.com/takahirom/webview-in-coordinatorlayout
  */
 
-@Suppress("TooManyFunctions", "ClickableViewAccessibility")
+@Suppress("ClickableViewAccessibility")
 open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrollingChild {
 
     @VisibleForTesting

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -54,7 +54,6 @@ typealias AC_FILE_FACING_MODE = PromptRequest.File.FacingMode
 /**
  * Gecko-based PromptDelegate implementation.
  */
-@Suppress("TooManyFunctions")
 internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSession) :
     PromptDelegate {
 

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -31,7 +31,6 @@ import org.mozilla.geckoview.WebExtension.Action as GeckoNativeWebExtensionActio
  * Gecko-based implementation of [WebExtension], wrapping the native web
  * extension object provided by GeckoView.
  */
-@Suppress("TooManyFunctions")
 class GeckoWebExtension(
     val nativeExtension: GeckoNativeWebExtension,
     val runtime: GeckoRuntime

--- a/components/browser/engine-gecko/src/androidTest/java/mozilla/components/browser/engine/gecko/fetch/geckoview/GeckoViewFetchTestCases.kt
+++ b/components/browser/engine-gecko/src/androidTest/java/mozilla/components/browser/engine/gecko/fetch/geckoview/GeckoViewFetchTestCases.kt
@@ -13,7 +13,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 @MediumTest
-@Suppress("TooManyFunctions")
 class GeckoViewFetchTestCases : mozilla.components.tooling.fetch.tests.FetchTestCases() {
     override fun createNewClient(): Client = GeckoViewFetchClient(ApplicationProvider.getApplicationContext())
 

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -65,7 +65,7 @@ import java.lang.ref.WeakReference
 /**
  * Gecko-based implementation of Engine interface.
  */
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("LargeClass")
 class GeckoEngine(
     context: Context,
     private val defaultSettings: Settings? = null,

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -24,7 +24,6 @@ import org.mozilla.geckoview.GeckoSession
 /**
  * Gecko-based EngineView implementation.
  */
-@Suppress("TooManyFunctions")
 class GeckoEngineView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
@@ -26,7 +26,7 @@ import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_UNHANDLED
  * https://github.com/takahirom/webview-in-coordinatorlayout
  */
 
-@Suppress("TooManyFunctions", "ClickableViewAccessibility")
+@Suppress("ClickableViewAccessibility")
 open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrollingChild {
 
     @VisibleForTesting

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -54,7 +54,6 @@ typealias AC_FILE_FACING_MODE = PromptRequest.File.FacingMode
 /**
  * Gecko-based PromptDelegate implementation.
  */
-@Suppress("TooManyFunctions")
 internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSession) :
     PromptDelegate {
 

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -31,7 +31,6 @@ import org.mozilla.geckoview.WebExtension.Action as GeckoNativeWebExtensionActio
  * Gecko-based implementation of [WebExtension], wrapping the native web
  * extension object provided by GeckoView.
  */
-@Suppress("TooManyFunctions")
 class GeckoWebExtension(
     val nativeExtension: GeckoNativeWebExtension,
     val runtime: GeckoRuntime

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/NestedWebView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/NestedWebView.kt
@@ -29,8 +29,6 @@ import mozilla.components.concept.engine.EngineView
  * Based on:
  * https://github.com/takahirom/webview-in-coordinatorlayout
  */
-
-@Suppress("TooManyFunctions")
 class NestedWebView(context: Context) : WebView(context), NestedScrollingChild {
 
     @VisibleForTesting

--- a/components/browser/search/src/main/java/mozilla/components/browser/search/SearchEngineManager.kt
+++ b/components/browser/search/src/main/java/mozilla/components/browser/search/SearchEngineManager.kt
@@ -24,7 +24,6 @@ import kotlin.coroutines.CoroutineContext
 /**
  * This class provides access to a centralized registry of search engines.
  */
-@Suppress("TooManyFunctions")
 class SearchEngineManager(
     private val providers: List<SearchEngineProvider> = listOf(
             AssetsSearchEngineProvider(LocaleSearchLocalizationProvider())),

--- a/components/browser/search/src/main/java/mozilla/components/browser/search/provider/AssetsSearchEngineProvider.kt
+++ b/components/browser/search/src/main/java/mozilla/components/browser/search/provider/AssetsSearchEngineProvider.kt
@@ -33,7 +33,7 @@ import org.json.JSONObject
  * Optionally <code>additionalIdentifiers</code> to be loaded can be specified. A search engine
  * identifier corresponds to the search plugin XML file name (e.g. duckduckgo -> duckduckgo.xml).
  */
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("LargeClass")
 class AssetsSearchEngineProvider(
     private val localizationProvider: SearchLocalizationProvider,
     private val filters: List<SearchEngineFilter> = emptyList(),

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/LegacySessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/LegacySessionManager.kt
@@ -16,7 +16,7 @@ import kotlin.math.min
 /**
  * This class provides access to a centralized registry of all active sessions.
  */
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("LargeClass")
 class LegacySessionManager(
     val engine: Engine,
     delegate: DeprecatedObserverRegistry<SessionManager.Observer> = DeprecatedObserverRegistry()

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -34,7 +34,7 @@ import kotlin.properties.Delegates
 /**
  * Value type that represents the state of a browser session. Changes can be observed.
  */
-@Suppress("TooManyFunctions", "LongParameterList")
+@Suppress("LongParameterList")
 class Session(
     initialUrl: String,
     val private: Boolean = false,

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -33,7 +33,7 @@ import mozilla.components.support.base.observer.DeprecatedObservable
 /**
  * This class provides access to a centralized registry of all active sessions.
  */
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("LargeClass")
 class SessionManager(
     val engine: Engine,
     private val store: BrowserStore? = null,

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/middleware/EngineDelegateMiddleware.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/middleware/EngineDelegateMiddleware.kt
@@ -25,7 +25,6 @@ import mozilla.components.support.base.log.logger.Logger
  * [Middleware] responsible for delegating calls to the appropriate [EngineSession] instance for
  * actions like [EngineAction.LoadUrlAction].
  */
-@Suppress("TooManyFunctions")
 internal class EngineDelegateMiddleware(
     private val engine: Engine,
     private val sessionLookup: (String) -> Session?,

--- a/components/browser/storage-memory/src/main/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorage.kt
+++ b/components/browser/storage-memory/src/main/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorage.kt
@@ -25,7 +25,6 @@ const val AUTOCOMPLETE_SOURCE_NAME = "memoryHistory"
 /**
  * An in-memory implementation of [mozilla.components.concept.storage.HistoryStorage].
  */
-@SuppressWarnings("TooManyFunctions")
 class InMemoryHistoryStorage : HistoryStorage {
     @VisibleForTesting
     internal var pages: HashMap<String, MutableList<Visit>> = linkedMapOf()

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Connection.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Connection.kt
@@ -61,7 +61,6 @@ internal interface Connection : Closeable {
 /**
  * A singleton implementation of the [Connection] interface backed by the Rust Places library.
  */
-@Suppress("TooManyFunctions")
 internal object RustPlacesConnection : Connection {
     @GuardedBy("this")
     private var api: PlacesApi? = null

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorage.kt
@@ -21,7 +21,6 @@ import org.json.JSONObject
 /**
  * Implementation of the [BookmarksStorage] which is backed by a Rust Places lib via [PlacesApi].
  */
-@Suppress("TooManyFunctions")
 open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), BookmarksStorage, SyncableStore {
 
     override val logger = Logger("PlacesBookmarksStorage")

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
@@ -32,7 +32,6 @@ const val AUTOCOMPLETE_SOURCE_NAME = "placesHistory"
 /**
  * Implementation of the [HistoryStorage] which is backed by a Rust Places lib via [PlacesApi].
  */
-@SuppressWarnings("TooManyFunctions")
 open class PlacesHistoryStorage(
     context: Context,
     crashReporter: CrashReporting? = null

--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsAdapter.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsAdapter.kt
@@ -25,7 +25,6 @@ typealias ViewHolderProvider = (ViewGroup) -> TabViewHolder
  * @param viewHolderProvider a function that creates a `TabViewHolder`.
  * @param delegate TabsTray.Observer registry to allow `TabsAdapter` to conform to `Observable<TabsTray.Observer>`.
  */
-@Suppress("TooManyFunctions")
 open class TabsAdapter(
     thumbnailLoader: ImageLoader? = null,
     private val viewHolderProvider: ViewHolderProvider = { parent ->

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -59,7 +59,6 @@ const val MAX_URI_LENGTH = 25000
  *  +----------------+ +----------------+
  * ```
  */
-@Suppress("TooManyFunctions")
 class BrowserToolbar @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBehavior.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBehavior.kt
@@ -38,7 +38,6 @@ enum class ToolbarPosition {
  * - On showing a [Snackbar] position it above the [BrowserToolbar].
  * - Snap the [BrowserToolbar] to be hidden or visible when the user stops scrolling.
  */
-@Suppress("TooManyFunctions")
 class BrowserToolbarBehavior(
     val context: Context?,
     attrs: AttributeSet?,

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -65,7 +65,7 @@ import mozilla.components.concept.toolbar.Toolbar
  * Progress (optional):
  *     A horizontal progress bar showing the loading progress (at the top or bottom of the toolbar).
  */
-@Suppress("LargeClass", "TooManyFunctions")
+@Suppress("LargeClass")
 class DisplayToolbar internal constructor(
     private val context: Context,
     private val toolbar: BrowserToolbar,

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
@@ -50,7 +50,7 @@ private const val AUTOCOMPLETE_QUERY_THREADS = 3
  * - actions: Optional action icons injected by other components (e.g. barcode scanner)
  * - exit: Button that switches back to display mode or invoke an app-defined callback.
  */
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("LargeClass")
 class EditToolbar internal constructor(
     context: Context,
     private val toolbar: BrowserToolbar,

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/DataCleanable.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/DataCleanable.kt
@@ -7,7 +7,6 @@ package mozilla.components.concept.engine
 /**
  * Contract to indicate how objects with the ability to clear data should behave.
  */
-@Suppress("TooManyFunctions")
 interface DataCleanable {
     /**
      * Clears browsing data stored.

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -22,7 +22,6 @@ import org.json.JSONObject
 /**
  * Entry point for interacting with the engine implementation.
  */
-@Suppress("TooManyFunctions")
 interface Engine : WebExtensionRuntime, DataCleanable {
 
     /**

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineView.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineView.kt
@@ -13,7 +13,6 @@ import mozilla.components.concept.engine.selection.SelectionActionDelegate
 /**
  * View component that renders web content.
  */
-@Suppress("TooManyFunctions")
 interface EngineView {
 
     /**

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/WebAppManifestParser.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/WebAppManifestParser.kt
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-@file:Suppress("TooManyFunctions")
-
 package mozilla.components.concept.engine.manifest
 
 import android.graphics.Color

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/parser/WebAppManifestIconParser.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/parser/WebAppManifestIconParser.kt
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-@file:Suppress("TooManyFunctions")
-
 package mozilla.components.concept.engine.manifest.parser
 
 import mozilla.components.concept.engine.manifest.Size

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -20,7 +20,6 @@ import org.json.JSONObject
  * @property supportActions whether or not browser and page actions are handled when
  * received from the web extension
  */
-@Suppress("TooManyFunctions")
 abstract class WebExtension(
     val id: String,
     val url: String,

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionDelegate.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionDelegate.kt
@@ -11,7 +11,6 @@ import mozilla.components.concept.engine.EngineSession
  * extensions e.g. an extension was installed, or an extension wants to open
  * a new tab.
  */
-@Suppress("TooManyFunctions")
 interface WebExtensionDelegate {
 
     /**

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.Deferred
 /**
  * An interface which defines read/write methods for credit card and address data.
  */
-@SuppressWarnings("TooManyFunctions")
 interface CreditCardsAddressesStorage {
 
     /**

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryStorage.kt
@@ -7,7 +7,6 @@ package mozilla.components.concept.storage
 /**
  * An interface which defines read/write methods for history data.
  */
-@SuppressWarnings("TooManyFunctions")
 interface HistoryStorage : Storage {
     /**
      * Records a visit to a page.

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/LoginsStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/LoginsStorage.kt
@@ -10,7 +10,6 @@ import org.json.JSONObject
 /**
  * An interface describing a storage layer for logins/passwords.
  */
-@SuppressWarnings("TooManyFunctions")
 interface LoginsStorage : AutoCloseable {
     /**
      * Deletes all login records. These deletions will be synced to the server on the next call to sync.

--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/Devices.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/Devices.kt
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-@file:SuppressWarnings("TooManyFunctions")
+
 package mozilla.components.concept.sync
 
 import android.content.Context

--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
@@ -43,7 +43,6 @@ data class MigratingAccountInfo(
 /**
  * Facilitates testing consumers of FirefoxAccount.
  */
-@SuppressWarnings("TooManyFunctions")
 interface OAuthAccount : AutoCloseable {
 
     /**

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -22,7 +22,6 @@ import java.lang.ref.WeakReference
 /**
  * Interface to be implemented by components that provide browser toolbar functionality.
  */
-@Suppress("TooManyFunctions")
 interface Toolbar {
     /**
      * Sets/Gets the title to be displayed on the toolbar.

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-@file:Suppress("TooManyFunctions")
-
 package mozilla.components.feature.addons.amo
 
 import android.content.Context

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/migration/SupportedAddonsChecker.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/migration/SupportedAddonsChecker.kt
@@ -66,7 +66,7 @@ interface SupportedAddonsChecker {
  * @param onNotificationClickIntent (Optional) Indicates which intent should be passed to the notification
  * when new supported add-ons are available.
  */
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("LargeClass")
 class DefaultSupportedAddonsChecker(
     private val applicationContext: Context,
     private val frequency: Frequency = Frequency(1, TimeUnit.DAYS),

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
@@ -54,7 +54,7 @@ private const val VIEW_HOLDER_TYPE_ADDON = 2
  * @property style Indicates how items should look like.
  * @property excludedAddonIDs The list of add-on IDs to be excluded from the recommended section.
  */
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("LargeClass")
 class AddonsManagerAdapter(
     private val addonCollectionProvider: AddonCollectionProvider,
     private val addonsManagerDelegate: AddonsManagerAdapterDelegate,

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/update/AddonUpdater.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/update/AddonUpdater.kt
@@ -151,7 +151,7 @@ interface AddonUpdater {
  * @param frequency (Optional) indicates how often updates should be performed, defaults
  * to one day.
  */
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("LargeClass")
 class DefaultAddonUpdater(
     private val applicationContext: Context,
     private val frequency: Frequency = Frequency(1, TimeUnit.DAYS)

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/structure/ParsedStructureBuilder.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/structure/ParsedStructureBuilder.kt
@@ -9,7 +9,6 @@ import android.view.View
 import androidx.annotation.RequiresApi
 
 @RequiresApi(Build.VERSION_CODES.O)
-@Suppress("TooManyFunctions")
 internal class ParsedStructureBuilder<ViewNode, AutofillId>(
     private val navigator: AutofillNodeNavigator<ViewNode, AutofillId>
 ) {

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/structure/ViewNodeNavigator.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/structure/ViewNodeNavigator.kt
@@ -20,7 +20,6 @@ import java.util.Locale
  * Original implementation imported from Lockwise:
  * https://github.com/mozilla-lockwise/lockwise-android/blob/f303f8aee7cc96dcdf4e7863fef6c19ae874032e/app/src/main/java/mozilla/lockbox/autofill/ViewNodeNavigator.kt#L13
  */
-@Suppress("TooManyFunctions")
 internal interface AutofillNodeNavigator<Node, Id> {
     companion object {
         val editTextMask = InputType.TYPE_CLASS_TEXT
@@ -87,7 +86,6 @@ internal interface AutofillNodeNavigator<Node, Id> {
  * https://github.com/mozilla-lockwise/lockwise-android/blob/f303f8aee7cc96dcdf4e7863fef6c19ae874032e/app/src/main/java/mozilla/lockbox/autofill/ViewNodeNavigator.kt#L72
  */
 @RequiresApi(Build.VERSION_CODES.O)
-@Suppress("TooManyFunctions")
 internal class ViewNodeNavigator(
     private val structure: AssistStructure,
     override val activityPackageName: String

--- a/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
+++ b/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
@@ -31,7 +31,6 @@ import mozilla.components.support.ktx.kotlin.takeOrReplace
  * will be displayed in the context menu.
  * @property action The action to be invoked once the user selects this item.
  */
-@Suppress("TooManyFunctions")
 data class ContextMenuCandidate(
     val id: String,
     val label: String,

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadMiddleware.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadMiddleware.kt
@@ -35,7 +35,7 @@ import kotlin.coroutines.CoroutineContext
  * purpose is to react to global download state changes (e.g. of [BrowserState.downloads])
  * and notify the download service, as needed.
  */
-@Suppress("ComplexMethod", "TooManyFunctions")
+@Suppress("ComplexMethod")
 class DownloadMiddleware(
     private val applicationContext: Context,
     private val downloadServiceClass: Class<*>,

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadNotification.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadNotification.kt
@@ -33,7 +33,7 @@ import mozilla.components.feature.downloads.AbstractFetchDownloadService.Compani
 import mozilla.components.feature.downloads.AbstractFetchDownloadService.DownloadJobState
 import kotlin.random.Random
 
-@Suppress("LargeClass", "TooManyFunctions")
+@Suppress("LargeClass")
 internal object DownloadNotification {
 
     private const val NOTIFICATION_CHANNEL_ID = "mozac.feature.downloads.generic"

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
@@ -62,7 +62,7 @@ import mozilla.components.support.utils.Browsers
  * @property shouldForwardToThirdParties Indicates if downloads should be forward to third party apps,
  * if there are multiple apps a chooser dialog will shown.
  */
-@Suppress("TooManyFunctions", "LongParameterList", "LargeClass")
+@Suppress("LongParameterList", "LargeClass")
 class DownloadsFeature(
     private val applicationContext: Context,
     private val store: BrowserStore,

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/share/ShareDownloadFeature.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/share/ShareDownloadFeature.kt
@@ -83,7 +83,6 @@ internal var cacheDirName = "mozac_share_cache"
  *  @param store a reference to the application's [BrowserStore]
  * param Coroutine dispatcher used for the cleanup of old cached files. Defaults to IO.
 */
-@Suppress("TooManyFunctions")
 class ShareDownloadFeature(
     private val context: Context,
     private val httpClient: Client,

--- a/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/view/FindInPageBar.kt
+++ b/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/view/FindInPageBar.kt
@@ -26,7 +26,6 @@ private const val DEFAULT_VALUE = 0
 /**
  * A customizable "Find in page" bar implementing [FindInPageView].
  */
-@Suppress("TooManyFunctions")
 class FindInPageBar @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,

--- a/components/feature/media/src/main/java/mozilla/components/feature/media/service/MediaSessionServiceDelegate.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/service/MediaSessionServiceDelegate.kt
@@ -42,7 +42,6 @@ import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
  *
  * The implementation was moved from [AbstractMediaSessionService] to this delegate for better testability.
  */
-@Suppress("TooManyFunctions")
 internal class MediaSessionServiceDelegate(
     private val context: Context,
     private val service: AbstractMediaSessionService,

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -114,7 +114,7 @@ internal const val FRAGMENT_TAG = "mozac_feature_prompt_dialog"
  * need to be requested before a prompt (e.g. a file picker) can be displayed.
  * Once the request is completed, [onPermissionsResult] needs to be invoked.
  */
-@Suppress("TooManyFunctions", "LargeClass", "LongParameterList")
+@Suppress("LargeClass", "LongParameterList")
 class PromptFeature private constructor(
     private val container: PromptContainer,
     private val store: BrowserStore,

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/SaveLoginDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/SaveLoginDialogFragment.kt
@@ -61,7 +61,7 @@ private const val KEY_LOGIN_HTTP_REALM = "KEY_LOGIN_HTTP_REALM"
  * [android.support.v4.app.DialogFragment] implementation to display a
  * dialog that allows users to save/update usernames and passwords for a given domain.
  */
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("LargeClass")
 internal class SaveLoginDialogFragment : PromptDialogFragment() {
 
     private inner class SafeArgString(private val key: String) {

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/TimePickerDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/TimePickerDialogFragment.kt
@@ -42,7 +42,6 @@ private const val KEY_SELECTION_TYPE = "KEY_SELECTION_TYPE"
 /**
  * [DialogFragment][androidx.fragment.app.DialogFragment] implementation to display date picker with a native dialog.
  */
-@Suppress("TooManyFunctions")
 internal class TimePickerDialogFragment : PromptDialogFragment(), DatePicker.OnDateChangedListener,
     TimePicker.OnTimeChangedListener, TimePickerDialog.OnTimeSetListener,
     DatePickerDialog.OnDateSetListener, DialogInterface.OnClickListener,

--- a/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
@@ -70,7 +70,7 @@ import kotlin.coroutines.CoroutineContext
  * @param connection An implementation of [PushConnection] to communicate with any native layer.
  * @param crashReporter An optional instance of a [CrashReporting].
  */
-@Suppress("TooManyFunctions", "LargeClass", "LongParameterList")
+@Suppress("LargeClass", "LongParameterList")
 class AutoPushFeature(
     private val context: Context,
     private val service: PushService,

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ManifestStorage.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ManifestStorage.kt
@@ -19,7 +19,6 @@ import mozilla.components.feature.pwa.db.ManifestEntity
  * @param activeThresholdMs a timeout in milliseconds after which the storage will consider a manifest
  *                      as unused. By default this is [ACTIVE_THRESHOLD_MS].
  */
-@Suppress("TooManyFunctions")
 class ManifestStorage(context: Context, private val activeThresholdMs: Long = ACTIVE_THRESHOLD_MS) {
 
     @VisibleForTesting

--- a/components/feature/qr/src/main/java/mozilla/components/feature/qr/QrFragment.kt
+++ b/components/feature/qr/src/main/java/mozilla/components/feature/qr/QrFragment.kt
@@ -83,7 +83,7 @@ import kotlin.math.min
  * https://github.com/googlesamples/android-Camera2Basic
  * https://github.com/kismkof/camera2basic
  */
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("LargeClass")
 class QrFragment : Fragment() {
     private val logger = Logger("mozac-qr")
     @VisibleForTesting

--- a/components/feature/qr/src/main/java/mozilla/components/feature/qr/views/CustomViewFinder.kt
+++ b/components/feature/qr/src/main/java/mozilla/components/feature/qr/views/CustomViewFinder.kt
@@ -33,7 +33,7 @@ import kotlin.math.roundToInt
 /**
  * A [View] that shows a ViewFinder positioned in center of the camera view and draws an Overlay
  */
-@Suppress("LargeClass", "TooManyFunctions")
+@Suppress("LargeClass")
 class CustomViewFinder @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null

--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
@@ -47,7 +47,6 @@ typealias onReaderViewStatusChange = (available: Boolean, active: Boolean) -> Un
  * loaded or refreshed, on any navigation (back or forward), and when the
  * selected session changes.
  */
-@Suppress("TooManyFunctions")
 class ReaderViewFeature(
     private val context: Context,
     private val engine: Engine,

--- a/components/feature/recentlyclosed/src/main/java/mozilla/components/feature/recentlyclosed/RecentlyClosedTabsStorage.kt
+++ b/components/feature/recentlyclosed/src/main/java/mozilla/components/feature/recentlyclosed/RecentlyClosedTabsStorage.kt
@@ -24,7 +24,6 @@ import java.io.File
 /**
  * A storage implementation that saves snapshots of recently closed tabs / sessions.
  */
-@Suppress("TooManyFunctions")
 internal class RecentlyClosedTabsStorage(
     context: Context,
     private val engine: Engine,

--- a/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/TabCollectionStorage.kt
+++ b/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/TabCollectionStorage.kt
@@ -23,7 +23,6 @@ import java.util.UUID
 /**
  * A storage implementation that saves snapshots of tabs / sessions in named collections.
  */
-@Suppress("TooManyFunctions")
 class TabCollectionStorage(
     context: Context,
     private val reader: BrowserStateReader = BrowserStateReader(),

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarPresenter.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarPresenter.kt
@@ -24,7 +24,6 @@ import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
  * Presenter implementation for a toolbar implementation in order to update the toolbar whenever
  * the state of the selected session.
  */
-@Suppress("TooManyFunctions")
 class ToolbarPresenter(
     private val toolbar: Toolbar,
     private val store: BrowserStore,

--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/CrashReporter.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/CrashReporter.kt
@@ -58,7 +58,7 @@ import mozilla.components.support.base.log.logger.Logger
  *                            happened. This gives the app the opportunity to show an in-app confirmation UI before
  *                            sending a crash report. See component README for details.
  */
-@Suppress("TooManyFunctions", "LongParameterList")
+@Suppress("LongParameterList")
 class CrashReporter(
     context: Context,
     private val services: List<CrashReporterService> = emptyList(),

--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/MozillaSocorroService.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/MozillaSocorroService.kt
@@ -75,7 +75,7 @@ private const val FILE_REGEX = "([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}
  * @param versionCode The version code of the application.
  * @param releaseChannel The release channel of the application.
  */
-@Suppress("TooManyFunctions", "LargeClass", "LongParameterList")
+@Suppress("LargeClass", "LongParameterList")
 class MozillaSocorroService(
     private val applicationContext: Context,
     private val appName: String,

--- a/components/lib/jexl/src/main/java/mozilla/components/lib/jexl/evaluator/EvaluatorHandlers.kt
+++ b/components/lib/jexl/src/main/java/mozilla/components/lib/jexl/evaluator/EvaluatorHandlers.kt
@@ -29,7 +29,6 @@ import mozilla.components.lib.jexl.value.JexlValue
  *
  * This mapping could be moved inside [Evaluator].
  */
-@SuppressWarnings("TooManyFunctions")
 internal object EvaluatorHandlers {
 
     internal fun evaluateWith(evaluator: Evaluator, node: AstNode): JexlValue = when (node) {

--- a/components/lib/jexl/src/main/java/mozilla/components/lib/jexl/lexer/LexerInput.kt
+++ b/components/lib/jexl/src/main/java/mozilla/components/lib/jexl/lexer/LexerInput.kt
@@ -7,7 +7,6 @@ package mozilla.components.lib.jexl.lexer
 /**
  * Helper class for reading a string character by character with the ability to "peek" at upcoming characters.
  */
-@Suppress("TooManyFunctions")
 internal class LexerInput(private val value: String) {
     private var position: Int = 0
     private var mark: Int = 0

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
@@ -24,7 +24,6 @@ typealias PersistCallback = mozilla.appservices.fxaclient.PersistedFirefoxAccoun
 /**
  * FirefoxAccount represents the authentication state of a client.
  */
-@Suppress("TooManyFunctions")
 class FirefoxAccount internal constructor(
     private val inner: InternalFxAcct,
     crashReporter: CrashReporting? = null

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
@@ -38,7 +38,6 @@ internal sealed class FxaDeviceConstellationException : Exception() {
 /**
  * Provides an implementation of [DeviceConstellation] backed by a [FirefoxAccount].
  */
-@SuppressWarnings("TooManyFunctions")
 class FxaDeviceConstellation(
     private val account: FirefoxAccount,
     private val scope: CoroutineScope,

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Types.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Types.kt
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-@file:SuppressWarnings("TooManyFunctions", "MatchingDeclarationName")
+@file:SuppressWarnings("MatchingDeclarationName")
 package mozilla.components.service.fxa
 
 import mozilla.appservices.fxaclient.AccessTokenInfo

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/SyncManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/SyncManager.kt
@@ -106,7 +106,6 @@ internal interface SyncDispatcher : Closeable, Observable<SyncStatusObserver> {
  * A base sync manager implementation.
  * @param syncConfig A [SyncConfig] object describing how sync should behave.
  */
-@SuppressWarnings("TooManyFunctions")
 internal abstract class SyncManager(
     private val syncConfig: SyncConfig
 ) {

--- a/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/Nimbus.kt
+++ b/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/Nimbus.kt
@@ -180,7 +180,7 @@ private val loggingErrorReporter: ErrorReporter = { e: Throwable ->
 /**
  * A implementation of the [NimbusApi] interface backed by the Nimbus SDK.
  */
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("LargeClass")
 class Nimbus(
     private val context: Context,
     server: NimbusServerSettings?,

--- a/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorage.kt
+++ b/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorage.kt
@@ -23,7 +23,6 @@ const val AUTOFILL_DB_NAME = "autofill.sqlite"
  * An implementation of [CreditCardsAddressesStorage] back by the application-services' `autofill`
  * library.
  */
-@SuppressWarnings("TooManyFunctions")
 class AutofillCreditCardsAddressesStorage(
     context: Context
 ) : CreditCardsAddressesStorage, AutoCloseable {

--- a/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/SyncableLoginsStorage.kt
+++ b/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/SyncableLoginsStorage.kt
@@ -111,7 +111,6 @@ typealias RequestFailedException = mozilla.appservices.logins.RequestFailedExcep
  * Synchronization support is provided both directly (via [sync]) when only syncing this storage layer,
  * or via [getHandle] when syncing multiple stores. Use the latter in conjunction with [FxaAccountManager].
  */
-@SuppressWarnings("TooManyFunctions")
 class SyncableLoginsStorage(
     private val context: Context,
     private val key: String

--- a/components/support/base/src/main/java/mozilla/components/support/base/observer/Observable.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/observer/Observable.kt
@@ -19,7 +19,6 @@ import androidx.lifecycle.LifecycleOwner
  *     }
  * </code>
  */
-@Suppress("TooManyFunctions")
 interface Observable<T> {
     /**
      * Registers an observer to get notified about changes.
@@ -115,7 +114,6 @@ interface Observable<T> {
  * in each component separately.
  */
 @Deprecated(OBSERVER_DEPRECATION_MESSAGE)
-@Suppress("TooManyFunctions")
 interface DeprecatedObservable<T> : Observable<T> {
 
     @Deprecated(OBSERVER_DEPRECATION_MESSAGE)

--- a/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
@@ -24,7 +24,6 @@ import java.util.WeakHashMap
  *
  * ObserverRegistry is thread-safe.
  */
-@Suppress("TooManyFunctions")
 open class ObserverRegistry<T> : Observable<T> {
     private val observers = mutableSetOf<T>()
     private val lifecycleObservers = WeakHashMap<T, LifecycleBoundObserver<T>>()

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-@file:Suppress("TooManyFunctions")
-
 package mozilla.components.support.ktx.android.content
 
 import android.app.ActivityManager
@@ -178,7 +176,6 @@ fun Context.shareMedia(
  * @param subject of the intent [EXTRA_TEXT]
  * @return true it is able to share email false otherwise.
  */
-@SuppressWarnings("TooManyFunctions")
 fun Context.email(
     address: String,
     subject: String = getString(R.string.mozac_support_ktx_share_dialog_title)

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-@file:Suppress("TooManyFunctions")
-
 package mozilla.components.support.ktx.kotlin
 
 import mozilla.components.support.utils.URLStringUtils

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/FennecLoginsMigration.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/FennecLoginsMigration.kt
@@ -123,7 +123,7 @@ internal data class FennecLoginRecords(
     val totalRecordsDetected: Int
 )
 
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("LargeClass")
 internal object FennecLoginsMigration {
     const val DEFAULT_MASTER_PASSWORD = ""
     private const val EXPECTED_DB_VERSION = 6

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/FennecMigrator.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/FennecMigrator.kt
@@ -219,7 +219,7 @@ sealed class FennecMigratorException(cause: Exception) : Exception(cause) {
  * @param bookmarksStorage An optional instance of [PlacesBookmarksStorage] used to store migrated bookmarks data.
  * @param coroutineContext An instance of [CoroutineContext] used for executing async migration tasks.
  */
-@Suppress("LargeClass", "TooManyFunctions", "LongParameterList")
+@Suppress("LargeClass", "LongParameterList")
 class FennecMigrator private constructor(
     private val context: Context,
     private val crashReporter: CrashReporting,
@@ -245,7 +245,6 @@ class FennecMigrator private constructor(
     /**
      * Data migration builder. Allows configuring which migrations to run, their versions and relative order.
      */
-    @Suppress("TooManyFunctions")
     class Builder(private val context: Context, private val crashReporter: CrashReporting) {
         private var historyStorage: Lazy<PlacesHistoryStorage>? = null
         private var bookmarksStorage: Lazy<PlacesBookmarksStorage>? = null

--- a/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
+++ b/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
@@ -57,7 +57,6 @@ typealias onUpdatePermissionRequest = (
  * is completed and the [WebExtensionRuntime] (engine) has direct access to the
  * [BrowserStore]: https://github.com/orgs/mozilla-mobile/projects/31
  */
-@Suppress("TooManyFunctions")
 object WebExtensionSupport {
     private val logger = Logger("mozac-webextensions")
     private var onUpdatePermissionRequest: ((

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -84,10 +84,10 @@ complexity:
     ignoreStringsRegex: '$^'
   TooManyFunctions:
     active: true
-    thresholdInFiles: 11
-    thresholdInClasses: 11
-    thresholdInInterfaces: 11
-    thresholdInObjects: 11
+    thresholdInFiles: 26
+    thresholdInClasses: 26
+    thresholdInInterfaces: 26
+    thresholdInObjects: 26
     thresholdInEnums: 11
 
 empty-blocks:

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonsFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonsFragment.kt
@@ -33,7 +33,6 @@ import java.util.concurrent.CancellationException
 /**
  * Fragment use for managing add-ons.
  */
-@Suppress("TooManyFunctions")
 class AddonsFragment : Fragment(), AddonsManagerAdapterDelegate {
     private lateinit var recyclerView: RecyclerView
     private val scope = CoroutineScope(Dispatchers.IO)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/storage/DummyLoginsStorage.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/storage/DummyLoginsStorage.kt
@@ -13,7 +13,6 @@ import java.util.UUID
  * A dummy [LoginsStorage] that returns a fixed set of fake logins. Currently sample browser does
  * not use an actual login storage backend.
  */
-@Suppress("TooManyFunctions")
 class DummyLoginsStorage : LoginsStorage {
     // A list of fake logins for testing purposes.
     private val logins = mutableListOf(

--- a/samples/firefox-accounts/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
+++ b/samples/firefox-accounts/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
@@ -30,7 +30,6 @@ import mozilla.components.support.rusthttp.RustHttpConfig
 import mozilla.components.support.rustlog.RustLog
 import kotlin.coroutines.CoroutineContext
 
-@Suppress("TooManyFunctions")
 open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteListener, CoroutineScope {
     private lateinit var account: FirefoxAccount
     private var scopesWithoutKeys: Set<String> = setOf("profile")

--- a/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/ToolbarActivity.kt
+++ b/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/ToolbarActivity.kt
@@ -51,7 +51,7 @@ import mozilla.components.ui.tabcounter.TabCounter
 /**
  * This sample application shows how to use and customize the browser-toolbar component.
  */
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("LargeClass")
 class ToolbarActivity : AppCompatActivity() {
     private val shippedDomainsProvider = ShippedDomainsProvider()
     private val customDomainsProvider = CustomDomainsProvider()


### PR DESCRIPTION
Looking at the 94 :) `@Suppress` affected by this, we wouldn't actually ever do anything about those. Having <=25 methods in an interface or class seems fine, imo. I played with different values here and this seems like a good trade-off e.g. `SystemEngineView` still triggers a warning.