### PR TITLE
For #10521 - New maxNumberOfResults in history providers

### DIFF
--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/AwesomeBarFeature.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/AwesomeBarFeature.kt
@@ -176,9 +176,14 @@ class AwesomeBarFeature(
     fun addHistoryProvider(
         historyStorage: HistoryStorage,
         loadUrlUseCase: SessionUseCases.LoadUrlUseCase,
-        engine: Engine? = null
+        engine: Engine? = null,
+        maxNumberOfResults: Int = -1
     ): AwesomeBarFeature {
-        awesomeBar.addProviders(HistoryStorageSuggestionProvider(historyStorage, loadUrlUseCase, icons, engine))
+        awesomeBar.addProviders(
+            HistoryStorageSuggestionProvider(
+                historyStorage, loadUrlUseCase, icons, engine, maxNumberOfResults
+            )
+        )
         return this
     }
 

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/HistoryMetadataSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/HistoryMetadataSuggestionProvider.kt
@@ -58,6 +58,7 @@ class HistoryMetadataSuggestionProvider(
 
         val suggestions = historyStorage
             .queryHistoryMetadata(text, METADATA_SUGGESTION_LIMIT)
+            .filter { it.totalViewTime > 0 }
             .take(maxReturnedSuggestions)
 
         suggestions.firstOrNull()?.key?.url?.let { url -> engine?.speculativeConnect(url) }

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/AwesomeBarFeatureTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/AwesomeBarFeatureTest.kt
@@ -179,6 +179,19 @@ class AwesomeBarFeatureTest {
     }
 
     @Test
+    fun `addHistoryProvider adds the limit of suggestions to be returned to suggestion provider`() {
+        val awesomeBar: AwesomeBar = mock()
+
+        val feature = AwesomeBarFeature(awesomeBar, mock())
+        feature.addHistoryProvider(
+            historyStorage = mock(), loadUrlUseCase = mock(), maxNumberOfResults = 42)
+
+        val provider = argumentCaptor<HistoryStorageSuggestionProvider>()
+        verify(awesomeBar).addProviders(provider.capture())
+        assertSame(42, provider.value.maxNumberOfResults)
+    }
+
+    @Test
     fun `addClipboardProvider adds provider`() {
         val awesomeBar: AwesomeBar = mock()
 

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryMetadataSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryMetadataSuggestionProviderTest.kt
@@ -102,6 +102,20 @@ class HistoryMetadataSuggestionProviderTest {
     }
 
     @Test
+    fun `provider only as suggestions pages on which users actually spent some time`() = runBlocking {
+        val storage: HistoryMetadataStorage = mock()
+        val historyEntries = mutableListOf<HistoryMetadata>().apply {
+            add(historyEntry)
+            add(historyEntry.copy(totalViewTime = 0))
+        }
+        whenever(storage.queryHistoryMetadata("moz", METADATA_SUGGESTION_LIMIT)).thenReturn(historyEntries)
+        val provider = HistoryMetadataSuggestionProvider(storage, mock())
+
+        val suggestions = provider.onInputChanged("moz")
+        assertEquals(1, suggestions.size)
+    }
+
+    @Test
     fun `provider suggestion should not get cleared when text changes`() {
         val provider = HistoryMetadataSuggestionProvider(mock(), mock())
         assertFalse(provider.shouldClearSuggestions)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **browser-feature-awesomebar**:
+  * 🌟️ Adds a new `maxNumberOfResults` to `HistoryStorageSuggestionProvider` as a way to lower the number of returned suggested history items to below the default of 20.
+
 * **concept-engine**
   * 🌟️ Adds a new `SitePermissionsStorage` interface that represents a common API to store site permissions.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ permalink: /changelog/
 
 * **browser-feature-awesomebar**:
   * 🌟️ Adds a new `maxNumberOfResults` to `HistoryStorageSuggestionProvider` as a way to lower the number of returned suggested history items to below the default of 20.
+  * 🌟️ Adds a new `maxNumberOfResults` to `HistoryMetadataSuggestionProvider` as a way to lower the number of returned suggested history items to below the default of 5.
 
 * **concept-engine**
   * 🌟️ Adds a new `SitePermissionsStorage` interface that represents a common API to store site permissions.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ permalink: /changelog/
 * **browser-feature-awesomebar**:
   * 🌟️ Adds a new `maxNumberOfResults` to `HistoryStorageSuggestionProvider` as a way to lower the number of returned suggested history items to below the default of 20.
   * 🌟️ Adds a new `maxNumberOfResults` to `HistoryMetadataSuggestionProvider` as a way to lower the number of returned suggested history items to below the default of 5.
+  * HistoryMetadataSuggestionProvider - only return pages user spent time on.
 
 * **concept-engine**
   * 🌟️ Adds a new `SitePermissionsStorage` interface that represents a common API to store site permissions.


### PR DESCRIPTION
This allows clients to limit the number of suggested history items to even
below that of the default 20.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
