### PR TITLE
For #10419: Add Places calls for recently added and updated bookmarks

### DIFF
--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorage.kt
@@ -76,6 +76,18 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
     }
 
     /**
+     * Retrieves a list of recently added bookmarks.
+     *
+     * @param limit The maximum number of entries to return.
+     * @return The list of matching bookmark nodes up to the limit number of items.
+     */
+    override suspend fun getRecentBookmarks(limit: Int): List<BookmarkNode> {
+        return withContext(readScope.coroutineContext) {
+            reader.getRecentBookmarks(limit).map { it.asBookmarkNode() }
+        }
+    }
+
+    /**
      * Adds a new bookmark item to a given node.
      *
      * Sync behavior: will add new bookmark item to remote devices.

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorageTest.kt
@@ -139,6 +139,18 @@ class PlacesBookmarksStorageTest {
             assertEquals(BookmarkRoot.Mobile.id, this.parentGuid)
         }
 
+        with(bookmarks.getRecentBookmarks(1)) {
+            assertEquals(insertedItem, this[0].guid)
+        }
+
+        val secondInsertedItem = bookmarks.addItem(BookmarkRoot.Unfiled.id, url, "Mozilla", 6)
+
+        with(bookmarks.getRecentBookmarks(2)) {
+            assertEquals(secondInsertedItem, this[0].guid)
+            assertEquals(insertedItem, this[1].guid)
+        }
+
+        assertTrue(bookmarks.deleteNode(secondInsertedItem))
         assertTrue(bookmarks.deleteNode(folderGuid))
 
         for (root in listOf(

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/BookmarksStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/BookmarksStorage.kt
@@ -35,6 +35,14 @@ interface BookmarksStorage : Storage {
     suspend fun getBookmarksWithUrl(url: String): List<BookmarkNode>
 
     /**
+     * Produces a list of the most recently added bookmarks.
+     *
+     * @param limit The maximum number of entries to return.
+     * @return The list of bookmarks that have been recently added up to the limit number of items.
+     */
+    suspend fun getRecentBookmarks(limit: Int): List<BookmarkNode>
+
+    /**
      * Searches bookmarks with a query string.
      *
      * @param query The query string to search.
@@ -104,7 +112,15 @@ interface BookmarksStorage : Storage {
 }
 
 /**
- * Class for holding metadata about any bookmark node
+ * Represents a bookmark metadata record which describes metadata for the page itself.
+ *
+ * @property type The [BookmarkNodeType] of this record.
+ * @property guid The id.
+ * @property parentGuid The id of the parent node in the tree.
+ * @property position The position of this node in the tree.
+ * @property title A title of the page.
+ * @property url The url of the page.
+ * @property children The list of children of this bookmark node in the tree.
  */
 data class BookmarkNode(
     val type: BookmarkNodeType,

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/BookmarksStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/BookmarksStorage.kt
@@ -112,7 +112,7 @@ interface BookmarksStorage : Storage {
 }
 
 /**
- * Represents a bookmark metadata record which describes metadata for the page itself.
+ * Represents a bookmark record.
  *
  * @property type The [BookmarkNodeType] of this record.
  * @property guid The id.

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt
@@ -134,6 +134,11 @@ class BookmarksStorageSuggestionProviderTest {
             throw NotImplementedError()
         }
 
+        override suspend fun getRecentBookmarks(limit: Int): List<BookmarkNode> {
+            // "Not needed for the test"
+            throw NotImplementedError()
+        }
+
         override suspend fun searchBookmarks(query: String, limit: Int): List<BookmarkNode> =
             synchronized(bookmarkMap) {
                 data class Hit(val key: String, val score: Int)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -64,6 +64,7 @@ permalink: /changelog/
   * `AutofillCreditCardsAddressesStorage` reflects these breaking changes.
   * Introduced a new `CreditCardCrypto` interface for for encrypting and decrypting a credit card number. [#10140](https://github.com/mozilla-mobile/android-components/issues/10140)
   * 🌟️ New APIs for managing keys - `ManagedKey`, `KeyProvider` and `KeyRecoveryHandler`. `AutofillCreditCardsAddressesStorage` implements these APIs for managing keys for credit card storage.
+  * 🌟️ New support for bookmarks to retrieve latest added bookmark nodes. `BookmarksStorage` now implements `getRecentBookmarks`.
 
 * **service-firefox-accounts**
   * 🌟️ When configuring syncable storage layers, `SyncManager` now takes an optional `KeyProvider` to handle encryption/decryption of protected values.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -64,7 +64,7 @@ permalink: /changelog/
   * `AutofillCreditCardsAddressesStorage` reflects these breaking changes.
   * Introduced a new `CreditCardCrypto` interface for for encrypting and decrypting a credit card number. [#10140](https://github.com/mozilla-mobile/android-components/issues/10140)
   * 🌟️ New APIs for managing keys - `ManagedKey`, `KeyProvider` and `KeyRecoveryHandler`. `AutofillCreditCardsAddressesStorage` implements these APIs for managing keys for credit card storage.
-  * 🌟️ New support for bookmarks to retrieve latest added bookmark nodes. `BookmarksStorage` now implements `getRecentBookmarks`.
+  * 🌟️ New support for bookmarks to retrieve latest added bookmark nodes. `PlacesBookmarksStorage` now implements `getRecentBookmarks`.
 
 * **service-firefox-accounts**
   * 🌟️ When configuring syncable storage layers, `SyncManager` now takes an optional `KeyProvider` to handle encryption/decryption of protected values.


### PR DESCRIPTION
For #10419 

We can use `getRecentBookmarks` from the Places API to receive a list of recently added bookmarks. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
