### PR TITLE
Issue #10214 - Add tests for GeckoAutocompleteStorageDelegate

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/autofill/GeckoAutocompleteStorageDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/autofill/GeckoAutocompleteStorageDelegate.kt
@@ -35,7 +35,7 @@ class GeckoAutocompleteStorageDelegate(
         val result = GeckoResult<Array<Autocomplete.CreditCard>>()
 
         GlobalScope.launch(IO) {
-            val creditCards = creditCardsAddressesStorageDelegate.onCreditCardsFetch().await()
+            val creditCards = creditCardsAddressesStorageDelegate.onCreditCardsFetch()
                 .mapNotNull {
                     val plaintextCardNumber =
                         creditCardsAddressesStorageDelegate.decrypt(it.encryptedCardNumber)?.number
@@ -67,12 +67,9 @@ class GeckoAutocompleteStorageDelegate(
         val result = GeckoResult<Array<Autocomplete.LoginEntry>>()
 
         GlobalScope.launch(IO) {
-            val storedLogins = loginStorageDelegate.onLoginFetch(domain)
-
-            val logins = storedLogins.await()
+            val logins = loginStorageDelegate.onLoginFetch(domain)
                 .map { it.toLoginEntry() }
                 .toTypedArray()
-
             result.complete(logins)
         }
 

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/autofill/GeckoLoginDelegateWrapper.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/autofill/GeckoLoginDelegateWrapper.kt
@@ -32,9 +32,7 @@ class GeckoLoginDelegateWrapper(private val storageDelegate: LoginStorageDelegat
         val result = GeckoResult<Array<Autocomplete.LoginEntry>>()
 
         GlobalScope.launch(IO) {
-            val storedLogins = storageDelegate.onLoginFetch(domain)
-
-            val logins = storedLogins.await()
+            val logins = storageDelegate.onLoginFetch(domain)
                 .map { it.toLoginEntry() }
                 .toTypedArray()
 

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/autofill/GeckoAutocompleteStorageDelegateTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/autofill/GeckoAutocompleteStorageDelegateTest.kt
@@ -1,0 +1,131 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.autofill
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import mozilla.components.browser.engine.gecko.await
+import mozilla.components.browser.engine.gecko.ext.toLogin
+import mozilla.components.concept.storage.CreditCard
+import mozilla.components.concept.storage.CreditCardNumber
+import mozilla.components.concept.storage.CreditCardsAddressesStorageDelegate
+import mozilla.components.concept.storage.LoginStorageDelegate
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
+import mozilla.components.test.createLogin
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.anyString
+import org.mockito.Mockito.verify
+import org.mozilla.geckoview.Autocomplete
+
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+class GeckoAutocompleteStorageDelegateTest {
+
+    private lateinit var creditCardsAddressesStorageDelegate: CreditCardsAddressesStorageDelegate
+    private lateinit var loginStorageDelegate: LoginStorageDelegate
+    private lateinit var geckoAutocompleteStorageDelegate: GeckoAutocompleteStorageDelegate
+
+    @Before
+    fun setup() {
+        creditCardsAddressesStorageDelegate = mock()
+        loginStorageDelegate = mock()
+        geckoAutocompleteStorageDelegate = GeckoAutocompleteStorageDelegate(
+            creditCardsAddressesStorageDelegate,
+            loginStorageDelegate
+        )
+    }
+
+    @Test
+    fun onCreditCardFetch() = runBlockingTest {
+        val cardNumber = "4111111111111110"
+        val plaintextCardNumber = CreditCardNumber.Plaintext(cardNumber)
+        val encryptedCardNumber = CreditCardNumber.Encrypted(cardNumber)
+        val creditCard = CreditCard(
+            guid = "id",
+            billingName = "Banana Apple",
+            encryptedCardNumber = encryptedCardNumber,
+            cardNumberLast4 = "1110",
+            expiryMonth = 5,
+            expiryYear = 2030,
+            cardType = "amex",
+            timeCreated = 1L,
+            timeLastUsed = 1L,
+            timeLastModified = 1L,
+            timesUsed = 1L
+        )
+        val creditCards = listOf(creditCard)
+
+        whenever(creditCardsAddressesStorageDelegate.onCreditCardsFetch()).thenReturn(creditCards)
+        whenever(creditCardsAddressesStorageDelegate.decrypt(any())).thenReturn(plaintextCardNumber)
+
+        val result = geckoAutocompleteStorageDelegate.onCreditCardFetch()
+
+        verify(creditCardsAddressesStorageDelegate).onCreditCardsFetch()
+        verify(creditCardsAddressesStorageDelegate).decrypt(encryptedCardNumber)
+
+        val autocompleteCreditCards = result?.await()
+
+        assertNotNull(autocompleteCreditCards)
+        assertEquals(creditCards.size, autocompleteCreditCards?.size)
+
+        with(autocompleteCreditCards?.get(0)!!) {
+            assertEquals(creditCard.guid, guid)
+            assertEquals(creditCard.billingName, name)
+            assertEquals(cardNumber, number)
+            assertEquals(creditCard.expiryMonth.toString(), expirationMonth)
+            assertEquals(creditCard.expiryYear.toString(), expirationYear)
+        }
+    }
+
+    @Test
+    fun onLoginSave() {
+        val login = Autocomplete.LoginEntry.Builder()
+            .guid("id")
+            .origin("https://www.origin.com")
+            .formActionOrigin("https://www.origin.com")
+            .httpRealm("httpRealm")
+            .username("usernameField")
+            .password("passwordField")
+            .build()
+
+        geckoAutocompleteStorageDelegate.onLoginSave(login)
+
+        verify(loginStorageDelegate).onLoginSave(login.toLogin())
+    }
+
+    @Test
+    fun onLoginFetch() = runBlockingTest {
+        val domain = "https://www.origin.com"
+        val login = createLogin()
+        val logins = listOf(createLogin())
+
+        whenever(loginStorageDelegate.onLoginFetch(anyString())).thenReturn(logins)
+
+        val result = geckoAutocompleteStorageDelegate.onLoginFetch(domain)
+
+        verify(loginStorageDelegate).onLoginFetch(domain)
+
+        val autocompleteLoginEntries = result?.await()
+
+        assertNotNull(autocompleteLoginEntries)
+        assertEquals(logins.size, autocompleteLoginEntries?.size)
+
+        with(autocompleteLoginEntries?.get(0)!!) {
+            assertEquals(login.guid, guid)
+            assertEquals(login.origin, origin)
+            assertEquals(login.formActionOrigin, formActionOrigin)
+            assertEquals(login.httpRealm, httpRealm)
+            assertEquals(login.username, username)
+            assertEquals(login.password, password)
+        }
+    }
+}

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -13,7 +13,6 @@ import mozilla.components.concept.engine.prompt.Choice
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.prompt.PromptRequest.MultipleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.SingleChoice
-import mozilla.components.concept.storage.Login
 import mozilla.components.support.ktx.kotlin.toDate
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
@@ -22,6 +21,7 @@ import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.whenever
 import mozilla.components.test.ReflectionUtils
+import mozilla.components.test.createLogin
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -734,26 +734,6 @@ class GeckoPromptDelegateTest {
 
         assertFalse(onLoginSelected)
     }
-
-    fun createLogin(
-        guid: String = "id",
-        password: String = "password",
-        username: String = "username",
-        origin: String = "https://www.origin.com",
-        httpRealm: String = "httpRealm",
-        formActionOrigin: String = "https://www.origin.com",
-        usernameField: String = "usernameField",
-        passwordField: String = "passwordField"
-    ) = Login(
-        guid = guid,
-        origin = origin,
-        password = password,
-        username = username,
-        httpRealm = httpRealm,
-        formActionOrigin = formActionOrigin,
-        usernameField = usernameField,
-        passwordField = passwordField
-    )
 
     @Test
     fun `Calling onAuthPrompt must provide an Authentication PromptRequest`() {

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/test/LoginUtils.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/test/LoginUtils.kt
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.test
+
+import mozilla.components.concept.storage.Login
+
+fun createLogin(
+    guid: String = "id",
+    password: String = "password",
+    username: String = "username",
+    origin: String = "https://www.origin.com",
+    httpRealm: String = "httpRealm",
+    formActionOrigin: String = "https://www.origin.com",
+    usernameField: String = "usernameField",
+    passwordField: String = "passwordField"
+) = Login(
+    guid = guid,
+    origin = origin,
+    password = password,
+    username = username,
+    httpRealm = httpRealm,
+    formActionOrigin = formActionOrigin,
+    usernameField = usernameField,
+    passwordField = passwordField
+)

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
@@ -6,7 +6,6 @@ package mozilla.components.concept.storage
 
 import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
-import kotlinx.coroutines.Deferred
 
 /**
  * An interface which defines read/write methods for credit card and address data.
@@ -325,22 +324,30 @@ interface CreditCardsAddressesStorageDelegate {
     /**
      * Returns all stored addresses. This is called when the engine believes an address field
      * should be autofilled.
+     *
+     * @return A list of all stored [Address]es.
      */
-    fun onAddressesFetch(): Deferred<List<Address>>
+    suspend fun onAddressesFetch(): List<Address>
 
     /**
      * Saves the given address to storage.
+     *
+     * @param address [Address] to be saved or updated in the address storage.
      */
     fun onAddressSave(address: Address)
 
     /**
      * Returns all stored credit cards. This is called when the engine believes a credit card
      * field should be autofilled.
+     *
+     * @return A list of all stored [CreditCard]s.
      */
-    fun onCreditCardsFetch(): Deferred<List<CreditCard>>
+    suspend fun onCreditCardsFetch(): List<CreditCard>
 
     /**
      * Saves the given credit card to storage.
+     *
+     * @param creditCard [CreditCard] to be saved or updated in the credit card storage.
      */
     fun onCreditCardSave(creditCard: CreditCard)
 }

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/LoginsStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/LoginsStorage.kt
@@ -264,7 +264,7 @@ interface LoginStorageDelegate {
      *
      * This is called when the engine believes a field should be autofilled.
      */
-    fun onLoginFetch(domain: String): Deferred<List<Login>>
+    suspend fun onLoginFetch(domain: String): List<Login>
 
     /**
      * Called when a [login] should be saved or updated.

--- a/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/GeckoCreditCardsAddressesStorageDelegate.kt
+++ b/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/GeckoCreditCardsAddressesStorageDelegate.kt
@@ -5,9 +5,8 @@
 package mozilla.components.service.sync.autofill
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
 import mozilla.components.concept.storage.Address
 import mozilla.components.concept.storage.CreditCard
 import mozilla.components.concept.storage.CreditCardNumber
@@ -28,21 +27,18 @@ class GeckoCreditCardsAddressesStorageDelegate(
         return crypto.decrypt(key, encryptedCardNumber)
     }
 
-    override fun onAddressesFetch(): Deferred<List<Address>> {
-        return scope.async {
-            storage.value.getAllAddresses()
-        }
+    override suspend fun onAddressesFetch(): List<Address> = withContext(scope.coroutineContext) {
+        storage.value.getAllAddresses()
     }
 
     override fun onAddressSave(address: Address) {
         TODO("Not yet implemented")
     }
 
-    override fun onCreditCardsFetch(): Deferred<List<CreditCard>> {
-        return scope.async {
+    override suspend fun onCreditCardsFetch(): List<CreditCard> =
+        withContext(scope.coroutineContext) {
             storage.value.getAllCreditCards()
         }
-    }
 
     override fun onCreditCardSave(creditCard: CreditCard) {
         TODO("Not yet implemented")

--- a/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/GeckoLoginStorageDelegate.kt
+++ b/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/GeckoLoginStorageDelegate.kt
@@ -5,10 +5,9 @@
 package mozilla.components.service.sync.logins
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import mozilla.components.concept.storage.Login
 import mozilla.components.concept.storage.LoginStorageDelegate
 import mozilla.components.concept.storage.LoginValidationDelegate
@@ -58,11 +57,10 @@ class GeckoLoginStorageDelegate(
         }
     }
 
-    override fun onLoginFetch(domain: String): Deferred<List<Login>> {
-        return scope.async {
+    override suspend fun onLoginFetch(domain: String): List<Login> =
+        withContext(scope.coroutineContext) {
             loginStorage.value.getByBaseDomain(domain)
         }
-    }
 
     @Synchronized
     override fun onLoginSave(login: Login) {


### PR DESCRIPTION
Fixes #10214.

Need some 👀 for why this is failing when `GeckoAutocompleteStorageDelegateTest` is ran. I am able to get them to pass individually locally. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
