### PR TITLE
Add basic (but non-functioning) support for encrypted credit-cards.

### DIFF
--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
@@ -105,11 +105,47 @@ interface CreditCardsAddressesStorage {
 }
 
 /**
+ * An interface which defines methods for managing the crypto for autofill.
+ *
+ * XXX - maybe this interface should hide the "key" param and instead magically
+ * XXX - manage the key internally?
+ *
+ * eg: just `encryptString(cleartext: String): String` and the key is
+ * automatically fetched from storage and used when calling app-services?
+ */
+interface CreditCardsAddressesCrypto {
+    /**
+     * Encrypt a string using the specified key. Used to encrypt the
+     * credit-card number.
+     * [key] must have come from [createEncryptionKey()]
+     */
+    fun encryptString(key: String, cleartext: String): String
+
+    /**
+     * Decrypt a string using the specified key. Used to decrypt the
+     * credit-card number.
+     * [key] must have come from [createEncryptionKey()], [ciphertext] must
+     * have come from [encryptString]
+     */
+    fun decryptString(key: String, ciphertext: String): String
+
+    /**
+     * Create a new encryption key, suitable for passing to [encryptString()]
+     * and [decryptString[]). Any keys must be stored securely because (a) them
+     * being generally available would defeat the purpose of encryption and
+     * (b) them being list will render all existing excrypted string unable to
+     * be decrypted.
+     */
+    fun createEncryptionKey(): String
+}
+
+/**
  * Information about a credit card.
  *
  * @property guid The unique identifier for this credit card.
  * @property billingName The credit card billing name.
- * @property cardNumber The credit card number.
+ * @property encryptedCardNumber The encrypted credit card number.
+ * @property cardNumberLast4 The last 4 digits of the credit card number.
  * @property expiryMonth The credit card expiry month.
  * @property expiryYear The credit card expiry year.
  * @property cardType The credit card network ID.
@@ -121,7 +157,8 @@ interface CreditCardsAddressesStorage {
 data class CreditCard(
     val guid: String,
     val billingName: String,
-    val cardNumber: String,
+    val encryptedCardNumber: String,
+    val cardNumberLast4: String,
     val expiryMonth: Long,
     val expiryYear: Long,
     val cardType: String,
@@ -135,14 +172,16 @@ data class CreditCard(
  * Information about a new credit card. This is what you pass to create or update a credit card.
  *
  * @property billingName The credit card billing name.
- * @property cardNumber The credit card number.
+ * @property encryptedCardNumber The encrypted credit card number.
+ * @property cardNumberLast4 The credit card number.
  * @property expiryMonth The credit card expiry month.
  * @property expiryYear The credit card expiry year.
  * @property cardType The credit card network ID.
  */
 data class UpdatableCreditCardFields(
     val billingName: String,
-    val cardNumber: String,
+    val encryptedCardNumber: String,
+    val cardNumberLast4: String,
     val expiryMonth: Long,
     val expiryYear: Long,
     val cardType: String

--- a/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesCrypto.kt
+++ b/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesCrypto.kt
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.sync.autofill
+
+import mozilla.components.concept.storage.CreditCardsAddressesCrypto
+
+/**
+ * An implementation of [AutofillCreditCardsAddressesCrypto] back by the application-services' `autofill`
+ * library.
+ */
+class AutofillCreditCardsAddressesCrypto() : CreditCardsAddressesCrypto {
+    override fun encryptString(key: String, cleartext: String): String {
+        return mozilla.appservices.autofill.encryptString(key, cleartext)
+    }
+
+    override fun decryptString(key: String, ciphertext: String): String  {
+        return mozilla.appservices.autofill.decryptString(key, ciphertext)
+    }
+
+    override fun createEncryptionKey(): String  {
+        return mozilla.appservices.autofill.createKey()
+    }
+}

--- a/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorage.kt
+++ b/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorage.kt
@@ -20,7 +20,7 @@ import mozilla.appservices.autofill.Store as RustAutofillStorage
 const val AUTOFILL_DB_NAME = "autofill.sqlite"
 
 /**
- * An implementation of [CreditCardsAddressesStorage] back by the application-services' `autofill`
+ * An implementation of [CreditCardsAddressesStorage] backed by the application-services' `autofill`
  * library.
  */
 class AutofillCreditCardsAddressesStorage(

--- a/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/Types.kt
+++ b/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/Types.kt
@@ -38,7 +38,8 @@ internal fun mozilla.components.concept.storage.UpdatableAddressFields.into(): U
 internal fun mozilla.components.concept.storage.UpdatableCreditCardFields.into(): UpdatableCreditCardFields {
     return UpdatableCreditCardFields(
         ccName = this.billingName,
-        ccNumber = this.cardNumber,
+        ccNumberEnc = this.encryptedCardNumber,
+        ccNumberLast4 = this.cardNumberLast4,
         ccExpMonth = this.expiryMonth,
         ccExpYear = this.expiryYear,
         ccType = this.cardType
@@ -77,7 +78,8 @@ internal fun mozilla.appservices.autofill.CreditCard.into(): CreditCard {
     return CreditCard(
         guid = this.guid,
         billingName = this.ccName,
-        cardNumber = this.ccNumber,
+        encryptedCardNumber = this.ccNumberEnc,
+        cardNumberLast4 = this.ccNumberLast4,
         expiryMonth = this.ccExpMonth,
         expiryYear = this.ccExpYear,
         cardType = this.ccType,

--- a/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorageCryptoTest.kt
+++ b/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorageCryptoTest.kt
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.sync.autofill
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.appservices.autofill.ErrorException as AutofillException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+
+@RunWith(AndroidJUnit4::class)
+class AutofillCryptoTest {
+    @Test
+    fun `testEncryptDecrypt`() {
+        val crypto = AutofillCreditCardsAddressesCrypto()
+        val key = crypto.createEncryptionKey()
+        val ciphertext = crypto.encryptString(key, "hello")
+        assertTrue(ciphertext != "hello") // would be embarrasing :)
+        assertEquals(crypto.decryptString(key, ciphertext), "hello")
+    }
+
+    @Test(expected=AutofillException.CryptoError::class)
+    fun `testBadKey`() {
+        val crypto = AutofillCreditCardsAddressesCrypto()
+        val key1 = crypto.createEncryptionKey()
+        val ciphertext = crypto.encryptString(key1, "hello")
+        val key2 = crypto.createEncryptionKey()
+        crypto.decryptString(key2, ciphertext) // should fail with CryptoError
+    }
+}


### PR DESCRIPTION
This unbreaks the breaking change introduced in
https://github.com/mozilla/application-services/pull/3906.

(A a draft because the changes in that PR are yet to be released)

Note that this isn't really that useful - it doesn't actually
perform encryption or decryption, although it should give all
the framework necessary to do so. It does however allow the
tests to pass which is a good first step.

cc @grigoryk @gabrielluong