### PR TITLE
Migrate test code to away from using FeatureConfig without JSONObject

### DIFF
--- a/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/ui/NimbusBranchItemViewHolderTest.kt
+++ b/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/ui/NimbusBranchItemViewHolderTest.kt
@@ -16,18 +16,13 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
 import org.mozilla.experiments.nimbus.Branch
-import org.mozilla.experiments.nimbus.FeatureConfig
 
 @RunWith(AndroidJUnit4::class)
 class NimbusBranchItemViewHolderTest {
 
     private val branch = Branch(
         slug = "control",
-        ratio = 1,
-        feature = FeatureConfig(
-            featureId = "first_switch",
-            enabled = false
-        )
+        ratio = 1
     )
     private lateinit var nimbusBranchesDelegate: NimbusBranchesAdapterDelegate
     private lateinit var selectedIconView: ImageView


### PR DESCRIPTION
Story: because https://github.com/mozilla/uniffi-rs/pull/440 didn't land, the Feature API work needed to remove `FeatureConfig` from the Nimbus FFI.

The only place to use the `FeatureConfig` API was in the tests for the Nimbus UI QA tooling, which has not migrated as part of https://github.com/mozilla-mobile/android-components/pull/10144

Thus, we're only just hitting it now.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.