### PR TITLE
For mozila-mobile/fenix#18565: Remove filtering of duplicate search requests

### DIFF
--- a/components/feature/search/src/main/java/mozilla/components/feature/search/SearchFeature.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/SearchFeature.kt
@@ -7,7 +7,6 @@ package mozilla.components.feature.search
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import mozilla.components.browser.state.action.ContentAction
@@ -44,8 +43,6 @@ class SearchFeature(
                 // Do nothing if searchRequest or sessionId is null
                 .mapNotNull { pair -> pair.toNullablePair() }
                 // We may see repeat values if other state changes before we handle the request.
-                // Filter these out.
-                .distinctUntilChangedBy { (searchRequest, _) -> searchRequest }
                 .collect { (searchRequest, sessionId) ->
                     performSearch(searchRequest, sessionId)
                     store.dispatch(ContentAction.ConsumeSearchRequestAction(sessionId))


### PR DESCRIPTION
Remove filtering of duplicate search requests

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

This doesn't have a test because the sole reason why this issue occurs is due to a filter catching changes between states localized in SearchFeature.kt. The simple removal of that filter with the effect localized within that file resolves that issue. If it's really needed, I can try to add it.