### PR TITLE
Closes #10040: Media session launch intent will always call startForeground

### DIFF
--- a/components/feature/media/src/main/java/mozilla/components/feature/media/service/MediaSessionServiceDelegate.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/service/MediaSessionServiceDelegate.kt
@@ -119,7 +119,7 @@ internal class MediaSessionServiceDelegate(
             MediaSession.PlaybackState.PLAYING -> {
                 audioFocus.request(state.id)
                 emitStatePlayFact()
-                startForegroundNotification()
+                startForegroundNotificationIfNeeded()
             }
             MediaSession.PlaybackState.PAUSED -> {
                 emitStatePauseFact()
@@ -153,10 +153,14 @@ internal class MediaSessionServiceDelegate(
     }
 
     private fun startForegroundNotification() {
+        val notification = notification.createDummy(mediaSession)
+        service.startForeground(notificationId, notification)
+        isForegroundService = true
+    }
+
+    private fun startForegroundNotificationIfNeeded() {
         if (!isForegroundService) {
-            val notification = notification.createDummy(mediaSession)
-            service.startForeground(notificationId, notification)
-            isForegroundService = true
+            startForegroundNotification()
         }
     }
 


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
