### PR TITLE
Fixes #10415 - Limit the permissions of the GITHUB_TOKEN in workflows

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -14,12 +14,17 @@
 
 name: "Create Release"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   push:
     branches:
       - 'releases/**'
     paths:
       - '.buildconfig.yml'
+
 jobs:
   main:
     name: "Create Release"

--- a/.github/workflows/sync-strings.yml
+++ b/.github/workflows/sync-strings.yml
@@ -4,6 +4,10 @@
 
 name: "Sync Strings"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   schedule:
     - cron: '0 2 * * *'

--- a/.github/workflows/update-geckoview.yml
+++ b/.github/workflows/update-geckoview.yml
@@ -19,6 +19,10 @@
 
 name: "Update GeckoView"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   schedule:
     - cron: '*/15 * * * *'


### PR DESCRIPTION
This patch introduces the following permissions to all workflows:

```
permissions:
  contents: write
  pull-requests: write
```

This may still seem a bit broad, but it means that all permissions not listed will default to `none`. That includes:

 - actions
 - checks
 - deployments
 - issues
 - packages
 - repository-projects
 - security-events
 - statuses

These all default to `write` normally so I think this is a good improvement to start.
