### PR TITLE
For #10551 - Adds `clearFlagOnStop = true` in SecureWindowFeature

### DIFF
--- a/components/feature/privatemode/src/main/java/mozilla/components/feature/privatemode/feature/SecureWindowFeature.kt
+++ b/components/feature/privatemode/src/main/java/mozilla/components/feature/privatemode/feature/SecureWindowFeature.kt
@@ -23,13 +23,15 @@ import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
  * Prevents screenshots and screen recordings in private tabs.
  *
  * @param isSecure Returns true if the session should have [FLAG_SECURE] set.
+ * @param clearFlagOnStop Used to keep [FLAG_SECURE] enabled or not when calling [stop].
  * Can be overriden to customize when the secure flag is set.
  */
 class SecureWindowFeature(
     private val window: Window,
     private val store: BrowserStore,
     private val customTabId: String? = null,
-    private val isSecure: (SessionState) -> Boolean = { it.content.private }
+    private val isSecure: (SessionState) -> Boolean = { it.content.private },
+    private val clearFlagOnStop: Boolean = true
 ) : LifecycleAwareFeature {
 
     private var scope: CoroutineScope? = null
@@ -52,6 +54,8 @@ class SecureWindowFeature(
 
     override fun stop() {
         scope?.cancel()
-        window.clearFlags(FLAG_SECURE)
+        if (clearFlagOnStop) {
+            window.clearFlags(FLAG_SECURE)
+        }
     }
 }

--- a/components/feature/privatemode/src/test/java/mozilla/components/feature/privatemode/feature/SecureWindowFeatureTest.kt
+++ b/components/feature/privatemode/src/test/java/mozilla/components/feature/privatemode/feature/SecureWindowFeatureTest.kt
@@ -84,7 +84,7 @@ class SecureWindowFeatureTest {
     @Test
     fun `remove flags on stop`() {
         val store = BrowserStore()
-        val feature = SecureWindowFeature(window, store)
+        val feature = SecureWindowFeature(window, store, clearFlagOnStop = true)
 
         feature.start()
         feature.stop()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **feature-privatemode**
+  * Adds `clearFlagOnStop = true` in SecureWindowFeature to allow the option of keeping `FLAG_SECURE` when calling `stop()`
+
 * **browser-feature-awesomebar**:
   * 🌟️ Adds a new `maxNumberOfResults` to `HistoryStorageSuggestionProvider` as a way to lower the number of returned suggested history items to below the default of 20.
   * 🌟️ Adds a new `maxNumberOfResults` to `HistoryMetadataSuggestionProvider` as a way to lower the number of returned suggested history items to below the default of 5.


### PR DESCRIPTION
...to allow the option of keeping `FLAG_SECURE` when calling `stop()`

For https://github.com/mozilla-mobile/android-components/issues/10551
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
