### PR TITLE
Credit card autofill encryption & sync manager integration

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -30,7 +30,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "2.4"
 
-    const val mozilla_appservices = "74.0.1"
+    const val mozilla_appservices = "75.2.0"
 
     const val mozilla_glean = "35.0.0"
 

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorage.kt
@@ -192,4 +192,9 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
     override fun getHandle(): Long {
         return places.getHandle()
     }
+
+    override fun registerWithSyncManager() {
+        // See https://github.com/mozilla-mobile/android-components/issues/10128
+        throw NotImplementedError("Use getHandle instead")
+    }
 }

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
@@ -229,4 +229,9 @@ open class PlacesHistoryStorage(
     override fun getHandle(): Long {
         return places.getHandle()
     }
+
+    override fun registerWithSyncManager() {
+        // See https://github.com/mozilla-mobile/android-components/issues/10128
+        throw NotImplementedError("Use getHandle instead")
+    }
 }

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/RemoteTabsStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/RemoteTabsStorage.kt
@@ -105,6 +105,11 @@ open class RemoteTabsStorage : Storage, SyncableStore {
     override fun getHandle(): Long {
         return api.getHandle()
     }
+
+    override fun registerWithSyncManager() {
+        // See https://github.com/mozilla-mobile/android-components/issues/10128
+        throw NotImplementedError("Use getHandle instead")
+    }
 }
 
 /**

--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/Sync.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/Sync.kt
@@ -52,4 +52,9 @@ interface SyncableStore {
      * @return raw internal handle that could be used for referencing underlying [PlacesApi]. Use it with SyncManager.
      */
     fun getHandle(): Long
+
+    /**
+     * Registers this storage with a sync manager. Replaces [getHandle] for newer storage layers.
+     */
+    fun registerWithSyncManager()
 }

--- a/components/lib/dataprotect/src/main/java/mozilla/components/lib/dataprotect/ManagedKey.kt
+++ b/components/lib/dataprotect/src/main/java/mozilla/components/lib/dataprotect/ManagedKey.kt
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.lib.dataprotect
+
+/**
+ * Knows how to provide a [ManagedKey].
+ */
+interface KeyProvider {
+    /**
+     * Fetches or generates a new encryption key.
+     *
+     * @return [ManagedKey] that wraps the encryption key.
+     */
+    fun key(): ManagedKey
+}
+
+/**
+ * Knows how to recover from bad/missing encryption keys, e.g. instances of [KeyGenerationReason.RecoveryNeeded].
+ */
+interface KeyRecoveryHandler {
+    /**
+     * Performs storage-specific recovery.
+     *
+     * @param reason Describes what happened to the previous key and why a recovery is needed.
+     */
+    fun recoverFromBadKey(reason: KeyGenerationReason.RecoveryNeeded)
+}
+
+/**
+ * An encryption key, with an optional [wasGenerated] field used to indicate if it was freshly
+ * generated. In that case, a [KeyGenerationReason] is supplied, allowing consumers to detect
+ * potential key loss or corruption.
+ * If [wasGenerated] is `null`, that means an existing key was successfully read from the key storage.
+ */
+data class ManagedKey(
+    val key: String,
+    val wasGenerated: KeyGenerationReason? = null
+)
+
+/**
+ * Describes why a key was generated.
+ */
+sealed class KeyGenerationReason {
+    /**
+     * A new key, not previously present in the store.
+     */
+    object New : KeyGenerationReason()
+
+    /**
+     * Something went wrong with the previously stored key.
+     */
+    sealed class RecoveryNeeded : KeyGenerationReason() {
+        /**
+         * Previously stored key was lost, and a new key was generated as its replacement.
+         */
+        object Lost : RecoveryNeeded()
+
+        /**
+         * Previously stored key was corrupted, and a new key was generated as its replacement.
+         */
+        object Corrupt : RecoveryNeeded()
+
+        /**
+         * Storage layer encountered an abnormal state, which lead to key loss. A new key was generated.
+         */
+        object AbnormalState : RecoveryNeeded()
+    }
+}

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Config.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Config.kt
@@ -38,6 +38,10 @@ data class SyncConfig(
  * do not know about. At the public API level, we expose a concrete [SyncEngine] type to allow for more
  * robust integrations. We do not expose "unknown" engines via our public API, but do handle them
  * internally (by persisting their enabled/disabled status).
+ *
+ * [nativeName] must match engine strings defined in the sync15 crate, e.g. https://github.com/mozilla/application-services/blob/main/components/sync15/src/state.rs#L23-L38
+ *
+ * @property nativeName Name of the corresponding Sync1.5 collection.
 */
 sealed class SyncEngine(val nativeName: String) {
     // NB: When adding new types, make sure to think through implications for the SyncManager.
@@ -62,6 +66,16 @@ sealed class SyncEngine(val nativeName: String) {
      * A remote tabs engine.
      */
     object Tabs : SyncEngine("tabs")
+
+    /**
+     * A credit cards engine.
+     */
+    object CreditCards : SyncEngine("creditcards")
+
+    /**
+     * An addresses engine.
+     */
+    object Addresses : SyncEngine("addresses")
 
     /**
      * An engine that's none of the above, described by [name].

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
@@ -23,7 +23,7 @@ import androidx.work.WorkerParameters
 import mozilla.appservices.syncmanager.SyncParams
 import mozilla.appservices.syncmanager.SyncServiceStatus
 import mozilla.appservices.syncmanager.SyncManager as RustSyncManager
-import mozilla.components.concept.sync.SyncableStore
+import mozilla.components.lib.dataprotect.KeyProvider
 import mozilla.components.service.fxa.FxaDeviceSettingsCache
 import mozilla.components.service.fxa.SyncAuthInfoCache
 import mozilla.components.service.fxa.SyncConfig
@@ -293,9 +293,11 @@ internal class WorkManagerSyncWorker(
                 SyncEngine.Bookmarks.nativeName -> SyncEngine.Bookmarks
                 SyncEngine.Passwords.nativeName -> SyncEngine.Passwords
                 SyncEngine.Tabs.nativeName -> SyncEngine.Tabs
+                SyncEngine.CreditCards.nativeName -> SyncEngine.CreditCards
+                SyncEngine.Addresses.nativeName -> SyncEngine.Addresses
                 else -> throw IllegalStateException("Invalid syncable store: $it")
             }
-            engine to checkNotNull(GlobalSyncableStoreProvider.getStore(engine.nativeName)) {
+            engine to checkNotNull(GlobalSyncableStoreProvider.getLazyStoreWithKey(engine)) {
                 "SyncableStore missing from GlobalSyncableStoreProvider: ${engine.nativeName}"
             }
         }.ifEmpty {
@@ -308,17 +310,42 @@ internal class WorkManagerSyncWorker(
     }
 
     @Suppress("LongMethod", "ComplexMethod")
-    private suspend fun doSync(syncableStores: Map<SyncEngine, SyncableStore>): Result {
+    private suspend fun doSync(syncableStores: Map<SyncEngine, LazyStoreWithKey>): Result {
+        val engineKeyProviders = mutableMapOf<SyncEngine, KeyProvider>()
+
+        // We need to tell RustSyncManager which engines to sync.
+        // - 'null' means "sync all engines for which storage is registered with the sync manager"
+        // - empty list means sync metadata only (e.g. which engines are enabled)
+        // Currently, we pass along a list of all engines configured to sync.
+        // These should be Sync1.5 collection names for these engines.
+        val enginesToSync = syncableStores.map { it.key.nativeName }
+
         // We need to tell RustSyncManager about instances of supported stores ('places' and 'logins').
         syncableStores.entries.forEach {
             // We're assuming all syncable stores live in Rust.
             // Currently `RustSyncManager` doesn't support non-Rust sync engines.
             when (it.key) {
                 // NB: History and Bookmarks will have the same handle.
-                SyncEngine.History -> RustSyncManager.setPlaces(it.value.getHandle())
-                SyncEngine.Bookmarks -> RustSyncManager.setPlaces(it.value.getHandle())
-                SyncEngine.Passwords -> RustSyncManager.setLogins(it.value.getHandle())
-                SyncEngine.Tabs -> RustSyncManager.setTabs(it.value.getHandle())
+                SyncEngine.History -> RustSyncManager.setPlaces(it.value.lazyStore.value.getHandle())
+                SyncEngine.Bookmarks -> RustSyncManager.setPlaces(it.value.lazyStore.value.getHandle())
+                SyncEngine.Passwords -> RustSyncManager.setLogins(it.value.lazyStore.value.getHandle())
+                SyncEngine.Tabs -> RustSyncManager.setTabs(it.value.lazyStore.value.getHandle())
+
+                // These stores don't expose `getHandle` (yay!), and instead are able to handle
+                // sync manager registration on their own.
+                SyncEngine.CreditCards -> {
+                    it.value.lazyStore.value.registerWithSyncManager()
+
+                    checkNotNull(it.value.keyProvider) {
+                        "CreditCards store must be configured with a KeyProvider"
+                    }
+
+                    engineKeyProviders[it.key] = it.value.keyProvider!!.value
+                }
+                SyncEngine.Addresses -> {
+                    it.value.lazyStore.value.registerWithSyncManager()
+                }
+                else -> throw NotImplementedError("Unsupported engine: ${it.key}")
             }
         }
 
@@ -356,11 +383,6 @@ internal class WorkManagerSyncWorker(
             else -> emptyMap()
         }
 
-        // We need to tell RustSyncManager which engines to sync. 'null' means "sync all", which is an
-        // intersection of stores for which we've set a 'handle' and those that are enabled.
-        // This should be an empty list if we only want to sync metadata (e.g. which engines are enabled).
-        val enginesToSync = null
-
         // We need to tell RustSyncManager about our current FxA device. It needs that information
         // in order to sync the 'clients' collection.
         // We're depending on cache being populated. An alternative to using a "cache" is to
@@ -372,6 +394,14 @@ internal class WorkManagerSyncWorker(
         // to implement/reason about than worker reconfiguration.
         val deviceSettings = FxaDeviceSettingsCache(context).getCached()!!
 
+        // Obtain encryption keys for stores that came along with KeyProviders.
+        // This can take a bit of time!
+        val localEncryptionKeys = engineKeyProviders.mapKeys {
+            it.key.nativeName
+        }.mapValues {
+            it.value.key().key
+        }
+
         // We're now ready to sync.
         val syncParams = SyncParams(
             reason = reason.toRustSyncReason(),
@@ -379,7 +409,8 @@ internal class WorkManagerSyncWorker(
             authInfo = syncAuthInfo.toNative(),
             enabledChanges = enabledChanges,
             persistedState = currentSyncState,
-            deviceSettings = deviceSettings
+            deviceSettings = deviceSettings,
+            localEncryptionKeys = localEncryptionKeys
         )
 
         val syncResult = RustSyncManager.sync(syncParams)

--- a/components/service/sync-autofill/build.gradle
+++ b/components/service/sync-autofill/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     api Dependencies.mozilla_sync_autofill
 
     api project(':concept-storage')
+    api project(':concept-sync')
+    api project(':concept-base')
+    api project(':lib-dataprotect')
 
     implementation project(':support-utils')
 

--- a/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCrypto.kt
+++ b/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCrypto.kt
@@ -1,0 +1,168 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.sync.autofill
+
+import android.content.Context
+import android.content.SharedPreferences
+import mozilla.appservices.autofill.ErrorException
+import mozilla.appservices.autofill.createKey
+import mozilla.appservices.autofill.decryptString
+import mozilla.appservices.autofill.encryptString
+import mozilla.components.concept.storage.CreditCardNumber
+import mozilla.components.lib.dataprotect.KeyGenerationReason
+import mozilla.components.lib.dataprotect.KeyProvider
+import mozilla.components.lib.dataprotect.KeyRecoveryHandler
+import mozilla.components.lib.dataprotect.ManagedKey
+import mozilla.components.lib.dataprotect.SecureAbove22Preferences
+import mozilla.components.support.base.log.logger.Logger
+
+/**
+ * A class that knows how to encrypt & decrypt strings, backed by application-services' autofill lib.
+ * Used for protecting credit card numbers at rest.
+ *
+ * This class manages creation and storage of the encryption key.
+ * It also keeps track of abnormal events, such as managed key going missing or getting corrupted.
+ *
+ * @param context [Context] used for obtaining [SharedPreferences] for managing internal prefs.
+ * @param securePrefs A [SecureAbove22Preferences] instance used for storing the managed key.
+ * @param keyRecoveryHandler A [KeyRecoveryHandler] instance that knows how to recover from key failures.
+ */
+class AutofillCrypto(
+    private val context: Context,
+    private val securePrefs: SecureAbove22Preferences,
+    private val keyRecoveryHandler: KeyRecoveryHandler
+) : KeyProvider {
+    private val logger = Logger("AutofillCrypto")
+    private val plaintextPrefs by lazy { context.getSharedPreferences(AUTOFILL_PREFS, Context.MODE_PRIVATE) }
+
+    /**
+     * Encrypt a [CreditCardNumber.Plaintext] using provided key.
+     * A `null` result means a bad key was provided. In that case caller should obtain a new key and try again.
+     */
+    fun encrypt(key: ManagedKey, plaintextCardNumber: CreditCardNumber.Plaintext): CreditCardNumber.Encrypted? {
+        return try {
+            CreditCardNumber.Encrypted(encrypt(key, plaintextCardNumber.number))
+        } catch (e: ErrorException.JsonError) {
+            logger.warn("Failed to encrypt", e)
+            null
+        } catch (e: ErrorException.CryptoError) {
+            logger.warn("Failed to encrypt", e)
+            null
+        }
+    }
+
+    /**
+     * Decrypt a [CreditCardNumber.Encrypted] using provided key.
+     * A `null` result means a bad key was provided. In that case caller should obtain a new key and try again.
+     */
+    fun decrypt(key: ManagedKey, encryptedCardNumber: CreditCardNumber.Encrypted): CreditCardNumber.Plaintext? {
+        return try {
+            CreditCardNumber.Plaintext(decrypt(key, encryptedCardNumber.number))
+        } catch (e: ErrorException.JsonError) {
+            logger.warn("Failed to decrypt", e)
+            null
+        } catch (e: ErrorException.CryptoError) {
+            logger.warn("Failed to decrypt", e)
+            null
+        }
+    }
+
+    override fun key(): ManagedKey = synchronized(this) {
+        val managedKey = getManagedKey()
+
+        // Record abnormal events if any were detected.
+        // At this point, we should emit some telemetry.
+        // See https://github.com/mozilla-mobile/android-components/issues/10122
+        when (managedKey.wasGenerated) {
+            is KeyGenerationReason.RecoveryNeeded.Lost -> {
+                logger.warn("Key lost")
+            }
+            is KeyGenerationReason.RecoveryNeeded.Corrupt -> {
+                logger.warn("Key corrupted")
+            }
+            is KeyGenerationReason.RecoveryNeeded.AbnormalState -> {
+                logger.warn("Abnormal state while reading the key")
+            }
+            null, KeyGenerationReason.New -> {
+                // All good! Got either a brand new key or read a valid key.
+            }
+        }
+        (managedKey.wasGenerated as? KeyGenerationReason.RecoveryNeeded)?.let {
+            keyRecoveryHandler.recoverFromBadKey(it)
+        }
+        return managedKey
+    }
+
+    private fun encrypt(key: ManagedKey, cleartext: String) = encryptString(key.key, cleartext)
+    private fun decrypt(key: ManagedKey, ciphertext: String) = decryptString(key.key, ciphertext)
+
+    @Suppress("ComplexMethod")
+    private fun getManagedKey(): ManagedKey = synchronized(this) {
+        val encryptedCanaryPhrase = plaintextPrefs.getString(CANARY_PHRASE_CIPHERTEXT_KEY, null)
+        val storedKey = securePrefs.getString(AUTOFILL_KEY)
+
+        return@synchronized when {
+            // We expected the key to be present, and it is.
+            storedKey != null && encryptedCanaryPhrase != null -> {
+                // Make sure that the key is valid.
+                try {
+                    if (CANARY_PHRASE_PLAINTEXT == decryptString(storedKey, encryptedCanaryPhrase)) {
+                        ManagedKey(storedKey)
+                    } else {
+                        // A bad key should trigger a CryptoError, but check this branch just in case.
+                        ManagedKey(generateAndStoreKey(), KeyGenerationReason.RecoveryNeeded.Corrupt)
+                    }
+                } catch (e: ErrorException.JsonError) {
+                    ManagedKey(generateAndStoreKey(), KeyGenerationReason.RecoveryNeeded.Corrupt)
+                } catch (e: ErrorException.CryptoError) {
+                    ManagedKey(generateAndStoreKey(), KeyGenerationReason.RecoveryNeeded.Corrupt)
+                }
+            }
+
+            // The key is present, but we didn't expect it to be there.
+            storedKey != null && encryptedCanaryPhrase == null -> {
+                // This isn't expected to happen. We can't check this key's validity.
+                ManagedKey(generateAndStoreKey(), KeyGenerationReason.RecoveryNeeded.AbnormalState)
+            }
+
+            // We expected the key to be present, but it's gone missing on us.
+            storedKey == null && encryptedCanaryPhrase != null -> {
+                // At this point, we're forced to generate a new key to recover and move forward.
+                // However, that means that any data that was previously encrypted is now unreadable.
+                ManagedKey(generateAndStoreKey(), KeyGenerationReason.RecoveryNeeded.Lost)
+            }
+
+            // We didn't expect the key to be present, and it's not.
+            storedKey == null && encryptedCanaryPhrase == null -> {
+                // Normal case when interacting with this class for the first time.
+                ManagedKey(generateAndStoreKey(), KeyGenerationReason.New)
+            }
+
+            else -> throw AutofillCryptoException.IllegalState()
+        }
+    }
+
+    private fun generateAndStoreKey(): String {
+        return createKey().also { newKey ->
+            // To consider: should this be a non-destructive operation, just in case?
+            // e.g. if we thought we lost the key, but actually did not, that would let us recover data later on.
+            // otherwise, if we mess up and override a perfectly good key, the data is gone for good.
+            securePrefs.putString(AUTOFILL_KEY, newKey)
+            // To detect key corruption or absence, use the newly generated key to encrypt a known string.
+            // See isKeyValid below.
+            plaintextPrefs
+                .edit()
+                .putString(CANARY_PHRASE_CIPHERTEXT_KEY, encryptString(newKey, CANARY_PHRASE_PLAINTEXT))
+                .apply()
+        }
+    }
+
+    companion object {
+        const val AUTOFILL_PREFS = "autofillCrypto"
+        const val AUTOFILL_KEY = "autofillKey"
+        const val CANARY_PHRASE_CIPHERTEXT_KEY = "canaryPhrase"
+        const val CANARY_PHRASE_PLAINTEXT = "a string for checking validity of the key"
+    }
+}

--- a/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/Errors.kt
+++ b/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/Errors.kt
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.sync.autofill
+
+/**
+ * Unrecoverable errors related to [AutofillCreditCardsAddressesStorage].
+ * Do not catch these.
+ */
+internal sealed class AutofillStorageException(reason: Exception? = null) : RuntimeException(reason) {
+    /**
+     * Thrown if an attempt was made to persist a plaintext version of a credit card number.
+     */
+    class TriedToPersistPlaintextCardNumber : AutofillStorageException()
+}
+
+/**
+ * Unrecoverable errors related to [AutofillCrypto].
+ * Do not catch these.
+ */
+internal sealed class AutofillCryptoException(cause: Exception? = null) : RuntimeException(cause) {
+    /**
+     * Thrown if [AutofillCrypto] encounters an unexpected, unrecoverable state.
+     */
+    class IllegalState : AutofillCryptoException()
+}

--- a/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/AutofillCryptoTest.kt
+++ b/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/AutofillCryptoTest.kt
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.sync.autofill
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.concept.storage.CreditCardNumber
+import mozilla.components.lib.dataprotect.KeyGenerationReason
+import mozilla.components.lib.dataprotect.KeyRecoveryHandler
+import mozilla.components.lib.dataprotect.ManagedKey
+import mozilla.components.lib.dataprotect.SecureAbove22Preferences
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyZeroInteractions
+
+@RunWith(AndroidJUnit4::class)
+class AutofillCryptoTest {
+    private lateinit var securePrefs: SecureAbove22Preferences
+
+    @Before
+    fun setup() {
+        // forceInsecure is set in the tests because a keystore wouldn't be configured in the test environment.
+        securePrefs = SecureAbove22Preferences(testContext, "autofill", forceInsecure = true)
+    }
+
+    @Test
+    fun `get key - new`() {
+        val handler = mock<KeyRecoveryHandler>()
+        val crypto = AutofillCrypto(testContext, securePrefs, handler)
+        val key = crypto.key()
+        assertEquals(KeyGenerationReason.New, key.wasGenerated)
+
+        // key was persisted, subsequent fetches return it.
+        val key2 = crypto.key()
+        assertNull(key2.wasGenerated)
+
+        assertEquals(key.key, key2.key)
+        verifyZeroInteractions(handler)
+    }
+
+    @Test
+    fun `get key - lost`() {
+        val handler = mock<KeyRecoveryHandler>()
+        val crypto = AutofillCrypto(testContext, securePrefs, handler)
+        val key = crypto.key()
+        assertEquals(KeyGenerationReason.New, key.wasGenerated)
+
+        // now, let's loose the key. It'll be regenerated
+        securePrefs.clear()
+        val key2 = crypto.key()
+        assertEquals(KeyGenerationReason.RecoveryNeeded.Lost, key2.wasGenerated)
+
+        assertNotEquals(key.key, key2.key)
+        verify(handler).recoverFromBadKey(KeyGenerationReason.RecoveryNeeded.Lost)
+    }
+
+    @Test
+    fun `get key - corrupted`() {
+        val handler = mock<KeyRecoveryHandler>()
+        val crypto = AutofillCrypto(testContext, securePrefs, handler)
+        val key = crypto.key()
+        assertEquals(KeyGenerationReason.New, key.wasGenerated)
+
+        // now, let's corrupt the key. It'll be regenerated
+        securePrefs.putString(AutofillCrypto.AUTOFILL_KEY, "garbage")
+
+        val key2 = crypto.key()
+        assertEquals(KeyGenerationReason.RecoveryNeeded.Corrupt, key2.wasGenerated)
+
+        assertNotEquals(key.key, key2.key)
+        verify(handler).recoverFromBadKey(KeyGenerationReason.RecoveryNeeded.Corrupt)
+    }
+
+    @Test
+    fun `get key - corrupted subtly`() {
+        val handler = mock<KeyRecoveryHandler>()
+        val crypto = AutofillCrypto(testContext, securePrefs, handler)
+        val key = crypto.key()
+        assertEquals(KeyGenerationReason.New, key.wasGenerated)
+
+        // now, let's corrupt the key. It'll be regenerated
+        // this key is shaped correctly, but of course it won't be the same as what we got back in the first call to key()
+        securePrefs.putString(AutofillCrypto.AUTOFILL_KEY, "{\"kty\":\"oct\",\"k\":\"GhsmEtujZN_qMEgw1ZHhcJhdAFR9EkUgb94qANel-P4\"}")
+
+        val key2 = crypto.key()
+        assertEquals(KeyGenerationReason.RecoveryNeeded.Corrupt, key2.wasGenerated)
+
+        assertNotEquals(key.key, key2.key)
+        verify(handler).recoverFromBadKey(KeyGenerationReason.RecoveryNeeded.Corrupt)
+    }
+
+    @Test
+    fun `encrypt and decrypt card - normal`() {
+        val crypto = AutofillCrypto(testContext, securePrefs, mock())
+        val key = crypto.key()
+        val plaintext1 = CreditCardNumber.Plaintext("4111111111111111")
+        val plaintext2 = CreditCardNumber.Plaintext("4111111111111111")
+
+        val encrypted1 = crypto.encrypt(key, plaintext1)!!
+        val encrypted2 = crypto.encrypt(key, plaintext2)!!
+
+        // We use a non-deterministic encryption scheme.
+        assertNotEquals(encrypted1, encrypted2)
+
+        assertEquals("4111111111111111", crypto.decrypt(key, encrypted1)!!.number)
+        assertEquals("4111111111111111", crypto.decrypt(key, encrypted2)!!.number)
+    }
+
+    @Test
+    fun `encrypt and decrypt card - bad keys`() {
+        val crypto = AutofillCrypto(testContext, securePrefs, mock())
+        val plaintext = CreditCardNumber.Plaintext("4111111111111111")
+
+        val badKey = ManagedKey(key = "garbage", wasGenerated = null)
+        assertNull(crypto.encrypt(badKey, plaintext))
+
+        // This isn't a valid key.
+        val corruptKey = ManagedKey(key = "{\"kty\":\"oct\",\"k\":\"GhsmEtujZN_qMEgw1ZHhcJhdAFR9EkU\"}", wasGenerated = null)
+        assertNull(crypto.encrypt(corruptKey, plaintext))
+
+        val goodKey = crypto.key()
+        val encrypted = crypto.encrypt(goodKey, plaintext)!!
+
+        assertNull(crypto.decrypt(badKey, encrypted))
+        assertNull(crypto.decrypt(corruptKey, encrypted))
+    }
+}

--- a/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/GeckoCreditCardsAddressesStorageDelegateTest.kt
+++ b/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/GeckoCreditCardsAddressesStorageDelegateTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineScope
+import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Before
 import org.junit.Test
@@ -20,7 +21,7 @@ import org.mockito.Mockito.verify
 @RunWith(AndroidJUnit4::class)
 class GeckoCreditCardsAddressesStorageDelegateTest {
 
-    private val storage = AutofillCreditCardsAddressesStorage(testContext)
+    private val storage = AutofillCreditCardsAddressesStorage(testContext, mock())
     private lateinit var delegate: GeckoCreditCardsAddressesStorageDelegate
     private lateinit var scope: TestCoroutineScope
 

--- a/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/SyncableLoginsStorage.kt
+++ b/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/SyncableLoginsStorage.kt
@@ -225,6 +225,10 @@ class SyncableLoginsStorage(
 
     override fun getHandle() = conn.getHandle()
 
+    override fun registerWithSyncManager() {
+        throw NotImplementedError("Use getHandle instead")
+    }
+
     /**
      * @throws [LoginsStorageException] If DB isn't empty during an import; also, on unexpected errors
      * (IO failure, rust panics, etc).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,23 @@ permalink: /changelog/
 * **browser-engine-gecko(-nightly/beta)**
   * ⚠️ From now on there will be only one `concept-engine` implementation using [GeckoView](https://mozilla.github.io/geckoview/). On `master` this will be the Nightly version. In release versions it will be the corresponding Beta or Release version. More about this in [RFC 7](https://mozac.org/rfc/0007-synchronized-releases).
 
+* **concept-sync**, **browser-storage-sync**
+  * ⚠️ **This is a breaking change**: `SyncableStore` now has a `registerWithSyncManager` method for use in newer storage layers.
+
+* **concept-storage**, **service-sync-autofill**
+  * ⚠️ **This is a breaking change**: Update and add APIs now take specific `UpdatableCreditCardFields` and `NewCreditCardFields` data classes as arguments.
+  * ⚠️ **This is a breaking change**: `CreditCard`'s number field changed to `encryptedCardNumber`, `cardNumberLast4` added.
+  * New `CreditCardNumber` class, which encapsulate either an encrypted or plaintext versions of credit cards.
+  * `AutofillCreditCardsAddressesStorage` reflects these breaking changes.
+
+* **service-firefox-accounts**
+  * 🌟️ When configuring syncable storage layers, `SyncManager` now takes an optional `KeyProvider` to handle encryption/decryption of protected values.
+  * 🌟️ Support for syncing Address and Credit Cards
+
+* **lib-dataprotect**
+  * 🌟️ New APIs for managing keys - `ManagedKey`, `KeyProvider` and `KeyRecoveryHandler`.
+  * 🌟️ `AutofillCreditCardsAddressesStorage` implements these APIs for managing keys for credit card storage.
+
 # 75.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v74.0.0...v75.0.0)

--- a/samples/sync/build.gradle
+++ b/samples/sync/build.gradle
@@ -46,5 +46,6 @@ dependencies {
     implementation project(':lib-dataprotect')
 
     implementation Dependencies.kotlin_reflect
+    implementation Dependencies.androidx_fragment
     implementation Dependencies.androidx_recyclerview
 }

--- a/samples/sync/build.gradle
+++ b/samples/sync/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation project(':browser-storage-sync')
     implementation project(':service-firefox-accounts')
     implementation project(':service-sync-logins')
+    implementation project(':service-sync-autofill')
     implementation project(':support-rustlog')
     implementation project(':support-rusthttp')
     implementation project(':lib-fetch-httpurlconnection')

--- a/samples/sync/src/main/res/layout/activity_main.xml
+++ b/samples/sync/src/main/res/layout/activity_main.xml
@@ -130,7 +130,7 @@
                 style="?android:attr/listSeparatorTextViewStyle"
                 android:text="@string/devices" />
 
-            <FragmentContainerView android:name="org.mozilla.samples.sync.DeviceFragment"
+            <androidx.fragment.app.FragmentContainerView android:name="org.mozilla.samples.sync.DeviceFragment"
                 android:id="@+id/devices_fragment"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
This PR does a few things:
- fixes samples-sync so that it actually runs
- bumps A-S dependency to 75.2.0
- introduces encryption key management and encryption/decryption to credit cards storage
- allows consumers of `services-firefox-accounts` to sync addresses and credit cards
- adds addresses and credit cards sync to samples-sync (not exposed in the UI)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
