### PR TITLE
Workflow to sync strings

### DIFF
--- a/.github/workflows/sync-strings.yml
+++ b/.github/workflows/sync-strings.yml
@@ -6,7 +6,7 @@ name: "Sync Strings"
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 */4 * * *'
 
 jobs:
   main:

--- a/.github/workflows/sync-strings.yml
+++ b/.github/workflows/sync-strings.yml
@@ -6,7 +6,7 @@ name: "Sync Strings"
 
 on:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '0 0 * * *'
 
 jobs:
   main:

--- a/.github/workflows/sync-strings.yml
+++ b/.github/workflows/sync-strings.yml
@@ -1,0 +1,43 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+name: "Sync Strings"
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+
+jobs:
+  main:
+    name: "Sync Strings"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Discover A-C Version"
+        id: ac-version-for-fenix-beta
+        uses: mozilla-mobile/ac-version-for-fenix-beta@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Checkout Master Branch"
+        uses: actions/checkout@v2
+        with:
+          path: main
+          ref: master
+      - name: "Checkout Work Branch"
+        uses: actions/checkout@v2
+        with:
+          path: work
+          ref: "releases/${{ steps.ac-version-for-fenix-beta.outputs.major-ac-version }}.0"
+      - name: "Sync Strings"
+        uses: mozilla-mobile/sync-strings-action@1.0.0
+        with:
+          src: main
+          dst: work
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: work
+          branch: automation/sync-strings-${{ steps.ac-version-for-fenix-beta.outputs.major-ac-version }}
+          title: "Uplift Strings from master to releases/${{steps.ac-version-for-fenix-beta.outputs.major-ac-version}}.0"
+          body: "This (automated) PR sync strings from `master` to `releases/${{steps.ac-version-for-fenix-beta.outputs.major-ac-version}}.0`"


### PR DESCRIPTION
This patch introduces a `sync-strings.yml` _GitHub Actions Workflow_ that will periodically copy strings from `master` to the Android-Components release branch that is used in the current _Fenix Beta_.

 - It is configured to run daily at midnight UTC.
 - It will only create Pull Requests, but not land them. I'd like to start with manually reviewing these string sync PRs for a while and if we feel they are good to auto-land we can introduce a Mergify rule for that.
 - It will create PRs names `automation/string-sync-$RELEASE` and it will re-use the PR if new string changes need to be integrated and a previous PR has not been merged yet.

The _GitHub Actions_ used in this workflow are either from Mozilla or GItHUb, except for the [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request) one. I've read through the code and I think it is trustworthy. (Good version number, well maintained, high number of users, officially on the GitHub Marketplace - but let's have a discussion if we have doubts)

The string sync logic is in https://github.com/mozilla-mobile/sync-strings-action

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
