### PR TITLE
For #10005 - Replace layout manager to effectively change stackFromEnd

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
@@ -35,7 +35,8 @@ open class BrowserMenu internal constructor(
     internal val adapter: BrowserMenuAdapter
 ) : View.OnAttachStateChangeListener {
     protected var currentPopup: PopupWindow? = null
-    private var menuList: RecyclerView? = null
+    @VisibleForTesting
+    internal var menuList: RecyclerView? = null
     internal var currAnchor: View? = null
     internal var isShown = false
     @VisibleForTesting
@@ -133,12 +134,20 @@ open class BrowserMenu internal constructor(
 
         // When showing an expandable bottom menu it should always be scrolled to the top (default in LayoutManager).
         // Otherwise try showing the bottom of the menu when not enough space to fit it on the screen.
-        menuList?.let { list ->
-            list.setEndOfMenuAlwaysVisibleCompact(
-                endOfMenuAlwaysVisible, list.layoutManager as LinearLayoutManager
-            )
+        if (endOfMenuAlwaysVisible) {
+            menuList?.let {
+                showMenuBottom(it)
+            }
         }
+
         return view
+    }
+
+    @VisibleForTesting
+    internal fun showMenuBottom(menu: RecyclerView) {
+        menu.layoutManager = LinearLayoutManager(menu.context, RecyclerView.VERTICAL, false).also {
+            menu.setEndOfMenuAlwaysVisibleCompact(true, it)
+        }
     }
 
     @VisibleForTesting

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,9 @@ permalink: /changelog/
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
 * **browser-menu**:
+  * 🚒 Bug fixed [issue #](https://github.com/mozilla-mobile/android-components/issues/10005) - Fix a recent issue with BrowserMenu#show() - endOfMenuAlwaysVisible not being applied.
+
+* **browser-menu**:
   * 🚒 Bug fixed [issue #](https://github.com/mozilla-mobile/android-components/issues/9922) - The browser menu will have it's dynamic width calculated only once, before the first layout.
 
 * **browser-menu**


### PR DESCRIPTION
For #10005 

The `stackFromEnd` property is not initially set even though
`endOfMenuAlwaysVisible` might be true since when having a bottom expandable
menu, that should always be scrolled to the top.
And we know if we're in that situation only later, after menu is configured and
based on it it can be inferred if it should be collapsed or not.

Setting `stackFromEnd` only after this steps, even if the menu is not yet on
the screen seems to have no effect.

The only solution is to replace menu's layout manager with one that has this
`stackFromEnd` from the beginning.

| full height menu recording | collapsible menu recording |
| --- | --- |
| <video src="https://user-images.githubusercontent.com/11428869/113286284-a8681100-92f4-11eb-901b-4d49e143f1f5.mp4" /> | <video src="https://user-images.githubusercontent.com/11428869/113286817-6095b980-92f5-11eb-99a8-6ba37dce8ae2.mp4" /> |









### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
