### PR TITLE
Bug 1713635 - Import v23.1.0 of feature-webcompat.

### DIFF
--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/experiment-apis/appConstants.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/experiment-apis/appConstants.js
@@ -17,8 +17,8 @@ this.appConstants = class extends ExtensionAPI {
             return "dev_edition";
           } else if (AppConstants.EARLY_BETA_OR_EARLIER) {
             return "early_beta_or_earlier";
-          } else if (AppConstants.BETA_OR_RELEASE) {
-            return "beta_or_release";
+          } else if (AppConstants.RELEASE_OR_BETA) {
+            return "release_or_beta";
           }
           return "unknown";
         },

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/lib/about_compat_broker.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/lib/about_compat_broker.js
@@ -8,13 +8,18 @@
 
 class AboutCompatBroker {
   constructor(bindings) {
-    this.portsToAboutCompatTabs = this.buildPorts();
-
     this._injections = bindings.injections;
-    this._injections.bindAboutCompatBroker(this);
-
     this._uaOverrides = bindings.uaOverrides;
-    this._uaOverrides.bindAboutCompatBroker(this);
+
+    if (!this._injections && !this._uaOverrides) {
+      throw new Error(
+        "No injections or UA overrides; about:compat broker is not needed"
+      );
+    }
+
+    this.portsToAboutCompatTabs = this.buildPorts();
+    this._injections?.bindAboutCompatBroker(this);
+    this._uaOverrides?.bindAboutCompatBroker(this);
   }
 
   buildPorts() {
@@ -47,8 +52,8 @@ class AboutCompatBroker {
 
   getOverrideOrInterventionById(id) {
     for (const [type, things] of Object.entries({
-      overrides: this._uaOverrides.getAvailableOverrides(),
-      interventions: this._injections.getAvailableInjections(),
+      overrides: this._uaOverrides?.getAvailableOverrides() || [],
+      interventions: this._injections?.getAvailableInjections() || [],
     })) {
       for (const what of things) {
         if (what.id === id) {
@@ -76,17 +81,17 @@ class AboutCompatBroker {
               switch (type) {
                 case "interventions": {
                   if (what.active) {
-                    await this._injections.disableInjection(what);
+                    await this._injections?.disableInjection(what);
                   } else {
-                    await this._injections.enableInjection(what);
+                    await this._injections?.enableInjection(what);
                   }
                   break;
                 }
                 case "overrides": {
                   if (what.active) {
-                    await this._uaOverrides.disableOverride(what);
+                    await this._uaOverrides?.disableOverride(what);
                   } else {
-                    await this._uaOverrides.enableOverride(what);
+                    await this._uaOverrides?.enableOverride(what);
                   }
                   break;
                 }
@@ -101,15 +106,15 @@ class AboutCompatBroker {
         case "getOverridesAndInterventions": {
           return Promise.resolve({
             overrides:
-              (this._uaOverrides.isEnabled() &&
+              (this._uaOverrides?.isEnabled() &&
                 this.filterOverrides(
-                  this._uaOverrides.getAvailableOverrides()
+                  this._uaOverrides?.getAvailableOverrides()
                 )) ||
               false,
             interventions:
-              (this._injections.isEnabled() &&
+              (this._injections?.isEnabled() &&
                 this.filterOverrides(
-                  this._injections.getAvailableInjections()
+                  this._injections?.getAvailableInjections()
                 )) ||
               false,
           });

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/lib/shims.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/lib/shims.js
@@ -19,17 +19,17 @@ const platformPromise = browser.runtime.getPlatformInfo().then(info => {
 });
 
 let debug = async function() {
-  if ((await releaseBranchPromise) !== "beta_or_release") {
+  if ((await releaseBranchPromise) !== "release_or_beta") {
     console.debug.apply(this, arguments);
   }
 };
 let error = async function() {
-  if ((await releaseBranchPromise) !== "beta_or_release") {
+  if ((await releaseBranchPromise) !== "release_or_beta") {
     console.error.apply(this, arguments);
   }
 };
 let warn = async function() {
-  if ((await releaseBranchPromise) !== "beta_or_release") {
+  if ((await releaseBranchPromise) !== "release_or_beta") {
     console.warn.apply(this, arguments);
   }
 };
@@ -344,8 +344,10 @@ class Shims {
         }
       };
       browser.tabs.onRemoved.addListener(unmarkShimsActive);
-      browser.tabs.onUpdated.addListener(unmarkShimsActive, {
-        properties: ["discarded", "url"],
+      browser.tabs.onUpdated.addListener((tabId, changeInfo) => {
+        if (changeInfo.discarded || changeInfo.url) {
+          unmarkShimsActive(tabId);
+        }
       });
       browser.webRequest.onBeforeRequest.addListener(
         this._redirectLogos.bind(this),

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/manifest.json
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Mozilla Android Components - Web Compatibility Interventions",
   "description": "Urgent post-release fixes for web compatibility.",
-  "version": "23.0.0",
+  "version": "23.1.0",
 
   "applications": {
     "gecko": {

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/run.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/run.js
@@ -8,15 +8,33 @@
            AVAILABLE_PIP_OVERRIDES, AVAILABLE_UA_OVERRIDES, CUSTOM_FUNCTIONS,
            Injections, Shims, UAOverrides */
 
-const injections = new Injections(AVAILABLE_INJECTIONS, CUSTOM_FUNCTIONS);
-const uaOverrides = new UAOverrides(AVAILABLE_UA_OVERRIDES);
-const shims = new Shims(AVAILABLE_SHIMS);
+let injections, uaOverrides;
 
-const aboutCompatBroker = new AboutCompatBroker({
-  injections,
-  uaOverrides,
-});
+try {
+  injections = new Injections(AVAILABLE_INJECTIONS, CUSTOM_FUNCTIONS);
+  injections.bootup();
+} catch (e) {
+  console.error("Injections failed to start", e);
+  injections = undefined;
+}
 
-aboutCompatBroker.bootup();
-injections.bootup();
-uaOverrides.bootup();
+try {
+  uaOverrides = new UAOverrides(AVAILABLE_UA_OVERRIDES);
+  uaOverrides.bootup();
+} catch (e) {
+  console.error("UA overrides failed to start", e);
+  uaOverrides = undefined;
+}
+
+try {
+  const aboutCompatBroker = new AboutCompatBroker({ injections, uaOverrides });
+  aboutCompatBroker.bootup();
+} catch (e) {
+  console.error("about:compat broker failed to start", e);
+}
+
+try {
+  new Shims(AVAILABLE_SHIMS);
+} catch (e) {
+  console.error("Shims failed to start", e);
+}


### PR DESCRIPTION
We ran into an issue with `tabs.onUpdated` behaving differently on android-components, so this patch imports a fix for that, and some other safety-work.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
