### PR TITLE
Update appservices to v77.0.2.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -30,7 +30,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "2.4"
 
-    const val mozilla_appservices = "77.0.1"
+    const val mozilla_appservices = "77.0.2"
 
     const val mozilla_glean = "38.0.0"
 


### PR DESCRIPTION
This includes a fix for a failing runtime assertion which we believe
to have been the underlying cause of a recent spike in Fenix crashes.

I've run a manual smoketest of this latest appservices release using a
local build with Fenix, and sync/fxa functionality seems to work as expected.
I wasn't able to reproduce the crash from https://github.com/mozilla/application-services/issues/4035
with my local test setup, but we're pretty hopeful that this will resolve it
as the fix seems to match well with the observed symptoms of the crash.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
