### PR TITLE
update height of readerview lightbutton

### DIFF
--- a/components/feature/readerview/src/main/res/layout/mozac_feature_readerview_view.xml
+++ b/components/feature/readerview/src/main/res/layout/mozac_feature_readerview_view.xml
@@ -137,7 +137,7 @@
             android:text="@string/mozac_feature_readerview_light"
             android:textColor="#220033"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="48dp"
             android:layout_marginStart="8dp"
             android:layout_marginEnd="8dp"
             android:layout_weight="1"


### PR DESCRIPTION
Resolves : https://github.com/mozilla-mobile/fenix/issues/18710
updating the height of lightbutton



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
