### PR TITLE
For #10290: Create facts for credit card autofill feature

### DIFF
--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/creditcard/CreditCardSelectBar.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/creditcard/CreditCardSelectBar.kt
@@ -20,6 +20,7 @@ import androidx.recyclerview.widget.RecyclerView
 import mozilla.components.concept.engine.prompt.CreditCard
 import mozilla.components.feature.prompts.R
 import mozilla.components.feature.prompts.concept.SelectablePromptView
+import mozilla.components.feature.prompts.facts.emitSuccessfulCreditCardAutofillFact
 import mozilla.components.support.ktx.android.view.hideKeyboard
 
 /**
@@ -39,7 +40,10 @@ class CreditCardSelectBar @JvmOverloads constructor(
     private var headerTextStyle: Int? = null
 
     private val listAdapter = CreditCardsAdapter { creditCard ->
-        listener?.onOptionSelect(creditCard)
+        listener?.apply {
+            onOptionSelect(creditCard)
+            emitSuccessfulCreditCardAutofillFact()
+        }
     }
 
     override var listener: SelectablePromptView.Listener<CreditCard>? = null

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/SaveLoginDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/SaveLoginDialogFragment.kt
@@ -40,6 +40,10 @@ import mozilla.components.concept.storage.Login
 import mozilla.components.concept.storage.LoginValidationDelegate.Result
 import mozilla.components.feature.prompts.R
 import mozilla.components.feature.prompts.ext.onDone
+import mozilla.components.feature.prompts.facts.emitCancelFact
+import mozilla.components.feature.prompts.facts.emitDisplayFact
+import mozilla.components.feature.prompts.facts.emitNeverSaveFact
+import mozilla.components.feature.prompts.facts.emitSaveFact
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.content.res.resolveAttribute
 import mozilla.components.support.ktx.android.view.hideKeyboard

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/facts/CreditCardAutofillDialogFacts.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/facts/CreditCardAutofillDialogFacts.kt
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts.facts
+
+import mozilla.components.support.base.Component
+import mozilla.components.support.base.facts.Action
+import mozilla.components.support.base.facts.Fact
+import mozilla.components.support.base.facts.collect
+
+/**
+ * Facts emitted for telemetry related to the Autofill prompt feature for credit cards.
+ */
+class CreditCardAutofillDialogFacts {
+    /**
+     * Specific types of telemetry items.
+     */
+    object Items {
+        const val AUTOFILL_CREDIT_CARD_SUCCESS = "autofill_credit_card_success"
+    }
+}
+
+private fun emitCreditCardAutofillDialogFact(
+    action: Action,
+    item: String,
+    value: String? = null,
+    metadata: Map<String, Any>? = null
+) {
+    Fact(
+        Component.FEATURE_PROMPTS,
+        action,
+        item,
+        value,
+        metadata
+    ).collect()
+}
+
+internal fun emitSuccessfulCreditCardAutofillFact() {
+    emitCreditCardAutofillDialogFact(
+        Action.INTERACTION,
+        CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_SUCCESS
+    )
+}

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/facts/LoginDialogFacts.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/facts/LoginDialogFacts.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.feature.prompts.dialog
+package mozilla.components.feature.prompts.facts
 
 import mozilla.components.support.base.Component
 import mozilla.components.support.base.facts.Action

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/creditcard/CreditCardSelectBarTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/creditcard/CreditCardSelectBarTest.kt
@@ -9,12 +9,17 @@ import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.engine.prompt.CreditCard
 import mozilla.components.feature.prompts.R
 import mozilla.components.feature.prompts.concept.SelectablePromptView
+import mozilla.components.support.base.facts.Fact
+import mozilla.components.support.base.facts.FactProcessor
+import mozilla.components.support.base.facts.Facts
 import mozilla.components.support.test.ext.appCompatContext
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -73,9 +78,16 @@ class CreditCardSelectBarTest {
     }
 
     @Test
-    fun `GIVEN a listener WHEN a credit card is selected THEN onOptionSelect is called`() {
+    fun `GIVEN a listener WHEN a credit card is selected THEN onOptionSelect is called`() = runBlocking {
         val listener: SelectablePromptView.Listener<CreditCard> = mock()
         creditCardSelectBar.listener = listener
+
+        val facts = mutableListOf<Fact>()
+        Facts.registerProcessor(object : FactProcessor {
+            override fun process(fact: Fact) {
+                facts.add(fact)
+            }
+        })
 
         creditCardSelectBar.showPrompt(listOf(creditCard))
 
@@ -86,6 +98,7 @@ class CreditCardSelectBarTest {
         holder.itemView.performClick()
 
         verify(listener).onOptionSelect(creditCard)
+        Assert.assertEquals(1, facts.size)
     }
 
     @Test

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/facts/CreditCardAutofillDialogFactsTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/facts/CreditCardAutofillDialogFactsTest.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.awesomebar.facts
+
+import mozilla.components.feature.prompts.facts.CreditCardAutofillDialogFacts
+import mozilla.components.feature.prompts.facts.emitSuccessfulCreditCardAutofillFact
+import mozilla.components.support.base.Component
+import mozilla.components.support.base.facts.Action
+import mozilla.components.support.base.facts.processor.CollectionProcessor
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CreditCardAutofillDialogFactsTest {
+    @Test
+    fun `Emits facts for autofill events`() {
+        CollectionProcessor.withFactCollection { facts ->
+
+            emitSuccessfulCreditCardAutofillFact()
+
+            assertEquals(1, facts.size)
+
+            facts[0].apply {
+                assertEquals(Component.FEATURE_PROMPTS, component)
+                assertEquals(Action.INTERACTION, action)
+                assertEquals(CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_SUCCESS, item)
+            }
+        }
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@ permalink: /changelog/
 
 * **feature-prompts** **browser-storage-sync**
   * ⚠️ A new `isCreditCardAutofillEnabled` callback is available in `PromptFeature` and `GeckoCreditCardsAddressesStorageDelegate` to allow clients controlling whether credit cards should be autofilled or not. Default is false*
+  * ⚠️ Emit fact when a credit card is selected from the autofill prompt.
 
 * **service-pocket**
   * ⚠️ **This is a breaking change**: Rebuilt from the ground up to better support offering to clients Pocket recommended articles.


### PR DESCRIPTION
For #10290 

* Creates a `Fact` for a successful credit card autofill (used for https://github.com/mozilla-mobile/fenix/pull/19548).
* Create a `.facts` package in the `feature-prompts` for the logins facts and cc facts to live in
* Verify fact is emitted when a CC is selected from autofill
* Tests for `Fact`s

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
