### PR TITLE
Don't dismiss on load SaveLoginPrompt requests

### DIFF
--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
@@ -99,7 +99,7 @@ sealed class PromptRequest(
         val logins: List<Login>,
         override val onDismiss: () -> Unit,
         val onConfirm: (Login) -> Unit
-    ) : PromptRequest(), Dismissible
+    ) : PromptRequest(shouldDismissOnLoad = false), Dismissible
 
     /**
      * Value type that represents a request for a select login prompt.


### PR DESCRIPTION
Related https://github.com/mozilla-mobile/fenix/pull/19767#issuecomment-853427599, we have to override the 
`shouldDismissOnLoad` property for `SaveLoginPrompt`s as this the value that we are using for dismissing on load


https://github.com/mozilla-mobile/android-components/blob/c8205670bd592557a0c0da7223fa8d1075de697d/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt#L335


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
