### PR TITLE
For fenix#18142: Fixing regex in WebURLFinder causing jank

### DIFF
--- a/components/support/utils/src/main/java/mozilla/components/support/utils/WebURLFinder.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/WebURLFinder.kt
@@ -75,7 +75,7 @@ class WebURLFinder {
     companion object {
         // Taken from mozilla.components.support.utils.URLStringUtils. See documentation
         // there for a complete description.
-        private const val autolinkWebUrlPattern = "(\\w+-)*\\w+(://[/]*|:|\\.)(\\w+-)*\\w+([\\S&&[^\\w-]]\\S*)?"
+        private const val autolinkWebUrlPattern = "^\\s*(\\w+-+)*\\w+(://[/]*|:|\\.)(\\w+-+)*\\w+([\\S&&[^\\w-]]\\S*)?\\s*\$"
 
         private val autolinkWebUrl by lazy {
             Pattern.compile(autolinkWebUrlPattern, 0)


### PR DESCRIPTION
The Regex in WebURLFinder would cause backtracking on super long strings. I noticed that the Regex that we have in URLStringUtils (which the comment inWebURLFinder.kt refers to) is slightly different and doesn't cause the backtracking on super long string, so I decided to just switch it instead of creating a new regex / using another class (such as Java.net.URL class). 

For reference here's issue [#18142 in fenix](https://github.com/mozilla-mobile/fenix/issues/18142)



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
