### PR TITLE
Closes #10082: Update port delegate when registering new message handler

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -65,6 +65,8 @@ class GeckoWebExtension(
             }
         }
 
+        connectedPorts[PortId(name)]?.nativePort?.setDelegate(portDelegate)
+
         val messageDelegate = object : GeckoNativeWebExtension.MessageDelegate {
 
             override fun onConnect(port: GeckoNativeWebExtension.Port) {
@@ -106,6 +108,8 @@ class GeckoWebExtension(
                 }
             }
         }
+
+        connectedPorts[PortId(name, session)]?.nativePort?.setDelegate(portDelegate)
 
         val messageDelegate = object : GeckoNativeWebExtension.MessageDelegate {
 

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -48,6 +48,7 @@ class GeckoWebExtensionTest {
         val runtime: GeckoRuntime = mock()
         val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val messageHandler: MessageHandler = mock()
+        val updatedMessageHandler: MessageHandler = mock()
         val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
         val portCaptor = argumentCaptor<Port>()
         val portDelegateCaptor = argumentCaptor<WebExtension.PortDelegate>()
@@ -87,6 +88,12 @@ class GeckoWebExtensionTest {
         verify(messageHandler).onPortMessage(eq(portMessage), portCaptor.capture())
         assertSame(port, (portCaptor.value as GeckoPort).nativePort)
 
+        // Verify content message handler can be updated and receive messages
+        extension.registerBackgroundMessageHandler("mozacTest", updatedMessageHandler)
+        verify(port, times(2)).setDelegate(portDelegateCaptor.capture())
+        portDelegateCaptor.value.onPortMessage(portMessage, port)
+        verify(updatedMessageHandler).onPortMessage(eq(portMessage), portCaptor.capture())
+
         // Verify disconnected port is forwarded to message handler if connected
         portDelegate.onDisconnect(mock())
         verify(messageHandler, never()).onPortDisconnected(portCaptor.capture())
@@ -103,6 +110,7 @@ class GeckoWebExtensionTest {
         val webExtensionSessionController: WebExtension.SessionController = mock()
         val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val messageHandler: MessageHandler = mock()
+        val updatedMessageHandler: MessageHandler = mock()
         val session: GeckoEngineSession = mock()
         val geckoSession: GeckoSession = mock()
         val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
@@ -148,6 +156,12 @@ class GeckoWebExtensionTest {
         verify(messageHandler).onPortMessage(eq(portMessage), portCaptor.capture())
         assertSame(port, (portCaptor.value as GeckoPort).nativePort)
         assertSame(session, (portCaptor.value as GeckoPort).engineSession)
+
+        // Verify content message handler can be updated and receive messages
+        extension.registerContentMessageHandler(session, "mozacTest", updatedMessageHandler)
+        verify(port, times(2)).setDelegate(portDelegateCaptor.capture())
+        portDelegateCaptor.value.onPortMessage(portMessage, port)
+        verify(updatedMessageHandler).onPortMessage(eq(portMessage), portCaptor.capture())
 
         // Verify disconnected port is forwarded to message handler if connected
         portDelegate.onDisconnect(mock())


### PR DESCRIPTION
When we're setting a new message handler it's possible there's already a port connected which currently will use the old port delegate and therefore old message handler. This is because we're only updating the port delegate when the port connects which isn't correct.