### PR TITLE
For #10537 - Applies tint to imageView instead of drawable

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItem.kt
@@ -111,7 +111,7 @@ class WebExtensionBrowserMenuItem(
     internal fun setupIcon(view: View, imageView: ImageView, iconTintColorResource: Int?) {
         MainScope().launch {
             loadIcon(view.context, imageView.measuredHeight)?.let {
-                iconTintColorResource?.let { tint -> it.setTint(tint) }
+                iconTintColorResource?.let { tint -> imageView.setTintResource(tint) }
                 imageView.setImageDrawable(it)
             }
         }


### PR DESCRIPTION
 `Drawable.setTint` did not correctly apply the tint received from Fenix. Switching to `imageView.setTintResource` fixes the issue.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes no tests as it's only a minor change.
- [x] **Changelog**: This PR does not need [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.


Thanks @mcarare for the help.🥇 