### PR TITLE
Closes #10126: Expose the new gecko API for controlling CookieBehaviorPrivateMode.

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -554,6 +554,10 @@ class GeckoEngine(
                             cookieBehavior = value.cookiePolicy.id
                         }
 
+                        if (cookieBehaviorPrivateMode != value.cookiePolicyPrivateMode.id) {
+                            cookieBehaviorPrivateMode = value.cookiePolicyPrivateMode.id
+                        }
+
                         if (cookiePurging != value.cookiePurging) {
                             setCookiePurging(value.cookiePurging)
                         }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicy.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicy.kt
@@ -19,6 +19,7 @@ fun TrackingProtectionPolicy.toContentBlockingSetting(
     enhancedTrackingProtectionLevel(getEtpLevel())
     antiTracking(getAntiTrackingPolicy())
     cookieBehavior(cookiePolicy.id)
+    cookieBehaviorPrivateMode(cookiePolicyPrivateMode.id)
     cookiePurging(cookiePurging)
     safeBrowsing(safeBrowsingPolicy.sumBy { it.id })
     strictSocialTrackingProtection(getStrictSocialTrackingProtection())

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -294,6 +294,7 @@ class GeckoEngineTest {
 
         assertEquals(defaultSettings.trackingProtectionPolicy, TrackingProtectionPolicy.strict())
         assertEquals(contentBlockingSettings.cookieBehavior, CookiePolicy.ACCEPT_NON_TRACKERS.id)
+        assertEquals(contentBlockingSettings.cookieBehaviorPrivateMode, CookiePolicy.ACCEPT_NON_TRACKERS.id)
 
         try {
             engine.settings.domStorageEnabled
@@ -430,6 +431,32 @@ class GeckoEngineTest {
         engine.settings.trackingProtectionPolicy = policy
 
         verify(mockRuntime.settings.contentBlocking, never()).setCookieBehavior(
+            policy.cookiePolicy.id
+        )
+    }
+
+    @Test
+    fun `setCookieBehavior private mode is only invoked when the value is changed`() {
+        val mockRuntime = mock<GeckoRuntime>()
+        val settings = spy(ContentBlocking.Settings.Builder().build())
+        whenever(mockRuntime.settings).thenReturn(mock())
+        whenever(mockRuntime.settings.contentBlocking).thenReturn(settings)
+        whenever(mockRuntime.settings.contentBlocking.cookieBehaviorPrivateMode).thenReturn(CookieBehavior.ACCEPT_NONE)
+
+        val engine = GeckoEngine(testContext, runtime = mockRuntime)
+        val policy = TrackingProtectionPolicy.recommended()
+
+        engine.settings.trackingProtectionPolicy = policy
+
+        verify(mockRuntime.settings.contentBlocking).setCookieBehaviorPrivateMode(
+            policy.cookiePolicy.id
+        )
+
+        reset(settings)
+
+        engine.settings.trackingProtectionPolicy = policy
+
+        verify(mockRuntime.settings.contentBlocking, never()).setCookieBehaviorPrivateMode(
             policy.cookiePolicy.id
         )
     }
@@ -578,6 +605,7 @@ class GeckoEngineTest {
         assertEquals(SafeBrowsingPolicy.RECOMMENDED.id, contentBlockingSettings.safeBrowsingCategories)
 
         assertEquals(CookiePolicy.ACCEPT_NON_TRACKERS.id, contentBlockingSettings.cookieBehavior)
+        assertEquals(CookiePolicy.ACCEPT_NON_TRACKERS.id, contentBlockingSettings.cookieBehaviorPrivateMode)
         assertTrue(engine.settings.testingModeEnabled)
         assertEquals("test-ua", engine.settings.userAgentString)
         assertEquals(PreferredColorScheme.Light, engine.settings.preferredColorScheme)

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicyKtTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicyKtTest.kt
@@ -26,6 +26,7 @@ class TrackingProtectionPolicyKtTest {
         assertEquals(policy.getEtpLevel(), setting.enhancedTrackingProtectionLevel)
         assertEquals(policy.getAntiTrackingPolicy(), setting.antiTrackingCategories)
         assertEquals(policy.cookiePolicy.id, setting.cookieBehavior)
+        assertEquals(policy.cookiePolicyPrivateMode.id, setting.cookieBehavior)
         assertEquals(defaultSafeBrowsing.sumBy { it.id }, setting.safeBrowsingCategories)
         assertEquals(setting.strictSocialTrackingProtection, policy.strictSocialTrackingProtection)
         assertEquals(setting.cookiePurging, policy.cookiePurging)

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -275,6 +275,7 @@ abstract class EngineSession(
         val useForPrivateSessions: Boolean = true,
         val useForRegularSessions: Boolean = true,
         val cookiePolicy: CookiePolicy = ACCEPT_NON_TRACKERS,
+        val cookiePolicyPrivateMode: CookiePolicy = cookiePolicy,
         val strictSocialTrackingProtection: Boolean? = null,
         val cookiePurging: Boolean = false
     ) {
@@ -312,7 +313,14 @@ abstract class EngineSession(
              * to block cookies which are not associated with the domain of the visited
              * site set by known trackers.
              */
-            ACCEPT_NON_TRACKERS(4)
+            ACCEPT_NON_TRACKERS(4),
+
+            /**
+             * Enable dynamic first party isolation (dFPI); this will block third-party tracking
+             * cookies in accordance with the ETP level and isolate non-tracking third-party
+             * cookies.
+             */
+            ACCEPT_FIRST_PARTY_AND_ISOLATE_OTHERS(5)
         }
 
         @Suppress("MagicNumber")
@@ -406,7 +414,9 @@ abstract class EngineSession(
             /**
             *  Creates a custom [TrackingProtectionPolicyForSessionTypes] using the provide values .
             *  @param trackingCategories a list of tracking categories to apply.
-            *  @param cookiePolicy indicate how cookies should behave for this policy.
+            *  @param cookiePolicy indicates how cookies should behave for this policy.
+            *  @param cookiePolicyPrivateMode indicates how cookies should behave in private mode for this policy,
+            *  default to [cookiePolicy] if not set.
             *  @param strictSocialTrackingProtection indicate  if content should be blocked from the
             *  social-tracking-protection-digest256 list, when given a null value,
             *  it is only applied when the [EngineSession.TrackingProtectionPolicy.TrackingCategory.STRICT]
@@ -418,12 +428,14 @@ abstract class EngineSession(
             fun select(
                 trackingCategories: Array<TrackingCategory> = arrayOf(TrackingCategory.RECOMMENDED),
                 cookiePolicy: CookiePolicy = ACCEPT_NON_TRACKERS,
+                cookiePolicyPrivateMode: CookiePolicy = cookiePolicy,
                 strictSocialTrackingProtection: Boolean? = null,
                 cookiePurging: Boolean = false
             ) = TrackingProtectionPolicyForSessionTypes(
-                trackingCategories,
-                cookiePolicy,
-                strictSocialTrackingProtection,
+                trackingCategory = trackingCategories,
+                cookiePolicy = cookiePolicy,
+                cookiePolicyPrivateMode = cookiePolicyPrivateMode,
+                strictSocialTrackingProtection = strictSocialTrackingProtection,
                 cookiePurging = cookiePurging
             )
         }
@@ -435,6 +447,7 @@ abstract class EngineSession(
             if (useForPrivateSessions != other.useForPrivateSessions) return false
             if (useForRegularSessions != other.useForRegularSessions) return false
             if (cookiePurging != other.cookiePurging) return false
+            if (cookiePolicyPrivateMode != other.cookiePolicyPrivateMode) return false
             if (strictSocialTrackingProtection != other.strictSocialTrackingProtection) return false
             return true
         }
@@ -449,7 +462,9 @@ abstract class EngineSession(
      * Subtype of [TrackingProtectionPolicy] to control the type of session this policy
      * should be applied to. By default, a policy will be applied to all sessions.
      *  @param trackingCategory a list of tracking categories to apply.
-     *  @param cookiePolicy indicate how cookies should behave for this policy.
+     *  @param cookiePolicy indicates how cookies should behave for this policy.
+     *  @param cookiePolicyPrivateMode indicates how cookies should behave in private mode for this policy,
+     *  default to [cookiePolicy] if not set.
      *  @param strictSocialTrackingProtection indicate  if content should be blocked from the
      *  social-tracking-protection-digest256 list, when given a null value,
      *  it is only applied when the [EngineSession.TrackingProtectionPolicy.TrackingCategory.STRICT]
@@ -460,11 +475,13 @@ abstract class EngineSession(
     class TrackingProtectionPolicyForSessionTypes internal constructor(
         trackingCategory: Array<TrackingCategory> = arrayOf(TrackingCategory.RECOMMENDED),
         cookiePolicy: CookiePolicy = ACCEPT_NON_TRACKERS,
+        cookiePolicyPrivateMode: CookiePolicy = cookiePolicy,
         strictSocialTrackingProtection: Boolean? = null,
         cookiePurging: Boolean = false
     ) : TrackingProtectionPolicy(
         trackingCategories = trackingCategory,
         cookiePolicy = cookiePolicy,
+        cookiePolicyPrivateMode = cookiePolicyPrivateMode,
         strictSocialTrackingProtection = strictSocialTrackingProtection,
         cookiePurging = cookiePurging
     ) {
@@ -476,6 +493,7 @@ abstract class EngineSession(
             useForPrivateSessions = true,
             useForRegularSessions = false,
             cookiePolicy = cookiePolicy,
+            cookiePolicyPrivateMode = cookiePolicyPrivateMode,
             strictSocialTrackingProtection = strictSocialTrackingProtection,
             cookiePurging = cookiePurging
         )
@@ -488,6 +506,7 @@ abstract class EngineSession(
             useForPrivateSessions = false,
             useForRegularSessions = true,
             cookiePolicy = cookiePolicy,
+            cookiePolicyPrivateMode = cookiePolicyPrivateMode,
             strictSocialTrackingProtection = strictSocialTrackingProtection,
             cookiePurging = cookiePurging
         )

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -704,6 +704,10 @@ class EngineSessionTest {
             recommendedPolicy.trackingCategories.sumBy { it.id },
             TrackingCategory.RECOMMENDED.id
         )
+
+        assertEquals(recommendedPolicy.cookiePolicy.id, CookiePolicy.ACCEPT_NON_TRACKERS.id)
+        assertEquals(recommendedPolicy.cookiePolicyPrivateMode.id, recommendedPolicy.cookiePolicy.id)
+
         val strictPolicy = TrackingProtectionPolicy.strict()
 
         assertEquals(
@@ -712,6 +716,7 @@ class EngineSessionTest {
         )
 
         assertEquals(strictPolicy.cookiePolicy.id, CookiePolicy.ACCEPT_NON_TRACKERS.id)
+        assertEquals(strictPolicy.cookiePolicyPrivateMode.id, strictPolicy.cookiePolicy.id)
 
         val nonePolicy = TrackingProtectionPolicy.none()
 
@@ -721,6 +726,7 @@ class EngineSessionTest {
         )
 
         assertEquals(nonePolicy.cookiePolicy.id, CookiePolicy.ACCEPT_ALL.id)
+        assertEquals(nonePolicy.cookiePolicyPrivateMode.id, CookiePolicy.ACCEPT_ALL.id)
 
         val newPolicy = TrackingProtectionPolicy.select(
             trackingCategories = arrayOf(

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **concept-engine** and **browser-engine-gecko**
+  * 🌟️ Added `TrackingProtectionPolicy.cookiePolicyPrivateMode` it allows to control how cookies should behave in private mode, if not specified it defaults to the value of `TrackingProtectionPolicy.cookiePolicyPrivateMode`.
+
 * **feature-prompts** **browser-storage-sync**
   * ⚠️ A new `isCreditCardAutofillEnabled` callback is available in `PromptFeature` and `GeckoCreditCardsAddressesStorageDelegate` to allow clients controlling whether credit cards should be autofilled or not. Default is false*
 


### PR DESCRIPTION
This will address this issue https://github.com/mozilla-mobile/focus-android/issues/4740, the same issue is also present in Fenix.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
