### PR TITLE
Supply an empty localEncryptionKeys element to SyncParams.

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
@@ -372,10 +372,15 @@ internal class WorkManagerSyncWorker(
         // to implement/reason about than worker reconfiguration.
         val deviceSettings = FxaDeviceSettingsCache(context).getCached()!!
 
+        // If engines have local encryption keys they are specified here.
+        // Only autofill's CreditCard engine has one, so, TODO: add it!
+        val localEncryptionKeys: Map<String, String> = emptyMap()
+
         // We're now ready to sync.
         val syncParams = SyncParams(
             reason = reason.toRustSyncReason(),
             engines = enginesToSync,
+            localEncryptionKeys = localEncryptionKeys,
             authInfo = syncAuthInfo.toNative(),
             enabledChanges = enabledChanges,
             persistedState = currentSyncState,


### PR DESCRIPTION
This should unbreak the breaking change in https://github.com/mozilla/application-services/pull/3995

(A draft because that referenced PR is yet to be in a release)

cc @grigoryk @gabrielluong 