### PR TITLE
Issue #10140: Introduce GeckoStorageDelegateWrapper to replace GeckoLoginDelegateWrapper 

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/autofill/GeckoAutocompleteStorageDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/autofill/GeckoAutocompleteStorageDelegate.kt
@@ -9,30 +9,65 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import mozilla.components.browser.engine.gecko.ext.toLogin
 import mozilla.components.browser.engine.gecko.ext.toLoginEntry
+import mozilla.components.concept.storage.CreditCard
+import mozilla.components.concept.storage.CreditCardsAddressesStorageDelegate
 import mozilla.components.concept.storage.Login
 import mozilla.components.concept.storage.LoginStorageDelegate
 import org.mozilla.geckoview.Autocomplete
 import org.mozilla.geckoview.GeckoResult
 
 /**
- * This class exists only to convert incoming [LoginEntry] arguments into [Login]s, then forward
- * them to [storageDelegate]. This allows us to avoid duplicating [LoginStorageDelegate] code
- * between different versions of GeckoView, by duplicating this wrapper instead.
+ * Gecko credit card and login storage delegate that handles runtime storage requests. This allows
+ * the Gecko runtime to call the underlying storage to handle requests for fetching, saving and
+ * updating of autocomplete items in the storage.
+ *
+ * @param creditCardsAddressesStorageDelegate An instance of [CreditCardsAddressesStorageDelegate].
+ * Provides methods for retrieving [CreditCard]s from the underlying storage.
+ * @param loginStorageDelegate An instance of [LoginStorageDelegate].
+ * Provides read/write methods for the [Login] storage.
  */
-@Suppress("Deprecation")
-// This will be addressed in https://github.com/mozilla-mobile/android-components/issues/10093
-class GeckoLoginDelegate(private val storageDelegate: LoginStorageDelegate) :
-    Autocomplete.LoginStorageDelegate {
+class GeckoAutocompleteStorageDelegate(
+    private val creditCardsAddressesStorageDelegate: CreditCardsAddressesStorageDelegate,
+    private val loginStorageDelegate: LoginStorageDelegate
+) : Autocomplete.StorageDelegate {
+
+    override fun onCreditCardFetch(): GeckoResult<Array<Autocomplete.CreditCard>>? {
+        val result = GeckoResult<Array<Autocomplete.CreditCard>>()
+
+        GlobalScope.launch(IO) {
+            val creditCards = creditCardsAddressesStorageDelegate.onCreditCardsFetch().await()
+                .mapNotNull {
+                    val plaintextCardNumber =
+                        creditCardsAddressesStorageDelegate.decrypt(it.encryptedCardNumber)?.number
+
+                    if (plaintextCardNumber == null) {
+                        null
+                    } else {
+                        Autocomplete.CreditCard.Builder()
+                            .guid(it.guid)
+                            .name(it.billingName)
+                            .number(plaintextCardNumber)
+                            .expirationMonth(it.expiryMonth.toString())
+                            .expirationYear(it.expiryYear.toString())
+                            .build()
+                    }
+                }
+                .toTypedArray()
+            result.complete(creditCards)
+        }
+
+        return result
+    }
 
     override fun onLoginSave(login: Autocomplete.LoginEntry) {
-        storageDelegate.onLoginSave(login.toLogin())
+        loginStorageDelegate.onLoginSave(login.toLogin())
     }
 
     override fun onLoginFetch(domain: String): GeckoResult<Array<Autocomplete.LoginEntry>>? {
         val result = GeckoResult<Array<Autocomplete.LoginEntry>>()
 
         GlobalScope.launch(IO) {
-            val storedLogins = storageDelegate.onLoginFetch(domain)
+            val storedLogins = loginStorageDelegate.onLoginFetch(domain)
 
             val logins = storedLogins.await()
                 .map { it.toLoginEntry() }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/autofill/GeckoAutocompleteStorageDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/autofill/GeckoAutocompleteStorageDelegate.kt
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.autofill
+
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import mozilla.components.browser.engine.gecko.ext.toLogin
+import mozilla.components.browser.engine.gecko.ext.toLoginEntry
+import mozilla.components.concept.storage.Login
+import mozilla.components.concept.storage.LoginStorageDelegate
+import org.mozilla.geckoview.Autocomplete
+import org.mozilla.geckoview.GeckoResult
+
+/**
+ * This class exists only to convert incoming [LoginEntry] arguments into [Login]s, then forward
+ * them to [storageDelegate]. This allows us to avoid duplicating [LoginStorageDelegate] code
+ * between different versions of GeckoView, by duplicating this wrapper instead.
+ */
+@Suppress("Deprecation")
+// This will be addressed in https://github.com/mozilla-mobile/android-components/issues/10093
+class GeckoLoginDelegate(private val storageDelegate: LoginStorageDelegate) :
+    Autocomplete.LoginStorageDelegate {
+
+    override fun onLoginSave(login: Autocomplete.LoginEntry) {
+        storageDelegate.onLoginSave(login.toLogin())
+    }
+
+    override fun onLoginFetch(domain: String): GeckoResult<Array<Autocomplete.LoginEntry>>? {
+        val result = GeckoResult<Array<Autocomplete.LoginEntry>>()
+
+        GlobalScope.launch(IO) {
+            val storedLogins = storageDelegate.onLoginFetch(domain)
+
+            val logins = storedLogins.await()
+                .map { it.toLoginEntry() }
+                .toTypedArray()
+
+            result.complete(logins)
+        }
+
+        return result
+    }
+}

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/autofill/GeckoLoginDelegateWrapper.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/autofill/GeckoLoginDelegateWrapper.kt
@@ -7,6 +7,8 @@ package mozilla.components.browser.engine.gecko.autofill
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import mozilla.components.browser.engine.gecko.ext.toLogin
+import mozilla.components.browser.engine.gecko.ext.toLoginEntry
 import mozilla.components.concept.storage.Login
 import mozilla.components.concept.storage.LoginStorageDelegate
 import org.mozilla.geckoview.Autocomplete
@@ -42,27 +44,3 @@ class GeckoLoginDelegateWrapper(private val storageDelegate: LoginStorageDelegat
         return result
     }
 }
-
-/**
- * Converts a GeckoView [LoginStorage.LoginEntry] to an Android Components [Login]
- */
-private fun Autocomplete.LoginEntry.toLogin() = Login(
-    guid = guid,
-    origin = origin,
-    formActionOrigin = formActionOrigin,
-    httpRealm = httpRealm,
-    username = username,
-    password = password
-)
-
-/**
- * Converts an Android Components [Login] to a GeckoView [LoginStorage.LoginEntry]
- */
-private fun Login.toLoginEntry() = Autocomplete.LoginEntry.Builder()
-    .guid(guid)
-    .origin(origin)
-    .formActionOrigin(formActionOrigin)
-    .httpRealm(httpRealm)
-    .username(username)
-    .password(password)
-    .build()

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/ext/Login.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/ext/Login.kt
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.ext
+
+import mozilla.components.concept.storage.Login
+import org.mozilla.geckoview.Autocomplete
+
+/**
+ * Converts a GeckoView [Autocomplete.LoginEntry] to an Android Components [Login].
+ */
+fun Autocomplete.LoginEntry.toLogin() = Login(
+    guid = guid,
+    origin = origin,
+    formActionOrigin = formActionOrigin,
+    httpRealm = httpRealm,
+    username = username,
+    password = password
+)
+
+/**
+ * Converts an Android Components [Login] to a GeckoView [Autocomplete.LoginEntry].
+ */
+fun Login.toLoginEntry() = Autocomplete.LoginEntry.Builder()
+    .guid(guid)
+    .origin(origin)
+    .formActionOrigin(formActionOrigin)
+    .httpRealm(httpRealm)
+    .username(username)
+    .password(password)
+    .build()

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -8,6 +8,8 @@ import android.content.Context
 import android.net.Uri
 import androidx.annotation.VisibleForTesting
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.browser.engine.gecko.ext.toLogin
+import mozilla.components.browser.engine.gecko.ext.toLoginEntry
 import mozilla.components.concept.engine.prompt.Choice
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.prompt.PromptRequest.MenuChoice
@@ -56,24 +58,6 @@ typealias AC_FILE_FACING_MODE = PromptRequest.File.FacingMode
  */
 internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSession) :
     PromptDelegate {
-
-    private fun Autocomplete.LoginEntry.toLogin() = Login(
-        guid = guid,
-        origin = origin,
-        formActionOrigin = formActionOrigin,
-        httpRealm = httpRealm,
-        username = username,
-        password = password
-    )
-
-    private fun Login.toLoginEntry() = Autocomplete.LoginEntry.Builder()
-        .guid(guid)
-        .origin(origin)
-        .formActionOrigin(formActionOrigin)
-        .httpRealm(httpRealm)
-        .username(username)
-        .password(password)
-        .build()
 
     override fun onLoginSave(
         session: GeckoSession,

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.engine.gecko.prompt
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.browser.engine.gecko.ext.toLoginEntry
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.prompt.Choice
 import mozilla.components.concept.engine.prompt.PromptRequest
@@ -753,18 +754,6 @@ class GeckoPromptDelegateTest {
         usernameField = usernameField,
         passwordField = passwordField
     )
-
-    /**
-     * Converts an Android Components [Login] to a GeckoView [LoginStorage.LoginEntry]
-     */
-    private fun Login.toLoginEntry() = Autocomplete.LoginEntry.Builder()
-        .guid(guid)
-        .origin(origin)
-        .formActionOrigin(formActionOrigin)
-        .httpRealm(httpRealm)
-        .username(username)
-        .password(password)
-        .build()
 
     @Test
     fun `Calling onAuthPrompt must provide an Authentication PromptRequest`() {

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
@@ -104,6 +104,46 @@ interface CreditCardsAddressesStorage {
      * @param guid Unique identifier for the desired address.
      */
     suspend fun touchAddress(guid: String)
+
+    /**
+     * Returns an instance of [CreditCardCrypto] that knows how to encrypt and decrypt credit card
+     * numbers.
+     *
+     * @return [CreditCardCrypto] instance.
+     */
+    fun getCreditCardCrypto(): CreditCardCrypto
+}
+
+/**
+ * An interface that defines methods for encrypting and decrypting a credit card number.
+ */
+interface CreditCardCrypto : KeyProvider {
+
+    /**
+     * Encrypt a [CreditCardNumber.Plaintext] using the provided key. A `null` result means a
+     * bad key was provided. In that case caller should obtain a new key and try again.
+     *
+     * @param key The encryption key to encrypt the plaintext credit card number.
+     * @param plaintextCardNumber A plaintext credit card number to be encrypted.
+     * @return An encrypted credit card number or `null` if a bad [key] was provided.
+     */
+    fun encrypt(
+        key: ManagedKey,
+        plaintextCardNumber: CreditCardNumber.Plaintext
+    ): CreditCardNumber.Encrypted?
+
+    /**
+     * Decrypt a [CreditCardNumber.Encrypted] using the provided key. A `null` result means a
+     * bad key was provided. In that case caller should obtain a new key and try again.
+     *
+     * @param key The encryption key to decrypt the decrypt credit card number.
+     * @param encryptedCardNumber An encrypted credit card number to be decrypted.
+     * @return A plaintext, non-encrypted credit card number or `null` if a bad [key] was provided.
+     */
+    fun decrypt(
+        key: ManagedKey,
+        encryptedCardNumber: CreditCardNumber.Encrypted
+    ): CreditCardNumber.Plaintext?
 }
 
 /**
@@ -272,6 +312,15 @@ data class UpdatableAddressFields(
  * An instance of this should be attached to the Gecko runtime in order to be used.
  */
 interface CreditCardsAddressesStorageDelegate {
+
+    /**
+     * Decrypt a [CreditCardNumber.Encrypted] into its plaintext equivalent or `null` if
+     * it fails to decrypt.
+     *
+     * @param encryptedCardNumber An encrypted credit card number to be decrypted.
+     * @return A plaintext, non-encrypted credit card number.
+     */
+    fun decrypt(encryptedCardNumber: CreditCardNumber.Encrypted): CreditCardNumber.Plaintext?
 
     /**
      * Returns all stored addresses. This is called when the engine believes an address field

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/KeyProvider.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/KeyProvider.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.lib.dataprotect
+package mozilla.components.concept.storage
 
 /**
  * Knows how to provide a [ManagedKey].

--- a/components/service/firefox-accounts/build.gradle
+++ b/components/service/firefox-accounts/build.gradle
@@ -30,6 +30,7 @@ android {
 dependencies {
     // Types defined in concept-sync are part of the public API of this module.
     api project(':concept-sync')
+    api project(':concept-storage')
 
     // Parts of this dependency are typealiase'd or are otherwise part of this module's public API.
     api Dependencies.mozilla_fxa

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/SyncManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/SyncManager.kt
@@ -4,8 +4,8 @@
 
 package mozilla.components.service.fxa.sync
 
+import mozilla.components.concept.storage.KeyProvider
 import mozilla.components.concept.sync.SyncableStore
-import mozilla.components.lib.dataprotect.KeyProvider
 import mozilla.components.service.fxa.SyncConfig
 import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.service.fxa.manager.SyncEnginesStorage

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
@@ -22,8 +22,8 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import mozilla.appservices.syncmanager.SyncParams
 import mozilla.appservices.syncmanager.SyncServiceStatus
+import mozilla.components.concept.storage.KeyProvider
 import mozilla.appservices.syncmanager.SyncManager as RustSyncManager
-import mozilla.components.lib.dataprotect.KeyProvider
 import mozilla.components.service.fxa.FxaDeviceSettingsCache
 import mozilla.components.service.fxa.SyncAuthInfoCache
 import mozilla.components.service.fxa.SyncConfig

--- a/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorage.kt
+++ b/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorage.kt
@@ -13,12 +13,12 @@ import mozilla.components.concept.storage.Address
 import mozilla.components.concept.storage.CreditCard
 import mozilla.components.concept.storage.CreditCardNumber
 import mozilla.components.concept.storage.CreditCardsAddressesStorage
+import mozilla.components.concept.storage.KeyGenerationReason
+import mozilla.components.concept.storage.KeyRecoveryHandler
 import mozilla.components.concept.storage.NewCreditCardFields
 import mozilla.components.concept.storage.UpdatableAddressFields
 import mozilla.components.concept.storage.UpdatableCreditCardFields
 import mozilla.components.concept.sync.SyncableStore
-import mozilla.components.lib.dataprotect.KeyGenerationReason
-import mozilla.components.lib.dataprotect.KeyRecoveryHandler
 import mozilla.components.lib.dataprotect.SecureAbove22Preferences
 import mozilla.components.support.base.log.logger.Logger
 import java.io.Closeable
@@ -155,6 +155,10 @@ class AutofillCreditCardsAddressesStorage(
 
     override suspend fun touchAddress(guid: String) = withContext(coroutineContext) {
         conn.getStorage().touchAddress(guid)
+    }
+
+    override fun getCreditCardCrypto(): AutofillCrypto {
+        return crypto
     }
 
     override fun registerWithSyncManager() {

--- a/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCrypto.kt
+++ b/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCrypto.kt
@@ -10,11 +10,11 @@ import mozilla.appservices.autofill.ErrorException
 import mozilla.appservices.autofill.createKey
 import mozilla.appservices.autofill.decryptString
 import mozilla.appservices.autofill.encryptString
+import mozilla.components.concept.storage.CreditCardCrypto
 import mozilla.components.concept.storage.CreditCardNumber
-import mozilla.components.lib.dataprotect.KeyGenerationReason
-import mozilla.components.lib.dataprotect.KeyProvider
-import mozilla.components.lib.dataprotect.KeyRecoveryHandler
-import mozilla.components.lib.dataprotect.ManagedKey
+import mozilla.components.concept.storage.KeyGenerationReason
+import mozilla.components.concept.storage.KeyRecoveryHandler
+import mozilla.components.concept.storage.ManagedKey
 import mozilla.components.lib.dataprotect.SecureAbove22Preferences
 import mozilla.components.support.base.log.logger.Logger
 
@@ -33,15 +33,14 @@ class AutofillCrypto(
     private val context: Context,
     private val securePrefs: SecureAbove22Preferences,
     private val keyRecoveryHandler: KeyRecoveryHandler
-) : KeyProvider {
+) : CreditCardCrypto {
     private val logger = Logger("AutofillCrypto")
     private val plaintextPrefs by lazy { context.getSharedPreferences(AUTOFILL_PREFS, Context.MODE_PRIVATE) }
 
-    /**
-     * Encrypt a [CreditCardNumber.Plaintext] using provided key.
-     * A `null` result means a bad key was provided. In that case caller should obtain a new key and try again.
-     */
-    fun encrypt(key: ManagedKey, plaintextCardNumber: CreditCardNumber.Plaintext): CreditCardNumber.Encrypted? {
+    override fun encrypt(
+        key: ManagedKey,
+        plaintextCardNumber: CreditCardNumber.Plaintext
+    ): CreditCardNumber.Encrypted? {
         return try {
             CreditCardNumber.Encrypted(encrypt(key, plaintextCardNumber.number))
         } catch (e: ErrorException.JsonError) {
@@ -53,11 +52,10 @@ class AutofillCrypto(
         }
     }
 
-    /**
-     * Decrypt a [CreditCardNumber.Encrypted] using provided key.
-     * A `null` result means a bad key was provided. In that case caller should obtain a new key and try again.
-     */
-    fun decrypt(key: ManagedKey, encryptedCardNumber: CreditCardNumber.Encrypted): CreditCardNumber.Plaintext? {
+    override fun decrypt(
+        key: ManagedKey,
+        encryptedCardNumber: CreditCardNumber.Encrypted
+    ): CreditCardNumber.Plaintext? {
         return try {
             CreditCardNumber.Plaintext(decrypt(key, encryptedCardNumber.number))
         } catch (e: ErrorException.JsonError) {

--- a/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/GeckoCreditCardsAddressesStorageDelegate.kt
+++ b/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/GeckoCreditCardsAddressesStorageDelegate.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import mozilla.components.concept.storage.Address
 import mozilla.components.concept.storage.CreditCard
+import mozilla.components.concept.storage.CreditCardNumber
 import mozilla.components.concept.storage.CreditCardsAddressesStorage
 import mozilla.components.concept.storage.CreditCardsAddressesStorageDelegate
 
@@ -20,6 +21,12 @@ class GeckoCreditCardsAddressesStorageDelegate(
     private val storage: Lazy<CreditCardsAddressesStorage>,
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 ) : CreditCardsAddressesStorageDelegate {
+
+    override fun decrypt(encryptedCardNumber: CreditCardNumber.Encrypted): CreditCardNumber.Plaintext? {
+        val crypto = storage.value.getCreditCardCrypto()
+        val key = crypto.key()
+        return crypto.decrypt(key, encryptedCardNumber)
+    }
 
     override fun onAddressesFetch(): Deferred<List<Address>> {
         return scope.async {

--- a/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/AutofillCryptoTest.kt
+++ b/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/AutofillCryptoTest.kt
@@ -6,9 +6,9 @@ package mozilla.components.service.sync.autofill
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.storage.CreditCardNumber
-import mozilla.components.lib.dataprotect.KeyGenerationReason
-import mozilla.components.lib.dataprotect.KeyRecoveryHandler
-import mozilla.components.lib.dataprotect.ManagedKey
+import mozilla.components.concept.storage.KeyGenerationReason
+import mozilla.components.concept.storage.KeyRecoveryHandler
+import mozilla.components.concept.storage.ManagedKey
 import mozilla.components.lib.dataprotect.SecureAbove22Preferences
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext

--- a/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/GeckoCreditCardsAddressesStorageDelegateTest.kt
+++ b/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/GeckoCreditCardsAddressesStorageDelegateTest.kt
@@ -9,8 +9,11 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineScope
-import mozilla.components.support.test.mock
+import mozilla.components.concept.storage.CreditCardNumber
+import mozilla.components.concept.storage.NewCreditCardFields
+import mozilla.components.lib.dataprotect.SecureAbove22Preferences
 import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -21,7 +24,8 @@ import org.mockito.Mockito.verify
 @RunWith(AndroidJUnit4::class)
 class GeckoCreditCardsAddressesStorageDelegateTest {
 
-    private val storage = AutofillCreditCardsAddressesStorage(testContext, mock())
+    private lateinit var storage: AutofillCreditCardsAddressesStorage
+    private lateinit var securePrefs: SecureAbove22Preferences
     private lateinit var delegate: GeckoCreditCardsAddressesStorageDelegate
     private lateinit var scope: TestCoroutineScope
 
@@ -32,7 +36,29 @@ class GeckoCreditCardsAddressesStorageDelegateTest {
     @Before
     fun before() = runBlocking {
         scope = TestCoroutineScope()
+        // forceInsecure is set in the tests because a keystore wouldn't be configured in the test environment.
+        securePrefs = SecureAbove22Preferences(testContext, "autofill", forceInsecure = true)
+        storage = AutofillCreditCardsAddressesStorage(testContext, lazy { securePrefs })
         delegate = GeckoCreditCardsAddressesStorageDelegate(lazy { storage }, scope)
+    }
+
+    @Test
+    fun `decrypt`() = runBlocking {
+        val plaintextNumber = CreditCardNumber.Plaintext("4111111111111111")
+        val creditCardFields = NewCreditCardFields(
+            billingName = "Jon Doe",
+            plaintextCardNumber = plaintextNumber,
+            cardNumberLast4 = "1111",
+            expiryMonth = 12,
+            expiryYear = 2028,
+            cardType = "amex"
+        )
+        val creditCard = storage.addCreditCard(creditCardFields)
+
+        assertEquals(
+            plaintextNumber,
+            delegate.decrypt(creditCard.encryptedCardNumber)
+        )
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,9 @@ permalink: /changelog/
 * **browser-menu**:
   * 🚒 Bug fixed [issue #10133](https://github.com/mozilla-mobile/android-components/issues/10133) - A BrowserMenuCompoundButton used in our BrowserMenu setup with a DynamicWidthRecyclerView is not clipped anymore.
 
+* **browser-engine-gecko**:
+  * Implements the new GeckoView `Autocomplete.StorageDelegate` interface in `GeckoStorageDelegateWrapper`. This will replace the deprecated `GeckoLoginDelegateWrapper` and provide additional autocomplete support for credit cards. [#10140](https://github.com/mozilla-mobile/android-components/issues/10140)
+
 * **feature-downloads**:
   * ⚠️ **This is a breaking change**: `AbstractFetchDownloadService.openFile()` changed its signature from `AbstractFetchDownloadService.openFile(context: Context, filePath: String, contentType: String?)` to `AbstractFetchDownloadService.openFile(applicationContext: Context, download: DownloadState)`.
   * 🚒 Bug fixed [issue #10138](https://github.com/mozilla-mobile/android-components/issues/10138) - The downloaded files cannot be seen.
@@ -37,6 +40,8 @@ permalink: /changelog/
   * ⚠️ **This is a breaking change**: `CreditCard`'s number field changed to `encryptedCardNumber`, `cardNumberLast4` added.
   * New `CreditCardNumber` class, which encapsulate either an encrypted or plaintext versions of credit cards.
   * `AutofillCreditCardsAddressesStorage` reflects these breaking changes.
+  * Introduced a new `CreditCardCrypto` interface for for encrypting and decrypting a credit card number. [#10140](https://github.com/mozilla-mobile/android-components/issues/10140)
+  * 🌟️ New APIs for managing keys - `ManagedKey`, `KeyProvider` and `KeyRecoveryHandler`. `AutofillCreditCardsAddressesStorage` implements these APIs for managing keys for credit card storage.
 
 * **service-firefox-accounts**
   * 🌟️ When configuring syncable storage layers, `SyncManager` now takes an optional `KeyProvider` to handle encryption/decryption of protected values.
@@ -44,10 +49,6 @@ permalink: /changelog/
 
 * **service-glean**
   * `ConceptFetchHttpUploader` adds support for private requests. By default, all requests are non-private.
-
-* **lib-dataprotect**
-  * 🌟️ New APIs for managing keys - `ManagedKey`, `KeyProvider` and `KeyRecoveryHandler`.
-  * 🌟️ `AutofillCreditCardsAddressesStorage` implements these APIs for managing keys for credit card storage.
 
 * **lib-state**
   * 🌟️ Added `AbstractBinding` for simple features that want to observe changes to the `State` in a `Store` without needing to manually manage the CoroutineScope. This can now be handled like other `LifecycleAwareFeature` implementations:


### PR DESCRIPTION
Fixes #10140 

Reviewing individual commits might make this easier.

Part 1: Refactor autocomplete extension functions into ext/Login.kt
- Moves `Autocomplete.LoginEntry.toLogin()` and `Login.toLoginEntry()` extension functions
into `ext/Login.kt`
- Remove duplicates of `Autocomplete.LoginEntry.toLogin()` and `Login.toLoginEntry()`

Part 2: Make a copy of GeckoLoginDelegateWrapper as GeckoStorageDelegateWrapper
- We make a copy of GeckoLoginDelegateWrapper to not break the deprecated usage of `Autocomplete.LoginStorageDelegate` until we are ready to replace with `GeckoStorageDelegateWrapper` which will use the new GV API `Autocomplete.StorageDelegate`.

Part 3: Implement the new Autocomplete.StorageDelegate interface in GeckoStorageDelegateWrapper
- Uses the new GV `Autocomplete.StorageDelegate` interface in GeckoStorageDelegateWrapper
- Implements GeckoView's `Autocomplete.StorageDelegate.onCreditCardFetch`

------------------------------------------------------

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
