### PR TITLE
For #9954: Ignore for intermittent test failure

### DIFF
--- a/components/support/locale/src/test/java/mozilla/components/support/locale/LocaleMiddlewareTest.kt
+++ b/components/support/locale/src/test/java/mozilla/components/support/locale/LocaleMiddlewareTest.kt
@@ -22,6 +22,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
@@ -55,6 +56,7 @@ class LocaleMiddlewareTest {
     }
 
     @Test
+    @Ignore("Failing intermittently. To be fixed for https://github.com/mozilla-mobile/android-components/issues/9954")
     @Config(qualifiers = "en-rUS")
     fun `GIVEN a locale has been chosen in the app WHEN we restore state THEN locale is retrieved from storage`() = runBlockingTest {
         val localeManager = spy(LocaleManager)


### PR DESCRIPTION
For #9954 
```
SUITE: mozilla.components.support.locale.LocaleMiddlewareTest
TEST: GIVEN a locale has been chosen in the app WHEN we restore state THEN locale is retrieved from storage
```


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
