### PR TITLE
Issue #10084: Expose Nimbus API to retrieve all available experiments

### DIFF
--- a/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/Nimbus.kt
+++ b/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/Nimbus.kt
@@ -27,6 +27,7 @@ import mozilla.components.support.base.observer.ObserverRegistry
 import mozilla.components.support.base.utils.NamedThreadFactory
 import mozilla.components.support.locale.getLocaleTag
 import org.mozilla.experiments.nimbus.AppContext
+import org.mozilla.experiments.nimbus.AvailableExperiment
 import org.mozilla.experiments.nimbus.AvailableRandomizationUnits
 import org.mozilla.experiments.nimbus.Branch
 import org.mozilla.experiments.nimbus.EnrolledExperiment
@@ -55,6 +56,13 @@ interface NimbusApi : Observable<NimbusApi.Observer> {
      * @return A list of [EnrolledExperiment]s
      */
     fun getActiveExperiments(): List<EnrolledExperiment> = listOf()
+
+    /**
+     * Get the list of available experiments
+     *
+     * @return A list of [AvailableExperiment]s
+     */
+    fun getAvailableExperiments(): List<AvailableExperiment> = listOf()
 
     /**
      * Get the currently enrolled branch for the given experiment
@@ -293,6 +301,10 @@ class Nimbus(
     @WorkerThread
     override fun getActiveExperiments(): List<EnrolledExperiment> =
         nimbus.getActiveExperiments()
+
+    @WorkerThread
+    override fun getAvailableExperiments(): List<AvailableExperiment> =
+        nimbus.getAvailableExperiments()
 
     override fun getExperimentBranch(experimentId: String): String? {
         recordExposure(experimentId)


### PR DESCRIPTION
Fixes #10084. This is blocked on landing waiting for AS 75.1.0 to land.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
