### PR TITLE
Add private flag to TabsTray Tab

### DIFF
--- a/components/concept/tabstray/src/main/java/mozilla/components/concept/tabstray/Tab.kt
+++ b/components/concept/tabstray/src/main/java/mozilla/components/concept/tabstray/Tab.kt
@@ -13,6 +13,7 @@ import mozilla.components.concept.engine.mediasession.MediaSession
  * @property id Unique ID of the tab.
  * @property url Current URL of the tab.
  * @property title Current title of the tab (or an empty [String]]).
+ * @property private whether or not the session is private.
  * @property icon Current icon of the tab (or null)
  * @property thumbnail Current thumbnail of the tab (or null)
  * @property playbackState Current media session playback state for the tab (or null)
@@ -22,6 +23,7 @@ data class Tab(
     val id: String,
     val url: String,
     val title: String = "",
+    val private: Boolean = false,
     val icon: Bitmap? = null,
     val thumbnail: Bitmap? = null,
     val playbackState: MediaSession.PlaybackState? = null,

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/ext/TabSessionState.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/ext/TabSessionState.kt
@@ -11,6 +11,7 @@ internal fun TabSessionState.toTab() = Tab(
     id,
     content.url,
     content.title,
+    content.private,
     content.icon,
     content.thumbnail,
     mediaSessionState?.playbackState,


### PR DESCRIPTION
When presenting the tray, embedders want to be able to style or react
differently to private tabs. Instead of them querying this value for
each tab, we can just provide it in the `Tab` abstraction of the tray.

No tests to add or changelog worth mentioning this.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
