### PR TITLE
For #9932 - Sticky header / footer in the menu

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -46,7 +46,7 @@ object Versions {
         const val coordinatorlayout = "1.1.0"
         const val core = "1.3.2"
         const val fragment = "1.2.5"
-        const val recyclerview = "1.1.0"
+        const val recyclerview = "1.2.0"
         const val test = "1.3.0"
         const val test_ext = "1.1.2"
         const val espresso = "3.3.0"

--- a/components/browser/menu/build.gradle
+++ b/components/browser/menu/build.gradle
@@ -4,6 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuAdapter.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuAdapter.kt
@@ -5,10 +5,12 @@
 package mozilla.components.browser.menu
 
 import android.content.Context
+import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.browser.menu.view.StickyItemsAdapter
 
 /**
  * Adapter implementation used by the browser menu to display menu items in a RecyclerView.
@@ -16,7 +18,7 @@ import androidx.recyclerview.widget.RecyclerView
 internal class BrowserMenuAdapter(
     context: Context,
     items: List<BrowserMenuItem>
-) : RecyclerView.Adapter<BrowserMenuItemViewHolder>() {
+) : RecyclerView.Adapter<BrowserMenuItemViewHolder>(), StickyItemsAdapter {
     var menu: BrowserMenu? = null
 
     internal val visibleItems = items.filter { it.visible() }
@@ -41,6 +43,25 @@ internal class BrowserMenuAdapter(
                 item.invalidate(itemView)
             }
         }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    override fun isStickyItem(position: Int): Boolean {
+        return try {
+            visibleItems[position].isSticky
+        } catch (e: IndexOutOfBoundsException) {
+            false
+        }
+    }
+
+    override fun setupStickyItem(stickyItem: View) {
+        menu?.let {
+            stickyItem.setBackgroundColor(it.backgroundColor)
+        }
+    }
+
+    override fun tearDownStickyItem(stickyItem: View) {
+        stickyItem.setBackgroundColor(Color.TRANSPARENT)
     }
 }
 

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuItem.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.menu
 import android.content.Context
 import android.view.View
 import mozilla.components.browser.menu.view.ExpandableLayout
+import mozilla.components.browser.menu.view.StickyItemsLinearLayoutManager
 import mozilla.components.concept.menu.candidate.MenuCandidate
 
 /**
@@ -32,6 +33,13 @@ interface BrowserMenuItem {
      * @see [ExpandableLayout]
      */
     val isCollapsingMenuLimit: Boolean get() = false
+
+    /**
+     * Whether this menu item should not be scrollable off-screen.
+     *
+     * @see [StickyItemsLinearLayoutManager]
+     */
+    val isSticky: Boolean get() = false
 
     /**
      * Returns the layout resource ID of the layout to be inflated for showing a menu item of this

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/AbstractParentBrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/AbstractParentBrowserMenuItem.kt
@@ -16,11 +16,14 @@ import mozilla.components.browser.menu.BrowserMenuItem
  * @param endOfMenuAlwaysVisible when is set to true makes sure the bottom of the menu is always visible
  * otherwise, the top of the menu is always visible.
  * @param isCollapsingMenuLimit Whether this menu item can serve as the limit of a collapsing menu.
+ * @param isSticky whether this item menu should not be scrolled offscreen (downwards or upwards
+ * depending on the menu position).
  */
 abstract class AbstractParentBrowserMenuItem(
     private val subMenu: BrowserMenu,
     private val endOfMenuAlwaysVisible: Boolean,
-    override val isCollapsingMenuLimit: Boolean = false
+    override val isCollapsingMenuLimit: Boolean = false,
+    override val isSticky: Boolean = false
 ) : BrowserMenuItem {
     /**
      * Listener called when the sub menu is shown.

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuCategory.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuCategory.kt
@@ -28,6 +28,8 @@ import mozilla.components.concept.menu.candidate.TypefaceStyle
  * @param textStyle: The style to apply to the text.
  * @param textAlignment The alignment of text
  * @param isCollapsingMenuLimit Whether this menu item can serve as the limit of a collapsing menu.
+ * @param isSticky whether this item menu should not be scrolled offscreen (downwards or upwards
+ * depending on the menu position).
  */
 @Suppress("LongParameterList")
 class BrowserMenuCategory(
@@ -37,7 +39,8 @@ class BrowserMenuCategory(
     private val textColorResource: Int = NO_ID,
     @TypefaceStyle private val textStyle: Int = Typeface.BOLD,
     @TextAlignment private val textAlignment: Int = View.TEXT_ALIGNMENT_VIEW_START,
-    override val isCollapsingMenuLimit: Boolean = false
+    override val isCollapsingMenuLimit: Boolean = false,
+    override val isSticky: Boolean = false
 ) : BrowserMenuItem {
     override var visible: () -> Boolean = { true }
 

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuCheckbox.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuCheckbox.kt
@@ -14,14 +14,17 @@ import mozilla.components.concept.menu.candidate.CompoundMenuCandidate
  * @param label The visible label of this menu item.
  * @param initialState The initial value the checkbox should have.
  * @param isCollapsingMenuLimit Whether this menu item can serve as the limit of a collapsing menu.
+ * @param isSticky whether this item menu should not be scrolled offscreen (downwards or upwards
+ * depending on the menu position).
  * @param listener Callback to be invoked when this menu item is checked.
  */
 class BrowserMenuCheckbox(
     label: String,
     initialState: () -> Boolean = { false },
     override val isCollapsingMenuLimit: Boolean = false,
+    override val isSticky: Boolean = false,
     listener: (Boolean) -> Unit
-) : BrowserMenuCompoundButton(label, isCollapsingMenuLimit, initialState, listener) {
+) : BrowserMenuCompoundButton(label, isCollapsingMenuLimit, isSticky, initialState, listener) {
     override fun getLayoutResource() = R.layout.mozac_browser_menu_item_checkbox
 
     override fun asCandidate(context: Context) = super.asCandidate(context).copy(

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButton.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButton.kt
@@ -20,6 +20,8 @@ import java.lang.reflect.Modifier.PRIVATE
  *
  * @param label The visible label of this menu item.
  * @param isCollapsingMenuLimit Whether this menu item can serve as the limit of a collapsing menu.
+ * @param isSticky whether this item menu should not be scrolled offscreen (downwards or upwards
+ * depending on the menu position).
  * @param initialState The initial value the checkbox should have.
  * @param listener Callback to be invoked when this menu item is checked.
  */
@@ -27,6 +29,7 @@ abstract class BrowserMenuCompoundButton(
     @VisibleForTesting(otherwise = PRIVATE)
     val label: String,
     override val isCollapsingMenuLimit: Boolean = false,
+    override val isSticky: Boolean = false,
     private val initialState: () -> Boolean = { false },
     private val listener: (Boolean) -> Unit
 ) : BrowserMenuItem {

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableItem.kt
@@ -32,6 +32,8 @@ private val defaultHighlight = BrowserMenuHighlightableItem.Highlight(0, 0, 0, 0
  * @param iconTintColorResource Optional ID of color resource to tint the icon.
  * @param textColorResource Optional ID of color resource to tint the text.
  * @param isCollapsingMenuLimit Whether this menu item can serve as the limit of a collapsing menu.
+ * @param isSticky whether this item menu should not be scrolled offscreen (downwards or upwards
+ * depending on the menu position).
  * @param highlight Highlight object representing how the menu item will be displayed when highlighted.
  * @param isHighlighted Whether or not to display the highlight
  * @param listener Callback to be invoked when this menu item is clicked.
@@ -43,6 +45,7 @@ class BrowserMenuHighlightableItem(
     @ColorRes private val iconTintColorResource: Int = NO_ID,
     @ColorRes private val textColorResource: Int = NO_ID,
     override val isCollapsingMenuLimit: Boolean = false,
+    override val isSticky: Boolean = false,
     override val highlight: BrowserMenuHighlight,
     override val isHighlighted: () -> Boolean = { true },
     private val listener: () -> Unit = {}
@@ -52,6 +55,7 @@ class BrowserMenuHighlightableItem(
     iconTintColorResource,
     textColorResource,
     isCollapsingMenuLimit,
+    isSticky,
     listener
 ), HighlightableMenuItem {
 
@@ -66,6 +70,7 @@ class BrowserMenuHighlightableItem(
         @ColorRes
         textColorResource: Int = NO_ID,
         isCollapsingMenuLimit: Boolean = false,
+        isSticky: Boolean = false,
         highlight: Highlight? = null,
         listener: () -> Unit = {}
     ) : this(
@@ -74,6 +79,7 @@ class BrowserMenuHighlightableItem(
         iconTintColorResource,
         textColorResource,
         isCollapsingMenuLimit,
+        isSticky,
         highlight ?: defaultHighlight,
         { highlight != null },
         listener

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableSwitch.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableSwitch.kt
@@ -25,6 +25,8 @@ import mozilla.components.concept.menu.candidate.LowPriorityHighlightEffect
  *
  * @param label The visible label of this menu item.
  * @param isCollapsingMenuLimit Whether this menu item can serve as the limit of a collapsing menu.
+ * @param isSticky whether this item menu should not be scrolled offscreen (downwards or upwards
+ * depending on the menu position).
  * @param initialState The initial value the checkbox should have.
  * @param listener Callback to be invoked when this menu item is checked.
  */
@@ -35,11 +37,12 @@ class BrowserMenuHighlightableSwitch(
     @ColorRes private val iconTintColorResource: Int = NO_ID,
     @ColorRes private val textColorResource: Int = NO_ID,
     override val isCollapsingMenuLimit: Boolean = false,
+    override val isSticky: Boolean = false,
     override val highlight: BrowserMenuHighlight.LowPriority,
     override val isHighlighted: () -> Boolean = { true },
     initialState: () -> Boolean = { false },
     listener: (Boolean) -> Unit
-) : BrowserMenuCompoundButton(label, isCollapsingMenuLimit, initialState, listener), HighlightableMenuItem {
+) : BrowserMenuCompoundButton(label, isCollapsingMenuLimit, isSticky, initialState, listener), HighlightableMenuItem {
 
     private var wasHighlighted = false
 

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageSwitch.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageSwitch.kt
@@ -21,18 +21,22 @@ import java.lang.reflect.Modifier
  * @param imageResource ID of a drawable resource to be shown as icon.
  * @param label The visible label of this menu item.
  * @param isCollapsingMenuLimit Whether this menu item can serve as the limit of a collapsing menu.
+ * @param isSticky whether this item menu should not be scrolled offscreen (downwards or upwards
+ * depending on the menu position).
  * @param initialState The initial value the checkbox should have.
  * @param listener Callback to be invoked when this menu item is checked.
  */
+@Suppress("LongParameterList")
 class BrowserMenuImageSwitch(
     @VisibleForTesting(otherwise = Modifier.PRIVATE)
     @DrawableRes
     val imageResource: Int,
     label: String,
     override val isCollapsingMenuLimit: Boolean = false,
+    override val isSticky: Boolean = false,
     initialState: () -> Boolean = { false },
     listener: (Boolean) -> Unit
-) : BrowserMenuCompoundButton(label, isCollapsingMenuLimit, initialState, listener) {
+) : BrowserMenuCompoundButton(label, isCollapsingMenuLimit, isSticky, initialState, listener) {
     override fun getLayoutResource(): Int = R.layout.mozac_browser_menu_item_image_switch
 
     override fun bind(menu: BrowserMenu, view: View) {

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageText.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageText.kt
@@ -44,6 +44,8 @@ internal fun TextView.setColorResource(@ColorRes textColorResource: Int) {
  * @param iconTintColorResource Optional ID of color resource to tint the icon.
  * @param textColorResource Optional ID of color resource to tint the text.
  * @param isCollapsingMenuLimit Whether this menu item can serve as the limit of a collapsing menu.
+ * @param isSticky whether this item menu should not be scrolled offscreen (downwards or upwards
+ * depending on the menu position).
  * @param listener Callback to be invoked when this menu item is clicked.
  */
 @Suppress("LongParameterList")
@@ -56,6 +58,7 @@ open class BrowserMenuImageText(
     @ColorRes
     private val textColorResource: Int = NO_ID,
     override val isCollapsingMenuLimit: Boolean = false,
+    override val isSticky: Boolean = false,
     private val listener: () -> Unit = {}
 ) : BrowserMenuItem {
 

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageTextCheckboxButton.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageTextCheckboxButton.kt
@@ -24,6 +24,9 @@ import mozilla.components.support.ktx.android.util.dpToPx
  * @param labelListener Callback to be invoked when this menu item is clicked.
  * @param primaryStateIconResource ID of a drawable resource for checkbox drawable in primary state.
  * @param secondaryStateIconResource ID of a drawable resource for checkbox drawable in secondary state.
+ * @param isCollapsingMenuLimit Whether this menu item can serve as the limit of a collapsing menu.
+ * @param isSticky whether this item menu should not be scrolled offscreen (downwards or upwards
+ * depending on the menu position).
  * @param iconTintColorResource Optional ID of color resource to tint the checkbox drawable.
  * @param primaryLabel The visible label of the checkbox in primary state.
  * @param secondaryLabel The visible label of this menu item in secondary state.
@@ -43,10 +46,11 @@ class BrowserMenuImageTextCheckboxButton(
     private val primaryLabel: String,
     private val secondaryLabel: String,
     override val isCollapsingMenuLimit: Boolean = false,
+    override val isSticky: Boolean = false,
     val isInPrimaryState: () -> Boolean = { true },
     private val onCheckedChangedListener: (Boolean) -> Unit
 ) : BrowserMenuImageText(
-    label, imageResource, iconTintColorResource, textColorResource, isCollapsingMenuLimit, labelListener
+    label, imageResource, iconTintColorResource, textColorResource, isCollapsingMenuLimit, isSticky, labelListener
 ) {
     override var visible: () -> Boolean = { true }
     override fun getLayoutResource(): Int = R.layout.mozac_browser_menu_item_image_text_checkbox_button

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
@@ -29,10 +29,13 @@ import mozilla.components.support.ktx.android.content.res.resolveAttribute
  *
  * @param items buttons that will be shown in a horizontal layout
  * @param isCollapsingMenuLimit Whether this menu item can serve as the limit of a collapsing menu.
+ * @param isSticky whether this item menu should not be scrolled offscreen (downwards or upwards
+ * depending on the menu position).
  */
 class BrowserMenuItemToolbar(
     private val items: List<Button>,
-    override val isCollapsingMenuLimit: Boolean = false
+    override val isCollapsingMenuLimit: Boolean = false,
+    override val isSticky: Boolean = false
 ) : BrowserMenuItem {
     override var visible: () -> Boolean = { true }
 

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuSwitch.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuSwitch.kt
@@ -13,15 +13,18 @@ import mozilla.components.concept.menu.candidate.CompoundMenuCandidate
  *
  * @param label The visible label of this menu item.
  * @param isCollapsingMenuLimit Whether this menu item can serve as the limit of a collapsing menu.
+ * @param isSticky whether this item menu should not be scrolled offscreen (downwards or upwards
+ * depending on the menu position).
  * @param initialState The initial value the checkbox should have.
  * @param listener Callback to be invoked when this menu item is checked.
  */
 class BrowserMenuSwitch(
     label: String,
     override val isCollapsingMenuLimit: Boolean = false,
+    override val isSticky: Boolean = false,
     initialState: () -> Boolean = { false },
     listener: (Boolean) -> Unit
-) : BrowserMenuCompoundButton(label, isCollapsingMenuLimit, initialState, listener) {
+) : BrowserMenuCompoundButton(label, isCollapsingMenuLimit, isSticky, initialState, listener) {
     override fun getLayoutResource(): Int = R.layout.mozac_browser_menu_item_switch
 
     override fun asCandidate(context: Context) = super.asCandidate(context).copy(

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/ParentBrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/ParentBrowserMenuItem.kt
@@ -29,6 +29,11 @@ import mozilla.components.concept.menu.candidate.TextStyle
  * @param iconTintColorResource Optional ID of color resource to tint the icon.
  * @param textColorResource Optional ID of color resource to tint the text.
  * @property subMenu Target sub menu to be shown when this menu item is clicked.
+ * @param isCollapsingMenuLimit Whether this menu item can serve as the limit of a collapsing menu.
+ * @param isSticky whether this item menu should not be scrolled offscreen (downwards or upwards
+ * depending on the menu position).
+ * @param endOfMenuAlwaysVisible when is set to true makes sure the bottom of the menu is always visible
+ * otherwise, the top of the menu is always visible.
  */
 @Suppress("LongParameterList")
 class ParentBrowserMenuItem(
@@ -42,6 +47,7 @@ class ParentBrowserMenuItem(
     private val textColorResource: Int = NO_ID,
     internal val subMenu: BrowserMenu,
     override val isCollapsingMenuLimit: Boolean = false,
+    override val isSticky: Boolean = false,
     endOfMenuAlwaysVisible: Boolean = false
 ) : AbstractParentBrowserMenuItem(subMenu, isCollapsingMenuLimit, endOfMenuAlwaysVisible) {
 

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/SimpleBrowserMenuHighlightableItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/SimpleBrowserMenuHighlightableItem.kt
@@ -27,6 +27,9 @@ import mozilla.components.concept.menu.candidate.TextStyle
  * @param textColorResource Optional ID of color resource to tint the text.
  * @param textSize The size of the label.
  * @param backgroundTint Tint for the menu item background color
+ * @param isCollapsingMenuLimit Whether this menu item can serve as the limit of a collapsing menu.
+ * @param isSticky whether this item menu should not be scrolled offscreen (downwards or upwards
+ * depending on the menu position).
  * @param isHighlighted Whether or not to display the highlight
  * @param listener Callback to be invoked when this menu item is clicked.
  */
@@ -37,6 +40,7 @@ class SimpleBrowserMenuHighlightableItem(
     private val textSize: Float = NO_ID.toFloat(),
     @ColorInt val backgroundTint: Int,
     override val isCollapsingMenuLimit: Boolean = false,
+    override val isSticky: Boolean = false,
     var isHighlighted: () -> Boolean = { true },
     private val listener: () -> Unit = {}
 ) : BrowserMenuItem {

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItem.kt
@@ -30,12 +30,15 @@ import mozilla.components.support.base.log.Log
  * @param action the [Action] to display.
  * @param listener a callback to be invoked when this menu item is clicked.
  * @param isCollapsingMenuLimit Whether this menu item can serve as the limit of a collapsing menu.
+ * @param isSticky whether this item menu should not be scrolled offscreen (downwards or upwards
+ * depending on the menu position).
  */
 class WebExtensionBrowserMenuItem(
     internal var action: Action,
     internal val listener: () -> Unit,
     internal val id: String = "",
-    override val isCollapsingMenuLimit: Boolean = false
+    override val isCollapsingMenuLimit: Boolean = false,
+    override val isSticky: Boolean = false
 ) : BrowserMenuItem {
     override var visible: () -> Boolean = { true }
 

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/ExpandableLayout.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/ExpandableLayout.kt
@@ -20,6 +20,7 @@ import androidx.core.view.marginLeft
 import androidx.core.view.marginRight
 import androidx.core.view.marginTop
 import androidx.core.view.updateLayoutParams
+import androidx.recyclerview.widget.RecyclerView
 
 /**
  * ViewGroup intended to wrap another to then allow for the following automatic behavior:
@@ -46,6 +47,12 @@ internal class ExpandableLayout private constructor(context: Context) : FrameLay
      */
     @VisibleForTesting
     internal var lastVisibleItemIndexWhenCollapsed: Int = Int.MAX_VALUE
+
+    /**
+     * Index of the sticky footer, if such an item is set.
+     */
+    @VisibleForTesting
+    internal var stickyItemIndex: Int = RecyclerView.NO_POSITION
 
     /**
      * Height of wrapped view when collapsed.
@@ -321,19 +328,34 @@ internal class ExpandableLayout private constructor(context: Context) : FrameLay
         result += listView.paddingTop
         result += listView.paddingBottom
 
-        listView.children.forEachIndexed { index, view ->
-            if (index < lastVisibleItemIndexWhenCollapsed) {
-                result += view.marginTop
-                result += view.marginBottom
-                result += view.paddingTop
-                result += view.paddingBottom
-                result += view.measuredHeight
-            } else if (index == lastVisibleItemIndexWhenCollapsed) {
-                result += view.marginTop
-                result += view.paddingTop
-                result += view.measuredHeight / 2
+        run loop@ {
+            listView.children.forEachIndexed { index, view ->
+                if (index < lastVisibleItemIndexWhenCollapsed) {
+                    result += view.marginTop
+                    result += view.marginBottom
+                    result += view.paddingTop
+                    result += view.paddingBottom
+                    result += view.measuredHeight
+                } else if (index == lastVisibleItemIndexWhenCollapsed) {
+                    result += view.marginTop
+                    result += view.paddingTop
 
-                return@forEachIndexed
+                    // Edgecase: if the same item is the sticky footer and the lastVisibleItemIndexWhenCollapsed
+                    // the menu will be collapsed to this item but shown with full height.
+                    if (index == stickyItemIndex) {
+                        result += view.measuredHeight
+                        return@loop
+                    } else {
+                        result += view.measuredHeight / 2
+                    }
+                } else {
+                    // If there is a sticky item below we need to add it's height as an offset.
+                    // Otherwise the sticky item will cover the the view of lastVisibleItemIndexWhenCollapsed.
+                    if (index <= stickyItemIndex) {
+                        result += listView.getChildAt(stickyItemIndex).measuredHeight
+                    }
+                    return@loop
+                }
             }
         }
 
@@ -362,6 +384,7 @@ internal class ExpandableLayout private constructor(context: Context) : FrameLay
         internal fun wrapContentInExpandableView(
             contentView: ViewGroup,
             lastVisibleItemIndexWhenCollapsed: Int = Int.MAX_VALUE,
+            stickyFooterItemIndex: Int = RecyclerView.NO_POSITION,
             blankTouchListener: (() -> Unit)? = null
         ): ExpandableLayout {
 
@@ -376,6 +399,7 @@ internal class ExpandableLayout private constructor(context: Context) : FrameLay
             expandableView.addView(contentView, params)
 
             expandableView.wrappedView = contentView
+            expandableView.stickyItemIndex = stickyFooterItemIndex
             expandableView.blankTouchListener = blankTouchListener
             expandableView.lastVisibleItemIndexWhenCollapsed = lastVisibleItemIndexWhenCollapsed
 

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/ExpandableLayout.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/ExpandableLayout.kt
@@ -309,6 +309,7 @@ internal class ExpandableLayout private constructor(context: Context) : FrameLay
     // That distance will be the collapsed height of the ViewGroup used when this will be first shown on the screen.
     // Users will be able to afterwards expand the ViewGroup to the full height.
     @VisibleForTesting
+    @Suppress("ReturnCount")
     internal fun calculateCollapsedHeight(): Int {
         val listView = (wrappedView.getChildAt(0) as ViewGroup)
         // Simple sanity check
@@ -328,17 +329,14 @@ internal class ExpandableLayout private constructor(context: Context) : FrameLay
         result += listView.paddingTop
         result += listView.paddingBottom
 
-        run loop@ {
+        run loop@{
             listView.children.forEachIndexed { index, view ->
                 if (index < lastVisibleItemIndexWhenCollapsed) {
                     result += view.marginTop
                     result += view.marginBottom
-                    result += view.paddingTop
-                    result += view.paddingBottom
                     result += view.measuredHeight
                 } else if (index == lastVisibleItemIndexWhenCollapsed) {
                     result += view.marginTop
-                    result += view.paddingTop
 
                     // Edgecase: if the same item is the sticky footer and the lastVisibleItemIndexWhenCollapsed
                     // the menu will be collapsed to this item but shown with full height.

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/StickyFooterLinearLayoutManager.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/StickyFooterLinearLayoutManager.kt
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.view
+
+import android.content.Context
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+
+/**
+ * Vertical LinearLayoutManager that will ensure an item at a position specified through
+ * [StickyItemsAdapter.isStickyItem] will not scroll past the list bottom.
+ *
+ * The list would otherwise scroll normally with the other elements being scrolled beneath the sticky item.
+ *
+ * @param context [Context] needed for various Android interactions.
+ * @param reverseLayout When set to true, layouts from end to start.
+ */
+open class StickyFooterLinearLayoutManager<T> constructor(
+    context: Context,
+    reverseLayout: Boolean = false
+) : StickyItemsLinearLayoutManager<T>(
+    context,
+    StickyItemPlacement.BOTTOM,
+    reverseLayout
+) where T : RecyclerView.Adapter<*>, T : StickyItemsAdapter {
+
+    override fun scrollToIndicatedPositionWithOffset(
+        position: Int,
+        offset: Int,
+        actuallyScrollToPositionWithOffset: (Int, Int) -> Unit
+    ) {
+        // The following scenarios are handled:
+        // - if position is bigger than [stickyItemPosition]
+        //      -> the default behavior will have the list scrolled downwards enough to show that.
+        // - if position is the one of the stickyItem
+        //      -> the default behavior will scroll to exactly the header. Perfect match.
+        // - if position is before that of the [stickyItem] and does not fit the screen
+        //      -> only scenario we need to handle: the sticky footer must be shown and the default implementation
+        //      would scroll to show as the last item in the list the item at [position]. But that is where the sticky
+        //      item is anchored. Need to scroll to the next position so that that item will be obscured by the sticky
+        //      item and not the now above item at [position].
+        //
+        // Providing any offsets with the stickyView shown and the above scenarios handles means they are handled also.
+
+        if (position < stickyItemPosition && getChildAt(position) == null) {
+            actuallyScrollToPositionWithOffset(position + 1, offset)
+            return
+        }
+
+        actuallyScrollToPositionWithOffset(position, offset)
+    }
+
+    override fun shouldStickyItemBeShownForCurrentPosition(): Boolean {
+        if (stickyItemPosition == RecyclerView.NO_POSITION) {
+            return false
+        }
+
+        // The item at [stickyItemPosition] should be anchored to the top if:
+        // - it or a lower indexed item is shown at the bottom of the list
+        // - the last shown item is translated downwards off screen
+        // (happens when [scrollToPositionWithOffset] was called with a big enough offset)
+        val lastVisibleElement = stickyItemView?.let { childCount - 2 } ?: childCount - 1
+        return getAdapterPositionForItemIndex(lastVisibleElement) <= stickyItemPosition
+    }
+
+    override fun getY(itemView: View): Float {
+        return when (reverseLayout) {
+            true -> 0f
+            false -> height - itemView.height.toFloat()
+        }
+    }
+}

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/StickyHeaderLinearLayoutManager.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/StickyHeaderLinearLayoutManager.kt
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.view
+
+import android.content.Context
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+
+/**
+ * Vertical LinearLayoutManager that will ensure an item at a position specified through
+ * [StickyItemsAdapter.isStickyItem] will not scroll past the list's top.
+ *
+ * The list would otherwise scroll normally with the other elements being scrolled beneath the sticky item.
+ *
+ * @param context [Context] needed for various Android interactions.
+ * @param reverseLayout When set to true, layouts from end to start.
+ */
+open class StickyHeaderLinearLayoutManager<T> constructor(
+    context: Context,
+    reverseLayout: Boolean = false
+) : StickyItemsLinearLayoutManager<T>(
+    context,
+    StickyItemPlacement.TOP,
+    reverseLayout
+) where T : RecyclerView.Adapter<*>, T : StickyItemsAdapter {
+
+    override fun scrollToIndicatedPositionWithOffset(
+        position: Int,
+        offset: Int,
+        actuallyScrollToPositionWithOffset: (Int, Int) -> Unit
+    ) {
+        // The following scenarios are handled:
+        // - if position is smaller than [stickyItemPosition]
+        //      -> the default behavior will have the list scrolled upwards enough to show that.
+        // - if position is the one of the stickyItem
+        //      -> the default behavior will scroll to exactly the header. Perfect match.
+        // - if position is bigger than [stickyItemPosition]
+        //      -> only scenario we need to handle: default implementation would scroll to show at the top of the list
+        //      the item at that position. But that is where the sticky item is anchored. Need to ask for the item at
+        //      the before position being shown at the top of the list and let that be obscured by the sticky item.
+        //
+        // Providing any offsets with the stickyView shown and the above scenarios handles means they are handled also.
+
+        if (position + 1 > stickyItemPosition) {
+            actuallyScrollToPositionWithOffset(position - 1, offset)
+            return
+        }
+
+        actuallyScrollToPositionWithOffset(position, offset)
+    }
+
+    override fun shouldStickyItemBeShownForCurrentPosition(): Boolean {
+        if (stickyItemPosition == RecyclerView.NO_POSITION) {
+            return false
+        }
+
+        // The item at [stickyItemPosition] should be anchored to the top if:
+        // - it or a below item is shown at the top of the list
+        // - the first shown item is translated upwards off screen
+        // (happens when [scrollToPositionWithOffset] was called with a big enough offset)
+        return getAdapterPositionForItemIndex(0) >= stickyItemPosition ||
+            getChildAt(0)?.bottom ?: 1 <= 0 // return false if there is no item at index 0
+    }
+
+    override fun getY(itemView: View): Float {
+        return when (reverseLayout) {
+            true -> height - itemView.height.toFloat()
+            false -> 0f
+        }
+    }
+}

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/StickyItemLayoutManager.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/StickyItemLayoutManager.kt
@@ -1,0 +1,478 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.view
+
+import android.content.Context
+import android.graphics.PointF
+import android.os.Parcelable
+import android.view.View
+import android.view.ViewTreeObserver
+import androidx.annotation.VisibleForTesting
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.android.parcel.Parcelize
+
+// Inspired from
+// https://github.com/qiujayen/sticky-layoutmanager/blob/b1ddb086db5b04ff3c5357dabe1bff47a935dd37/
+// sticky-layoutmanager/src/main/java/com/jay/widget/StickyHeadersLinearLayoutManager.java
+
+/**
+ * Contract needed to be implemented by all [RecyclerView.Adapter]s
+ * that want to display a list with a sticky header / footer.
+ */
+interface StickyItemsAdapter {
+    /**
+     * Whether this should be considered a sticky item.
+     *
+     * All items will be checked. Only the last one presenting as sticky will be used as such.
+     */
+    fun isStickyItem(position: Int): Boolean
+
+    /**
+     * Callback allowing any customization for the view that will become sticky.
+     */
+    fun setupStickyItem(stickyItem: View) {}
+
+    /**
+     * Callback allowing cleanup after the previous sticky view becomes a regular view.
+     */
+    fun tearDownStickyItem(stickyItem: View) {}
+}
+
+/**
+ * Whether the sticky item should be a header or a footer.
+ */
+enum class StickyItemPlacement {
+    /**
+     * The sticky item will be fixed at the top of the list.
+     *
+     * If the list is scrolled down until past the sticky item's position that view
+     * will become a regular view and will be scrolled down as the others.
+     *
+     * If the list is scrolled up past the sticky item's position that view
+     * will be anchored to the top of the list, always being shown as the first item.
+     */
+    TOP,
+
+    /**
+     * The sticky item will be fixed at the bottom of the list.
+     *
+     * If the list is scrolled up until past the sticky item's position that view
+     * will become a regular view and will be scrolled up as the others.
+     *
+     * If the list is scrolled down past the sticky item's position that view
+     * will be anchored to the bottom of the list, always being shown as the last item.
+     */
+    BOTTOM
+}
+
+/**
+ * Vertical LinearLayoutManager that will prevent certain items from being scrolled off-screen.
+ *
+ * @param context [Context] needed for various Android interactions.
+ * @param stickyItemPlacement whether the sticky item should be blocked from being scrolled off
+ * to the top of the screen or off to the bottom of the screen.
+ * @param reverseLayout When set to true, layouts from end to start.
+ */
+@Suppress("TooManyFunctions")
+abstract class StickyItemsLinearLayoutManager<T> constructor(
+    context: Context,
+    private val stickyItemPlacement: StickyItemPlacement,
+    reverseLayout: Boolean = false
+) : LinearLayoutManager(context, RecyclerView.VERTICAL, reverseLayout)
+    where T : RecyclerView.Adapter<*>, T : StickyItemsAdapter {
+
+    @VisibleForTesting
+    internal var listAdapter: T? = null
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+    internal var stickyItemPosition = RecyclerView.NO_POSITION
+    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+    internal var stickyItemView: View? = null
+
+    // Allows to re-evaluate and display a possibly new sticky item if data / adapter changed.
+    @VisibleForTesting
+    internal var stickyItemPositionsObserver = ItemPositionsAdapterDataObserver()
+
+    // Save / Restore scroll state
+    @VisibleForTesting
+    internal var scrollPosition = RecyclerView.NO_POSITION
+    @VisibleForTesting
+    internal var scrollOffset = 0
+
+    /**
+     * @see [LinearLayoutManager.scrollToPositionWithOffset]
+     *
+     * @param position list item index which needs to be shown.
+     * @param offset optional distance offset from the top of the list to be applied after scrolling to [position]
+     * @param actuallyScrollToPositionWithOffset callback to be used for actually scrolling to an updated position
+     * ad offset based on the relation with the sticky item.
+     *
+     * Use [setScrollState] before and after
+     */
+    abstract fun scrollToIndicatedPositionWithOffset(
+        position: Int,
+        offset: Int,
+        actuallyScrollToPositionWithOffset: (Int, Int) -> Unit
+    )
+
+    /**
+     * Whether the sticky item should be shown.
+     *
+     * Expected to return if the sticky header item is scrolled past the list top or the sticky bottom item
+     * is scrolled past the list bottom.
+     */
+    abstract fun shouldStickyItemBeShownForCurrentPosition(): Boolean
+
+    /**
+     * Returns the position in the Y axis to position the header appropriately,
+     * depending on direction and [android.R.attr.clipToPadding].
+     */
+    abstract fun getY(itemView: View): Float
+
+    override fun onAttachedToWindow(recyclerView: RecyclerView) {
+        super.onAttachedToWindow(recyclerView)
+        setAdapter(recyclerView.adapter)
+    }
+
+    override fun onAdapterChanged(
+        oldAdapter: RecyclerView.Adapter<*>?,
+        newAdapter: RecyclerView.Adapter<*>?
+    ) {
+        super.onAdapterChanged(oldAdapter, newAdapter)
+        setAdapter(newAdapter)
+    }
+
+    override fun onSaveInstanceState(): Parcelable {
+        return SavedState(
+            superState = super.onSaveInstanceState(),
+            scrollPosition = scrollPosition,
+            scrollOffset = scrollOffset
+        )
+    }
+
+    override fun onRestoreInstanceState(state: Parcelable?) {
+        (state as? mozilla.components.browser.menu.view.SavedState)?.let {
+            scrollPosition = it.scrollPosition
+            scrollOffset = it.scrollOffset
+            super.onRestoreInstanceState(it.superState)
+        }
+    }
+
+    override fun onLayoutChildren(recycler: RecyclerView.Recycler, state: RecyclerView.State) {
+        restoreView { super.onLayoutChildren(recycler, state) }
+
+        if (!state.isPreLayout) {
+            updateStickyItem(recycler, true)
+        }
+    }
+
+    override fun scrollVerticallyBy(
+        dy: Int,
+        recycler: RecyclerView.Recycler,
+        state: RecyclerView.State?
+    ): Int {
+        val distanceScrolled = restoreView { super.scrollVerticallyBy(dy, recycler, state) }
+        if (distanceScrolled != 0) {
+            updateStickyItem(recycler, false)
+        }
+        return distanceScrolled
+    }
+
+    override fun findLastVisibleItemPosition(): Int =
+        restoreView { super.findLastVisibleItemPosition() }
+
+    override fun findFirstVisibleItemPosition(): Int =
+        restoreView { super.findFirstVisibleItemPosition() }
+
+    override fun findFirstCompletelyVisibleItemPosition(): Int =
+        restoreView { super.findFirstCompletelyVisibleItemPosition() }
+
+    override fun findLastCompletelyVisibleItemPosition(): Int =
+        restoreView { super.findLastCompletelyVisibleItemPosition() }
+
+    override fun computeVerticalScrollExtent(state: RecyclerView.State): Int =
+        restoreView { super.computeVerticalScrollExtent(state) }
+
+    override fun computeVerticalScrollOffset(state: RecyclerView.State): Int =
+        restoreView { super.computeVerticalScrollOffset(state) }
+
+    override fun computeVerticalScrollRange(state: RecyclerView.State): Int =
+        restoreView { super.computeVerticalScrollRange(state) }
+
+    override fun computeScrollVectorForPosition(targetPosition: Int): PointF? =
+        restoreView { super.computeScrollVectorForPosition(targetPosition) }
+
+    override fun scrollToPosition(position: Int) {
+        if (stickyItemView != null) {
+            scrollToPositionWithOffset(position, INVALID_OFFSET)
+        } else {
+            super.scrollToPosition(position)
+        }
+    }
+
+    override fun scrollToPositionWithOffset(position: Int, offset: Int) {
+        if (stickyItemView != null) {
+            // Reset pending scroll.
+            setScrollState(RecyclerView.NO_POSITION, INVALID_OFFSET)
+
+            scrollToIndicatedPositionWithOffset(position, offset) { updatedPosition, updatedOffset ->
+                super.scrollToPositionWithOffset(updatedPosition, updatedOffset)
+            }
+
+            // Remember this position and offset and scroll to it to trigger creating the sticky view.
+            setScrollState(position, offset)
+        } else {
+            super.scrollToPositionWithOffset(position, offset)
+        }
+    }
+
+    override fun onFocusSearchFailed(
+        focused: View,
+        focusDirection: Int,
+        recycler: RecyclerView.Recycler,
+        state: RecyclerView.State
+    ): View? = restoreView { super.onFocusSearchFailed(focused, focusDirection, recycler, state) }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+    internal fun getAdapterPositionForItemIndex(index: Int): Int {
+        return (getChildAt(index)?.layoutParams as? RecyclerView.LayoutParams)
+            ?.absoluteAdapterPosition ?: RecyclerView.NO_POSITION
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @VisibleForTesting
+    internal fun setAdapter(newAdapter: RecyclerView.Adapter<*>?) {
+        listAdapter?.unregisterAdapterDataObserver(stickyItemPositionsObserver)
+
+        (newAdapter as? T)?.let {
+            listAdapter = newAdapter
+            listAdapter?.registerAdapterDataObserver(stickyItemPositionsObserver)
+            stickyItemPositionsObserver.onChanged()
+        } ?: run {
+            listAdapter = null
+            stickyItemView = null
+        }
+    }
+
+    /**
+     * Perform any [operation] ignoring the sticky item. Accomplished by:
+     * - detaching the sticky view
+     * - performing the [operation]
+     * - reattaching the sticky view.
+     */
+    @VisibleForTesting
+    internal fun <T> restoreView(operation: () -> T): T {
+        stickyItemView?.let(this::detachView)
+        val result = operation()
+        stickyItemView?.let(this::attachView)
+        return result
+    }
+
+    /**
+     * Updates the sticky item state (creation, binding, display).
+     *
+     * To be called whenever there's a layout or scroll.
+     *
+     * @param recycler [RecyclerView.Recycler] instance handling views recycling
+     * @param layout whether this is called while layout or while scrolling.
+     */
+    @VisibleForTesting
+    internal fun updateStickyItem(recycler: RecyclerView.Recycler, layout: Boolean) {
+        if (shouldStickyItemBeShownForCurrentPosition()) {
+            if (stickyItemView == null) {
+                createStickyView(recycler, stickyItemPosition)
+            }
+
+            if (layout) {
+                bindStickyItem(stickyItemView!!)
+            }
+
+            stickyItemView?.let {
+                it.translationY = getY(it)
+            }
+        } else {
+            stickyItemView?.let {
+                recycleStickyItem(recycler)
+            }
+        }
+    }
+
+    /**
+     * Construct and configure a [RecyclerView.ViewHolder] for [position],
+     * including measure, layout, and data binding and assigns this to [stickyItemView].
+     */
+    @VisibleForTesting
+    internal fun createStickyView(recycler: RecyclerView.Recycler, position: Int) {
+        val stickyItem = recycler.getViewForPosition(position)
+
+        listAdapter?.setupStickyItem(stickyItem)
+
+        // Add sticky item as a child view, to be detached / reattached whenever
+        // LinearLayoutManager#fill() is called, which happens on layout and scroll (see overrides).
+        addView(stickyItem)
+        measureAndLayout(stickyItem)
+
+        // Hide this new sticky item from the parent LayoutManager, as it's fully managed by this LayoutManager.
+        ignoreView(stickyItem)
+
+        stickyItemView = stickyItem
+    }
+
+    /**
+     * Binds a new [stickyItem].
+     */
+    @VisibleForTesting
+    internal fun bindStickyItem(stickyItem: View) {
+        measureAndLayout(stickyItem)
+
+        // If we have a pending scroll wait until the end of layout and scroll again.
+        if (scrollPosition != RecyclerView.NO_POSITION) {
+            stickyItem.viewTreeObserver.addOnGlobalLayoutListener(object :
+                ViewTreeObserver.OnGlobalLayoutListener {
+                override fun onGlobalLayout() {
+                    stickyItem.viewTreeObserver.removeOnGlobalLayoutListener(this)
+                    if (scrollPosition != RecyclerView.NO_POSITION) {
+                        scrollToPositionWithOffset(scrollPosition, scrollOffset)
+                        setScrollState(RecyclerView.NO_POSITION, INVALID_OFFSET)
+                    }
+                }
+            })
+        }
+    }
+
+    /**
+     * Measures and lays out [stickyItemView].
+     */
+    @VisibleForTesting
+    internal fun measureAndLayout(stickyItem: View) {
+        measureChildWithMargins(stickyItem, 0, 0)
+        stickyItem.layout(
+            paddingLeft,
+            0,
+            width - paddingRight,
+            stickyItem.measuredHeight
+        )
+    }
+
+    /**
+     * Returns a no longer needed [stickyItemView] View to the [RecyclerView]'s [RecyclerView.RecycledViewPool]
+     * allowing it to be recycled and reused later after being re-binded in the Adapter.
+     *
+     * @param recycler [RecyclerView.Recycler] instance handling views recycling.
+     */
+    @VisibleForTesting
+    internal fun recycleStickyItem(recycler: RecyclerView.Recycler?) {
+        val stickyItem = stickyItemView ?: return
+        stickyItemView = null
+
+        stickyItem.translationY = 0f
+
+        listAdapter?.tearDownStickyItem(stickyItem)
+
+        // Stop ignoring sticky header so that it can be recycled.
+        stopIgnoringView(stickyItem)
+
+        removeView(stickyItem)
+        recycler?.recycleView(stickyItem)
+    }
+
+    @VisibleForTesting
+    internal fun setScrollState(position: Int, offset: Int) {
+        scrollPosition = position
+        scrollOffset = offset
+    }
+
+    /**
+     * Observer for any changes in the items displayed or even when the Adapter changes.
+     */
+    @VisibleForTesting
+    internal inner class ItemPositionsAdapterDataObserver : RecyclerView.AdapterDataObserver() {
+        override fun onChanged() = handleChange()
+
+        override fun onItemRangeInserted(positionStart: Int, itemCount: Int) = handleChange()
+
+        override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) = handleChange()
+
+        override fun onItemRangeMoved(fromPosition: Int, toPosition: Int, itemCount: Int) = handleChange()
+
+        @VisibleForTesting
+        internal fun handleChange() {
+            listAdapter?.let {
+                stickyItemPosition = calculateNewStickyItemPosition(it)
+
+                // Remove sticky header immediately. A layout will follow.
+                if (stickyItemView != null) {
+                    recycleStickyItem(null)
+                }
+            }
+        }
+
+        /**
+         * Get the position of the closest to the anchor sticky item.
+         *
+         * @return sticky item's index in the adapter or RecyclerView.NO_POSITION is such an item doesn't exists.
+         */
+        @VisibleForTesting
+        internal fun calculateNewStickyItemPosition(adapter: T): Int {
+            var newStickyItemPosition = RecyclerView.NO_POSITION
+
+            if (stickyItemPlacement == StickyItemPlacement.TOP) {
+                for (i in (itemCount - 1) downTo 0) {
+                    if (adapter.isStickyItem(i)) {
+                        newStickyItemPosition = i
+                    }
+                }
+            } else {
+                for (i in 0 until itemCount) {
+                    if (adapter.isStickyItem(i)) {
+                        newStickyItemPosition = i
+                    }
+                }
+            }
+
+            return newStickyItemPosition
+        }
+    }
+
+    companion object {
+        /**
+         * Get a new instance of a vertical [LinearLayoutManager] that can show one specific item
+         * as a fixed header / footer in the list, be that reversed or not.
+         *
+         * @param stickyItemPlacement whether the sticky item should be anchored to the top or bottom of the list
+         * @param reverseLayout when set to true, layouts from end to start.
+         */
+        fun <T> get(
+            context: Context,
+            stickyItemPlacement: StickyItemPlacement = StickyItemPlacement.TOP,
+            reverseLayout: Boolean = false
+        ): StickyItemsLinearLayoutManager<T>
+            where T : RecyclerView.Adapter<*>, T : StickyItemsAdapter {
+
+            return when (stickyItemPlacement) {
+                StickyItemPlacement.TOP -> StickyHeaderLinearLayoutManager(
+                    context,
+                    reverseLayout
+                )
+                StickyItemPlacement.BOTTOM -> StickyFooterLinearLayoutManager(
+                    context,
+                    reverseLayout
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Save / restore existing [RecyclerView] state and scrolling position and offset.
+ */
+@Parcelize
+@VisibleForTesting
+internal data class SavedState(
+    val superState: Parcelable?,
+    val scrollPosition: Int,
+    val scrollOffset: Int
+) : Parcelable

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuAdapterTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuAdapterTest.kt
@@ -4,11 +4,16 @@
 
 package mozilla.components.browser.menu
 
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -120,6 +125,48 @@ class BrowserMenuAdapterTest {
         assertEquals(6, adapter.interactiveCount)
     }
 
+    @Test
+    fun `GIVEN a stickyItem exists in the visible items WHEN isStickyItem is called THEN it returns true`() {
+        val items = listOf(
+            createMenuItem(1, { true }, { 1 }),
+            createMenuItem(3, { true }, { 10 }, true),
+            createMenuItem(4, { true }, { 5 }),
+            createMenuItem(3, { false }, { 3 }, true)
+        )
+
+        val adapter = BrowserMenuAdapter(testContext, items)
+
+        assertFalse(adapter.isStickyItem(0))
+        assertTrue(adapter.isStickyItem(1))
+        assertFalse(adapter.isStickyItem(2))
+        assertFalse(adapter.isStickyItem(3))
+        assertFalse(adapter.isStickyItem(4))
+    }
+
+    @Test
+    fun `GIVEN a BrowserMenu exists WHEN setupStickyItem is called THEN the item background color is set for the View parameter`() {
+        val adapter = BrowserMenuAdapter(testContext, emptyList())
+        val menu: BrowserMenu = mock()
+        menu.backgroundColor = Color.CYAN
+        adapter.menu = menu
+        val view = View(testContext)
+
+        adapter.setupStickyItem(view)
+
+        assertEquals(menu.backgroundColor, (view.background as ColorDrawable).color)
+    }
+
+    @Test
+    fun `GIVEN BrowserMenuAdapter WHEN tearDownStickyItem is called THEN the item background is reset to transparent`() {
+        val adapter = BrowserMenuAdapter(testContext, emptyList())
+        val view = View(testContext)
+        view.setBackgroundColor(Color.CYAN)
+
+        adapter.tearDownStickyItem(view)
+
+        assertEquals(Color.TRANSPARENT, (view.background as ColorDrawable).color)
+    }
+
     private fun List<BrowserMenuItem>.assertTrueForOne(predicate: (BrowserMenuItem) -> Boolean) {
         for (item in this) {
             if (predicate(item)) {
@@ -140,7 +187,8 @@ class BrowserMenuAdapterTest {
     private fun createMenuItem(
         layout: Int = 0,
         visible: () -> Boolean = { true },
-        interactiveCount: () -> Int = { 1 }
+        interactiveCount: () -> Int = { 1 },
+        isSticky: Boolean = false
     ): BrowserMenuItem {
         return object : BrowserMenuItem {
             override val visible = visible
@@ -152,6 +200,8 @@ class BrowserMenuAdapterTest {
             override fun bind(menu: BrowserMenu, view: View) {}
 
             override fun invalidate(view: View) {}
+
+            override val isSticky = isSticky
         }
     }
 }

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButtonTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButtonTest.kt
@@ -118,7 +118,7 @@ class BrowserMenuCompoundButtonTest {
         label: String,
         initialState: () -> Boolean = { false },
         listener: (Boolean) -> Unit
-    ) : BrowserMenuCompoundButton(label, false, initialState, listener) {
+    ) : BrowserMenuCompoundButton(label, false, false, initialState, listener) {
         override fun getLayoutResource(): Int = R.layout.mozac_browser_menu_item_simple
     }
 }

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/view/ExpandableLayoutTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/view/ExpandableLayoutTest.kt
@@ -589,8 +589,8 @@ class ExpandableLayoutTest {
         var expected = 0
         expected += viewHeightForEachProperty * 4 // marginTop + marginBottom + paddingTop + paddingBottom
         expected += listHeightForEachProperty * 4 // marginTop + marginBottom + paddingTop + paddingBottom
-        expected += itemHeightForEachProperty * 5 // height + marginTop + marginBottom + paddingTop + paddingBottom for the top item shown in entirety
-        expected += itemHeightForEachProperty * 2 // marginTop + paddingTop for the special view
+        expected += itemHeightForEachProperty * 3 // height + marginTop + marginBottom for the top item shown in entirety
+        expected += itemHeightForEachProperty // marginTop for the special view
         expected += itemHeightForEachProperty / 2 // as per the specs, show only half of the special view
         assertEquals(expected, result)
     }
@@ -617,10 +617,10 @@ class ExpandableLayoutTest {
         var expected = 0
         expected += viewHeightForEachProperty * 4 // marginTop + marginBottom + paddingTop + paddingBottom
         expected += listHeightForEachProperty * 4 // marginTop + marginBottom + paddingTop + paddingBottom
-        expected += itemHeightForEachProperty * 5 // height + marginTop + marginBottom + paddingTop + paddingBottom for the top item shown in entirety
-        expected += itemHeightForEachProperty * 2 // marginTop + paddingTop for the special view
+        expected += itemHeightForEachProperty * 3 // height + marginTop + marginBottom for the top item shown in entirety
+        expected += itemHeightForEachProperty // marginTop for the special view
         expected += itemHeightForEachProperty / 2 // as per the specs, show only half of the special view
-        expected += itemHeightForEachProperty     // height of the sticky item
+        expected += itemHeightForEachProperty // height of the sticky item
         assertEquals(expected, result)
     }
 
@@ -646,9 +646,9 @@ class ExpandableLayoutTest {
         var expected = 0
         expected += viewHeightForEachProperty * 4 // marginTop + marginBottom + paddingTop + paddingBottom
         expected += listHeightForEachProperty * 4 // marginTop + marginBottom + paddingTop + paddingBottom
-        expected += itemHeightForEachProperty * 5 // height + marginTop + marginBottom + paddingTop + paddingBottom for the top item shown in entirety
-        expected += itemHeightForEachProperty * 2 // marginTop + paddingTop for the special view
-        expected += itemHeightForEachProperty     // height of the sticky item
+        expected += itemHeightForEachProperty * 3 // height + marginTop + marginBottom for the top item shown in entirety
+        expected += itemHeightForEachProperty // marginTop for the special view
+        expected += itemHeightForEachProperty // height of the sticky item
         assertEquals(expected, result)
     }
 }

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/view/FakeStickyItemLayoutManager.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/view/FakeStickyItemLayoutManager.kt
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.view
+
+import android.content.Context
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+
+/**
+ * A default implementation of a the abstract [StickyItemsLinearLayoutManager] to be used in tests.
+ */
+open class FakeStickyItemLayoutManager<T> constructor(
+    context: Context,
+    internal val stickyItemPlacement: StickyItemPlacement = StickyItemPlacement.TOP,
+    reverseLayout: Boolean = false
+) : StickyItemsLinearLayoutManager<T>(
+    context,
+    stickyItemPlacement,
+    reverseLayout
+) where T : RecyclerView.Adapter<*>, T : StickyItemsAdapter {
+    override fun scrollToIndicatedPositionWithOffset(
+        position: Int,
+        offset: Int,
+        actuallyScrollToPositionWithOffset: (Int, Int) -> Unit
+    ) { }
+
+    override fun shouldStickyItemBeShownForCurrentPosition() = true
+
+    override fun getY(itemView: View) = 0f
+}

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/view/FakeStickyItemsAdapter.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/view/FakeStickyItemsAdapter.kt
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.view
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.support.test.mock
+
+/**
+ * A default implementation of [StickyItemsAdapter] to be used in tests.
+ */
+class FakeStickyItemsAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>(), StickyItemsAdapter {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder =
+        mock()
+
+    override fun getItemCount(): Int = 42
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {}
+
+    override fun isStickyItem(position: Int): Boolean = false
+}

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/view/StickyFooterLinearLayoutManagerTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/view/StickyFooterLinearLayoutManagerTest.kt
@@ -1,0 +1,189 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.view
+
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.support.test.mock
+import org.junit.Assert
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+
+class StickyFooterLinearLayoutManagerTest {
+    private lateinit var manager: StickyFooterLinearLayoutManager<FakeStickyItemsAdapter>
+
+    @Before
+    fun setup() {
+        manager = StickyFooterLinearLayoutManager(mock(), false)
+    }
+
+    @Test
+    fun `GIVEN scrollToIndicatedPositionWithOffset WHEN called with a position smaller than stickyItemPosition THEN will scroll to after that`() {
+        manager.stickyItemPosition = 5
+        var positionToScrollResult = -1
+        var offsetToScrollResult = -1
+        val scrollCallback: (Int, Int) -> Unit = { position, offset ->
+            positionToScrollResult = position
+            offsetToScrollResult = offset
+        }
+
+        manager.scrollToIndicatedPositionWithOffset(4, 22, scrollCallback)
+        Assert.assertEquals(5, positionToScrollResult)
+        Assert.assertEquals(22, offsetToScrollResult)
+
+        manager.scrollToIndicatedPositionWithOffset(0, 22, scrollCallback)
+        Assert.assertEquals(1, positionToScrollResult)
+        Assert.assertEquals(22, offsetToScrollResult)
+    }
+
+    @Test
+    fun `GIVEN scrollToIndicatedPositionWithOffset WHEN called with a position smaller than stickyItemPosition which is displayed THEN will scroll to that`() {
+        manager = spy(manager)
+        doReturn(mock<View>()).`when`(manager).getChildAt(ArgumentMatchers.anyInt())
+        manager.stickyItemPosition = 5
+        var positionToScrollResult = -1
+        var offsetToScrollResult = -1
+        val scrollCallback: (Int, Int) -> Unit = { position, offset ->
+            positionToScrollResult = position
+            offsetToScrollResult = offset
+        }
+
+        manager.scrollToIndicatedPositionWithOffset(4, 22, scrollCallback)
+        Assert.assertEquals(4, positionToScrollResult)
+        Assert.assertEquals(22, offsetToScrollResult)
+
+        manager.scrollToIndicatedPositionWithOffset(0, 22, scrollCallback)
+        Assert.assertEquals(0, positionToScrollResult)
+        Assert.assertEquals(22, offsetToScrollResult)
+    }
+
+    @Test
+    fun `GIVEN scrollToIndicatedPositionWithOffset WHEN called with a position equal to stickyItemPosition THEN will scroll to that position`() {
+        manager.stickyItemPosition = 6
+        var positionToScrollResult = -1
+        var offsetToScrollResult = -1
+        val scrollCallback: (Int, Int) -> Unit = { position, offset ->
+            positionToScrollResult = position
+            offsetToScrollResult = offset
+        }
+
+        manager.scrollToIndicatedPositionWithOffset(6, 22, scrollCallback)
+        Assert.assertEquals(6, positionToScrollResult)
+        Assert.assertEquals(22, offsetToScrollResult)
+    }
+
+    @Test
+    fun `GIVEN scrollToIndicatedPositionWithOffset WHEN called with a position bigger than stickyItemPosition THEN will scroll to that position`() {
+        manager.stickyItemPosition = 6
+        var positionToScrollResult = -1
+        var offsetToScrollResult = -1
+        val scrollCallback: (Int, Int) -> Unit = { position, offset ->
+            positionToScrollResult = position
+            offsetToScrollResult = offset
+        }
+
+        manager.scrollToIndicatedPositionWithOffset(7, 22, scrollCallback)
+        Assert.assertEquals(7, positionToScrollResult)
+        Assert.assertEquals(22, offsetToScrollResult)
+
+        manager.scrollToIndicatedPositionWithOffset(10, 22, scrollCallback)
+        Assert.assertEquals(10, positionToScrollResult)
+        Assert.assertEquals(22, offsetToScrollResult)
+
+        // Negative positions are handled by Android'd LayoutManager. We should pass any to it.
+        manager.scrollToIndicatedPositionWithOffset(3333, 22, scrollCallback)
+        Assert.assertEquals(3333, positionToScrollResult)
+        Assert.assertEquals(22, offsetToScrollResult)
+    }
+
+    @Test
+    fun `GIVEN stickyItemPosition not set WHEN shouldStickyItemBeShownForCurrentPosition is called THEN it returns false`() {
+        manager.stickyItemPosition = RecyclerView.NO_POSITION
+
+        Assert.assertFalse(manager.shouldStickyItemBeShownForCurrentPosition())
+    }
+
+    @Test
+    fun `GIVEN sticky item shown WHEN shouldStickyItemBeShownForCurrentPosition is called THEN it checks the item above the sticky one`() {
+        val manager = spy(manager)
+        manager.stickyItemPosition = 5
+        manager.stickyItemView = mock()
+        doReturn(10).`when`(manager).childCount
+
+        manager.shouldStickyItemBeShownForCurrentPosition()
+
+        verify(manager).getAdapterPositionForItemIndex(8)
+    }
+
+    @Test
+    fun `GIVEN sticky item not shown WHEN shouldStickyItemBeShownForCurrentPosition is called THEN it checks the bottom most item`() {
+        val manager = spy(manager)
+        manager.stickyItemPosition = 5
+        doReturn(10).`when`(manager).childCount
+
+        manager.shouldStickyItemBeShownForCurrentPosition()
+
+        verify(manager).getAdapterPositionForItemIndex(9)
+    }
+
+    @Test
+    fun ` GIVEN sticky item being the last shown item WHEN shouldStickyItemBeShownForCurrentPosition is called THEN it returns true`() {
+        val manager = spy(manager)
+        manager.stickyItemPosition = 5
+        doReturn(5).`when`(manager).getAdapterPositionForItemIndex(ArgumentMatchers.anyInt())
+
+        assertTrue(manager.shouldStickyItemBeShownForCurrentPosition())
+    }
+
+    @Test
+    fun ` GIVEN sticky item being scrolled upwards from the bottom WHEN shouldStickyItemBeShownForCurrentPosition is called THEN it returns false`() {
+        val manager = spy(manager)
+        manager.stickyItemPosition = 5
+
+        doReturn(6).`when`(manager).getAdapterPositionForItemIndex(ArgumentMatchers.anyInt())
+        assertFalse(manager.shouldStickyItemBeShownForCurrentPosition())
+
+        doReturn(60).`when`(manager).getAdapterPositionForItemIndex(ArgumentMatchers.anyInt())
+        assertFalse(manager.shouldStickyItemBeShownForCurrentPosition())
+    }
+
+    @Test
+    fun ` GIVEN sticky item being scrolled downwards offscreen WHEN shouldStickyItemBeShownForCurrentPosition is called THEN it returns true`() {
+        val manager = spy(manager)
+        manager.stickyItemPosition = 5
+
+        doReturn(4).`when`(manager).getAdapterPositionForItemIndex(ArgumentMatchers.anyInt())
+        assertTrue(manager.shouldStickyItemBeShownForCurrentPosition())
+
+        doReturn(0).`when`(manager).getAdapterPositionForItemIndex(ArgumentMatchers.anyInt())
+        assertTrue(manager.shouldStickyItemBeShownForCurrentPosition())
+    }
+
+    @Test
+    fun `GIVEN a default layout menu WHEN getY is called THEN it returns the translation needed to push the sticky item to the top`() {
+        manager = spy(manager)
+        val stickyView: View = mock()
+        doReturn(100).`when`(manager).height
+        doReturn(33).`when`(stickyView).height
+
+        Assert.assertEquals(67f, manager.getY(stickyView))
+    }
+
+    @Test
+    fun `GIVEN a reverseLayout menu WHEN getY is called THEN it returns 0 as the translation to be set for the sticky item`() {
+        manager = spy(StickyFooterLinearLayoutManager(mock(), true))
+        doReturn(100).`when`(manager).height
+        val stickyView: View = mock()
+        doReturn(33).`when`(stickyView).height
+
+        Assert.assertEquals(0f, manager.getY(stickyView))
+    }
+}

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/view/StickyHeaderLinearLayoutManagerTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/view/StickyHeaderLinearLayoutManagerTest.kt
@@ -1,0 +1,155 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.view
+
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
+
+class StickyHeaderLinearLayoutManagerTest {
+    private lateinit var manager: StickyHeaderLinearLayoutManager<FakeStickyItemsAdapter>
+
+    @Before
+    fun setup() {
+        manager = StickyHeaderLinearLayoutManager(mock(), false)
+    }
+
+    @Test
+    fun `GIVEN scrollToIndicatedPositionWithOffset WHEN called with a position bigger than stickyItemPosition THEN will scroll to before that`() {
+        manager.stickyItemPosition = 5
+        var positionToScrollResult = -1
+        var offsetToScrollResult = -1
+        val scrollCallback: (Int, Int) -> Unit = { position, offset ->
+            positionToScrollResult = position
+            offsetToScrollResult = offset
+        }
+
+        manager.scrollToIndicatedPositionWithOffset(6, 22, scrollCallback)
+        assertEquals(5, positionToScrollResult)
+        assertEquals(22, offsetToScrollResult)
+
+        manager.scrollToIndicatedPositionWithOffset(10, 22, scrollCallback)
+        assertEquals(9, positionToScrollResult)
+        assertEquals(22, offsetToScrollResult)
+    }
+
+    @Test
+    fun `GIVEN scrollToIndicatedPositionWithOffset WHEN called with a position equal to stickyItemPosition THEN will scroll to before that`() {
+        manager.stickyItemPosition = 6
+        var positionToScrollResult = -1
+        var offsetToScrollResult = -1
+        val scrollCallback: (Int, Int) -> Unit = { position, offset ->
+            positionToScrollResult = position
+            offsetToScrollResult = offset
+        }
+
+        manager.scrollToIndicatedPositionWithOffset(6, 22, scrollCallback)
+        assertEquals(5, positionToScrollResult)
+        assertEquals(22, offsetToScrollResult)
+    }
+
+    @Test
+    fun `GIVEN scrollToIndicatedPositionWithOffset WHEN called with a position smaller than stickyItemPosition THEN will scroll to that position`() {
+        manager.stickyItemPosition = 6
+        var positionToScrollResult = -1
+        var offsetToScrollResult = -1
+        val scrollCallback: (Int, Int) -> Unit = { position, offset ->
+            positionToScrollResult = position
+            offsetToScrollResult = offset
+        }
+
+        manager.scrollToIndicatedPositionWithOffset(5, 22, scrollCallback)
+        assertEquals(5, positionToScrollResult)
+        assertEquals(22, offsetToScrollResult)
+
+        manager.scrollToIndicatedPositionWithOffset(0, 22, scrollCallback)
+        assertEquals(0, positionToScrollResult)
+        assertEquals(22, offsetToScrollResult)
+
+        // Negative positions are handled by Android'd LayoutManager. We should pass any to it.
+        manager.scrollToIndicatedPositionWithOffset(-33, 22, scrollCallback)
+        assertEquals(-33, positionToScrollResult)
+        assertEquals(22, offsetToScrollResult)
+    }
+
+    @Test
+    fun `GIVEN stickyItemPosition not set WHEN shouldStickyItemBeShownForCurrentPosition is called THEN it returns false`() {
+        manager.stickyItemPosition = RecyclerView.NO_POSITION
+
+        assertFalse(manager.shouldStickyItemBeShownForCurrentPosition())
+    }
+
+    @Test
+    fun `GIVEN the top item is the sticky one WHEN shouldStickyItemBeShownForCurrentPosition is called THEN it returns true`() {
+        val manager = spy(manager)
+        manager.stickyItemPosition = 3
+        doReturn(3).`when`(manager).getAdapterPositionForItemIndex(0)
+
+        assertTrue(manager.shouldStickyItemBeShownForCurrentPosition())
+    }
+
+    @Test
+    fun `GIVEN items below the sticky item are scrolled upwards offscreen WHEN shouldStickyItemBeShownForCurrentPosition is called THEN it returns true`() {
+        val manager = spy(manager)
+        manager.stickyItemPosition = 3
+
+        doReturn(4).`when`(manager).getAdapterPositionForItemIndex(0)
+        assertTrue(manager.shouldStickyItemBeShownForCurrentPosition())
+
+        doReturn(5).`when`(manager).getAdapterPositionForItemIndex(0)
+        assertTrue(manager.shouldStickyItemBeShownForCurrentPosition())
+    }
+
+    @Test
+    fun `GIVEN items above the sticky item shown at top but ofsetted offscreen WHEN shouldStickyItemBeShownForCurrentPosition is called THEN it returns true`() {
+        val manager = spy(manager)
+        manager.stickyItemPosition = 3
+        doReturn(1).`when`(manager).getAdapterPositionForItemIndex(0)
+        val topMostItem: View = mock()
+        doReturn(topMostItem).`when`(manager).getChildAt(0)
+
+        doReturn(0).`when`(topMostItem).bottom
+        assertTrue(manager.shouldStickyItemBeShownForCurrentPosition())
+
+        doReturn(-5).`when`(topMostItem).bottom
+        assertTrue(manager.shouldStickyItemBeShownForCurrentPosition())
+    }
+
+    @Test
+    fun `GIVEN the sticky item is shown below the top of the list WHEN shouldStickyItemBeShownForCurrentPosition is called THEN it returns false`() {
+        val manager = spy(manager)
+        manager.stickyItemPosition = 3
+        doReturn(1).`when`(manager).getAdapterPositionForItemIndex(0)
+
+        assertFalse(manager.shouldStickyItemBeShownForCurrentPosition())
+    }
+
+    @Test
+    fun `GIVEN a default layout menu WHEN getY is called THEN it returns 0 as the translation to be set for the sticky item`() {
+        manager = spy(manager)
+        val stickyView: View = mock()
+        doReturn(100).`when`(manager).height
+        doReturn(33).`when`(stickyView).height
+
+        assertEquals(0f, manager.getY(stickyView))
+    }
+
+    @Test
+    fun `GIVEN a reverseLayout menu WHEN getY is called THEN it returns the translation needed to push the sticky item to the top`() {
+        manager = spy(StickyHeaderLinearLayoutManager(mock(), true))
+        doReturn(100).`when`(manager).height
+        val stickyView: View = mock()
+        doReturn(33).`when`(stickyView).height
+
+        assertEquals(67f, manager.getY(stickyView))
+    }
+}

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/view/StickyItemsLinearLayoutManagerTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/view/StickyItemsLinearLayoutManagerTest.kt
@@ -1,0 +1,623 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.view
+
+import android.graphics.PointF
+import android.view.View
+import android.view.ViewTreeObserver
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.LinearLayoutManager.INVALID_OFFSET
+import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.support.test.any
+import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.eq
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito
+import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.never
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+
+class StickyItemsLinearLayoutManagerTest {
+    // For shorter test names "StickyItemsLinearLayoutManager" is referred to as SILLM.
+
+    private lateinit var manager: FakeStickyItemLayoutManager<FakeStickyItemsAdapter>
+
+    @Before
+    fun setup() {
+        manager = FakeStickyItemLayoutManager(mock())
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN a new instance is contructed THEN it has specific default values`() {
+        assertEquals(RecyclerView.NO_POSITION, manager.stickyItemPosition)
+        assertEquals(RecyclerView.NO_POSITION, manager.scrollPosition)
+        assertEquals(0, manager.scrollOffset)
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN onAttachedToWindow called THEN it calls super and sets the new adapter`() {
+        manager = spy(manager)
+        val list = Mockito.mock(RecyclerView::class.java)
+
+        manager.onAttachedToWindow(list)
+
+        verify(manager).setAdapter(list.adapter)
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN onSaveInstanceState called THEN it returns a new SavedState with the scroll data`() {
+        manager.scrollPosition = 42
+        manager.scrollOffset = 422
+
+        val result: SavedState = manager.onSaveInstanceState() as SavedState
+
+        assertTrue(result.superState is LinearLayoutManager.SavedState)
+        assertEquals(42, result.scrollPosition)
+        assertEquals(422, result.scrollOffset)
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN onRestoreInstanceState is called with a new state THEN it updates scrollPosition and scrollOffset`() {
+        val newState = SavedState(
+            null,
+            scrollPosition = 222,
+            scrollOffset = 221
+        )
+
+        manager.onRestoreInstanceState(newState)
+
+        assertEquals(222, manager.scrollPosition)
+        assertEquals(221, manager.scrollOffset)
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN onRestoreInstanceState is called with a null state THEN scrollPosition and scrollOffset are left unchanged`() {
+        manager.onRestoreInstanceState(null)
+
+        assertEquals(RecyclerView.NO_POSITION, manager.scrollPosition)
+        assertEquals(0, manager.scrollOffset)
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN onLayoutChildren is called while in preLayout THEN it execute the super with the sticky item detached and not updates stickyItem`() {
+        manager = spy(manager)
+        val listState: RecyclerView.State = mock()
+        doReturn(true).`when`(listState).isPreLayout
+
+        manager.onLayoutChildren(mock(), listState)
+
+        verify(manager).restoreView<Unit>(any())
+        verify(manager, never()).updateStickyItem(any(), ArgumentMatchers.anyBoolean())
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN onLayoutChildren is called while not in preLayout THEN it execute the super with the sticky item detached and updates stickyItem`() {
+        manager = spy(manager)
+        val recycler: RecyclerView.Recycler = mock()
+        val listState: RecyclerView.State = mock()
+        doReturn(false).`when`(listState).isPreLayout
+        // Prevent side effects following the "manager.onLayoutChildren" call
+        doReturn(false).`when`(manager).shouldStickyItemBeShownForCurrentPosition()
+
+        manager.onLayoutChildren(recycler, listState)
+
+        verify(manager).restoreView<Unit>(any())
+        verify(manager).updateStickyItem(recycler, true)
+    }
+
+    @Test
+    fun `GIVEN A SILLM WHEN scrollVerticallyBy is called THEN it detaches the sticky item to scroll using parent and not updates the sticky item`() {
+        manager = spy(manager)
+
+        val result = manager.scrollVerticallyBy(0, mock(), mock())
+
+        verify(manager).restoreView<Int>(any())
+        verify(manager, never()).updateStickyItem(any(), ArgumentMatchers.anyBoolean())
+        assertEquals(0, result)
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN findLastVisibleItemPosition is called THEN it detaches the sticky item to call the super method`() {
+        manager = spy(manager)
+
+        manager.findLastVisibleItemPosition()
+
+        verify(manager).restoreView<Int>(any())
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN findFirstVisibleItemPosition is called THEN it detaches the sticky item to call the super method`() {
+        manager = spy(manager)
+
+        manager.findFirstVisibleItemPosition()
+
+        verify(manager).restoreView<Int>(any())
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN findFirstCompletelyVisibleItemPosition is called THEN it detaches the sticky item to call the super method`() {
+        manager = spy(manager)
+
+        manager.findFirstCompletelyVisibleItemPosition()
+
+        verify(manager).restoreView<Int>(any())
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN findLastCompletelyVisibleItemPosition is called THEN it detaches the sticky item to call the super method`() {
+        manager = spy(manager)
+
+        manager.findLastCompletelyVisibleItemPosition()
+
+        verify(manager).restoreView<Int>(any())
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN computeVerticalScrollExtent is called THEN it detaches the sticky item to call the super method`() {
+        manager = spy(manager)
+
+        manager.computeVerticalScrollExtent(mock())
+
+        verify(manager).restoreView<Int>(any())
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN computeVerticalScrollOffset is called THEN it detaches the sticky item to call the super method`() {
+        manager = spy(manager)
+
+        manager.computeVerticalScrollOffset(mock())
+
+        verify(manager).restoreView<Int>(any())
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN computeVerticalScrollRange is called THEN it detaches the sticky item to call the super method`() {
+        manager = spy(manager)
+
+        manager.computeVerticalScrollRange(mock())
+
+        verify(manager).restoreView<Int>(any())
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN computeScrollVectorForPosition is called THEN it detaches the sticky item to call the super method`() {
+        manager = spy(manager)
+
+        manager.computeScrollVectorForPosition(33)
+
+        verify(manager).restoreView<PointF>(any())
+    }
+
+    @Test
+    fun `GIVEN sticky item is null WHEN scrollToPosition is called THEN scrollToPositionWithOffset is not called`() {
+        manager = spy(manager)
+
+        manager.scrollToPosition(32)
+
+        verify(manager, never()).scrollToPositionWithOffset(ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())
+    }
+
+    @Test
+    fun `GIVEN sticky item is not null WHEN scrollToPosition is called THEN it calls scrollToPositionWithOffset with INVALID_OFFSET`() {
+        manager = spy(manager)
+        manager.stickyItemView = mock()
+
+        manager.scrollToPosition(32)
+
+        verify(manager).scrollToPositionWithOffset(32, INVALID_OFFSET)
+    }
+
+    @Test
+    fun `GIVEN sticky item is not null WHEN scrollToPositionWithOffset is called THEN scrollToIndicatedPositionWithOffset is delegated`() {
+        manager = spy(manager)
+        manager.stickyItemView = mock()
+
+        manager.scrollToPositionWithOffset(23, 9)
+
+        verify(manager).setScrollState(RecyclerView.NO_POSITION, INVALID_OFFSET)
+        verify(manager).scrollToIndicatedPositionWithOffset(eq(23), eq(9), any())
+        verify(manager).setScrollState(23, 9)
+    }
+
+    @Test
+    fun `GIVEN sticky item is null WHEN onFocusSearchFailed is called THEN it detaches the sticky item to call the super method`() {
+        manager = spy(manager)
+
+        manager.onFocusSearchFailed(mock(), 3, mock(), mock())
+
+        verify(manager).restoreView<View?>(any())
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN getAdapterPositionForItemIndex is called with a index for which there is no bound view THEN it returns -1`() {
+        assertEquals(RecyclerView.NO_POSITION, manager.getAdapterPositionForItemIndex(22))
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN getAdapterPositionForItemIndex is called with a index of an existing view THEN it returns it's absoluteAdapterPosition`() {
+        manager = spy(manager)
+        val params: RecyclerView.LayoutParams = mock()
+        doReturn(7).`when`(params).absoluteAdapterPosition
+        val view: View = mock()
+        doReturn(params).`when`(view).layoutParams
+        doReturn(view).`when`(manager).getChildAt(ArgumentMatchers.anyInt())
+
+        assertEquals(7, manager.getAdapterPositionForItemIndex(22))
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN setAdapter is called with a null argument THEN the current adapter and stickyItem are set to null`() {
+        val initialAdapter = mock<FakeStickyItemsAdapter>()
+        manager.listAdapter = initialAdapter
+
+        manager.setAdapter(null)
+
+        verify(initialAdapter).unregisterAdapterDataObserver(manager.stickyItemPositionsObserver)
+        assertNull(manager.listAdapter)
+        assertNull(manager.stickyItemView)
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN setAdapter is called with a new valid adapter THEN the current adapter is reset`() {
+        val initialAdapter: FakeStickyItemsAdapter = mock()
+        val newAdapter: FakeStickyItemsAdapter = mock()
+        manager.listAdapter = initialAdapter
+        manager.stickyItemPositionsObserver = spy(manager.stickyItemPositionsObserver)
+
+        manager.setAdapter(newAdapter)
+
+        verify(initialAdapter).unregisterAdapterDataObserver(manager.stickyItemPositionsObserver)
+        assertSame(newAdapter, manager.listAdapter)
+        verify(newAdapter).registerAdapterDataObserver(manager.stickyItemPositionsObserver)
+        verify(manager.stickyItemPositionsObserver).onChanged()
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN restoreView is called with a method parameter THEN the sticky item is detached, method executed, item reattached`() {
+        manager = spy(manager)
+        val stickyView: View = mock()
+        manager.stickyItemView = stickyView
+        doNothing().`when`(manager).detachView(any())
+        doNothing().`when`(manager).attachView(any())
+        val orderVerifier = Mockito.inOrder(manager)
+
+        val result = manager.restoreView { 3 }
+
+        orderVerifier.verify(manager).detachView(stickyView)
+        orderVerifier.verify(manager).attachView(stickyView)
+        assertEquals(3, result)
+    }
+
+    @Test
+    fun `GIVEN sticky item should not be shown WHEN updateStickyItem is called THEN the stickyItemView is recycled`() {
+        manager = spy(manager)
+        manager.stickyItemView = mock()
+        doReturn(false).`when`(manager).shouldStickyItemBeShownForCurrentPosition()
+        doNothing().`when`(manager).recycleStickyItem(any())
+        val recycler: RecyclerView.Recycler = mock()
+
+        manager.updateStickyItem(recycler, true)
+
+        verify(manager).recycleStickyItem(recycler)
+    }
+
+    @Test
+    fun `GIVEN sticky item should be shown and not exists WHEN updateStickyItem is called THEN a new stickyItemView is created`() {
+        manager = spy(manager)
+        doReturn(true).`when`(manager).shouldStickyItemBeShownForCurrentPosition()
+        doReturn(0f).`when`(manager).getY(any())
+        manager.stickyItemPosition = 42
+        val recycler: RecyclerView.Recycler = mock()
+        doNothing().`when`(manager).createStickyView(any(), ArgumentMatchers.anyInt())
+
+        manager.updateStickyItem(recycler, false)
+
+        verify(manager).createStickyView(recycler, 42)
+        verify(manager, never()).recycleStickyItem(any())
+    }
+
+    @Test
+    fun `GIVEN sticky item should be shown and exists WHEN updateStickyItem is called THEN another stickyItemView is not created`() {
+        manager = spy(manager)
+        val stickyView: View = mock()
+        manager.stickyItemView = stickyView
+        doReturn(true).`when`(manager).shouldStickyItemBeShownForCurrentPosition()
+        doReturn(0f).`when`(manager).getY(any())
+        manager.stickyItemPosition = 42
+        val recycler: RecyclerView.Recycler = mock()
+        doNothing().`when`(manager).createStickyView(any(), ArgumentMatchers.anyInt())
+
+        manager.updateStickyItem(recycler, false)
+
+        verify(manager, never()).createStickyView(any(), ArgumentMatchers.anyInt())
+        verify(manager, never()).recycleStickyItem(any())
+    }
+
+    @Test
+    fun `GIVEN sticky item should be shown WHEN updateStickyItem is called while layout THEN bindStickyItem is called`() {
+        manager = spy(manager)
+        val stickyView: View = mock()
+        manager.stickyItemView = stickyView
+        doReturn(true).`when`(manager).shouldStickyItemBeShownForCurrentPosition()
+        doReturn(0f).`when`(manager).getY(any())
+        doNothing().`when`(manager).createStickyView(any(), ArgumentMatchers.anyInt())
+        doNothing().`when`(manager).bindStickyItem(any())
+
+        manager.updateStickyItem(mock(), true)
+
+        verify(manager).bindStickyItem(stickyView)
+        verify(manager, never()).recycleStickyItem(any())
+    }
+
+    @Test
+    fun `GIVEN sticky item should be shown WHEN updateStickyItem is called while not layout THEN bindStickyItem is not called`() {
+        manager = spy(manager)
+        val stickyView: View = mock()
+        manager.stickyItemView = stickyView
+        doReturn(true).`when`(manager).shouldStickyItemBeShownForCurrentPosition()
+        doReturn(0f).`when`(manager).getY(any())
+        doNothing().`when`(manager).createStickyView(any(), ArgumentMatchers.anyInt())
+        doNothing().`when`(manager).bindStickyItem(any())
+
+        manager.updateStickyItem(mock(), false)
+
+        verify(manager, never()).bindStickyItem(any())
+        verify(manager, never()).recycleStickyItem(any())
+    }
+
+    @Test
+    fun `GIVEN sticky item should be shown and it's view exists WHEN updateStickyItem is called THEN the stickyItemView gets set a new Y translation`() {
+        manager = spy(manager)
+        val stickyView: View = mock()
+        manager.stickyItemView = stickyView
+        doReturn(true).`when`(manager).shouldStickyItemBeShownForCurrentPosition()
+        doReturn(44f).`when`(manager).getY(any())
+        doNothing().`when`(manager).createStickyView(any(), ArgumentMatchers.anyInt())
+
+        manager.updateStickyItem(mock(), false)
+
+        verify(manager).getY(stickyView)
+        verify(stickyView).translationY = 44f
+        verify(manager, never()).recycleStickyItem(any())
+    }
+
+    @Test
+    fun `GIVEN SILLM WHEN createStickyView is called THEN a new View is created and cached in stickyItemView`() {
+        manager = spy(manager)
+        val adapter: FakeStickyItemsAdapter = mock()
+        manager.listAdapter = adapter
+        val recycler: RecyclerView.Recycler = mock()
+        val newStickyView: View = mock()
+        doReturn(newStickyView).`when`(recycler).getViewForPosition(ArgumentMatchers.anyInt())
+        doNothing().`when`(manager).addView(any())
+        doNothing().`when`(manager).measureAndLayout(any())
+        doNothing().`when`(manager).ignoreView(any())
+
+        manager.createStickyView(recycler, 22)
+
+        verify(adapter).setupStickyItem(newStickyView)
+        verify(manager).addView(newStickyView)
+        verify(manager).measureAndLayout(newStickyView)
+        verify(manager).ignoreView(newStickyView)
+        assertSame(newStickyView, manager.stickyItemView)
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN bindStickyItem is called for a new View THEN the view is measured and layout`() {
+        manager = spy(manager)
+        val view: View = mock()
+        doNothing().`when`(manager).measureAndLayout(any())
+
+        manager.bindStickyItem(view)
+
+        verify(manager).measureAndLayout(view)
+    }
+
+    @Test
+    fun `GIVEN a pending scroll WHEN bindStickyItem is called for a new View THEN a OnGlobalLayoutListener is set`() {
+        manager = spy(manager)
+        manager.scrollPosition = 22
+        val view: View = mock()
+        val viewObserver: ViewTreeObserver = mock()
+        doReturn(viewObserver).`when`(view).viewTreeObserver
+        doNothing().`when`(manager).measureAndLayout(any())
+
+        manager.bindStickyItem(view)
+
+        verify(manager).measureAndLayout(view)
+        verify(viewObserver).addOnGlobalLayoutListener(any())
+    }
+
+    @Test
+    fun `GIVEN no pending scroll WHEN bindStickyItem is called for a new View THEN no OnGlobalLayoutListener is set`() {
+        manager = spy(manager)
+        val view: View = mock()
+        val viewObserver: ViewTreeObserver = mock()
+        doReturn(viewObserver).`when`(view).viewTreeObserver
+        doNothing().`when`(manager).measureAndLayout(any())
+
+        manager.bindStickyItem(view)
+
+        verify(manager).measureAndLayout(view)
+        verify(viewObserver, never()).addOnGlobalLayoutListener(any())
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN measureAndLayout is called for a new View THEN it is measured and layout`() {
+        manager = spy(manager)
+        val newView: View = mock()
+        doReturn(22).`when`(manager).paddingLeft
+        doReturn(33).`when`(manager).paddingRight
+        doReturn(100).`when`(manager).width
+        doReturn(112).`when`(newView).measuredHeight
+
+        doNothing().`when`(manager).measureChildWithMargins(any(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())
+
+        manager.measureAndLayout(newView)
+
+        verify(manager).measureChildWithMargins(newView, 0, 0)
+        verify(newView).layout(22, 0, (100 - 33), 112)
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN recycleStickyItem is called THEN the view holder is reset and allowed to be recycled`() {
+        manager = spy(manager)
+        val stickyView: View = mock()
+        manager.stickyItemView = stickyView
+        val adapter: FakeStickyItemsAdapter = mock()
+        manager.listAdapter = adapter
+        val recycler: RecyclerView.Recycler = mock()
+        val captor = argumentCaptor<View>()
+        doNothing().`when`(manager).stopIgnoringView(any())
+        doNothing().`when`(manager).removeView(any())
+
+        manager.recycleStickyItem(recycler)
+
+        verify(adapter).tearDownStickyItem(captor.capture())
+        verify(manager).stopIgnoringView(captor.value)
+        verify(manager).removeView(captor.value)
+        verify(recycler).recycleView(captor.value)
+    }
+
+    @Test
+    fun `GIVEN a SILLM WHEN is called with a new position and offset THEN they are cached in scrollPosition and scrollOffset properties`() {
+        manager.setScrollState(222, 333)
+
+        assertEquals(222, manager.scrollPosition)
+        assertEquals(333, manager.scrollOffset)
+    }
+
+    @Test
+    fun `GIVEN an ItemPositionsAdapterDataObserver WHEN onChanged is called THEN handleChange() is delegated`() {
+        val observer = spy(manager.stickyItemPositionsObserver)
+        manager.stickyItemPositionsObserver = observer
+
+        observer.onChanged()
+
+        verify(observer).handleChange()
+    }
+
+    @Test
+    fun `GIVEN an ItemPositionsAdapterDataObserver WHEN onItemRangeInserted is called THEN handleChange() is delegated`() {
+        val observer = spy(manager.stickyItemPositionsObserver)
+        manager.stickyItemPositionsObserver = observer
+
+        observer.onItemRangeInserted(22, 33)
+
+        verify(observer).handleChange()
+    }
+
+    @Test
+    fun `GIVEN an ItemPositionsAdapterDataObserver WHEN onItemRangeRemoved is called THEN handleChange() is delegated`() {
+        val observer = spy(manager.stickyItemPositionsObserver)
+        manager.stickyItemPositionsObserver = observer
+
+        observer.onItemRangeRemoved(22, 33)
+
+        verify(observer).handleChange()
+    }
+
+    @Test
+    fun `GIVEN an ItemPositionsAdapterDataObserver WHEN onItemRangeMoved is called THEN handleChange() is delegated`() {
+        val observer = spy(manager.stickyItemPositionsObserver)
+        manager.stickyItemPositionsObserver = observer
+
+        observer.onItemRangeMoved(11, 22, 33)
+
+        verify(observer).handleChange()
+    }
+
+    @Test
+    fun `GIVEN an ItemPositionsAdapterDataObserver WHEN handleChange is called THEN the sticky item is updated`() {
+        manager = spy(manager)
+        val adapter: FakeStickyItemsAdapter = mock()
+        manager.listAdapter = adapter
+        val stickyView: View = mock()
+        manager.stickyItemView = stickyView
+        val observer = spy(manager.ItemPositionsAdapterDataObserver())
+        manager.stickyItemPositionsObserver = observer
+        doReturn(23).`when`(observer).calculateNewStickyItemPosition(any())
+        doNothing().`when`(manager).recycleStickyItem(any())
+
+        observer.handleChange()
+
+        verify(observer).calculateNewStickyItemPosition(adapter)
+        verify(manager).recycleStickyItem(null)
+    }
+
+    @Test
+    fun `GIVEN an ItemPositionsAdapterDataObserver WHEN calculateNewStickyItemPosition is called for a top item the sticky position is first in adaptor`() {
+        manager = spy(FakeStickyItemLayoutManager(mock(), StickyItemPlacement.TOP))
+        val adapter: FakeStickyItemsAdapter = mock()
+        doReturn(true).`when`(adapter).isStickyItem(3)
+        doReturn(true).`when`(adapter).isStickyItem(5)
+        doReturn(10).`when`(manager).itemCount
+        manager.stickyItemPositionsObserver = manager.ItemPositionsAdapterDataObserver()
+
+        assertEquals(3, manager.stickyItemPositionsObserver.calculateNewStickyItemPosition(adapter))
+    }
+
+    @Test
+    fun `GIVEN an ItemPositionsAdapterDataObserver WHEN calculateNewStickyItemPosition is called for a bottom item the sticky position is last in adaptor`() {
+        manager = spy(FakeStickyItemLayoutManager(mock(), StickyItemPlacement.BOTTOM))
+        val adapter: FakeStickyItemsAdapter = mock()
+        doReturn(true).`when`(adapter).isStickyItem(3)
+        doReturn(true).`when`(adapter).isStickyItem(5)
+        doReturn(10).`when`(manager).itemCount
+        manager.stickyItemPositionsObserver = manager.ItemPositionsAdapterDataObserver()
+
+        assertEquals(5, manager.stickyItemPositionsObserver.calculateNewStickyItemPosition(adapter))
+    }
+
+    @Test
+    fun `WHEN get is called for a reversed StickyItemPlacement#TOP layout manager THEN a StickyHeaderLinearLayoutManager is returned`() {
+        val result = StickyItemsLinearLayoutManager.get<FakeStickyItemsAdapter>(
+            mock(), StickyItemPlacement.TOP, true
+        )
+
+        assertTrue(result is StickyHeaderLinearLayoutManager)
+        assertTrue(result.reverseLayout)
+    }
+
+    @Test
+    fun `WHEN get is called for a not reversed StickyItemPlacement#TOP layout manager THEN a StickyHeaderLinearLayoutManager is returned`() {
+        val result = StickyItemsLinearLayoutManager.get<FakeStickyItemsAdapter>(
+            mock(), StickyItemPlacement.TOP, false
+        )
+
+        assertTrue(result is StickyHeaderLinearLayoutManager)
+        assertFalse(result.reverseLayout)
+    }
+
+    @Test
+    fun `WHEN get is called for a reversed StickyItemPlacement#BOTTOM layout manager THEN a StickyFooterLinearLayoutManager is returned`() {
+        val result = StickyItemsLinearLayoutManager.get<FakeStickyItemsAdapter>(
+            mock(), StickyItemPlacement.BOTTOM, true
+        )
+
+        assertTrue(result is StickyFooterLinearLayoutManager)
+        assertTrue(result.reverseLayout)
+    }
+
+    @Test
+    fun `WHEN get is called for a not reversed StickyItemPlacement#BOTTOM layout manager THEN a StickyFooterLinearLayoutManager is returned`() {
+        val result = StickyItemsLinearLayoutManager.get<FakeStickyItemsAdapter>(
+            mock(), StickyItemPlacement.BOTTOM, false
+        )
+
+        assertTrue(result is StickyFooterLinearLayoutManager)
+        assertFalse(result.reverseLayout)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+
+* **browser-menu**:
+  * 🌟️ New StickyHeaderLinearLayoutManager and StickyFooterLinearLayoutManager that can be used to keep an item from being scrolled off-screen.
+
 * **browser-menu**:
   * 🚒 Bug fixed [issue #](https://github.com/mozilla-mobile/android-components/issues/10032) - Fix a recent issue with ExpandableLayout - user touches on an expanded menu might not have any effect on Samsung devices.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,7 @@ permalink: /changelog/
 
 * **browser-menu**:
   * 🌟️ New StickyHeaderLinearLayoutManager and StickyFooterLinearLayoutManager that can be used to keep an item from being scrolled off-screen.
+  * To use this set `isSticky = true` for any menu item of the menu. Since only one sticky item is supported if more items have this property the sticky item will be the one closest to the top the menu anchor.
 
 * **browser-menu**:
   * 🚒 Bug fixed [issue #](https://github.com/mozilla-mobile/android-components/issues/10032) - Fix a recent issue with ExpandableLayout - user touches on an expanded menu might not have any effect on Samsung devices.


### PR DESCRIPTION
Add support for having a specific menu item as a sticky header - won't be 
scrolled off screen to the top or as a sticky footer - won't be scrolled
offscreen past the list's bottom.
    
To use this the item intended to be sticky must be configured with the
"isSticky" property returning true.

https://user-images.githubusercontent.com/11428869/114214477-00de8480-996d-11eb-9993-d3c157da37f4.mp4



### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
