### PR TITLE
Issue #10302: Android Autofill: Support manually searching logins.

### DIFF
--- a/components/feature/autofill/build.gradle
+++ b/components/feature/autofill/build.gradle
@@ -33,12 +33,15 @@ dependencies {
     implementation project(':lib-publicsuffixlist')
     implementation project(':service-digitalassetlinks')
     implementation project(':support-base')
+    implementation project(':support-ktx')
     implementation project(":support-utils")
 
     implementation Dependencies.androidx_annotation
     implementation Dependencies.androidx_biometric
     implementation Dependencies.androidx_fragment
     implementation Dependencies.androidx_lifecycle_runtime
+    implementation Dependencies.androidx_recyclerview
+    implementation Dependencies.androidx_core_ktx
 
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/AutofillConfiguration.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/AutofillConfiguration.kt
@@ -8,6 +8,7 @@ import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.storage.LoginsStorage
 import mozilla.components.feature.autofill.lock.AutofillLock
 import mozilla.components.feature.autofill.ui.AbstractAutofillConfirmActivity
+import mozilla.components.feature.autofill.ui.AbstractAutofillSearchActivity
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import mozilla.components.feature.autofill.ui.AbstractAutofillUnlockActivity
 import mozilla.components.feature.autofill.verify.CredentialAccessVerifier
@@ -21,6 +22,7 @@ import mozilla.components.service.digitalassetlinks.local.StatementRelationCheck
  * @property publicSuffixList Global instance of the public suffix list used for matching domains.
  * @property unlockActivity Activity class that implements [AbstractAutofillUnlockActivity].
  * @property confirmActivity Activity class that implements [AbstractAutofillConfirmActivity].
+ * @property searchActivity Activity class that implements [AbstractAutofillSearchActivity].
  * @property applicationName The name of the application that integrates this feature. Used in UI.
  * @property lock Global [AutofillLock] instance used for unlocking the autofill service.
  * @property verifier Helper for verifying the connection between a domain and an application.
@@ -32,6 +34,7 @@ data class AutofillConfiguration(
     val publicSuffixList: PublicSuffixList,
     val unlockActivity: Class<*>,
     val confirmActivity: Class<*>,
+    val searchActivity: Class<*>,
     val applicationName: String,
     val httpClient: Client,
     val lock: AutofillLock = AutofillLock(),

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/handler/FillRequestHandler.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/handler/FillRequestHandler.kt
@@ -22,6 +22,8 @@ import mozilla.components.feature.autofill.structure.getLookupDomain
 import mozilla.components.feature.autofill.structure.parseStructure
 
 internal const val EXTRA_LOGIN_ID = "loginId"
+// Maximum number of logins we are going to display in the autofill overlay.
+internal const val MAX_LOGINS = 10
 
 /**
  * Class responsible for handling [FillRequest]s and returning [FillResponse]s.
@@ -53,7 +55,10 @@ internal class FillRequestHandler(
             parsedStructure.packageName
         )
 
-        val logins = configuration.storage.getByBaseDomain(lookupDomain)
+        val logins = configuration.storage
+            .getByBaseDomain(lookupDomain)
+            .take(MAX_LOGINS)
+
         if (logins.isEmpty()) {
             return null
         }

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/dataset/LoginDatasetBuilder.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/dataset/LoginDatasetBuilder.kt
@@ -70,7 +70,7 @@ internal data class LoginDatasetBuilder(
     }
 }
 
-private fun Login.usernamePresentationOrFallback(context: Context): String {
+internal fun Login.usernamePresentationOrFallback(context: Context): String {
     return if (username.isNotEmpty()) {
         username
     } else {

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/dataset/SearchDatasetBuilder.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/dataset/SearchDatasetBuilder.kt
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.autofill.response.dataset
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.IntentSender
+import android.os.Build
+import android.service.autofill.Dataset
+import android.widget.RemoteViews
+import androidx.annotation.RequiresApi
+import mozilla.components.feature.autofill.AutofillConfiguration
+import mozilla.components.feature.autofill.R
+import mozilla.components.feature.autofill.handler.MAX_LOGINS
+import mozilla.components.feature.autofill.structure.ParsedStructure
+
+@RequiresApi(Build.VERSION_CODES.O)
+internal data class SearchDatasetBuilder(
+    val parsedStructure: ParsedStructure
+) : DatasetBuilder {
+    override fun build(context: Context, configuration: AutofillConfiguration): Dataset {
+        val dataset = Dataset.Builder()
+
+        val title = context.getString(
+            R.string.mozac_feature_autofill_search_suggestions,
+            configuration.applicationName
+        )
+
+        val usernamePresentation = RemoteViews(context.packageName, android.R.layout.simple_list_item_1)
+        usernamePresentation.setTextViewText(android.R.id.text1, title)
+        val passwordPresentation = RemoteViews(context.packageName, android.R.layout.simple_list_item_1)
+        passwordPresentation.setTextViewText(android.R.id.text1, title)
+
+        parsedStructure.usernameId?.let { id ->
+            dataset.setValue(
+                id,
+                null,
+                usernamePresentation
+            )
+        }
+
+        parsedStructure.passwordId?.let { id ->
+            dataset.setValue(
+                id,
+                null,
+                passwordPresentation
+            )
+        }
+
+        val searchIntent = Intent(context, configuration.searchActivity)
+
+        val intentSender: IntentSender = PendingIntent.getActivity(
+            context,
+            configuration.activityRequestCode + MAX_LOGINS,
+            searchIntent,
+            PendingIntent.FLAG_CANCEL_CURRENT
+        ).intentSender
+
+        dataset.setAuthentication(intentSender)
+
+        return dataset.build()
+    }
+}

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/fill/LoginFillResponseBuilder.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/fill/LoginFillResponseBuilder.kt
@@ -11,6 +11,7 @@ import androidx.annotation.RequiresApi
 import mozilla.components.concept.storage.Login
 import mozilla.components.feature.autofill.AutofillConfiguration
 import mozilla.components.feature.autofill.response.dataset.LoginDatasetBuilder
+import mozilla.components.feature.autofill.response.dataset.SearchDatasetBuilder
 import mozilla.components.feature.autofill.structure.ParsedStructure
 
 /**
@@ -23,6 +24,8 @@ internal data class LoginFillResponseBuilder(
     val logins: List<Login>,
     val needsConfirmation: Boolean
 ) : FillResponseBuilder {
+    private val searchDatasetBuilder = SearchDatasetBuilder(parsedStructure)
+
     override fun build(
         context: Context,
         configuration: AutofillConfiguration
@@ -44,6 +47,10 @@ internal data class LoginFillResponseBuilder(
 
             builder.addDataset(dataset)
         }
+
+        builder.addDataset(
+            searchDatasetBuilder.build(context, configuration)
+        )
 
         return builder.build()
     }

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/ui/AbstractAutofillSearchActivity.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/ui/AbstractAutofillSearchActivity.kt
@@ -1,0 +1,125 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.autofill.ui
+
+import android.app.assist.AssistStructure
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.view.autofill.AutofillManager
+import android.widget.EditText
+import androidx.annotation.RequiresApi
+import androidx.core.widget.doOnTextChanged
+import androidx.fragment.app.FragmentActivity
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import mozilla.components.concept.storage.Login
+import mozilla.components.feature.autofill.AutofillConfiguration
+import mozilla.components.feature.autofill.R
+import mozilla.components.feature.autofill.response.dataset.LoginDatasetBuilder
+import mozilla.components.feature.autofill.structure.ParsedStructure
+import mozilla.components.feature.autofill.structure.parseStructure
+import mozilla.components.feature.autofill.structure.toRawStructure
+import mozilla.components.feature.autofill.ui.search.LoginsAdapter
+import mozilla.components.support.ktx.android.view.showKeyboard
+
+/**
+ * Activity responsible for letting the user manually search and pick credentials for auto-filling a
+ * third-party app.
+ */
+@RequiresApi(Build.VERSION_CODES.O)
+abstract class AbstractAutofillSearchActivity : FragmentActivity() {
+    abstract val configuration: AutofillConfiguration
+
+    private lateinit var parsedStructure: ParsedStructure
+    private lateinit var loginsDeferred: Deferred<List<Login>>
+    private val scope = CoroutineScope(Dispatchers.IO)
+    private val adapter = LoginsAdapter(::onLoginSelected)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val structure: AssistStructure? =
+            intent.getParcelableExtra(AutofillManager.EXTRA_ASSIST_STRUCTURE)
+        if (structure == null) {
+            finish()
+            return
+        }
+
+        val parsedStructure = parseStructure(this, structure.toRawStructure())
+        if (parsedStructure == null) {
+            finish()
+            return
+        }
+
+        this.parsedStructure = parsedStructure
+        this.loginsDeferred = loadAsync()
+
+        setContentView(R.layout.mozac_feature_autofill_search)
+
+        val recyclerView = findViewById<RecyclerView>(R.id.mozac_feature_autofill_list)
+        recyclerView.layoutManager = LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false)
+        recyclerView.adapter = adapter
+        recyclerView.addItemDecoration(DividerItemDecoration(this, DividerItemDecoration.HORIZONTAL))
+
+        val searchView = findViewById<EditText>(R.id.mozac_feature_autofill_search)
+        searchView.doOnTextChanged { text, _, _, _ ->
+            if (text != null && text.isNotEmpty()) {
+                performSearch(text)
+            } else {
+                clearResults()
+            }
+        }
+
+        searchView.showKeyboard()
+    }
+
+    private fun onLoginSelected(login: Login) {
+        val builder = LoginDatasetBuilder(parsedStructure, login, needsConfirmation = false)
+        val dataset = builder.build(this, configuration)
+
+        val replyIntent = Intent()
+        replyIntent.putExtra(AutofillManager.EXTRA_AUTHENTICATION_RESULT, dataset)
+
+        setResult(RESULT_OK, replyIntent)
+        finish()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scope.cancel()
+    }
+
+    private fun performSearch(text: CharSequence) = scope.launch {
+        val logins = loginsDeferred.await()
+
+        val filteredLogins = logins.filter { login ->
+            login.username.contains(text) ||
+                login.origin.contains(text)
+        }
+
+        withContext(Dispatchers.Main) {
+            adapter.update(filteredLogins)
+        }
+    }
+
+    private fun clearResults() {
+        adapter.clear()
+    }
+
+    private fun loadAsync(): Deferred<List<Login>> {
+        return scope.async {
+            configuration.storage.list()
+        }
+    }
+}

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/ui/search/LoginViewHolder.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/ui/search/LoginViewHolder.kt
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.autofill.ui.search
+
+import android.view.View
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.concept.storage.Login
+import mozilla.components.feature.autofill.R
+import mozilla.components.feature.autofill.response.dataset.usernamePresentationOrFallback
+
+/**
+ * ViewHolder for a login item in the autofill search view.
+ */
+internal class LoginViewHolder(
+    itemView: View,
+    private val onLoginSelected: (Login) -> Unit
+) : RecyclerView.ViewHolder(itemView) {
+    private val usernameView = itemView.findViewById<TextView>(R.id.mozac_feature_autofill_username)
+    private val originView = itemView.findViewById<TextView>(R.id.mozac_feature_autofill_origin)
+
+    fun bind(login: Login) {
+        usernameView.text = login.usernamePresentationOrFallback(itemView.context)
+        originView.text = login.origin
+
+        itemView.setOnClickListener { onLoginSelected(login) }
+    }
+}

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/ui/search/LoginsAdapter.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/ui/search/LoginsAdapter.kt
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.autofill.ui.search
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.concept.storage.Login
+import mozilla.components.feature.autofill.R
+
+/**
+ * Adapter for showing a list of logins.
+ */
+internal class LoginsAdapter(
+    private val onLoginSelected: (Login) -> Unit
+) : RecyclerView.Adapter<LoginViewHolder>() {
+    private var logins: List<Login> = emptyList()
+
+    fun update(logins: List<Login>) {
+        this.logins = logins
+        notifyDataSetChanged()
+    }
+
+    fun clear() {
+        this.logins = emptyList()
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): LoginViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val view = inflater.inflate(R.layout.mozac_feature_autofill_login, parent, false)
+        return LoginViewHolder(view, onLoginSelected)
+    }
+
+    override fun onBindViewHolder(holder: LoginViewHolder, position: Int) {
+        val login = logins[position]
+        holder.bind(login)
+    }
+
+    override fun getItemCount(): Int {
+        return logins.count()
+    }
+}

--- a/components/feature/autofill/src/main/res/layout/mozac_feature_autofill_login.xml
+++ b/components/feature/autofill/src/main/res/layout/mozac_feature_autofill_login.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="4dp"
+    tools:ignore="Overdraw"
+    android:background="?android:attr/selectableItemBackground">
+    <TextView
+        android:id="@+id/mozac_feature_autofill_username"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="4dp"/>
+    <TextView
+        android:id="@+id/mozac_feature_autofill_origin"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="4dp"/>
+</LinearLayout>

--- a/components/feature/autofill/src/main/res/layout/mozac_feature_autofill_search.xml
+++ b/components/feature/autofill/src/main/res/layout/mozac_feature_autofill_search.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+    <EditText
+        android:id="@+id/mozac_feature_autofill_search"
+        android:background="@android:color/transparent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="text"
+        android:singleLine="true"
+        android:hint="@string/mozac_feature_autofill_search_hint"
+        android:importantForAutofill="no" />
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/mozac_feature_autofill_list"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</LinearLayout>

--- a/components/feature/autofill/src/main/res/values/strings.xml
+++ b/components/feature/autofill/src/main/res/values/strings.xml
@@ -36,4 +36,13 @@
     <!-- Autofill: Negative button shown in dialog asking the user to confirm before autofilling
     credentials in a third-part app (Also see string mozac_feature_autofill_confirmation_authenticity). -->
     <string name="mozac_feature_autofill_confirmation_no">No</string>
+
+    <!-- Autofill: When showing a list of logins to autofill in a third-party app, then this is the
+    last item in the list. When clicking it a new screen opens which allows the user to search for
+    a specific login. %1$s will be replaced with the name of the application (e.g. "Firefox") -->
+    <string name="mozac_feature_autofill_search_suggestions">Search %1$s</string>
+
+    <!-- Autofill: Hint shown in the text field used to search specific logins. Shown when the field
+     is empty and the user has not entered any text into it yet. -->
+    <string name="mozac_feature_autofill_search_hint">Search logins</string>
 </resources>

--- a/components/feature/autofill/src/test/java/mozilla/components/feature/autofill/handler/FillRequestHandlerTest.kt
+++ b/components/feature/autofill/src/test/java/mozilla/components/feature/autofill/handler/FillRequestHandlerTest.kt
@@ -12,6 +12,7 @@ import mozilla.components.feature.autofill.response.fill.FillResponseBuilder
 import mozilla.components.feature.autofill.response.fill.LoginFillResponseBuilder
 import mozilla.components.feature.autofill.test.createMockStructure
 import mozilla.components.feature.autofill.ui.AbstractAutofillConfirmActivity
+import mozilla.components.feature.autofill.ui.AbstractAutofillSearchActivity
 import mozilla.components.feature.autofill.ui.AbstractAutofillUnlockActivity
 import mozilla.components.feature.autofill.verify.CredentialAccessVerifier
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
@@ -172,6 +173,7 @@ private fun <B : FillResponseBuilder> FillRequestHandlerTest.createTestCase(
         publicSuffixList = PublicSuffixList(testContext),
         unlockActivity = AbstractAutofillUnlockActivity::class.java,
         confirmActivity = AbstractAutofillConfirmActivity::class.java,
+        searchActivity = AbstractAutofillSearchActivity::class.java,
         applicationName = "Test",
         httpClient = mock(),
         verifier = verifier

--- a/samples/browser/src/main/AndroidManifest.xml
+++ b/samples/browser/src/main/AndroidManifest.xml
@@ -128,6 +128,9 @@
             android:exported="false"
             android:theme="@style/Theme.AppCompat.Translucent" />
 
+        <activity android:name=".autofill.AutofillSearchActivity"
+            android:exported="false" />
+
         <service
             android:name=".autofill.AutofillService"
             android:label="@string/app_name"

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -78,6 +78,7 @@ import mozilla.components.service.digitalassetlinks.local.StatementRelationCheck
 import mozilla.components.service.location.LocationService
 import org.mozilla.samples.browser.addons.AddonsActivity
 import org.mozilla.samples.browser.autofill.AutofillConfirmActivity
+import org.mozilla.samples.browser.autofill.AutofillSearchActivity
 import org.mozilla.samples.browser.autofill.AutofillUnlockActivity
 import org.mozilla.samples.browser.downloads.DownloadService
 import org.mozilla.samples.browser.ext.components
@@ -101,6 +102,7 @@ open class DefaultComponents(private val applicationContext: Context) {
             publicSuffixList = publicSuffixList,
             unlockActivity = AutofillUnlockActivity::class.java,
             confirmActivity = AutofillConfirmActivity::class.java,
+            searchActivity = AutofillSearchActivity::class.java,
             applicationName = "Sample Browser",
             httpClient = client
         )

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/autofill/AutofillSearchActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/autofill/AutofillSearchActivity.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.samples.browser.autofill
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import mozilla.components.feature.autofill.AutofillConfiguration
+import mozilla.components.feature.autofill.ui.AbstractAutofillSearchActivity
+import org.mozilla.samples.browser.ext.components
+
+/**
+ * Activity responsible for letting the user manually search and pick credentials for auto-filling a
+ * third-party app.
+ */
+@RequiresApi(Build.VERSION_CODES.O)
+class AutofillSearchActivity : AbstractAutofillSearchActivity() {
+    override val configuration: AutofillConfiguration by lazy { components.autofillConfiguration }
+}


### PR DESCRIPTION
Like in Lockwise, this adds a "search" autofill suggestion which allows the user to search a specific login for autofilling.