### PR TITLE
For #10133 - BrowserMenuCompoundButton now reports the right dimensions 

### DIFF
--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButtonTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButtonTest.kt
@@ -6,18 +6,26 @@ package mozilla.components.browser.menu.item
 
 import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewTreeObserver
 import android.widget.CheckBox
+import androidx.appcompat.widget.SwitchCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
 import mozilla.components.concept.menu.candidate.CompoundMenuCandidate
+import mozilla.components.support.test.any
+import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
@@ -112,6 +120,64 @@ class BrowserMenuCompoundButtonTest {
                 listener = listener
             ).asCandidate(testContext)
         )
+    }
+
+    @Test
+    fun `GIVEN the View is attached to Window WHEN bind is called THEN the layout direction is not updated`() {
+        val item = SimpleTestBrowserCompoundButton("Hello") {}
+        val menu = mock(BrowserMenu::class.java)
+        val view: SwitchCompat = mock()
+        doReturn(true).`when`(view).isAttachedToWindow
+        doReturn(mock<ViewTreeObserver>()).`when`(view).viewTreeObserver
+
+        item.bind(menu, view)
+
+        verify(view, never()).layoutDirection = ArgumentMatchers.anyInt()
+    }
+
+    @Test
+    fun `GIVEN the View is not attached to Window WHEN bind is called THEN the layout direction is changed to locale`() {
+        val item = SimpleTestBrowserCompoundButton("Hello") {}
+        val menu = mock(BrowserMenu::class.java)
+        val view: SwitchCompat = mock()
+        doReturn(false).`when`(view).isAttachedToWindow
+        doReturn(mock<ViewTreeObserver>()).`when`(view).viewTreeObserver
+
+        item.bind(menu, view)
+
+        verify(view).layoutDirection = View.LAYOUT_DIRECTION_LOCALE
+    }
+
+    @Test
+    fun `GIVEN the View is not attached to Window WHEN bind is called THEN the a viewTreeObserver for preDraw is set`() {
+        val item = SimpleTestBrowserCompoundButton("Hello") {}
+        val menu = mock(BrowserMenu::class.java)
+        val view: SwitchCompat = mock()
+        val viewTreeObserver: ViewTreeObserver = mock()
+        doReturn(false).`when`(view).isAttachedToWindow
+        doReturn(viewTreeObserver).`when`(view).viewTreeObserver
+
+        item.bind(menu, view)
+
+        verify(viewTreeObserver).addOnPreDrawListener(any())
+    }
+
+    @Test
+    fun `GIVEN a view with updated layout direction WHEN it is about to be drawn THEN the layout direction reset`() {
+        val item = SimpleTestBrowserCompoundButton("Hello") {}
+        val menu = mock(BrowserMenu::class.java)
+        val view: SwitchCompat = mock()
+        val viewTreeObserver: ViewTreeObserver = mock()
+        doReturn(false).`when`(view).isAttachedToWindow
+        doReturn(viewTreeObserver).`when`(view).viewTreeObserver
+        val captor = argumentCaptor<ViewTreeObserver.OnPreDrawListener>()
+
+        item.bind(menu, view)
+        verify(viewTreeObserver).addOnPreDrawListener(captor.capture())
+
+        captor.value.onPreDraw()
+        verify(viewTreeObserver).removeOnPreDrawListener(captor.value)
+        verify(view).layoutDirection = View.LAYOUT_DIRECTION_INHERIT
     }
 
     class SimpleTestBrowserCompoundButton(

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **browser-menu**:
+  * 🚒 Bug fixed [issue #10032](https://github.com/mozilla-mobile/android-components/issues/10032) - A BrowserMenuCompoundButton used in our BrowserMenu setup with a DynamicWidthRecyclerView is not clipped anymore.
+
 * **feature-downloads**:
   * ⚠️ **This is a breaking change**: `AbstractFetchDownloadService.openFile()` changed its signature from `AbstractFetchDownloadService.openFile(context: Context, filePath: String, contentType: String?)` to `AbstractFetchDownloadService.openFile(applicationContext: Context, download: DownloadState)`.
   * 🚒 Bug fixed [issue #](https://github.com/mozilla-mobile/android-components/issues/10138) - The downloaded files cannot be seen.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -51,9 +51,9 @@ permalink: /changelog/
 * **browser-menu**:
   * 🌟️ New StickyHeaderLinearLayoutManager and StickyFooterLinearLayoutManager that can be used to keep an item from being scrolled off-screen.
   * To use this set `isSticky = true` for any menu item of the menu. Since only one sticky item is supported if more items have this property the sticky item will be the one closest to the top the menu anchor.
-  * 🚒 Bug fixed [issue #](https://github.com/mozilla-mobile/android-components/issues/10032) - Fix a recent issue with ExpandableLayout - user touches on an expanded menu might not have any effect on Samsung devices.
-  * 🚒 Bug fixed [issue #](https://github.com/mozilla-mobile/android-components/issues/10005) - Fix a recent issue with BrowserMenu#show() - endOfMenuAlwaysVisible not being applied.
-  * 🚒 Bug fixed [issue #](https://github.com/mozilla-mobile/android-components/issues/9922) - The browser menu will have it's dynamic width calculated only once, before the first layout.
+  * 🚒 Bug fixed [issue #10032](https://github.com/mozilla-mobile/android-components/issues/10032) - Fix a recent issue with ExpandableLayout - user touches on an expanded menu might not have any effect on Samsung devices.
+  * 🚒 Bug fixed [issue #10005](https://github.com/mozilla-mobile/android-components/issues/10005) - Fix a recent issue with BrowserMenu#show() - endOfMenuAlwaysVisible not being applied.
+  * 🚒 Bug fixed [issue #9922](https://github.com/mozilla-mobile/android-components/issues/9922) - The browser menu will have it's dynamic width calculated only once, before the first layout.
   * 🌟️ BrowserMenu support a bottom collapsed/expandable layout through a new ExpandableLayout that will wrap a menu layout before being used in a PopupWindow and automatically allow the collapse/expand behaviors.
   * To use this set `isCollapsingMenuLimit = true` for any menu item of a bottom anchored menu.
   * 🌟️ `WebExtensionBrowserMenuBuilder` provide a new way to customize how items look like via `Style()` where the `tintColor`, `backPressDrawable` and `addonsManagerDrawable` can be customized.


### PR DESCRIPTION
A BrowserMenuCompoundButton setup with compound drawables and used in our
BrowserMenu configured with a DynamicWidthRecyclerVIew will return a width
smaller with the size + padding of the compound drawables.

By replacing the default `inherit` layout direction for the initial onMeasure
we ensure the menu will also count the bounds of the compound drawables.

More details in the ticket.

Result in Fenix:

| Before | After |
| -- | -- |
| <img src="https://user-images.githubusercontent.com/43795363/114916514-7ffb0f00-9dea-11eb-84ac-38e3468091fa.png" /> | <img src="https://user-images.githubusercontent.com/11428869/115690539-cfe75200-a365-11eb-9493-607c18a2b037.png" /> |




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
