### PR TITLE
For #10108 - Reconcile list and adapter positions in ExpandableLayout

### DIFF
--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/view/ExpandableLayoutTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/view/ExpandableLayoutTest.kt
@@ -21,8 +21,10 @@ import androidx.core.view.marginLeft
 import androidx.core.view.marginRight
 import androidx.core.view.marginTop
 import androidx.core.view.updateLayoutParams
+import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.any
+import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
@@ -545,9 +547,10 @@ class ExpandableLayoutTest {
 
     @Test
     fun `GIVEN a list of items WHEN calculateCollapsedHeight is called with an item index not found in the items list THEN it returns the value of measuredHeight`() {
-        val list = FrameLayout(testContext).apply {
-            addView(mock())
-            addView(mock())
+        val list = RecyclerView(testContext).apply {
+            layoutManager = mock()
+            addView(mock(), mock<RecyclerView.LayoutParams>())
+            addView(mock(), mock<RecyclerView.LayoutParams>())
         }
         val wrappedView = FrameLayout(testContext).apply { addView(list) }
         val measuredHeight = -42
@@ -557,13 +560,16 @@ class ExpandableLayoutTest {
 
         doReturn(measuredHeight).`when`(expandableLayout).measuredHeight
 
+        doReturn(0).`when`(expandableLayout).getChildPositionForAdapterIndex(any(), anyInt())
         assertEquals(measuredHeight, expandableLayout.calculateCollapsedHeight())
 
         // Here we test the list of two items collapsed to the first.
         expandableLayout.lastVisibleItemIndexWhenCollapsed = 1
+        doReturn(1).`when`(expandableLayout).getChildPositionForAdapterIndex(any(), anyInt())
         assertEquals(0, expandableLayout.calculateCollapsedHeight())
 
         expandableLayout.lastVisibleItemIndexWhenCollapsed = 2
+        doReturn(2).`when`(expandableLayout).getChildPositionForAdapterIndex(any(), anyInt())
         assertEquals(measuredHeight, expandableLayout.calculateCollapsedHeight())
     }
 
@@ -572,9 +578,16 @@ class ExpandableLayoutTest {
         val viewHeightForEachProperty = 1_000
         val listHeightForEachProperty = 100
         val itemHeightForEachProperty = 10
+        val layoutManager = mock<RecyclerView.LayoutManager>()
+        // Although correctly set below (in configureWithHeight) the params get overwritten in RecyclerView when adding items
+        // So we need to fake RecyclerView's LayoutParams response.
+        val layoutParams = mock<RecyclerView.LayoutParams>()
+            .also { it.configureMarginResponse(itemHeightForEachProperty) }
+        doReturn(layoutParams).`when`(layoutManager).generateLayoutParams(any())
         // Adding Views and creating spies in two stages because otherwise
         // the addView call for a spy will not get us the expected result.
-        var list = FrameLayout(testContext).apply {
+        var list = RecyclerView(testContext).apply {
+            this.layoutManager = layoutManager
             addView(spy(View(testContext)).configureWithHeight(itemHeightForEachProperty))
             addView(spy(View(testContext)).configureWithHeight(itemHeightForEachProperty))
             addView(spy(View(testContext)).configureWithHeight(itemHeightForEachProperty))
@@ -582,7 +595,8 @@ class ExpandableLayoutTest {
         list = spy(list).configureWithHeight(listHeightForEachProperty)
         var wrappedView = FrameLayout(testContext).apply { addView(list) }
         wrappedView = spy(wrappedView).configureWithHeight(viewHeightForEachProperty)
-        val expandableLayout = ExpandableLayout.wrapContentInExpandableView(wrappedView, 1) { }
+        val expandableLayout = spy(ExpandableLayout.wrapContentInExpandableView(wrappedView, 1) { })
+        doReturn(1).`when`(expandableLayout).getChildPositionForAdapterIndex(any(), eq(1))
 
         val result = expandableLayout.calculateCollapsedHeight()
 
@@ -600,9 +614,16 @@ class ExpandableLayoutTest {
         val viewHeightForEachProperty = 1_000
         val listHeightForEachProperty = 100
         val itemHeightForEachProperty = 10
+        val layoutManager = mock<RecyclerView.LayoutManager>()
+        // Although correctly set below (in configureWithHeight) the params get overwritten in RecyclerView when adding items
+        // So we need to fake RecyclerView's LayoutParams response.
+        val layoutParams = mock<RecyclerView.LayoutParams>()
+            .also { it.configureMarginResponse(itemHeightForEachProperty) }
+        doReturn(layoutParams).`when`(layoutManager).generateLayoutParams(any())
         // Adding Views and creating spies in two stages because otherwise
         // the addView call for a spy will not get us the expected result.
-        var list = FrameLayout(testContext).apply {
+        var list = RecyclerView(testContext).apply {
+            this.layoutManager = layoutManager
             addView(spy(View(testContext)).configureWithHeight(itemHeightForEachProperty))
             addView(spy(View(testContext)).configureWithHeight(itemHeightForEachProperty))
             addView(spy(View(testContext)).configureWithHeight(itemHeightForEachProperty))
@@ -610,7 +631,9 @@ class ExpandableLayoutTest {
         list = spy(list).configureWithHeight(listHeightForEachProperty)
         var wrappedView = FrameLayout(testContext).apply { addView(list) }
         wrappedView = spy(wrappedView).configureWithHeight(viewHeightForEachProperty)
-        val expandableLayout = ExpandableLayout.wrapContentInExpandableView(wrappedView, 1, 2) { }
+        val expandableLayout = spy(ExpandableLayout.wrapContentInExpandableView(wrappedView, 1, 2) { })
+        doReturn(1).`when`(expandableLayout).getChildPositionForAdapterIndex(any(), eq(1))
+        doReturn(2).`when`(expandableLayout).getChildPositionForAdapterIndex(any(), eq(2))
 
         val result = expandableLayout.calculateCollapsedHeight()
 
@@ -629,9 +652,16 @@ class ExpandableLayoutTest {
         val viewHeightForEachProperty = 1_000
         val listHeightForEachProperty = 100
         val itemHeightForEachProperty = 10
+        val layoutManager = mock<RecyclerView.LayoutManager>()
+        // Although correctly set below (in configureWithHeight) the params get overwritten in RecyclerView when adding items
+        // So we need to fake RecyclerView's LayoutParams response.
+        val layoutParams = mock<RecyclerView.LayoutParams>()
+            .also { it.configureMarginResponse(itemHeightForEachProperty) }
+        doReturn(layoutParams).`when`(layoutManager).generateLayoutParams(any())
         // Adding Views and creating spies in two stages because otherwise
         // the addView call for a spy will not get us the expected result.
-        var list = FrameLayout(testContext).apply {
+        var list = RecyclerView(testContext).apply {
+            this.layoutManager = layoutManager
             addView(spy(View(testContext)).configureWithHeight(itemHeightForEachProperty))
             addView(spy(View(testContext)).configureWithHeight(itemHeightForEachProperty))
             addView(spy(View(testContext)).configureWithHeight(itemHeightForEachProperty))
@@ -639,7 +669,8 @@ class ExpandableLayoutTest {
         list = spy(list).configureWithHeight(listHeightForEachProperty)
         var wrappedView = FrameLayout(testContext).apply { addView(list) }
         wrappedView = spy(wrappedView).configureWithHeight(viewHeightForEachProperty)
-        val expandableLayout = ExpandableLayout.wrapContentInExpandableView(wrappedView, 1, 1) { }
+        val expandableLayout = spy(ExpandableLayout.wrapContentInExpandableView(wrappedView, 1, 1) { })
+        doReturn(1).`when`(expandableLayout).getChildPositionForAdapterIndex(any(), eq(1))
 
         val result = expandableLayout.calculateCollapsedHeight()
 
@@ -650,6 +681,28 @@ class ExpandableLayoutTest {
         expected += itemHeightForEachProperty // marginTop for the special view
         expected += itemHeightForEachProperty // height of the sticky item
         assertEquals(expected, result)
+    }
+
+    @Test
+    fun `GIVEN a RecyclerView with a set Adapter WHEN getChildPositionForAdapterIndex is called THEN it returns the list position of the item in Adapter`() {
+        val layoutManager = mock<RecyclerView.LayoutManager>()
+        // Although correctly set below (in configureWithHeight) the params get overwritten in RecyclerView when adding items
+        // So we need to fake RecyclerView's LayoutParams response.
+        val layoutParams = mock<RecyclerView.LayoutParams>()
+        doReturn(layoutParams).`when`(layoutManager).generateLayoutParams(any())
+        val list = spy(RecyclerView(testContext).apply {
+            this.layoutManager = layoutManager
+            addView(View(testContext).apply { setLayoutParams(ViewGroup.LayoutParams(10, 10)) })
+            addView(View(testContext).apply { setLayoutParams(ViewGroup.LayoutParams(10, 10)) })
+            addView(View(testContext).apply { setLayoutParams(ViewGroup.LayoutParams(10, 10)) })
+        })
+        val wrappedView = FrameLayout(testContext).apply { addView(list) }
+        val expandableLayout = spy(ExpandableLayout.wrapContentInExpandableView(wrappedView))
+        doReturn(3).`when`(list).getChildAdapterPosition(any())
+
+        assertEquals(-1, expandableLayout.getChildPositionForAdapterIndex(list, 2))
+        // We'll get a match based on the above "doReturn().." and adapterIndex: 3 for the first child.
+        assertEquals(0, expandableLayout.getChildPositionForAdapterIndex(list, 3))
     }
 }
 
@@ -665,4 +718,14 @@ fun <V> V.configureWithHeight(height: Int): V where V : View {
     setPadding(height, height, height, height)
 
     return this
+}
+
+/**
+ * Convenience method for setting the [margin] value to all LayoutParams margins.
+ */
+fun <T> T.configureMarginResponse(margin: Int) where T : ViewGroup.MarginLayoutParams {
+    this.topMargin = margin
+    this.rightMargin = margin
+    this.bottomMargin = margin
+    this.leftMargin = margin
 }


### PR DESCRIPTION
For #10108

ExpandableLayout uses adapter based indexes to identify children.
In dynamic menus with list items being hidden this could lead to invalid
calculations and even to exceptions for indexes bigger that the then current
children count in the list.

To reconcile this we'll calculate a valid lastVisibleItemIndexWhenCollapsed and
stickyItemIndex to be used before the operations in calculateCollapsedHeight().

Because the code is now clearly tightly coupled to RecyclerView this patch also
refactors a previous general ViewGroup type to RecyclerView and because of this
part of the previous tests needed some adjustments.

Result in Fenix (observe that upon accessing a subpage of wikipedia the menu contains 2 dynamic options: "Open in app" and "Report Site Issue...". This menu would crash before this patch): 

https://user-images.githubusercontent.com/11428869/115269667-368d2580-a144-11eb-90ed-314e14b3ca9e.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
