### PR TITLE
Make sure crash state is updated before unlinking engine state

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/CrashMiddleware.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/CrashMiddleware.kt
@@ -21,11 +21,17 @@ internal class CrashMiddleware : Middleware<BrowserState, BrowserAction> {
         next: (BrowserAction) -> Unit,
         action: BrowserAction
     ) {
+
+        next(action)
+
+        // We need to do this after updating the crashed flag in the reducer
+        // because we want observers to see the crash state change before the
+        // engine session is cleared. This way the observers can react to
+        // crashes and will not request a new engine session until the user
+        // explicitly asked to restore the session.
         if (action is CrashAction.SessionCrashedAction) {
             onCrash(context, action)
         }
-
-        next(action)
     }
 
     private fun onCrash(


### PR DESCRIPTION
This makes sure observers see the crashed state of a tab update before the engine session is set to null. This is important so
observers can react to crashes and won't immediately request a new engine session.

