### PR TITLE
Closes #10361: Use IO dispatcher for sync and add-on workers

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/migration/SupportedAddonsChecker.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/migration/SupportedAddonsChecker.kt
@@ -147,7 +147,7 @@ internal class SupportedAddonsWorker(
     private val logger = Logger("SupportedAddonsWorker")
 
     @Suppress("TooGenericExceptionCaught", "MaxLineLength")
-    override suspend fun doWork(): Result {
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
         try {
             logger.info("Trying to check for new supported add-ons")
 
@@ -176,7 +176,7 @@ internal class SupportedAddonsWorker(
                 GlobalAddonDependencyProvider.onCrash?.invoke(exception)
             }
         }
-        return Result.success()
+        Result.success()
     }
 
     @VisibleForTesting


### PR DESCRIPTION
See https://github.com/mozilla-mobile/android-components/issues/10361 and https://github.com/mozilla-mobile/fenix/issues/19574#issuecomment-848860317 for details.

Basically `doWork` of those two workers is executed using the default dispatcher and the much smaller thread pool (number of cores).

`CoroutineWorker.coroutineContext` is also deprecated now and the instructions are to use `withContext` in `doWork` which I am doing here. Did some smoke testing in Fenix to make sure the workers run and finish in Result.Success.