### PR TITLE
Revert "For #10404: Remove deprecated kotlin-android-extensions plugin"

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // If you ever need to force a toolchain rebuild (taskcluster) then edit the following comment.
-// FORCE REBUILD 2021-06-07
+// FORCE REBUILD 2020-10-13
 
 // Synchronized version numbers for dependencies used by (some) modules
 object Versions {

--- a/components/browser/menu/build.gradle
+++ b/components/browser/menu/build.gradle
@@ -4,7 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-parcelize'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion
@@ -19,10 +19,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
-    }
-
-    buildFeatures {
-        viewBinding true
     }
 }
 

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/StickyItemLayoutManager.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/StickyItemLayoutManager.kt
@@ -4,7 +4,6 @@
 
 package mozilla.components.browser.menu.view
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.PointF
 import android.os.Parcelable
@@ -13,7 +12,7 @@ import android.view.ViewTreeObserver
 import androidx.annotation.VisibleForTesting
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.parcelize.Parcelize
+import kotlinx.android.parcel.Parcelize
 
 // Inspired from
 // https://github.com/qiujayen/sticky-layoutmanager/blob/b1ddb086db5b04ff3c5357dabe1bff47a935dd37/
@@ -470,7 +469,6 @@ abstract class StickyItemsLinearLayoutManager<T> constructor(
 /**
  * Save / restore existing [RecyclerView] state and scrolling position and offset.
  */
-@SuppressLint("ParcelCreator")
 @Parcelize
 @VisibleForTesting
 internal data class SavedState(

--- a/components/browser/state/build.gradle
+++ b/components/browser/state/build.gradle
@@ -4,7 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-parcelize'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/PermissionHighlightsState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/PermissionHighlightsState.kt
@@ -4,9 +4,8 @@
 
 package mozilla.components.browser.state.state.content
 
-import android.annotation.SuppressLint
 import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
+import kotlinx.android.parcel.Parcelize
 
 /**
  * Value type that represents any information about permissions that should
@@ -15,7 +14,6 @@ import kotlinx.parcelize.Parcelize
  * @property isAutoPlayBlocking indicates if the autoplay setting
  * disabled some web content from playing.
  */
-@SuppressLint("ParcelCreator")
 @Parcelize
 data class PermissionHighlightsState(
     val isAutoPlayBlocking: Boolean = false

--- a/components/concept/base/build.gradle
+++ b/components/concept/base/build.gradle
@@ -4,7 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-parcelize'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion

--- a/components/concept/base/src/main/java/mozilla/components/concept/base/crash/Breadcrumb.kt
+++ b/components/concept/base/src/main/java/mozilla/components/concept/base/crash/Breadcrumb.kt
@@ -4,9 +4,8 @@
 
 package mozilla.components.concept.base.crash
 
-import android.annotation.SuppressLint
 import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
+import kotlinx.android.parcel.Parcelize
 import org.json.JSONObject
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -16,7 +15,6 @@ import java.util.TimeZone
 /**
  * Represents a single crash breadcrumb.
  */
-@SuppressLint("ParcelCreator")
 @Parcelize
 data class Breadcrumb(
     /**

--- a/components/concept/engine/build.gradle
+++ b/components/concept/engine/build.gradle
@@ -4,7 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-parcelize'
+apply plugin: 'org.jetbrains.kotlin.android.extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion
@@ -19,6 +19,9 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+    androidExtensions {
+        experimental = true
     }
 }
 

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/permission/SitePermissions.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/permission/SitePermissions.kt
@@ -4,16 +4,14 @@
 
 package mozilla.components.concept.engine.permission
 
-import android.annotation.SuppressLint
 import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
+import kotlinx.android.parcel.Parcelize
 import mozilla.components.concept.engine.permission.SitePermissions.Status.NO_DECISION
 import mozilla.components.concept.engine.permission.SitePermissionsStorage.Permission
 
 /**
  * A site permissions and its state.
  */
-@SuppressLint("ParcelCreator")
 @Parcelize
 data class SitePermissions(
     val origin: String,

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/CreditCard.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/CreditCard.kt
@@ -4,9 +4,8 @@
 
 package mozilla.components.concept.engine.prompt
 
-import android.annotation.SuppressLint
 import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
+import kotlinx.android.parcel.Parcelize
 
 /**
  * Value type that represents a credit card.
@@ -18,7 +17,6 @@ import kotlinx.parcelize.Parcelize
  * @property expiryYear The credit card expiry year.
  * @property cardType The credit card network ID.
  */
-@SuppressLint("ParcelCreator")
 @Parcelize
 data class CreditCard(
     val guid: String?,

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/ShareData.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/ShareData.kt
@@ -4,9 +4,8 @@
 
 package mozilla.components.concept.engine.prompt
 
-import android.annotation.SuppressLint
 import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
+import kotlinx.android.parcel.Parcelize
 
 /**
  * Represents data to share for the Web Share and Web Share Target APIs.
@@ -15,7 +14,6 @@ import kotlinx.parcelize.Parcelize
  * @property text Text for the share request.
  * @property url URL for the share request.
  */
-@SuppressLint("ParcelCreator")
 @Parcelize
 data class ShareData(
     val title: String? = null,

--- a/components/concept/storage/build.gradle
+++ b/components/concept/storage/build.gradle
@@ -4,7 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-parcelize'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
@@ -4,9 +4,8 @@
 
 package mozilla.components.concept.storage
 
-import android.annotation.SuppressLint
 import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
+import kotlinx.android.parcel.Parcelize
 import kotlinx.coroutines.Deferred
 
 /**
@@ -156,7 +155,6 @@ sealed class CreditCardNumber(val number: String) {
     /**
      * An encrypted credit card number.
      */
-    @SuppressLint("ParcelCreator")
     @Parcelize
     data class Encrypted(private val data: String) : CreditCardNumber(data), Parcelable
 
@@ -181,7 +179,6 @@ sealed class CreditCardNumber(val number: String) {
  * @property timeLastModified Time of last modified in milliseconds from the unix epoch.
  * @property timesUsed Number of times the credit card was used.
  */
-@SuppressLint("ParcelCreator")
 @Parcelize
 data class CreditCard(
     val guid: String,

--- a/components/feature/addons/build.gradle
+++ b/components/feature/addons/build.gradle
@@ -4,8 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-parcelize'
-
+apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
@@ -38,10 +37,6 @@ android {
     lintOptions {
         warningsAsErrors true
         abortOnError true
-    }
-
-    buildFeatures {
-        viewBinding true
     }
 }
 

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
@@ -4,12 +4,11 @@
 
 package mozilla.components.feature.addons
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Bitmap
 import android.os.Parcelable
 import androidx.core.net.toUri
-import kotlinx.parcelize.Parcelize
+import kotlinx.android.parcel.Parcelize
 
 /**
  * Represents an add-on based on the AMO store:
@@ -37,7 +36,6 @@ import kotlinx.parcelize.Parcelize
  * the [Addon] is not installed.
  * @property defaultLocale Indicates which locale will be always available to display translatable fields.
  */
-@SuppressLint("ParcelCreator")
 @Parcelize
 data class Addon(
     val id: String,
@@ -66,8 +64,7 @@ data class Addon(
      * @property url The link to the profile page for of the author.
      * @property username The username of the author.
      */
-    @SuppressLint("ParcelCreator")
-@Parcelize
+    @Parcelize
     data class Author(
         val id: String,
         val name: String,
@@ -81,8 +78,7 @@ data class Addon(
      * @property average An average score from 1 to 5 of how users scored this add-on.
      * @property reviews The number of users that has scored this add-on.
      */
-    @SuppressLint("ParcelCreator")
-@Parcelize
+    @Parcelize
     data class Rating(
         val average: Float,
         val reviews: Int
@@ -105,8 +101,7 @@ data class Addon(
      * @property icon the icon of the installed extension, only used for temporary extensions
      * as we get the icon from AMO otherwise, see [iconUrl].
      */
-    @SuppressLint("ParcelCreator")
-@Parcelize
+    @Parcelize
     data class InstalledState(
         val id: String,
         val version: String,

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonInstallationDialogFragment.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonInstallationDialogFragment.kt
@@ -27,6 +27,7 @@ import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.appcompat.widget.AppCompatCheckBox
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentManager
+import kotlinx.android.synthetic.main.mozac_feature_addons_fragment_dialog_addon_installed.view.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -34,7 +35,6 @@ import kotlinx.coroutines.launch
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.R
 import mozilla.components.feature.addons.amo.AddonCollectionProvider
-import mozilla.components.feature.addons.databinding.MozacFeatureAddonsFragmentDialogAddonInstalledBinding
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.content.appName
 import mozilla.components.support.ktx.android.content.res.resolveAttribute
@@ -151,8 +151,6 @@ class AddonInstallationDialogFragment : AppCompatDialogFragment() {
             false
         )
 
-        val binding = MozacFeatureAddonsFragmentDialogAddonInstalledBinding.bind(rootView)
-
         rootView.findViewById<TextView>(R.id.title).text =
             requireContext().getString(
                 R.string.mozac_feature_addons_installed_dialog_title,
@@ -162,9 +160,9 @@ class AddonInstallationDialogFragment : AppCompatDialogFragment() {
 
         val icon = safeArguments.getParcelable<Bitmap>(KEY_ICON)
         if (icon != null) {
-            binding.icon.setImageDrawable(BitmapDrawable(resources, icon))
+            rootView.icon.setImageDrawable(BitmapDrawable(resources, icon))
         } else {
-            iconJob = fetchIcon(addon, binding.icon)
+            iconJob = fetchIcon(addon, rootView.icon)
         }
 
         val allowedInPrivateBrowsing = rootView.findViewById<AppCompatCheckBox>(R.id.allow_in_private_browsing)

--- a/components/feature/downloads/build.gradle
+++ b/components/feature/downloads/build.gradle
@@ -4,8 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-parcelize'
-
+apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
@@ -32,10 +31,6 @@ android {
 
     sourceSets {
         androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
-    }
-
-    buildFeatures {
-        viewBinding true
     }
 }
 

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/SimpleDownloadDialogFragment.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/SimpleDownloadDialogFragment.kt
@@ -18,8 +18,10 @@ import androidx.annotation.StringRes
 import androidx.annotation.StyleRes
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
+import kotlinx.android.synthetic.main.mozac_downloads_prompt.*
+import kotlinx.android.synthetic.main.mozac_downloads_prompt.view.*
+import kotlinx.android.synthetic.main.mozac_downloads_prompt.view.download_button
 import android.graphics.drawable.GradientDrawable
-import mozilla.components.feature.downloads.databinding.MozacDownloadsPromptBinding
 
 /**
  * A confirmation dialog to be called before a download is triggered.
@@ -78,10 +80,8 @@ class SimpleDownloadDialogFragment : DownloadDialogFragment() {
             false
         )
 
-        val binding = MozacDownloadsPromptBinding.bind(rootView)
-
         with(requireBundle()) {
-            binding.title.text = if (getLong(KEY_CONTENT_LENGTH) <= 0L) {
+            rootView.title.text = if (getLong(KEY_CONTENT_LENGTH) <= 0L) {
                 getString(R.string.mozac_feature_downloads_dialog_download)
             } else {
                 val contentSize = getLong(KEY_CONTENT_LENGTH).toMegabyteOrKilobyteString()
@@ -93,12 +93,12 @@ class SimpleDownloadDialogFragment : DownloadDialogFragment() {
                         requireContext(),
                         positiveButtonBackgroundColor
                 )
-                binding.downloadButton.backgroundTintList = backgroundTintList
+                rootView.download_button.backgroundTintList = backgroundTintList
             }
 
             if (positiveButtonTextColor != DEFAULT_VALUE) {
                 val color = ContextCompat.getColor(requireContext(), positiveButtonTextColor)
-                binding.downloadButton.setTextColor(color)
+                rootView.download_button.setTextColor(color)
             }
 
             if (positiveButtonRadius != DEFAULT_VALUE.toFloat()) {
@@ -109,20 +109,20 @@ class SimpleDownloadDialogFragment : DownloadDialogFragment() {
                         positiveButtonBackgroundColor
                 ))
                 shape.cornerRadius = positiveButtonRadius
-                binding.downloadButton.background = shape
+                rootView.download_button.background = shape
             }
 
-            binding.filename.text = getString(KEY_FILE_NAME, "")
-            binding.downloadButton.text = getString(
+            rootView.filename.text = getString(KEY_FILE_NAME, "")
+            rootView.download_button.text = getString(
                     getInt(KEY_DOWNLOAD_TEXT, R.string.mozac_feature_downloads_dialog_download)
             )
 
-            binding.closeButton.setOnClickListener {
+            rootView.close_button.setOnClickListener {
                 onCancelDownload()
                 dismiss()
             }
 
-            binding.downloadButton.setOnClickListener {
+            rootView.download_button.setOnClickListener {
                 onStartDownload()
                 dismiss()
             }

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/ui/DownloaderApp.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/ui/DownloaderApp.kt
@@ -4,10 +4,9 @@
 
 package mozilla.components.feature.downloads.ui
 
-import android.annotation.SuppressLint
 import android.content.pm.ResolveInfo
 import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
+import kotlinx.android.parcel.Parcelize
 
 /**
  * Represents an app that can perform downloads.
@@ -19,7 +18,6 @@ import kotlinx.parcelize.Parcelize
  * @property url The full url to the content that should be downloaded.
  * @property contentType Content type (MIME type) to indicate the media type of the download.
  */
-@SuppressLint("ParcelCreator")
 @Parcelize
 data class DownloaderApp(
     val name: String,

--- a/components/feature/intent/build.gradle
+++ b/components/feature/intent/build.gradle
@@ -4,6 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion

--- a/components/feature/privatemode/build.gradle
+++ b/components/feature/privatemode/build.gradle
@@ -4,6 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion

--- a/components/feature/push/build.gradle
+++ b/components/feature/push/build.gradle
@@ -4,6 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion

--- a/components/feature/qr/build.gradle
+++ b/components/feature/qr/build.gradle
@@ -4,6 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion

--- a/components/feature/sitepermissions/build.gradle
+++ b/components/feature/sitepermissions/build.gradle
@@ -4,9 +4,8 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-parcelize'
-
 apply plugin: 'kotlin-kapt'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion

--- a/components/feature/tabs/build.gradle
+++ b/components/feature/tabs/build.gradle
@@ -4,7 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion

--- a/components/feature/webauthn/build.gradle
+++ b/components/feature/webauthn/build.gradle
@@ -4,6 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion

--- a/components/feature/webnotifications/build.gradle
+++ b/components/feature/webnotifications/build.gradle
@@ -4,6 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion

--- a/components/lib/crash/build.gradle
+++ b/components/lib/crash/build.gradle
@@ -20,7 +20,7 @@ plugins {
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-
+apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
@@ -50,10 +50,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
-    }
-
-    buildFeatures {
-        viewBinding true
     }
 }
 

--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/prompt/CrashReporterActivity.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/prompt/CrashReporterActivity.kt
@@ -11,10 +11,14 @@ import android.view.View
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PRIVATE
 import androidx.appcompat.app.AppCompatActivity
+import kotlinx.android.synthetic.main.mozac_lib_crash_crashreporter.closeButton
+import kotlinx.android.synthetic.main.mozac_lib_crash_crashreporter.messageView
+import kotlinx.android.synthetic.main.mozac_lib_crash_crashreporter.restartButton
+import kotlinx.android.synthetic.main.mozac_lib_crash_crashreporter.sendCheckbox
+import kotlinx.android.synthetic.main.mozac_lib_crash_crashreporter.titleView
 import mozilla.components.lib.crash.Crash
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.lib.crash.R
-import mozilla.components.lib.crash.databinding.MozacLibCrashCrashreporterBinding
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
@@ -35,9 +39,6 @@ class CrashReporterActivity : AppCompatActivity() {
     @VisibleForTesting(otherwise = PRIVATE)
     internal var reporterCoroutineContext: CoroutineContext = EmptyCoroutineContext
 
-    @VisibleForTesting(otherwise = PRIVATE)
-    internal lateinit var binding: MozacLibCrashCrashreporterBinding
-
     override fun onCreate(savedInstanceState: Bundle?) {
         setTheme(crashReporter.promptConfiguration.theme)
 
@@ -52,23 +53,21 @@ class CrashReporterActivity : AppCompatActivity() {
         val appName = crashReporter.promptConfiguration.appName
         val organizationName = crashReporter.promptConfiguration.organizationName
 
-        binding = MozacLibCrashCrashreporterBinding.inflate(layoutInflater)
+        titleView.text = getString(R.string.mozac_lib_crash_dialog_title, appName)
+        sendCheckbox.text = getString(R.string.mozac_lib_crash_dialog_checkbox, organizationName)
 
-        binding.titleView.text = getString(R.string.mozac_lib_crash_dialog_title, appName)
-        binding.sendCheckbox.text = getString(R.string.mozac_lib_crash_dialog_checkbox, organizationName)
+        sendCheckbox.isChecked = sharedPreferences.getBoolean(PREFERENCE_KEY_SEND_REPORT, true)
 
-        binding.sendCheckbox.isChecked = sharedPreferences.getBoolean(PREFERENCE_KEY_SEND_REPORT, true)
-
-        binding.restartButton.apply {
+        restartButton.apply {
             text = getString(R.string.mozac_lib_crash_dialog_button_restart, appName)
             setOnClickListener { restart() }
         }
-        binding.closeButton.setOnClickListener { close() }
+        closeButton.setOnClickListener { close() }
 
         if (crashReporter.promptConfiguration.message == null) {
-            binding.messageView.visibility = View.GONE
+            messageView.visibility = View.GONE
         } else {
-            binding.messageView.text = crashReporter.promptConfiguration.message
+            messageView.text = crashReporter.promptConfiguration.message
         }
     }
 
@@ -91,9 +90,9 @@ class CrashReporterActivity : AppCompatActivity() {
     }
 
     private fun sendCrashReportIfNeeded(then: () -> Unit) {
-        sharedPreferences.edit().putBoolean(PREFERENCE_KEY_SEND_REPORT, binding.sendCheckbox.isChecked).apply()
+        sharedPreferences.edit().putBoolean(PREFERENCE_KEY_SEND_REPORT, sendCheckbox.isChecked).apply()
 
-        if (!binding.sendCheckbox.isChecked) {
+        if (!sendCheckbox.isChecked) {
             then()
             return
         }

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/prompt/CrashReporterActivityTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/prompt/CrashReporterActivityTest.kt
@@ -169,10 +169,10 @@ private fun TestCoroutineScope.launchActivityWith(
 }
 
 // Views
-private val CrashReporterActivity.closeButton: Button get() = binding.closeButton
-private val CrashReporterActivity.restartButton: Button get() = binding.restartButton
-private val CrashReporterActivity.messageView: TextView get() = binding.messageView
-private val CrashReporterActivity.sendCheckbox: CheckBox get() = binding.sendCheckbox
+private val CrashReporterActivity.closeButton: Button get() = findViewById(R.id.closeButton)
+private val CrashReporterActivity.restartButton: Button get() = findViewById(R.id.restartButton)
+private val CrashReporterActivity.messageView: TextView get() = findViewById(R.id.messageView)
+private val CrashReporterActivity.sendCheckbox: CheckBox get() = findViewById(R.id.sendCheckbox)
 
 // Preferences
 private val CrashReporterActivity.preferences: SharedPreferences

--- a/components/lib/publicsuffixlist/build.gradle
+++ b/components/lib/publicsuffixlist/build.gradle
@@ -4,7 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-
+apply plugin: 'kotlin-android-extensions'
 apply plugin: plugins.PublicSuffixListPlugin
 
 android {
@@ -22,10 +22,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
-    }
-
-    buildFeatures {
-        viewBinding true
     }
 }
 

--- a/components/lib/state/build.gradle
+++ b/components/lib/state/build.gradle
@@ -4,6 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion

--- a/components/support/base/build.gradle
+++ b/components/support/base/build.gradle
@@ -4,6 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 def generatedSrcDir = new File(buildDir, "generated/components/src/main/java")
 
@@ -47,10 +48,6 @@ android {
                 srcDirs += generatedSrcDir
             }
         }
-    }
-
-    buildFeatures {
-        viewBinding true
     }
 }
 

--- a/components/ui/tabcounter/build.gradle
+++ b/components/ui/tabcounter/build.gradle
@@ -4,6 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
@@ -19,10 +20,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
-    }
-
-    buildFeatures {
-        viewBinding true
     }
 }
 

--- a/components/ui/tabcounter/src/main/java/mozilla/components/ui/tabcounter/TabCounter.kt
+++ b/components/ui/tabcounter/src/main/java/mozilla/components/ui/tabcounter/TabCounter.kt
@@ -12,37 +12,26 @@ import android.graphics.Typeface
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.LayoutInflater
-import android.widget.FrameLayout
-import android.widget.ImageView
 import android.widget.RelativeLayout
-import android.widget.TextView
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
 import androidx.core.view.updatePadding
+import kotlinx.android.synthetic.main.mozac_ui_tabcounter_layout.view.*
 import mozilla.components.support.utils.DrawableUtils
-import mozilla.components.ui.tabcounter.databinding.MozacUiTabcounterLayoutBinding
 import java.text.NumberFormat
 
-class TabCounter @JvmOverloads constructor(
+open class TabCounter @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyle: Int = 0
 ) : RelativeLayout(context, attrs, defStyle) {
 
     private val animationSet: AnimatorSet
-    private var binding: MozacUiTabcounterLayoutBinding
-    private var counterBox: ImageView
-    private var counterText: TextView
-    private var counterRoot: FrameLayout
 
     init {
         val inflater = LayoutInflater.from(context)
         inflater.inflate(R.layout.mozac_ui_tabcounter_layout, this)
 
-        binding = MozacUiTabcounterLayoutBinding.inflate(LayoutInflater.from(context), this)
-        counterBox = binding.counterBox
-        counterText = binding.counterText
-        counterRoot = binding.counterRoot
         setCount(INTERNAL_COUNT)
 
         context.obtainStyledAttributes(attrs, R.styleable.TabCounter, defStyle, 0).apply {
@@ -67,12 +56,12 @@ class TabCounter @JvmOverloads constructor(
     internal fun setColor(colorStateList: ColorStateList) {
         val tabCounterBox =
             DrawableUtils.loadAndTintDrawable(context, R.drawable.mozac_ui_tabcounter_box, colorStateList)
-        counterBox.setImageDrawable(tabCounterBox)
-        counterText.setTextColor(colorStateList)
+        counter_box.setImageDrawable(tabCounterBox)
+        counter_text.setTextColor(colorStateList)
     }
 
     private fun updateContentDescription(count: Int) {
-        counterRoot.contentDescription = if (count == 1) {
+        counter_root.contentDescription = if (count == 1) {
             context?.getString(R.string.mozac_tab_counter_open_tab_tray_single)
         } else {
             String.format(
@@ -103,7 +92,7 @@ class TabCounter @JvmOverloads constructor(
     fun setCount(count: Int) {
         updateContentDescription(count)
         adjustTextSize(count)
-        counterText.text = formatCountForDisplay(count)
+        counter_text.text = formatCountForDisplay(count)
         INTERNAL_COUNT = count
     }
 
@@ -117,56 +106,56 @@ class TabCounter @JvmOverloads constructor(
     private fun createBoxAnimatorSet(animatorSet: AnimatorSet) {
         // The first animator, fadeout in 33 ms (49~51, 2 frames).
         val fadeOut = ObjectAnimator.ofFloat(
-            counterBox, "alpha",
+            counter_box, "alpha",
             ANIM_BOX_FADEOUT_FROM, ANIM_BOX_FADEOUT_TO
         ).setDuration(ANIM_BOX_FADEOUT_DURATION)
 
         // Move up on y-axis, from 0.0 to -5.3 in 50ms, with fadeOut (49~52, 3 frames).
         val moveUp1 = ObjectAnimator.ofFloat(
-            counterBox, "translationY",
+            counter_box, "translationY",
             ANIM_BOX_MOVEUP1_TO, ANIM_BOX_MOVEUP1_FROM
         ).setDuration(ANIM_BOX_MOVEUP1_DURATION)
 
         // Move down on y-axis, from -5.3 to -1.0 in 116ms, after moveUp1 (52~59, 7 frames).
         val moveDown2 = ObjectAnimator.ofFloat(
-            counterBox, "translationY",
+            counter_box, "translationY",
             ANIM_BOX_MOVEDOWN2_FROM, ANIM_BOX_MOVEDOWN2_TO
         ).setDuration(ANIM_BOX_MOVEDOWN2_DURATION)
 
         // FadeIn in 66ms, with moveDown2 (52~56, 4 frames).
         val fadeIn = ObjectAnimator.ofFloat(
-            counterBox, "alpha",
+            counter_box, "alpha",
             ANIM_BOX_FADEIN_FROM, ANIM_BOX_FADEIN_TO
         ).setDuration(ANIM_BOX_FADEIN_DURATION)
 
         // Move down on y-axis, from -1.0 to 2.7 in 116ms, after moveDown2 (59~66, 7 frames).
         val moveDown3 = ObjectAnimator.ofFloat(
-            counterBox, "translationY",
+            counter_box, "translationY",
             ANIM_BOX_MOVEDOWN3_FROM, ANIM_BOX_MOVEDOWN3_TO
         ).setDuration(ANIM_BOX_MOVEDOWN3_DURATION)
 
         // Move up on y-axis, from 2.7 to 0 in 133ms, after moveDown3 (66~74, 8 frames).
         val moveUp4 = ObjectAnimator.ofFloat(
-            counterBox, "translationY",
+            counter_box, "translationY",
             ANIM_BOX_MOVEDOWN4_FROM, ANIM_BOX_MOVEDOWN4_TO
         ).setDuration(ANIM_BOX_MOVEDOWN4_DURATION)
 
         // Scale up height from 2% to 105% in 100ms, after moveUp1 and delay 16ms (53~59, 6 frames).
         val scaleUp1 = ObjectAnimator.ofFloat(
-            counterBox, "scaleY",
+            counter_box, "scaleY",
             ANIM_BOX_SCALEUP1_FROM, ANIM_BOX_SCALEUP1_TO
         ).setDuration(ANIM_BOX_SCALEUP1_DURATION)
         scaleUp1.startDelay = ANIM_BOX_SCALEUP1_DELAY // delay 1 frame after moveUp1
 
         // Scale down height from 105% to 99% in 116ms, after scaleUp1 (59~66, 7 frames).
         val scaleDown2 = ObjectAnimator.ofFloat(
-            counterBox, "scaleY",
+            counter_box, "scaleY",
             ANIM_BOX_SCALEDOWN2_FROM, ANIM_BOX_SCALEDOWN2_TO
         ).setDuration(ANIM_BOX_SCALEDOWN2_DURATION)
 
         // Scale up height from 99% to 100% in 133ms, after scaleDown2 (66~74, 8 frames).
         val scaleUp3 = ObjectAnimator.ofFloat(
-            counterBox, "scaleY",
+            counter_box, "scaleY",
             ANIM_BOX_SCALEUP3_FROM, ANIM_BOX_SCALEUP3_TO
         ).setDuration(ANIM_BOX_SCALEUP3_DURATION)
 
@@ -186,27 +175,27 @@ class TabCounter @JvmOverloads constructor(
 
         // Fadeout in 100ms, with firstAnimator (49~51, 2 frames).
         val fadeOut = ObjectAnimator.ofFloat(
-            counterText, "alpha",
+            counter_text, "alpha",
             ANIM_TEXT_FADEOUT_FROM, ANIM_TEXT_FADEOUT_TO
         ).setDuration(ANIM_TEXT_FADEOUT_DURATION)
 
         // FadeIn in 66 ms, after fadeOut with delay 96ms (57~61, 4 frames).
         val fadeIn = ObjectAnimator.ofFloat(
-            counterText, "alpha",
+            counter_text, "alpha",
             ANIM_TEXT_FADEIN_FROM, ANIM_TEXT_FADEIN_TO
         ).setDuration(ANIM_TEXT_FADEIN_DURATION)
         fadeIn.startDelay = (ANIM_TEXT_FADEIN_DELAY) // delay 6 frames after fadeOut
 
         // Move down on y-axis, from 0 to 4.4 in 66ms, with fadeIn (57~61, 4 frames).
         val moveDown = ObjectAnimator.ofFloat(
-            counterText, "translationY",
+            counter_text, "translationY",
             ANIM_TEXT_MOVEDOWN_FROM, ANIM_TEXT_MOVEDOWN_TO
         ).setDuration(ANIM_TEXT_MOVEDOWN_DURATION)
         moveDown.startDelay = (ANIM_TEXT_MOVEDOWN_DELAY) // delay 6 frames after fadeOut
 
         // Move up on y-axis, from 0 to 4.4 in 66ms, after moveDown (61~69, 8 frames).
         val moveUp = ObjectAnimator.ofFloat(
-            counterText, "translationY",
+            counter_text, "translationY",
             ANIM_TEXT_MOVEUP_FROM, ANIM_TEXT_MOVEUP_TO
         ).setDuration(ANIM_TEXT_MOVEUP_DURATION)
 
@@ -218,7 +207,7 @@ class TabCounter @JvmOverloads constructor(
 
     private fun formatCountForDisplay(count: Int): String {
         return if (count > MAX_VISIBLE_TABS) {
-            counterText.updatePadding(bottom = INFINITE_CHAR_PADDING_BOTTOM)
+            counter_text.updatePadding(bottom = INFINITE_CHAR_PADDING_BOTTOM)
             SO_MANY_TABS_OPEN
         } else {
             NumberFormat.getInstance().format(count.toLong())
@@ -235,9 +224,9 @@ class TabCounter @JvmOverloads constructor(
         val counterBoxWidth =
             context.resources.getDimensionPixelSize(R.dimen.mozac_tab_counter_box_width_height)
         val textSize = newRatio * counterBoxWidth
-        counterText.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize)
-        counterText.setTypeface(null, Typeface.BOLD)
-        counterText.setPadding(0, 0, 0, 0)
+        counter_text.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize)
+        counter_text.setTypeface(null, Typeface.BOLD)
+        counter_text.setPadding(0, 0, 0, 0)
     }
 
     companion object {

--- a/components/ui/tabcounter/src/test/java/mozilla/components/ui/tabcounter/TabCounterTest.kt
+++ b/components/ui/tabcounter/src/test/java/mozilla/components/ui/tabcounter/TabCounterTest.kt
@@ -5,58 +5,50 @@
 package mozilla.components.ui.tabcounter
 
 import android.content.res.ColorStateList
-import android.view.LayoutInflater
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.android.synthetic.main.mozac_ui_tabcounter_layout.view.*
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.ui.tabcounter.TabCounter.Companion.SO_MANY_TABS_OPEN
-import mozilla.components.ui.tabcounter.databinding.MozacUiTabcounterLayoutBinding
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class TabCounterTest {
-
-    private lateinit var tabCounter: TabCounter
-    private lateinit var binding: MozacUiTabcounterLayoutBinding
-
-    @Before
-    fun setUp() {
-        tabCounter = TabCounter(testContext)
-        binding =
-            MozacUiTabcounterLayoutBinding.inflate(LayoutInflater.from(testContext), tabCounter)
-    }
-
     @Test
     fun `Default tab count is set to zero`() {
-        assertEquals("0", binding.counterText.text)
+        val tabCounter = TabCounter(testContext)
+        assertEquals("0", tabCounter.counter_text.text)
     }
 
     @Test
     fun `Set tab count as single digit value shows count`() {
+        val tabCounter = TabCounter(testContext)
         tabCounter.setCount(1)
-        assertEquals("1", binding.counterText.text)
+        assertEquals("1", tabCounter.counter_text.text)
     }
 
     @Test
     fun `Set tab count as two digit number shows count`() {
+        val tabCounter = TabCounter(testContext)
         tabCounter.setCount(99)
-        assertEquals("99", binding.counterText.text)
+        assertEquals("99", tabCounter.counter_text.text)
     }
 
     @Test
     fun `Setting tab count as three digit value shows correct icon`() {
+        val tabCounter = TabCounter(testContext)
         tabCounter.setCount(100)
-        assertEquals(SO_MANY_TABS_OPEN, binding.counterText.text)
+        assertEquals(SO_MANY_TABS_OPEN, tabCounter.counter_text.text)
     }
 
     @Test
     fun `Setting tab color shows correct icon`() {
+        val tabCounter = TabCounter(testContext)
         val colorStateList: ColorStateList = mock()
 
         tabCounter.setColor(colorStateList)
-        assertEquals(binding.counterText.textColors, colorStateList)
+        assertEquals(tabCounter.counter_text.textColors, colorStateList)
     }
 }

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -4,6 +4,7 @@
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion
@@ -46,10 +47,6 @@ android {
             // release versions.
             setIgnore(true)
         }
-    }
-
-    buildFeatures {
-        viewBinding true
     }
 }
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
@@ -11,6 +11,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.CallSuper
 import androidx.fragment.app.Fragment
+import kotlinx.android.synthetic.main.fragment_browser.view.*
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.mapNotNull
 import mozilla.components.browser.state.selector.findCustomTabOrSelectedTab
@@ -35,7 +36,6 @@ import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.arch.lifecycle.addObservers
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
-import org.mozilla.samples.browser.databinding.FragmentBrowserBinding
 import org.mozilla.samples.browser.downloads.DownloadService
 import org.mozilla.samples.browser.ext.components
 import org.mozilla.samples.browser.integration.ContextMenuIntegration
@@ -65,36 +65,33 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
         promptFeature
     )
 
-    private var _binding: FragmentBrowserBinding? = null
-    val binding get() = _binding!!
-
     @CallSuper
     @Suppress("LongMethod")
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentBrowserBinding.inflate(inflater, container, false)
+        val layout = inflater.inflate(R.layout.fragment_browser, container, false)
 
-        binding.toolbar.display.menuBuilder = components.menuBuilder
+        layout.toolbar.display.menuBuilder = components.menuBuilder
 
         sessionFeature.set(
             feature = SessionFeature(
                 components.store,
                 components.sessionUseCases.goBack,
-                binding.engineView,
+                layout.engineView,
                 sessionId),
             owner = this,
-            view = binding.root)
+            view = layout)
 
         toolbarFeature.set(
             feature = ToolbarFeature(
-                binding.toolbar,
+                layout.toolbar,
                 components.store,
                 components.sessionUseCases.loadUrl,
                 components.defaultSearchUseCase,
                 sessionId),
             owner = this,
-            view = binding.root)
+            view = layout)
 
-        binding.toolbar.display.indicators += listOf(
+        layout.toolbar.display.indicators += listOf(
             DisplayToolbar.Indicators.TRACKING_PROTECTION, DisplayToolbar.Indicators.HIGHLIGHT
         )
 
@@ -102,9 +99,9 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
             feature = SwipeRefreshFeature(
                 components.store,
                 components.sessionUseCases.reload,
-                binding.swipeToRefresh),
+                layout.swipeToRefresh),
             owner = this,
-            view = binding.root)
+            view = layout)
 
         downloadsFeature.set(
             feature = DownloadsFeature(
@@ -125,10 +122,10 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
                     requestPermissions(permissions, REQUEST_CODE_DOWNLOAD_PERMISSIONS)
                 }),
             owner = this,
-            view = binding.root
+            view = layout
         )
 
-        val scrollFeature = CoordinateScrollingFeature(components.store, binding.engineView, binding.toolbar)
+        val scrollFeature = CoordinateScrollingFeature(components.store, layout.engineView, layout.toolbar)
 
         contextMenuIntegration.set(
             feature = ContextMenuIntegration(
@@ -137,11 +134,11 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
                 browserStore = components.store,
                 tabsUseCases = components.tabsUseCases,
                 contextMenuUseCases = components.contextMenuUseCases,
-                parentView = binding.root,
+                parentView = layout,
                 sessionId = sessionId
             ),
             owner = this,
-            view = binding.root)
+            view = layout)
 
         appLinksFeature.set(
             feature = AppLinksFeature(
@@ -153,7 +150,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
                 loadUrlUseCase = components.sessionUseCases.loadUrl
             ),
             owner = this,
-            view = binding.root
+            view = layout
         )
 
         promptFeature.set(
@@ -166,7 +163,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
                     requestPermissions(permissions, REQUEST_CODE_PROMPT_PERMISSIONS)
                 }),
             owner = this,
-            view = binding.root)
+            view = layout)
 
         sitePermissionsFeature.set(
             feature = SitePermissionsFeature(
@@ -191,13 +188,13 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
                 store = components.store
             ),
             owner = this,
-            view = binding.root
+            view = layout
         )
 
         findInPageIntegration.set(
-            feature = FindInPageIntegration(components.store, binding.findInPage, binding.engineView),
+            feature = FindInPageIntegration(components.store, layout.findInPage, layout.engineView),
             owner = this,
-            view = binding.root)
+            view = layout)
 
         val secureWindowFeature = SecureWindowFeature(
             window = requireActivity().window,
@@ -211,7 +208,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
             secureWindowFeature
         )
 
-        return binding.root
+        return layout
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -225,7 +222,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
                     )
                 }
                 .collect {
-                    binding.toolbar.invalidateActions()
+                    view.toolbar.invalidateActions()
                 }
         }
     }
@@ -261,9 +258,5 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
         protected fun Bundle.putSessionId(sessionId: String?) {
             putString(SESSION_ID_KEY, sessionId)
         }
-    }
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import kotlinx.android.synthetic.main.fragment_browser.view.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.browser.thumbnails.BrowserThumbnails
 import mozilla.components.feature.awesomebar.AwesomeBarFeature
@@ -45,15 +46,15 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        super.onCreateView(inflater, container, savedInstanceState)
-        val binding = super.binding
-        ToolbarAutocompleteFeature(binding.toolbar, components.engine).apply {
+        val layout = super.onCreateView(inflater, container, savedInstanceState)
+
+        ToolbarAutocompleteFeature(layout.toolbar, components.engine).apply {
             addHistoryStorageProvider(components.historyStorage)
             addDomainProvider(components.shippedDomainsProvider)
         }
 
         TabsToolbarFeature(
-            toolbar = binding.toolbar,
+            toolbar = layout.toolbar,
             store = components.store,
             sessionId = sessionId,
             lifecycleOwner = viewLifecycleOwner,
@@ -61,7 +62,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
             countBasedOnSelectedTabType = false
         )
 
-        AwesomeBarFeature(binding.awesomeBar, binding.toolbar, binding.engineView, components.icons)
+        AwesomeBarFeature(layout.awesomeBar, layout.toolbar, layout.engineView, components.icons)
             .addHistoryProvider(
                 components.historyStorage,
                 components.sessionUseCases.loadUrl,
@@ -96,12 +97,12 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                 requireContext(),
                 components.engine,
                 components.store,
-                binding.toolbar,
-                binding.readerViewBar,
-                binding.readerViewAppearanceButton
+                layout.toolbar,
+                layout.readerViewBar,
+                layout.readerViewAppearanceButton
             ),
             owner = this,
-            view = binding.root
+            view = layout
         )
 
         fullScreenFeature.set(
@@ -117,7 +118,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                 }
             },
             owner = this,
-            view = binding.root
+            view = layout
         )
 
         mediaSessionFullscreenFeature.set(
@@ -126,22 +127,22 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                 components.store
             ),
             owner = this,
-            view = binding.root
+            view = layout
         )
 
         thumbnailsFeature.set(
-            feature = BrowserThumbnails(requireContext(), binding.engineView, components.store),
+            feature = BrowserThumbnails(requireContext(), layout.engineView, components.store),
             owner = this,
-            view = binding.root
+            view = layout
         )
 
         webExtToolbarFeature.set(
             feature = WebExtensionToolbarFeature(
-                binding.toolbar,
+                layout.toolbar,
                 components.store
             ),
             owner = this,
-            view = binding.root
+            view = layout
         )
 
         searchFeature.set(
@@ -153,13 +154,13 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                 }
             },
             owner = this,
-            view = binding.root
+            view = layout
         )
 
         val windowFeature = WindowFeature(components.store, components.tabsUseCases)
         lifecycle.addObserver(windowFeature)
 
-        return binding.root
+        return layout
     }
 
     private fun showTabs() {

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserFragment.kt
@@ -9,6 +9,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
+import kotlinx.android.synthetic.main.fragment_browser.view.*
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.feature.customtabs.CustomTabWindowFeature
 import mozilla.components.feature.customtabs.CustomTabsToolbarFeature
@@ -34,22 +35,21 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
         get() = arguments?.getWebAppManifest()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        super.onCreateView(inflater, container, savedInstanceState)
-        val binding = super.binding
+        val layout = super.onCreateView(inflater, container, savedInstanceState)
 
         val manifest = this.manifest
 
         customTabsToolbarFeature.set(
             feature = CustomTabsToolbarFeature(
                 components.store,
-                binding.toolbar,
+                layout.toolbar,
                 sessionId,
                 components.customTabsUseCases,
                 components.menuBuilder,
                 window = activity?.window,
                 closeListener = { activity?.finish() }),
             owner = this,
-            view = binding.root)
+            view = layout)
 
         hideToolbarFeature.set(
             feature = WebAppHideToolbarFeature(
@@ -58,10 +58,10 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
                 sessionId,
                 manifest
             ) { toolbarVisible ->
-                binding.toolbar.isVisible = toolbarVisible
+                layout.toolbar.isVisible = toolbarVisible
             },
             owner = this,
-            view = binding.toolbar)
+            view = layout.toolbar)
 
         val windowFeature = CustomTabWindowFeature(
             requireActivity(),
@@ -100,7 +100,7 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
             )
         }
 
-        return binding.root
+        return layout
     }
 
     /**

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/TabsTrayFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/TabsTrayFragment.kt
@@ -11,13 +11,14 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.GridLayoutManager
 import com.google.android.material.snackbar.Snackbar
+import kotlinx.android.synthetic.main.fragment_tabstray.tabsTray
+import kotlinx.android.synthetic.main.fragment_tabstray.toolbar
 import mozilla.components.browser.tabstray.TabsAdapter
 import mozilla.components.browser.thumbnails.loader.ThumbnailLoader
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.feature.tabs.tabstray.TabsFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
-import org.mozilla.samples.browser.databinding.FragmentTabstrayBinding
 import org.mozilla.samples.browser.ext.components
 
 /**
@@ -32,14 +33,13 @@ class TabsTrayFragment : Fragment(), UserInteractionHandler {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val binding = FragmentTabstrayBinding.bind(view)
-        binding.toolbar.setNavigationIcon(R.drawable.mozac_ic_back)
-        binding.toolbar.setNavigationOnClickListener {
+        toolbar.setNavigationIcon(R.drawable.mozac_ic_back)
+        toolbar.setNavigationOnClickListener {
             closeTabsTray()
         }
 
-        binding.toolbar.inflateMenu(R.menu.tabstray_menu)
-        binding.toolbar.setOnMenuItemClickListener {
+        toolbar.inflateMenu(R.menu.tabstray_menu)
+        toolbar.setOnMenuItemClickListener {
             when (it.itemId) {
                 R.id.newTab -> {
                     components.tabsUseCases.addTab.invoke("about:blank", selectTab = true)
@@ -50,8 +50,8 @@ class TabsTrayFragment : Fragment(), UserInteractionHandler {
         }
 
         val tabsAdapter = createTabsAdapter()
-        binding.tabsTray.adapter = tabsAdapter
-        binding.tabsTray.layoutManager = GridLayoutManager(context, 2)
+        tabsTray.adapter = tabsAdapter
+        tabsTray.layoutManager = GridLayoutManager(context, 2)
 
         tabsFeature.set(
             feature = TabsFeature(

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonSettingsActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonSettingsActivity.kt
@@ -12,13 +12,12 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import kotlinx.android.synthetic.main.fragment_add_on_settings.*
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.ui.translateName
 import org.mozilla.samples.browser.R
-import org.mozilla.samples.browser.databinding.ActivityAddOnSettingsBinding
-import org.mozilla.samples.browser.databinding.FragmentAddOnSettingsBinding
 import org.mozilla.samples.browser.ext.components
 
 /**
@@ -26,13 +25,9 @@ import org.mozilla.samples.browser.ext.components
  */
 class AddonSettingsActivity : AppCompatActivity() {
 
-    private lateinit var binding: ActivityAddOnSettingsBinding
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityAddOnSettingsBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(R.layout.activity_add_on_settings)
 
         val addon = requireNotNull(intent.getParcelableExtra<Addon>("add_on"))
         title = addon.translateName(this)
@@ -66,8 +61,7 @@ class AddonSettingsActivity : AppCompatActivity() {
         override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
             super.onViewCreated(view, savedInstanceState)
 
-            val binding = FragmentAddOnSettingsBinding.bind(view)
-            binding.addonSettingsEngineView.render(engineSession)
+            addonSettingsEngineView.render(engineSession)
             addon.installedState?.optionsPageUrl?.let {
                 engineSession.loadUrl(it)
             }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/WebExtensionActionPopupActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/WebExtensionActionPopupActivity.kt
@@ -12,6 +12,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import kotlinx.android.synthetic.main.fragment_add_on_settings.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.browser.state.action.WebExtensionAction
 import mozilla.components.concept.engine.EngineSession
@@ -19,7 +20,6 @@ import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.lib.state.ext.consumeFrom
 import org.mozilla.samples.browser.R
-import org.mozilla.samples.browser.databinding.FragmentAddOnSettingsBinding
 import org.mozilla.samples.browser.ext.components
 
 /**
@@ -67,10 +67,9 @@ class WebExtensionActionPopupActivity : AppCompatActivity() {
         override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
             super.onViewCreated(view, savedInstanceState)
 
-            val binding = FragmentAddOnSettingsBinding.bind(view)
             val session = engineSession
             if (session != null) {
-                binding.addonSettingsEngineView.render(session)
+                addonSettingsEngineView.render(session)
                 session.register(this, view)
                 consumePopupSession()
             } else {
@@ -78,7 +77,7 @@ class WebExtensionActionPopupActivity : AppCompatActivity() {
                     state.extensions[webExtensionId]?.let { extState ->
                         extState.popupSession?.let {
                             if (engineSession == null) {
-                                binding.addonSettingsEngineView.render(it)
+                                addonSettingsEngineView.render(it)
                                 it.register(this, view)
                                 consumePopupSession()
                                 engineSession = it

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/integration/ContextMenuIntegration.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/integration/ContextMenuIntegration.kt
@@ -7,6 +7,7 @@ package org.mozilla.samples.browser.integration
 import android.content.Context
 import android.view.View
 import androidx.fragment.app.FragmentManager
+import kotlinx.android.synthetic.main.fragment_browser.view.*
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.app.links.AppLinksUseCases
 import mozilla.components.feature.contextmenu.ContextMenuCandidate
@@ -23,7 +24,6 @@ import mozilla.components.feature.contextmenu.ContextMenuUseCases
 import mozilla.components.feature.contextmenu.DefaultSnackbarDelegate
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.support.base.feature.LifecycleAwareFeature
-import org.mozilla.samples.browser.databinding.FragmentBrowserBinding
 
 @Suppress("LongParameterList", "UndocumentedPublicClass")
 class ContextMenuIntegration(
@@ -42,12 +42,7 @@ class ContextMenuIntegration(
             listOf(
                 createCopyLinkCandidate(context, parentView, snackbarDelegate),
                 createShareLinkCandidate(context),
-                createOpenImageInNewTabCandidate(
-                    context,
-                    tabsUseCases,
-                    parentView,
-                    snackbarDelegate
-                ),
+                createOpenImageInNewTabCandidate(context, tabsUseCases, parentView, snackbarDelegate),
                 createSaveImageCandidate(context, contextMenuUseCases),
                 createCopyImageLocationCandidate(context, parentView, snackbarDelegate),
                 createAddContactCandidate(context),
@@ -72,11 +67,7 @@ class ContextMenuIntegration(
     }
 
     private val feature = ContextMenuFeature(
-        fragmentManager,
-        browserStore,
-        candidates,
-        FragmentBrowserBinding.bind(parentView).engineView,
-        contextMenuUseCases
+        fragmentManager, browserStore, candidates, parentView.engineView, contextMenuUseCases
     )
 
     override fun start() {

--- a/samples/browser/src/main/res/layout/activity_installed_add_on_details.xml
+++ b/samples/browser/src/main/res/layout/activity_installed_add_on_details.xml
@@ -15,7 +15,7 @@
             android:paddingStart="?android:attr/listPreferredItemPaddingStart"
             android:paddingEnd="?android:attr/listPreferredItemPaddingEnd">
 
-        <androidx.appcompat.widget.SwitchCompat
+        <SwitchCompat
                 android:id="@+id/enable_switch"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -69,7 +69,7 @@
                 android:textSize="18sp"
                 app:drawableStartCompat="@drawable/mozac_ic_permissions" />
 
-        <androidx.appcompat.widget.SwitchCompat
+        <SwitchCompat
             android:id="@+id/allow_in_private_browsing_switch"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/samples/browser/src/main/res/layout/fragment_add_ons.xml
+++ b/samples/browser/src/main/res/layout/fragment_add_ons.xml
@@ -18,6 +18,7 @@
 
 
     <include
+        android:id="@+id/addonProgressOverlay"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"

--- a/samples/browser/src/main/res/layout/overlay_add_on_progress.xml
+++ b/samples/browser/src/main/res/layout/overlay_add_on_progress.xml
@@ -2,10 +2,8 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<androidx.cardview.widget.CardView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/addonProgressOverlay"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:elevation="1dp">

--- a/samples/crash/build.gradle
+++ b/samples/crash/build.gradle
@@ -4,6 +4,7 @@
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion
@@ -23,10 +24,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
-    }
-
-    buildFeatures {
-        viewBinding true
     }
 }
 

--- a/samples/crash/src/main/java/org/mozilla/samples/crash/CrashActivity.kt
+++ b/samples/crash/src/main/java/org/mozilla/samples/crash/CrashActivity.kt
@@ -14,9 +14,9 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import com.google.android.material.snackbar.Snackbar
+import kotlinx.android.synthetic.main.activity_crash.*
 import mozilla.components.lib.crash.Crash
 import mozilla.components.concept.base.crash.Breadcrumb
-import org.mozilla.samples.crash.databinding.ActivityCrashBinding
 
 class CrashActivity : AppCompatActivity(), View.OnClickListener {
     private val receiver = object : BroadcastReceiver() {
@@ -27,26 +27,21 @@ class CrashActivity : AppCompatActivity(), View.OnClickListener {
 
             val crash = Crash.fromIntent(intent)
 
-            Snackbar.make(
-                findViewById(android.R.id.content),
-                "Sorry. We crashed.",
-                Snackbar.LENGTH_LONG
-            )
+            Snackbar.make(findViewById(android.R.id.content), "Sorry. We crashed.", Snackbar.LENGTH_LONG)
                 .setAction("Report") { crashReporter.submitReport(crash) }
                 .show()
         }
     }
-    private lateinit var binding: ActivityCrashBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityCrashBinding.inflate(layoutInflater)
-        setContentView(binding.root)
 
-        binding.fatalCrashButton.setOnClickListener(this)
-        binding.crashButton.setOnClickListener(this)
-        binding.fatalServiceCrashButton.setOnClickListener(this)
-        binding.crashList.setOnClickListener(this)
+        setContentView(R.layout.activity_crash)
+
+        fatalCrashButton.setOnClickListener(this)
+        crashButton.setOnClickListener(this)
+        fatalServiceCrashButton.setOnClickListener(this)
+        crashList.setOnClickListener(this)
 
         crashReporter.recordCrashBreadcrumb(
             Breadcrumb(
@@ -92,7 +87,7 @@ class CrashActivity : AppCompatActivity(), View.OnClickListener {
     @Suppress("TooGenericExceptionThrown")
     override fun onClick(view: View) {
         when (view) {
-            binding.fatalCrashButton -> {
+            fatalCrashButton -> {
                 crashReporter.recordCrashBreadcrumb(
                     Breadcrumb(
                         "fatal crash button clicked",
@@ -106,7 +101,7 @@ class CrashActivity : AppCompatActivity(), View.OnClickListener {
                 throw RuntimeException("Boom!")
             }
 
-            binding.crashButton -> {
+            crashButton -> {
                 crashReporter.recordCrashBreadcrumb(
                     Breadcrumb(
                         "crash button clicked",
@@ -137,7 +132,7 @@ class CrashActivity : AppCompatActivity(), View.OnClickListener {
                 ContextCompat.startForegroundService(this, intent)
             }
 
-            binding.fatalServiceCrashButton -> {
+            fatalServiceCrashButton -> {
                 crashReporter.recordCrashBreadcrumb(
                     Breadcrumb(
                         "fatal service crash button clicked",
@@ -152,7 +147,7 @@ class CrashActivity : AppCompatActivity(), View.OnClickListener {
                 finish()
             }
 
-            binding.crashList -> {
+            crashList -> {
                 startActivity(Intent(this, CrashListActivity::class.java))
             }
 

--- a/samples/dataprotect/build.gradle
+++ b/samples/dataprotect/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-
+apply plugin: 'kotlin-android-extensions'
 android {
     compileSdkVersion config.compileSdkVersion
 

--- a/samples/firefox-accounts/build.gradle
+++ b/samples/firefox-accounts/build.gradle
@@ -4,6 +4,7 @@
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion

--- a/samples/glean/build.gradle
+++ b/samples/glean/build.gradle
@@ -20,6 +20,7 @@ plugins {
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion
@@ -42,10 +43,6 @@ android {
         debug {
             applicationIdSuffix ".debug"
         }
-    }
-
-    buildFeatures {
-        viewBinding true
     }
 }
 

--- a/samples/glean/src/main/java/org/mozilla/samples/glean/MainActivity.kt
+++ b/samples/glean/src/main/java/org/mozilla/samples/glean/MainActivity.kt
@@ -8,35 +8,32 @@ import android.graphics.Color
 import android.os.Bundle
 import androidx.annotation.MainThread
 import androidx.appcompat.app.AppCompatActivity
+import kotlinx.android.synthetic.main.activity_main.*
 import org.mozilla.experiments.nimbus.EnrolledExperiment
 import org.mozilla.experiments.nimbus.NimbusInterface
 import org.mozilla.samples.glean.GleanMetrics.BrowserEngagement
 import org.mozilla.samples.glean.GleanMetrics.Test
-import org.mozilla.samples.glean.databinding.ActivityMainBinding
 import org.mozilla.samples.glean.library.SamplesGleanLibrary
 
 /**
  * Main Activity of the glean-sample-app
  */
 open class MainActivity : AppCompatActivity(), NimbusInterface.Observer {
-    private lateinit var binding: ActivityMainBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityMainBinding.inflate(layoutInflater)
-
-        setContentView(binding.root)
+        setContentView(R.layout.activity_main)
 
         // Generate an event when user clicks on the button.
-        binding.buttonGenerateData.setOnClickListener {
+        buttonGenerateData.setOnClickListener {
             // These first two actions, adding to the string list and incrementing the counter are
             // tied to a user lifetime metric which is persistent from launch to launch.
 
             // Adds the EditText's text content as a new string in the string list metric from the
             // metrics.yaml file.
-            Test.stringList.add(binding.etStringListInput.text.toString())
+            Test.stringList.add(etStringListInput.text.toString())
             // Clear current text to help indicate something happened
-            binding.etStringListInput.setText("")
+            etStringListInput.setText("")
 
             // Increments the test_counter metric from the metrics.yaml file.
             Test.counter.add()
@@ -72,7 +69,7 @@ open class MainActivity : AppCompatActivity(), NimbusInterface.Observer {
         GleanApplication.nimbus.register(this)
 
         // Attach the click listener for the experiments button to the updateExperiments function
-        binding.buttonCheckExperiments.setOnClickListener {
+        buttonCheckExperiments.setOnClickListener {
             // Once the experiments are fetched, then the activity's (a Nimbus observer)
             // `onExperimentFetched()` method is called.
             GleanApplication.nimbus.fetchExperiments()
@@ -115,8 +112,8 @@ open class MainActivity : AppCompatActivity(), NimbusInterface.Observer {
             else -> getString(R.string.experiment_active_branch, branch)
         }
 
-        binding.textViewExperimentStatus.setBackgroundColor(color)
-        binding.textViewExperimentStatus.text = text
+        textViewExperimentStatus.setBackgroundColor(color)
+        textViewExperimentStatus.text = text
     }
 
     /** End Nimbus component functions */

--- a/samples/sync-logins/build.gradle
+++ b/samples/sync-logins/build.gradle
@@ -4,6 +4,7 @@
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion

--- a/samples/sync/build.gradle
+++ b/samples/sync/build.gradle
@@ -4,6 +4,7 @@
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion
@@ -31,10 +32,6 @@ android {
             reset()
             include 'x86', 'arm64-v8a', 'armeabi-v7a'
         }
-    }
-
-    buildFeatures {
-        viewBinding true
     }
 }
 

--- a/samples/sync/src/main/java/org/mozilla/samples/sync/DeviceRecyclerViewAdapter.kt
+++ b/samples/sync/src/main/java/org/mozilla/samples/sync/DeviceRecyclerViewAdapter.kt
@@ -9,10 +9,11 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
+import kotlinx.android.synthetic.main.fragment_device.view.device_name
+import kotlinx.android.synthetic.main.fragment_device.view.device_type
 import mozilla.components.concept.sync.Device
 import mozilla.components.concept.sync.DeviceType
 import org.mozilla.samples.sync.DeviceFragment.OnDeviceListInteractionListener
-import org.mozilla.samples.sync.databinding.FragmentDeviceBinding
 
 /**
  * [RecyclerView.Adapter] that can display a [DummyItem] and makes a call to the
@@ -36,9 +37,9 @@ class DeviceRecyclerViewAdapter(
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        val binding = FragmentDeviceBinding
-            .inflate(LayoutInflater.from(parent.context), parent, false)
-        return ViewHolder(binding)
+        val view = LayoutInflater.from(parent.context)
+                .inflate(R.layout.fragment_device, parent, false)
+        return ViewHolder(view)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
@@ -53,7 +54,7 @@ class DeviceRecyclerViewAdapter(
             DeviceType.UNKNOWN -> "Unknown"
         }
 
-        with(holder.itemView) {
+        with(holder.mView) {
             tag = item
             setOnClickListener(mOnClickListener)
         }
@@ -61,8 +62,8 @@ class DeviceRecyclerViewAdapter(
 
     override fun getItemCount(): Int = devices.size
 
-    inner class ViewHolder(binding: FragmentDeviceBinding) : RecyclerView.ViewHolder(binding.root) {
-        val nameView: TextView = binding.deviceName
-        val typeView: TextView = binding.deviceType
+    inner class ViewHolder(val mView: View) : RecyclerView.ViewHolder(mView) {
+        val nameView: TextView = mView.device_name
+        val typeView: TextView = mView.device_type
     }
 }

--- a/samples/sync/src/main/java/org/mozilla/samples/sync/MainActivity.kt
+++ b/samples/sync/src/main/java/org/mozilla/samples/sync/MainActivity.kt
@@ -9,6 +9,7 @@ import android.text.method.ScrollingMovementMethod
 import android.view.View
 import android.widget.TextView
 import android.widget.Toast
+import kotlinx.android.synthetic.main.activity_main.syncStatus
 import androidx.appcompat.app.AppCompatActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -54,7 +55,6 @@ import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.base.log.sink.AndroidLogSink
 import mozilla.components.support.rusthttp.RustHttpConfig
 import mozilla.components.support.rustlog.RustLog
-import org.mozilla.samples.sync.databinding.ActivityMainBinding
 import java.lang.Exception
 import kotlin.coroutines.CoroutineContext
 
@@ -121,18 +121,14 @@ class MainActivity :
 
     private val logger = Logger("SampleSync")
 
-    private lateinit var binding: ActivityMainBinding
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityMainBinding.inflate(layoutInflater)
-
         RustLog.enable()
         RustHttpConfig.setClient(lazy { HttpURLConnectionClient() })
 
         Log.addSink(AndroidLogSink())
 
-        setContentView(binding.root)
+        setContentView(R.layout.activity_main)
 
         findViewById<View>(R.id.buttonSignIn).setOnClickListener {
             launch {
@@ -400,14 +396,14 @@ class MainActivity :
         override fun onStarted() {
             logger.info("onSyncStarted")
             CoroutineScope(Dispatchers.Main).launch {
-                binding.syncStatus.text = getString(R.string.syncing)
+                syncStatus?.text = getString(R.string.syncing)
             }
         }
 
         override fun onIdle() {
             logger.info("onSyncIdle")
             CoroutineScope(Dispatchers.Main).launch {
-                binding.syncStatus.text = getString(R.string.sync_idle)
+                syncStatus?.text = getString(R.string.sync_idle)
 
                 val historyResultTextView: TextView = findViewById(R.id.historySyncResult)
                 val visitedCount = withContext(Dispatchers.IO) { historyStorage.value.getVisited().size }
@@ -443,7 +439,7 @@ class MainActivity :
         override fun onError(error: Exception?) {
             logger.error("onSyncError", error)
             CoroutineScope(Dispatchers.Main).launch {
-                binding.syncStatus.text = getString(R.string.sync_error, error)
+                syncStatus?.text = getString(R.string.sync_error, error)
             }
         }
     }

--- a/samples/toolbar/build.gradle
+++ b/samples/toolbar/build.gradle
@@ -4,6 +4,7 @@
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion config.compileSdkVersion
@@ -23,10 +24,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
-    }
-
-    buildFeatures {
-        viewBinding true
     }
 }
 

--- a/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/ToolbarActivity.kt
+++ b/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/ToolbarActivity.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import kotlinx.android.synthetic.main.activity_toolbar.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -46,7 +47,6 @@ import mozilla.components.support.ktx.android.content.res.resolveAttribute
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import mozilla.components.support.utils.URLStringUtils
 import mozilla.components.ui.tabcounter.TabCounter
-import org.mozilla.samples.toolbar.databinding.ActivityToolbarBinding
 
 /**
  * This sample application shows how to use and customize the browser-toolbar component.
@@ -55,16 +55,14 @@ import org.mozilla.samples.toolbar.databinding.ActivityToolbarBinding
 class ToolbarActivity : AppCompatActivity() {
     private val shippedDomainsProvider = ShippedDomainsProvider()
     private val customDomainsProvider = CustomDomainsProvider()
-    private lateinit var binding: ActivityToolbarBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityToolbarBinding.inflate(layoutInflater)
 
         shippedDomainsProvider.initialize(this)
         customDomainsProvider.initialize(this)
 
-        setContentView(binding.root)
+        setContentView(R.layout.activity_toolbar)
 
         val configuration = getToolbarConfiguration(intent)
 
@@ -82,7 +80,7 @@ class ToolbarActivity : AppCompatActivity() {
         recyclerView.adapter = ConfigurationAdapter(configuration)
         recyclerView.layoutManager = LinearLayoutManager(this, RecyclerView.VERTICAL, false)
 
-        ToolbarAutocompleteFeature(binding.toolbar).apply {
+        ToolbarAutocompleteFeature(toolbar).apply {
             this.addDomainProvider(shippedDomainsProvider)
             this.addDomainProvider(customDomainsProvider)
         }
@@ -91,19 +89,19 @@ class ToolbarActivity : AppCompatActivity() {
     override fun onPause() {
         super.onPause()
 
-        binding.toolbar.hideKeyboard()
+        toolbar.hideKeyboard()
     }
 
     /**
      * A very simple toolbar with mostly default values.
      */
     private fun setupDefaultToolbar(private: Boolean = false) {
-        binding.toolbar.setBackgroundColor(
+        toolbar.setBackgroundColor(
                 ContextCompat.getColor(this, mozilla.components.ui.colors.R.color.photonBlue80))
 
-        binding.toolbar.private = private
+        toolbar.private = private
 
-        binding.toolbar.url = "https://www.mozilla.org/en-US/firefox/"
+        toolbar.url = "https://www.mozilla.org/en-US/firefox/"
     }
 
     /**
@@ -115,7 +113,7 @@ class ToolbarActivity : AppCompatActivity() {
         // //////////////////////////////////////////////////////////////////////////////////////////
 
         val background = ContextCompat.getDrawable(this, R.drawable.focus_background)
-        binding.toolbar.background = background
+        toolbar.background = background
 
         // //////////////////////////////////////////////////////////////////////////////////////////
         // Add "back" and "forward" navigation actions
@@ -128,7 +126,7 @@ class ToolbarActivity : AppCompatActivity() {
             simulateReload()
         }
 
-        binding.toolbar.addNavigationAction(back)
+        toolbar.addNavigationAction(back)
 
         val forward = BrowserToolbar.Button(
             resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_forward)!!,
@@ -137,7 +135,7 @@ class ToolbarActivity : AppCompatActivity() {
             simulateReload()
         }
 
-        binding.toolbar.addNavigationAction(forward)
+        toolbar.addNavigationAction(forward)
 
         // //////////////////////////////////////////////////////////////////////////////////////////
         // Add a "reload" browser action that simulates reloading the current page
@@ -148,7 +146,7 @@ class ToolbarActivity : AppCompatActivity() {
             "Reload") {
             simulateReload()
         }
-        binding.toolbar.addBrowserAction(reload)
+        toolbar.addBrowserAction(reload)
 
         // //////////////////////////////////////////////////////////////////////////////////////////
         // Create a menu that looks like the one in Firefox Focus
@@ -161,20 +159,20 @@ class ToolbarActivity : AppCompatActivity() {
         val settings = SimpleBrowserMenuItem("Settings") { /* Do nothing */ }
 
         val items = listOf(fenix, share, homeScreen, open, settings)
-        binding.toolbar.display.menuBuilder = BrowserMenuBuilder(items)
+        toolbar.display.menuBuilder = BrowserMenuBuilder(items)
 
         // //////////////////////////////////////////////////////////////////////////////////////////
         // Display a URL
         // //////////////////////////////////////////////////////////////////////////////////////////
 
-        binding.toolbar.url = "https://www.mozilla.org/en-US/firefox/mobile/"
+        toolbar.url = "https://www.mozilla.org/en-US/firefox/mobile/"
     }
 
     /**
      * A custom browser menu.
      */
     private fun setupCustomMenu() {
-        binding.toolbar.setBackgroundColor(
+        toolbar.setBackgroundColor(
             ContextCompat.getColor(this, mozilla.components.ui.colors.R.color.photonBlue80))
 
         // //////////////////////////////////////////////////////////////////////////////////////////
@@ -191,7 +189,7 @@ class ToolbarActivity : AppCompatActivity() {
             start = DrawableMenuIcon(this, R.drawable.mozac_ic_search)
         ) { /* Do nothing */ }
 
-        binding.toolbar.display.menuController = BrowserMenuController(Side.START).apply {
+        toolbar.display.menuController = BrowserMenuController(Side.START).apply {
             submitList(listOf(share, DividerMenuCandidate(), search))
         }
 
@@ -199,7 +197,7 @@ class ToolbarActivity : AppCompatActivity() {
         // Display a URL
         // //////////////////////////////////////////////////////////////////////////////////////////
 
-        binding.toolbar.url = "https://www.mozilla.org/"
+        toolbar.url = "https://www.mozilla.org/"
     }
 
     /**
@@ -211,7 +209,7 @@ class ToolbarActivity : AppCompatActivity() {
         // //////////////////////////////////////////////////////////////////////////////////////////
 
         val background = ContextCompat.getDrawable(this, R.drawable.focus_background)
-        binding.toolbar.background = background
+        toolbar.background = background
 
         // //////////////////////////////////////////////////////////////////////////////////////////
         // Create a "mini" toolbar to be shown inside the menu (forward, reload)
@@ -240,7 +238,7 @@ class ToolbarActivity : AppCompatActivity() {
             }
         }
         // Redraw the reload button when loading state changes
-        loading.observe(this, Observer { binding.toolbar.invalidateActions() })
+        loading.observe(this, Observer { toolbar.invalidateActions() })
 
         val menuToolbar = BrowserMenuItemToolbar(listOf(forward, reload))
 
@@ -270,14 +268,14 @@ class ToolbarActivity : AppCompatActivity() {
         val settings = SimpleBrowserMenuItem("Settings") { /* Do nothing */ }
 
         val items = listOf(menuToolbar, blocking, share, homeScreen, open, settings)
-        binding.toolbar.display.menuBuilder = BrowserMenuBuilder(items)
-        binding.toolbar.invalidateActions()
+        toolbar.display.menuBuilder = BrowserMenuBuilder(items)
+        toolbar.invalidateActions()
 
         // //////////////////////////////////////////////////////////////////////////////////////////
         // Display a URL
         // //////////////////////////////////////////////////////////////////////////////////////////
 
-        binding.toolbar.url = "https://www.mozilla.org/en-US/firefox/mobile/"
+        toolbar.url = "https://www.mozilla.org/en-US/firefox/mobile/"
     }
 
     private class FakeTabCounterToolbarButton : Toolbar.Action {
@@ -296,15 +294,15 @@ class ToolbarActivity : AppCompatActivity() {
      */
     @Suppress("MagicNumber")
     fun setupFenixToolbar() {
-        binding.toolbar.setBackgroundColor(0xFFFFFFFF.toInt())
+        toolbar.setBackgroundColor(0xFFFFFFFF.toInt())
 
-        binding.toolbar.display.indicators = listOf(
+        toolbar.display.indicators = listOf(
             DisplayToolbar.Indicators.SECURITY,
             DisplayToolbar.Indicators.TRACKING_PROTECTION,
             DisplayToolbar.Indicators.EMPTY
         )
 
-        binding.toolbar.display.colors = binding.toolbar.display.colors.copy(
+        toolbar.display.colors = toolbar.display.colors.copy(
             securityIconInsecure = 0xFF20123a.toInt(),
             securityIconSecure = 0xFF20123a.toInt(),
             text = 0xFF0c0c0d.toInt(),
@@ -315,14 +313,14 @@ class ToolbarActivity : AppCompatActivity() {
             hint = 0x1E15141a.toInt()
         )
 
-        binding.toolbar.display.urlFormatter = { url ->
+        toolbar.display.urlFormatter = { url ->
             URLStringUtils.toDisplayUrl(url)
         }
 
-        binding.toolbar.display.setUrlBackground(
+        toolbar.display.setUrlBackground(
             ContextCompat.getDrawable(this, R.drawable.fenix_url_background))
-        binding.toolbar.display.hint = "Search or enter address"
-        binding.toolbar.display.setOnUrlLongClickListener {
+        toolbar.display.hint = "Search or enter address"
+        toolbar.display.setOnUrlLongClickListener {
             Toast.makeText(this, "Long click!", Toast.LENGTH_SHORT).show()
             true
         }
@@ -341,32 +339,32 @@ class ToolbarActivity : AppCompatActivity() {
         )
 
         val items = listOf(share, homeScreen, open, settings)
-        binding.toolbar.display.menuController = BrowserMenuController().apply {
+        toolbar.display.menuController = BrowserMenuController().apply {
             submitList(items)
         }
 
-        binding.toolbar.url = "https://www.mozilla.org/en-US/firefox/mobile/"
+        toolbar.url = "https://www.mozilla.org/en-US/firefox/mobile/"
 
-        binding.toolbar.addBrowserAction(FakeTabCounterToolbarButton())
+        toolbar.addBrowserAction(FakeTabCounterToolbarButton())
 
-        binding.toolbar.display.setOnSiteSecurityClickedListener {
+        toolbar.display.setOnSiteSecurityClickedListener {
             Toast.makeText(this, "Site security", Toast.LENGTH_SHORT).show()
         }
 
-        binding.toolbar.edit.colors = binding.toolbar.edit.colors.copy(
+        toolbar.edit.colors = toolbar.edit.colors.copy(
             text = 0xFF0c0c0d.toInt(),
             clear = 0xFF0c0c0d.toInt(),
             icon = 0xFF0c0c0d.toInt()
         )
 
-        binding.toolbar.edit.setUrlBackground(
+        toolbar.edit.setUrlBackground(
             ContextCompat.getDrawable(this, R.drawable.fenix_url_background))
-        binding.toolbar.edit.setIcon(
+        toolbar.edit.setIcon(
             ContextCompat.getDrawable(this, R.drawable.mozac_ic_search)!!, "Search")
 
-        binding.toolbar.setOnUrlCommitListener { url ->
+        toolbar.setOnUrlCommitListener { url ->
             simulateReload()
-            binding.toolbar.url = url
+            toolbar.url = url
 
             true
         }
@@ -377,14 +375,14 @@ class ToolbarActivity : AppCompatActivity() {
      */
     @Suppress("MagicNumber")
     fun setupFenixCustomTabToolbar() {
-        binding.toolbar.setBackgroundColor(0xFFFFFFFF.toInt())
+        toolbar.setBackgroundColor(0xFFFFFFFF.toInt())
 
-        binding.toolbar.display.indicators = listOf(
+        toolbar.display.indicators = listOf(
             DisplayToolbar.Indicators.SECURITY,
             DisplayToolbar.Indicators.TRACKING_PROTECTION
         )
 
-        binding.toolbar.display.colors = binding.toolbar.display.colors.copy(
+        toolbar.display.colors = toolbar.display.colors.copy(
             securityIconSecure = 0xFF20123a.toInt(),
             securityIconInsecure = 0xFF20123a.toInt(),
             text = 0xFF0c0c0d.toInt(),
@@ -400,12 +398,12 @@ class ToolbarActivity : AppCompatActivity() {
         val settings = SimpleBrowserMenuItem("Settings") { /* Do nothing */ }
 
         val items = listOf(share, homeScreen, open, settings)
-        binding.toolbar.display.menuBuilder = BrowserMenuBuilder(items)
-        binding.toolbar.display.menuController = BrowserMenuController().apply {
+        toolbar.display.menuBuilder = BrowserMenuBuilder(items)
+        toolbar.display.menuController = BrowserMenuController().apply {
             submitList(items.asCandidateList(this@ToolbarActivity))
         }
 
-        binding.toolbar.url = "https://www.mozilla.org/en-US/firefox/mobile/"
+        toolbar.url = "https://www.mozilla.org/en-US/firefox/mobile/"
 
         val drawableIcon = ContextCompat.getDrawable(this, R.drawable.mozac_ic_close)
 
@@ -417,7 +415,7 @@ class ToolbarActivity : AppCompatActivity() {
             ) {
                 Toast.makeText(this, "Close!", Toast.LENGTH_SHORT).show()
             }
-            binding.toolbar.addNavigationAction(button)
+            toolbar.addNavigationAction(button)
         }
 
         val drawable = ContextCompat.getDrawable(this, R.drawable.mozac_ic_share)?.apply {
@@ -428,15 +426,15 @@ class ToolbarActivity : AppCompatActivity() {
             Toast.makeText(this, "Share!", Toast.LENGTH_SHORT).show()
         }
 
-        binding.toolbar.addBrowserAction(button)
+        toolbar.addBrowserAction(button)
 
-        binding.toolbar.display.setOnSiteSecurityClickedListener {
+        toolbar.display.setOnSiteSecurityClickedListener {
             Toast.makeText(this, "Site security", Toast.LENGTH_SHORT).show()
         }
 
         GlobalScope.launch(Dispatchers.Main) {
             delay(2000)
-            binding.toolbar.title = "Mobile browsers for iOS and Android | Firefox"
+            toolbar.title = "Mobile browsers for iOS and Android | Firefox"
         }
     }
 
@@ -475,7 +473,7 @@ class ToolbarActivity : AppCompatActivity() {
                     }
 
                     if (view == null) {
-                        binding.toolbar.displayProgress(progress)
+                        toolbar.displayProgress(progress)
                     } else {
                         view.progress = progress
                     }
@@ -484,7 +482,7 @@ class ToolbarActivity : AppCompatActivity() {
                 }
             } catch (t: Throwable) {
                 if (view == null) {
-                    binding.toolbar.displayProgress(0)
+                    toolbar.displayProgress(0)
                 } else {
                     view.progress = 0
                 }
@@ -494,12 +492,12 @@ class ToolbarActivity : AppCompatActivity() {
                 loading.value = false
 
                 // Update toolbar buttons to reflect loading state
-                binding.toolbar.invalidateActions()
+                toolbar.invalidateActions()
             }
         }
 
         // Update toolbar buttons to reflect loading state
-        binding.toolbar.invalidateActions()
+        toolbar.invalidateActions()
     }
 
     private fun Resources.getThemedDrawable(@DrawableRes resId: Int) = ResourcesCompat.getDrawable(this, resId, theme)


### PR DESCRIPTION
Reverts mozilla-mobile/android-components#10407

@mcarare we're reverting because we're seeing lots of UI test failures:
https://console.firebase.google.com/u/1/project/moz-fenix/testlab/histories/bh.66b7091e15d53d45/matrices/5544156462317413243/executions/bs.1f32f333bebb5360/

All seem to be related to the tabcounter:
```
androidx.test.espresso.AmbiguousViewMatcherException: 'with id: org.mozilla.fenix.debug:id/counter_box' matches multiple views in the hierarchy. 
```

Let's back it out for now. Gives us the time to look into this tomorrow without blocking the upgrade.