### PR TITLE
For fenix#19271: Custom tab toolbar display for maximum text size

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/OriginView.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/OriginView.kt
@@ -19,7 +19,7 @@ import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.browser.toolbar.R
 
 private const val TITLE_VIEW_WEIGHT = 5.7f
-private const val URL_VIEW_WEIGHT = 4.3f
+private const val URL_VIEW_WEIGHT = 5.7f
 
 /**
  * View displaying the URL and optionally the title of a website.

--- a/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_displaytoolbar.xml
+++ b/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_displaytoolbar.xml
@@ -101,8 +101,9 @@
     <mozilla.components.browser.toolbar.display.OriginView
         android:id="@+id/mozac_browser_toolbar_origin_view"
         android:layout_width="0dp"
-        android:layout_height="40dp"
+        android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
+        android:minHeight="40dp"
         app:layout_constraintEnd_toStartOf="@+id/mozac_browser_toolbar_page_actions"
         app:layout_constraintStart_toEndOf="@+id/mozac_browser_toolbar_security_indicator"
         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
- For proper display of title/url in custom tab toolbar, when maximum text size is set for display
- Aims to fix: mozilla-mobile/fenix#19271


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### Screenshots

1. For **normal text size (S)**, before and then after code changes (no breaking/change):

![image](https://user-images.githubusercontent.com/67039214/116739235-0e89a600-aa11-11eb-8852-3da50a5fb892.png)  

![image](https://user-images.githubusercontent.com/67039214/116739323-29f4b100-aa11-11eb-9dab-8a0189e25f82.png)


2. For XL text size, before and then after code changes (after code changes, the URL does not get cut-off):

![image](https://user-images.githubusercontent.com/67039214/116739487-5e686d00-aa11-11eb-9346-1fe1f0432cf0.png)  

![image](https://user-images.githubusercontent.com/67039214/116739537-6a542f00-aa11-11eb-8611-5d50b4a4b50f.png)


3. For largest text size (XXL), before and then after code changes (after code changes, although title does not get cut off, the url still does):

![image](https://user-images.githubusercontent.com/67039214/116739694-98d20a00-aa11-11eb-9c41-39cf7f2b4b2c.png)  

![image](https://user-images.githubusercontent.com/67039214/116739726-a5eef900-aa11-11eb-8fa9-14a05c5b8f3f.png)



