### PR TITLE
Close #10468: Fix intermittent test in CustomTabIntentProcessorTest

### DIFF
--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabIntentProcessorTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabIntentProcessorTest.kt
@@ -106,13 +106,14 @@ class CustomTabIntentProcessorTest {
 
         handler.process(intent)
 
+        store.waitUntilIdle()
+
         var customTabId: String? = null
 
         middleware.assertFirstAction(CustomTabListAction.AddCustomTabAction::class) { action ->
             customTabId = action.tab.id
         }
 
-        store.waitUntilIdle()
         middleware.assertFirstAction(EngineAction.LoadUrlAction::class) { action ->
             assertEquals(customTabId, action.tabId)
             assertEquals("http://mozilla.org", action.url)
@@ -148,13 +149,14 @@ class CustomTabIntentProcessorTest {
 
         handler.process(intent)
 
+        store.waitUntilIdle()
+
         var customTabId: String? = null
 
         middleware.assertFirstAction(CustomTabListAction.AddCustomTabAction::class) { action ->
             customTabId = action.tab.id
         }
 
-        store.waitUntilIdle()
         middleware.assertFirstAction(EngineAction.LoadUrlAction::class) { action ->
             assertEquals(customTabId, action.tabId)
             assertEquals("http://mozilla.org", action.url)


### PR DESCRIPTION
Closes #10468

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
