### PR TITLE
increased touch target of light button

### DIFF
--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/view/ReaderViewControlsBar.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/view/ReaderViewControlsBar.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.graphics.Rect
 import android.util.AttributeSet
 import android.view.View
+import android.widget.LinearLayout
 import android.widget.RadioGroup
 import androidx.annotation.IdRes
 import androidx.appcompat.widget.AppCompatButton
@@ -34,6 +35,7 @@ class ReaderViewControlsBar @JvmOverloads constructor(
     private lateinit var fontDecrementButton: AppCompatButton
     private lateinit var fontGroup: RadioGroup
     private lateinit var colorSchemeGroup: RadioGroup
+    private lateinit var colorSchemeContainerGroup: LinearLayout
 
     private var view: View? = null
 
@@ -152,6 +154,9 @@ class ReaderViewControlsBar @JvmOverloads constructor(
             }
             listener?.onColorSchemeChanged(colorSchemeChoice)
         }
+        colorSchemeContainerGroup = applyLayoutClickListener(R.id.linear_layout_mozac_feature_readerview_color_light) {
+            listener?.onColorSchemeChanged(ColorScheme.LIGHT)
+        }
         fontIncrementButton = applyClickListener(R.id.mozac_feature_readerview_font_size_increase) {
             listener?.onFontSizeIncreased()?.let { setFontSize(it) }
         }
@@ -169,6 +174,11 @@ class ReaderViewControlsBar @JvmOverloads constructor(
     private inline fun applyCheckedListener(@IdRes id: Int, crossinline block: (Int) -> Unit): RadioGroup {
         return findViewById<RadioGroup>(id).apply {
             setOnCheckedChangeListener { _, checkedId -> block(checkedId) }
+        }
+    }
+    private inline fun applyLayoutClickListener(@IdRes id: Int, crossinline block: () -> Unit): LinearLayout {
+        return findViewById<LinearLayout>(id).apply {
+            setOnClickListener { block() }
         }
     }
 }

--- a/components/feature/readerview/src/main/res/layout/mozac_feature_readerview_view.xml
+++ b/components/feature/readerview/src/main/res/layout/mozac_feature_readerview_view.xml
@@ -130,6 +130,15 @@
             android:gravity="center"
             android:contentDescription="@string/mozac_feature_readerview_sepia_color_scheme_desc" />
 
+        <LinearLayout
+            android:id="@+id/linear_layout_mozac_feature_readerview_color_light"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:clickable="true"
+            android:gravity="center"
+            android:orientation="horizontal">
+
         <androidx.appcompat.widget.AppCompatRadioButton
             android:id="@+id/mozac_feature_readerview_color_light"
             style="@style/RadioButtonSelectedBorderStyle"
@@ -142,6 +151,8 @@
             android:layout_marginEnd="8dp"
             android:layout_weight="1"
             android:gravity="center"
-            android:contentDescription="@string/mozac_feature_readerview_light_color_scheme_desc" />
+            android:contentDescription="@string/mozac_feature_readerview_light_color_scheme_desc"
+            android:duplicateParentState="true"/>
+        </LinearLayout>
     </RadioGroup>
 </merge>


### PR DESCRIPTION
issue: https://github.com/mozilla-mobile/fenix/issues/18710

wrapped light button inside linear layout  container and added click listener to the parent container.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
