### PR TITLE
TrackingProtectionIconView: Use correct icon for OFF_FOR_A_SITE state.

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/TrackingProtectionIconView.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/TrackingProtectionIconView.kt
@@ -97,7 +97,7 @@ internal class TrackingProtectionIconView @JvmOverloads constructor(
         val DEFAULT_ICON_ON_TRACKERS_BLOCKED =
             R.drawable.mozac_ic_tracking_protection_on_trackers_blocked
         val DEFAULT_ICON_OFF_FOR_A_SITE =
-            R.drawable.mozac_ic_tracking_protection_on_trackers_blocked
+            R.drawable.mozac_ic_tracking_protection_off_for_a_site
     }
 
     private fun SiteTrackingProtection.toUpdate(): Update = when (this) {


### PR DESCRIPTION
@Amejia481 It looks like we accidentally mapped the "off for a site" constant to the "on_trackers_blocked" icon? I was testing the TP icon in Focus with the default icons and was wondering why it didn't update. :)