### PR TITLE
Issue #10205: Add support for select credit card prompt

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/ext/CreditCard.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/ext/CreditCard.kt
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.ext
+
+import mozilla.components.concept.engine.prompt.CreditCard
+import org.mozilla.geckoview.Autocomplete
+
+// Placeholder for the card type. This will be replaced when we can identify the card type.
+// This is dependent on https://github.com/mozilla-mobile/android-components/issues/9813.
+private const val CARD_TYPE_PLACEHOLDER = ""
+
+/**
+ * Converts a GeckoView [Autocomplete.CreditCard] to an Android Components [CreditCard].
+ */
+fun Autocomplete.CreditCard.toCreditCard() = CreditCard(
+    guid = guid,
+    name = name,
+    number = number,
+    expiryMonth = expirationMonth,
+    expiryYear = expirationYear,
+    cardType = CARD_TYPE_PLACEHOLDER
+)
+
+/**
+ * Converts an Android Components [CreditCard] to a GeckoView [Autocomplete.CreditCard].
+ */
+fun CreditCard.toAutocompleteCreditCard() = Autocomplete.CreditCard.Builder()
+    .guid(guid)
+    .name(name)
+    .number(number)
+    .expirationMonth(expiryMonth)
+    .expirationYear(expiryYear)
+    .build()

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/CreditCard.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/CreditCard.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.prompt
+
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+/**
+ * Value type that represents a credit card.
+ *
+ * @property guid The unique identifier for this credit card.
+ * @property name The credit card billing name.
+ * @property number The credit card number.
+ * @property expiryMonth The credit card expiry month.
+ * @property expiryYear The credit card expiry year.
+ * @property cardType The credit card network ID.
+ */
+@Parcelize
+data class CreditCard(
+    val guid: String?,
+    val name: String,
+    val number: String,
+    val expiryMonth: String,
+    val expiryYear: String,
+    val cardType: String
+) : Parcelable

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
@@ -13,7 +13,6 @@ import mozilla.components.concept.engine.prompt.PromptRequest.TimeSelection.Type
 
 /**
  * Value type that represents a request for showing a native dialog for prompt web content.
- *
  */
 sealed class PromptRequest {
     /**
@@ -66,6 +65,18 @@ sealed class PromptRequest {
         val onLeave: () -> Unit,
         val onStay: () -> Unit
     ) : PromptRequest()
+
+    /**
+     * Value type that represents a request for a select credit card prompt.
+     * @property creditCards a list of [CreditCard]s to select from.
+     * @property onDismiss callback to let the page know the user dismissed the dialog.
+     * @property onConfirm callback that is called when the user confirms the credit card selection.
+     */
+    data class SelectCreditCard(
+        val creditCards: List<CreditCard>,
+        override val onDismiss: () -> Unit,
+        val onConfirm: (CreditCard) -> Unit
+    ) : PromptRequest(), Dismissible
 
     /**
      * Value type that represents a request for a save login prompt.

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/CreditCardTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/CreditCardTest.kt
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.prompt
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CreditCardTest {
+
+    @Test
+    fun `Create a CreditCard`() {
+        val guid = "1"
+        val name = "Banana Apple"
+        val number = "4111111111111110"
+        val expiryMonth = "5"
+        val expiryYear = "2030"
+        val cardType = "amex"
+        val creditCard = CreditCard(
+            guid = guid,
+            name = name,
+            number = number,
+            expiryMonth = expiryMonth,
+            expiryYear = expiryYear,
+            cardType = cardType
+        )
+
+        assertEquals(guid, creditCard.guid)
+        assertEquals(name, creditCard.name)
+        assertEquals(number, creditCard.number)
+        assertEquals(expiryMonth, creditCard.expiryMonth)
+        assertEquals(expiryYear, creditCard.expiryYear)
+        assertEquals(cardType, creditCard.cardType)
+    }
+}

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt
@@ -14,6 +14,7 @@ import mozilla.components.concept.engine.prompt.PromptRequest.MultipleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.Popup
 import mozilla.components.concept.engine.prompt.PromptRequest.Repost
 import mozilla.components.concept.engine.prompt.PromptRequest.SaveLoginPrompt
+import mozilla.components.concept.engine.prompt.PromptRequest.SelectCreditCard
 import mozilla.components.concept.engine.prompt.PromptRequest.SelectLoginPrompt
 import mozilla.components.concept.engine.prompt.PromptRequest.SingleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.TextPrompt
@@ -24,6 +25,7 @@ import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.Date
@@ -255,5 +257,48 @@ class PromptRequestTest {
 
         assertTrue(onAcceptWasCalled)
         assertTrue(onDismissWasCalled)
+    }
+
+    @Test
+    fun `GIVEN a list of credit cards WHEN SelectCreditCard is confirmed or dismissed THEN their respective callback is invoked`() {
+        val creditCard = CreditCard(
+            guid = "id",
+            name = "Banana Apple",
+            number = "4111111111111110",
+            expiryMonth = "5",
+            expiryYear = "2030",
+            cardType = "amex"
+        )
+        var onDismissCalled = false
+        var onConfirmCalled = false
+        var confirmedCreditCard: CreditCard? = null
+
+        val selectCreditCardPrompt = SelectCreditCard(
+            creditCards = listOf(creditCard),
+            onDismiss = {
+                onDismissCalled = true
+            },
+            onConfirm = {
+                confirmedCreditCard = it
+                onConfirmCalled = true
+            }
+        )
+
+        assertEquals(selectCreditCardPrompt.creditCards, listOf(creditCard))
+
+        selectCreditCardPrompt.onConfirm(creditCard)
+
+        assertTrue(onConfirmCalled)
+        assertFalse(onDismissCalled)
+        assertEquals(creditCard, confirmedCreditCard)
+
+        onConfirmCalled = false
+        confirmedCreditCard = null
+
+        selectCreditCardPrompt.onDismiss()
+
+        assertTrue(onDismissCalled)
+        assertFalse(onConfirmCalled)
+        assertNull(confirmedCreditCard)
     }
 }

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -35,6 +35,7 @@ import mozilla.components.concept.engine.prompt.PromptRequest.MultipleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.Popup
 import mozilla.components.concept.engine.prompt.PromptRequest.Repost
 import mozilla.components.concept.engine.prompt.PromptRequest.SaveLoginPrompt
+import mozilla.components.concept.engine.prompt.PromptRequest.SelectCreditCard
 import mozilla.components.concept.engine.prompt.PromptRequest.SelectLoginPrompt
 import mozilla.components.concept.engine.prompt.PromptRequest.Share
 import mozilla.components.concept.engine.prompt.PromptRequest.SingleChoice
@@ -689,6 +690,7 @@ class PromptFeature private constructor(
             is SaveLoginPrompt,
             is SelectLoginPrompt,
             is Share -> true
+            is SelectCreditCard -> false
             is Alert, is TextPrompt, is Confirm, is Repost, is Popup -> promptAbuserDetector.shouldShowMoreDialogs
         }
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,8 @@ permalink: /changelog/
 
 * **concept-engine**
   * 🌟️ `getBlockedSchemes()` now exposes the list of url shemes that the engine won't load.
+  * Adds a new `CreditCard` data class which is a parallel of GeckoView's `Autocomplete.CreditCard`. [#10205](https://github.com/mozilla-mobile/android-components/issues/10205)
+  * Adds a new `SelectCreditCard` in `PromptRequest` to display a prompt for selecting a credit card to autocomplete. [#10205](https://github.com/mozilla-mobile/android-components/issues/10205)
 
 * **browser-menu**:
   * 🚒 Bug fixed [issue #10133](https://github.com/mozilla-mobile/android-components/issues/10133) - A BrowserMenuCompoundButton used in our BrowserMenu setup with a DynamicWidthRecyclerView is not clipped anymore.
@@ -34,6 +36,7 @@ permalink: /changelog/
 
 * **browser-engine-gecko(-nightly/beta)**
   * ⚠️ From now on there will be only one `concept-engine` implementation using [GeckoView](https://mozilla.github.io/geckoview/). On `master` this will be the Nightly version. In release versions it will be the corresponding Beta or Release version. More about this in [RFC 7](https://mozac.org/rfc/0007-synchronized-releases).
+  * Implements `onCreditCardSelect` in `GeckoPromptDelegate` to handle a credit card selection prompt request. [#10205](https://github.com/mozilla-mobile/android-components/issues/10205)
 
 * **concept-sync**, **browser-storage-sync**
   * ⚠️ **This is a breaking change**: `SyncableStore` now has a `registerWithSyncManager` method for use in newer storage layers.


### PR DESCRIPTION
Fixes #10205

- Implements an override function of `onCreditCardSelect` in `GeckoPromptDelegate`
- Adds a new `CreditCard` data class in `concept-engine`. This is a parallel of GV's
`Autocomplete.CreditCard`. We can't using the existing `CreditCard` from `concept-storage`
since that has encryption dependencies whereas the card number is already decrypted
when it reaches GV.
- Adds a new `SelectCreditCardPrompt` in `PromptRequest`


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
