### PR TITLE
Issue #10455 - Add the proton home icon into ui-icons

### DIFF
--- a/components/ui/icons/src/main/res/drawable/mozac_ic_home.xml
+++ b/components/ui/icons/src/main/res/drawable/mozac_ic_home.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="14dp"
+    android:height="14dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillColor="@color/mozac_ui_icons_fill"
+        android:pathData="M21.302 10.8717L13.839 2.76875C12.896 1.74375 11.105 1.74375 10.161 2.76875L2.69802 10.8717C2.41702 11.1768 2.43702 11.6508 2.74102 11.9318C3.04702 12.2128 3.52102 12.1947 3.80102 11.8877L4.00002 11.6718V18.4998C4.00002 19.8787 5.12202 20.9998 6.50002 20.9998H17.5C18.878 20.9998 20 19.8787 20 18.4998V11.6718L20.198 11.8868C20.346 12.0478 20.548 12.1287 20.75 12.1287C20.932 12.1287 21.114 12.0638 21.258 11.9307C21.563 11.6508 21.583 11.1757 21.302 10.8717ZM13.5 19.4998H10.5V14.0998L11.1 13.4998H12.9L13.5 14.0998V19.4998ZM18.5 18.6998L17.7 19.4998H15V14.4998C15 13.1208 13.878 11.9998 12.5 11.9998H11.5C10.122 11.9998 9.00002 13.1208 9.00002 14.4998V19.4998H6.30002L5.50002 18.6998V10.0428L11.265 3.78375C11.648 3.36775 12.353 3.36775 12.736 3.78375L18.501 10.0428V18.6998H18.5Z" />
+</vector>


### PR DESCRIPTION
Fixes #10455 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
