### PR TITLE
Close #10207: Add support for private requests in Glean

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/net/ConceptFetchHttpUploader.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/net/ConceptFetchHttpUploader.kt
@@ -25,9 +25,12 @@ typealias PingUploader = CorePingUploader
  * A simple ping Uploader, which implements a "send once" policy, never
  * storing or attempting to send the ping again. This uses Android Component's
  * `concept-fetch`.
+ *
+ * @param usePrivateRequest Sets the [Request.private] flag in all requests using this uploader.
  */
 class ConceptFetchHttpUploader(
-    internal val client: Lazy<Client>
+    internal val client: Lazy<Client>,
+    private val usePrivateRequest: Boolean = false
 ) : PingUploader {
     private val logger = Logger("glean/ConceptFetchHttpUploader")
 
@@ -89,7 +92,8 @@ class ConceptFetchHttpUploader(
             // offer a better API to do that, so we nuke all cookies going to our telemetry
             // endpoint.
             cookiePolicy = Request.CookiePolicy.OMIT,
-            body = Request.Body(data.inputStream())
+            body = Request.Body(data.inputStream()),
+            private = usePrivateRequest
         )
     }
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/net/ConceptFetchHttpUploaderTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/net/ConceptFetchHttpUploaderTest.kt
@@ -288,4 +288,26 @@ class ConceptFetchHttpUploaderTest {
         uploader.upload("path", "ping".toByteArray(), emptyList())
         assertTrue(uploader.client.isInitialized())
     }
+
+    @Test
+    fun `usePrivateRequest sends all requests with private flag`() {
+        val mockClient: Client = mock()
+        `when`(mockClient.fetch(any())).thenReturn(
+            Response("URL", 200, mock(), mock()))
+
+        val expectedHeaders = mapOf(
+            "Content-Type" to "application/json; charset=utf-8",
+            "Test-header" to "SomeValue",
+            "OtherHeader" to "Glean/Test 25.0.2"
+        )
+
+        val uploader = ConceptFetchHttpUploader(lazy { mockClient }, true)
+        uploader.upload(testPath, testPing.toByteArray(), expectedHeaders.toList())
+
+        val captor = argumentCaptor<Request>()
+
+        verify(mockClient).fetch(captor.capture())
+
+        assertTrue(captor.value.private)
+    }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -42,6 +42,9 @@ permalink: /changelog/
   * 🌟️ When configuring syncable storage layers, `SyncManager` now takes an optional `KeyProvider` to handle encryption/decryption of protected values.
   * 🌟️ Support for syncing Address and Credit Cards
 
+* **service-glean**
+  * `ConceptFetchHttpUploader` adds support for private requests. By default, all requests are non-private.
+
 * **lib-dataprotect**
   * 🌟️ New APIs for managing keys - `ManagedKey`, `KeyProvider` and `KeyRecoveryHandler`.
   * 🌟️ `AutofillCreditCardsAddressesStorage` implements these APIs for managing keys for credit card storage.


### PR DESCRIPTION
In Focus, we want to ensure all requests are made within [a private session context](https://github.com/mozilla-mobile/focus-android/blob/main/app/src/main/java/org/mozilla/focus/engine/ClientWrapper.kt#L18-L20). When we make requests using the `ConceptFetchHttpUploader` for ping uploads, the request defaults to being non-private without a way to configure it.

The change in this patch is straight-forward to allow the application to decide on the request type. This should suffice for Focus.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
