### PR TITLE
Missing type conversion for the Addresses sync engine

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/Types.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/Types.kt
@@ -33,6 +33,7 @@ internal fun String.toSyncEngine(): SyncEngine {
         "passwords" -> SyncEngine.Passwords
         "tabs" -> SyncEngine.Tabs
         "creditcards" -> SyncEngine.CreditCards
+        "addresses" -> SyncEngine.Addresses
         // This handles a case of engines that we don't yet model in SyncEngine.
         else -> SyncEngine.Other(this)
     }

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/sync/TypesTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/sync/TypesTest.kt
@@ -19,6 +19,7 @@ class TypesTest {
         assertEquals(SyncEngine.Bookmarks, "bookmarks".toSyncEngine())
         assertEquals(SyncEngine.Passwords, "passwords".toSyncEngine())
         assertEquals(SyncEngine.CreditCards, "creditcards".toSyncEngine())
+        assertEquals(SyncEngine.Addresses, "addresses".toSyncEngine())
         assertEquals(SyncEngine.Other("other"), "other".toSyncEngine())
     }
 


### PR DESCRIPTION
That list of strings comes to bite us again...


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
