### PR TITLE
Create GeckoEngineSession with the display mode specified in the WebAppManifest of the browser Session if one exists

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -165,11 +165,11 @@ class GeckoEngine(
     }
 
     /**
-     * See [Engine.createSession].
+     * See [Engine.createSessionWithDisplayMode].
      */
-    override fun createSession(
+    override fun createSessionWithDisplayMode(
         private: Boolean,
-        manifestDisplayMode: WebAppManifest.DisplayMode?,
+        manifestDisplayMode: WebAppManifest.DisplayMode,
         contextId: String?
     ): EngineSession {
         ThreadUtils.assertOnUiThread()
@@ -179,7 +179,6 @@ class GeckoEngine(
             WebAppManifest.DisplayMode.STANDALONE -> GeckoSessionSettings.DISPLAY_MODE_STANDALONE
             WebAppManifest.DisplayMode.MINIMAL_UI -> GeckoSessionSettings.DISPLAY_MODE_MINIMAL_UI
             WebAppManifest.DisplayMode.BROWSER -> GeckoSessionSettings.DISPLAY_MODE_BROWSER
-            null -> GeckoSessionSettings.DISPLAY_MODE_BROWSER
         }
 
         val speculativeSession = speculativeConnectionFactory.get(private, contextId)

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineMiddleware.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineMiddleware.kt
@@ -106,7 +106,12 @@ private fun createEngineSession(
 
     val manifestDisplayMode = session.webAppManifest?.display
 
-    val engineSession = engine.createSession(tab.content.private, manifestDisplayMode, tab.contextId)
+    val engineSession = if (manifestDisplayMode != null) {
+        engine.createSessionWithDisplayMode(tab.content.private, manifestDisplayMode, tab.contextId)
+    } else {
+        engine.createSession(tab.content.private, tab.contextId)
+    }
+
     logger.debug("Created engine session for tab ${tab.id}")
 
     val engineSessionState = tab.engineState.engineSessionState

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineMiddleware.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineMiddleware.kt
@@ -104,7 +104,9 @@ private fun createEngineSession(
         return null
     }
 
-    val engineSession = engine.createSession(tab.content.private, tab.contextId)
+    val manifestDisplayMode = session.webAppManifest?.display
+
+    val engineSession = engine.createSession(tab.content.private, manifestDisplayMode, tab.contextId)
     logger.debug("Created engine session for tab ${tab.id}")
 
     val engineSessionState = tab.engineState.engineSessionState

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -105,9 +105,9 @@ interface Engine : WebExtensionRuntime, DataCleanable {
      * @return the newly created [EngineSession].
      */
     @MainThread
-    fun createSession(
+    fun createSessionWithDisplayMode(
         private: Boolean = false,
-        manifestDisplayMode: WebAppManifest.DisplayMode? = WebAppManifest.DisplayMode.STANDALONE,
+        manifestDisplayMode: WebAppManifest.DisplayMode = WebAppManifest.DisplayMode.BROWSER,
         contextId: String? = null
     ): EngineSession {
         return createSession(private, contextId)

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -12,6 +12,7 @@ import mozilla.components.concept.engine.content.blocking.TrackerLog
 import mozilla.components.concept.engine.content.blocking.TrackingProtectionExceptionStorage
 import mozilla.components.concept.base.profiler.Profiler
 import mozilla.components.concept.engine.activity.ActivityDelegate
+import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.engine.utils.EngineVersion
 import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
@@ -91,6 +92,26 @@ interface Engine : WebExtensionRuntime, DataCleanable {
      */
     @MainThread
     fun createSession(private: Boolean = false, contextId: String? = null): EngineSession
+
+    /**
+     * Creates a new engine session. If [speculativeCreateSession] is supported this
+     * method returns the prepared [EngineSession] if it is still applicable i.e.
+     * the parameter(s) ([private]) are equal.
+     *
+     * @param private whether or not this session should use private mode.
+     * @param manifestDisplayMode the display-mode CSS media feature as exposed in WebAppManifest
+     * @param contextId the session context ID for this session.
+     *
+     * @return the newly created [EngineSession].
+     */
+    @MainThread
+    fun createSession(
+        private: Boolean = false,
+        manifestDisplayMode: WebAppManifest.DisplayMode? = WebAppManifest.DisplayMode.STANDALONE,
+        contextId: String? = null
+    ): EngineSession {
+        return createSession(private, contextId)
+    }
 
     /**
      * Create a new [EngineSessionState] instance from the serialized JSON representation.


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

Fixes #8584 and mozilla-mobile/fenix#10252

I need some help with how to go about writing tests or what should be tested :sweat_smile: I'm not sure if it's sufficient to test whether, say, `EngineMiddleware.createEngineSession` returns a `GeckoSession` with the correct `displayMode` if given a mocked `sessionLookup` function that returns a `Session` with a `webAppManifest`, etc? or whether something more involved or integration test-like like really installing a PWA to the home screen should be done

I'm not sure what "category" I should put this under in the Changelog(browser-engine-gecko? browser-session?)

As of the time of writing, there appears to be various breaking, unrelated Nimbus-related changes https://github.com/mozilla-mobile/android-components/commit/661a91772e4f1292ad2e81321e8e081b0325cc18 so Fenix doesn't compile with `autoPublish.android-components.dir=../android-components`; I commented stuff out based on the compile errors just to get AC to build while I was manually testing with Fenix


A couple of websites which have `display: standalone` in their `manifest.json`: <https://my.unikname.app/> <https://app.sworkit.com> (no affiliation to either)

![image](https://user-images.githubusercontent.com/3119646/117281825-a4e91c00-ae96-11eb-9ebe-d90a0eced656.png)

