### PR TITLE
Fixes #10405 - Add a needs review label to the automatic String Sync PRs

### DIFF
--- a/.github/workflows/sync-strings.yml
+++ b/.github/workflows/sync-strings.yml
@@ -39,3 +39,4 @@ jobs:
           branch: automation/sync-strings-${{ steps.ac-version-for-fenix-beta.outputs.major-ac-version }}
           title: "Uplift Strings from master to releases/${{steps.ac-version-for-fenix-beta.outputs.major-ac-version}}.0"
           body: "This (automated) PR sync strings from `master` to `releases/${{steps.ac-version-for-fenix-beta.outputs.major-ac-version}}.0`"
+          labels: "🕵️‍♀️ needs review"


### PR DESCRIPTION
This patch updates the string sync workflow to automatically add a "🕵️‍♀️ needs review" label to the generated PRs.