### PR TITLE
No issue: REVERT renaming add-ons to extensions.

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilder.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilder.kt
@@ -63,13 +63,13 @@ class WebExtensionBrowserMenuBuilder(
 
         val webExtMenuItem = if (filteredExtensionMenuItems.isNotEmpty()) {
             val backPressMenuItem = BackPressMenuItem(
-                label = context.getString(R.string.mozac_browser_menu_addons2),
+                label = context.getString(R.string.mozac_browser_menu_addons),
                 imageResource = R.drawable.mozac_ic_back,
                 iconTintColorResource = webExtIconTintColorResource
             )
 
             val addonsManagerMenuItem = BrowserMenuImageText(
-                label = context.getString(R.string.mozac_browser_menu_addons_manager2),
+                label = context.getString(R.string.mozac_browser_menu_addons_manager),
                 imageResource = R.drawable.mozac_ic_extensions,
                 iconTintColorResource = webExtIconTintColorResource
             ) {
@@ -90,7 +90,7 @@ class WebExtensionBrowserMenuBuilder(
             val webExtMenu = WebExtensionBrowserMenu(webExtBrowserMenuAdapter, store)
 
             ParentBrowserMenuItem(
-                label = context.getString(R.string.mozac_browser_menu_addons2),
+                label = context.getString(R.string.mozac_browser_menu_addons),
                 imageResource = R.drawable.mozac_ic_extensions,
                 iconTintColorResource = webExtIconTintColorResource,
                 subMenu = webExtMenu,
@@ -98,7 +98,7 @@ class WebExtensionBrowserMenuBuilder(
             )
         } else {
             BrowserMenuImageText(
-                label = context.getString(R.string.mozac_browser_menu_addons2),
+                label = context.getString(R.string.mozac_browser_menu_addons),
                 imageResource = R.drawable.mozac_ic_extensions,
                 iconTintColorResource = webExtIconTintColorResource
             ) {

--- a/components/browser/menu/src/main/res/values/strings.xml
+++ b/components/browser/menu/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Highlighted</string>
     <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons2">Extensions</string>
+    <string name="mozac_browser_menu_addons">Add-ons</string>
     <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager2">Extensions Manager</string>
+    <string name="mozac_browser_menu_addons_manager">Add-ons Manager</string>
 </resources>

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilderTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilderTest.kt
@@ -339,7 +339,7 @@ class WebExtensionBrowserMenuBuilderTest {
         assertEquals("ParentBrowserMenuItem", parentMenuItem.javaClass.simpleName)
 
         // the replaced item should have the action title of the WebExtensionBrowserMenuItem
-        assertEquals("Extensions", parentMenuItem.label)
+        assertEquals("Add-ons", parentMenuItem.label)
 
         val subMenuItemSize = parentMenuItem.subMenu.adapter.visibleItems.size
 

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/menu/WebExtensionNestedMenuCandidate.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/menu/WebExtensionNestedMenuCandidate.kt
@@ -23,7 +23,7 @@ private fun createBackMenuItem(
     @ColorInt webExtIconTintColor: Int?
 ) = NestedMenuCandidate(
     id = R.drawable.mozac_ic_back,
-    text = context.getString(R.string.mozac_feature_addons_addons2),
+    text = context.getString(R.string.mozac_feature_addons_addons),
     start = DrawableMenuIcon(
         context,
         R.drawable.mozac_ic_back,
@@ -37,7 +37,7 @@ private fun createAddonsManagerItem(
     @ColorInt webExtIconTintColor: Int?,
     onAddonsManagerTapped: () -> Unit
 ) = TextMenuCandidate(
-    text = context.getString(R.string.mozac_feature_addons_addons_manager2),
+    text = context.getString(R.string.mozac_feature_addons_addons_manager),
     start = DrawableMenuIcon(
         context,
         R.drawable.mozac_ic_extensions,
@@ -134,15 +134,15 @@ fun BrowserState.createWebExtensionMenuCandidate(
         }
 
         NestedMenuCandidate(
-            id = R.string.mozac_feature_addons_addons2,
-            text = context.getString(R.string.mozac_feature_addons_addons2),
+            id = R.string.mozac_feature_addons_addons,
+            text = context.getString(R.string.mozac_feature_addons_addons),
             start = addonsManagerItem.start,
             subMenuItems = listOf(firstItem, DividerMenuCandidate()) +
                 items + listOf(DividerMenuCandidate(), lastItem)
         )
     } else {
         addonsManagerItem.copy(
-            text = context.getString(R.string.mozac_feature_addons_addons2)
+            text = context.getString(R.string.mozac_feature_addons_addons)
         )
     }
 }

--- a/components/feature/addons/src/main/res/values/strings.xml
+++ b/components/feature/addons/src/main/res/values/strings.xml
@@ -128,9 +128,9 @@
     <!-- Accessibility content description for the amount of stars that add-on has, where %1$.02f will be the amount of stars and / separator and 5 the maximum number of stars e.g (2/5, 4.5/5 or 5/5)  . -->
     <string name="mozac_feature_addons_rating_content_description">%1$.02f/5</string>
     <!-- This is the title of page where all the add-ons are listed-->
-    <string name="mozac_feature_addons_addons2">Extensions</string>
+    <string name="mozac_feature_addons_addons">Add-ons</string>
     <!-- Label for add-ons sub menu item for add-ons manager-->
-    <string name="mozac_feature_addons_addons_manager2">Extensions Manager</string>
+    <string name="mozac_feature_addons_addons_manager">Add-ons Manager</string>
     <!-- The label of the allow button, this will be shown to the user when an add-on needs new permissions, with the button the user will indicate that they want to accept the new permissions and update the add-on-->
     <string name="mozac_feature_addons_updater_notification_allow_button">Allow</string>
     <!-- The label of the deny button on a notification, this will be shown to the user when an add-on needs new permissions. Indicates the user denies the new permissions and prevents the add-on from be updated-->
@@ -162,7 +162,7 @@
     <!-- This is the caption for the add-on installation progress overlay -->
     <string name="mozac_add_on_install_progress_caption">Downloading and verifying add-on&#8230;</string>
     <!-- Error shown when something unexpected happened while trying to get the add-on list from the server -->
-    <string name="mozac_feature_addons_failed_to_query_add_ons">Failed to query Extensions!</string>
+    <string name="mozac_feature_addons_failed_to_query_add_ons">Failed to query Add-ons!</string>
     <!-- Error shown when unable to find a translation for an add-on field. %1$s is the locale of the user and %2$s is the default language of the add-on -->
     <string name="mozac_feature_addons_failed_to_translate">Translation not found, for locale %1$s neither default language %2$s</string>
     <!-- Text shown after successfully installed an add-on. %1$s is the add-on name. -->

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/menu/WebExtensionNestedMenuCandidateTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/menu/WebExtensionNestedMenuCandidateTest.kt
@@ -61,7 +61,7 @@ class WebExtensionNestedMenuCandidateTest {
         assertEquals(6, candidate.subMenuItems!!.size)
 
         assertEquals(
-            "Extensions Manager",
+            "Add-ons Manager",
             (candidate.subMenuItems!![0] as TextMenuCandidate).text
         )
         assertEquals(
@@ -92,7 +92,7 @@ class WebExtensionNestedMenuCandidateTest {
             candidate.subMenuItems!![4]
         )
         assertEquals(
-            "Extensions",
+            "Add-ons",
             (candidate.subMenuItems!![5] as NestedMenuCandidate).text
         )
     }
@@ -143,7 +143,7 @@ class WebExtensionNestedMenuCandidateTest {
         assertEquals(6, candidate.subMenuItems!!.size)
 
         assertEquals(
-            "Extensions",
+            "Add-ons",
             (candidate.subMenuItems!![0] as NestedMenuCandidate).text
         )
         assertNull((candidate.subMenuItems!![0] as NestedMenuCandidate).subMenuItems)
@@ -173,7 +173,7 @@ class WebExtensionNestedMenuCandidateTest {
             candidate.subMenuItems!![4]
         )
         assertEquals(
-            "Extensions Manager",
+            "Add-ons Manager",
             (candidate.subMenuItems!![5] as TextMenuCandidate).text
         )
     }

--- a/samples/browser/src/main/AndroidManifest.xml
+++ b/samples/browser/src/main/AndroidManifest.xml
@@ -50,37 +50,37 @@
         <activity
                 android:theme="@style/Theme.AppCompat.Light"
                 android:name=".addons.AddonsActivity"
-                android:label="@string/mozac_feature_addons_addons2"
+                android:label="@string/mozac_feature_addons_addons"
                 android:parentActivityName=".BrowserActivity" />
 
         <activity
                 android:theme="@style/Theme.AppCompat.Light"
                 android:name=".addons.AddonDetailsActivity"
-                android:label="@string/mozac_feature_addons_addons2" />
+                android:label="@string/mozac_feature_addons_addons" />
 
         <activity android:name=".addons.InstalledAddonDetailsActivity"
-                android:label="@string/mozac_feature_addons_addons2"
+                android:label="@string/mozac_feature_addons_addons"
                 android:parentActivityName=".addons.AddonsActivity"
                 android:theme="@style/Theme.AppCompat.Light" />
 
         <activity
                 android:name=".addons.PermissionsDetailsActivity"
-                android:label="@string/mozac_feature_addons_addons2"
+                android:label="@string/mozac_feature_addons_addons"
                 android:theme="@style/Theme.AppCompat.Light" />
 
         <activity
             android:name=".addons.AddonSettingsActivity"
-            android:label="@string/mozac_feature_addons_addons2"
+            android:label="@string/mozac_feature_addons_addons"
             android:theme="@style/Theme.AppCompat.Light" />
 
         <activity
             android:name=".addons.NotYetSupportedAddonActivity"
-            android:label="@string/mozac_feature_addons_addons2"
+            android:label="@string/mozac_feature_addons_addons"
             android:theme="@style/Theme.AppCompat.Light" />
 
         <activity
             android:name=".addons.WebExtensionActionPopupActivity"
-            android:label="@string/mozac_feature_addons_addons2"
+            android:label="@string/mozac_feature_addons_addons"
             android:theme="@style/Theme.AppCompat.Light" />
 
         <activity


### PR DESCRIPTION
Updating according to feedback from https://github.com/mozilla-l10n/android-l10n/pull/318

We are going to put-off the renaming to after the string freeze period. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
