### PR TITLE
For #10521 - Fix AwesomeBarFeature smoke tests

### DIFF
--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/AwesomeBarFeature.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/AwesomeBarFeature.kt
@@ -172,17 +172,21 @@ class AwesomeBarFeature(
      * @param loadUrlUseCase the use case invoked to load the url when the user clicks on the suggestion.
      * @param engine optional [Engine] instance to call [Engine.speculativeConnect] for the
      * highest scored suggestion URL.
+     * @param maxNumberOfSuggestions optional parameter to specify the maximum number of returned suggestions.
+     * Zero or a negative value here means the default number of history suggestions will be returned.
      */
     fun addHistoryProvider(
         historyStorage: HistoryStorage,
         loadUrlUseCase: SessionUseCases.LoadUrlUseCase,
         engine: Engine? = null,
-        maxNumberOfResults: Int = -1
+        maxNumberOfSuggestions: Int = -1
     ): AwesomeBarFeature {
         awesomeBar.addProviders(
-            HistoryStorageSuggestionProvider(
-                historyStorage, loadUrlUseCase, icons, engine, maxNumberOfResults
-            )
+            if (maxNumberOfSuggestions <= 0) {
+                HistoryStorageSuggestionProvider(historyStorage, loadUrlUseCase, icons, engine)
+            } else {
+                HistoryStorageSuggestionProvider(historyStorage, loadUrlUseCase, icons, engine, maxNumberOfSuggestions)
+            }
         )
         return this
     }

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/AwesomeBarFeatureTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/AwesomeBarFeatureTest.kt
@@ -13,6 +13,7 @@ import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.feature.awesomebar.provider.ClipboardSuggestionProvider
+import mozilla.components.feature.awesomebar.provider.DEFAULT_HISTORY_SUGGESTION_LIMIT
 import mozilla.components.feature.awesomebar.provider.HistoryStorageSuggestionProvider
 import mozilla.components.feature.awesomebar.provider.SearchSuggestionProvider
 import mozilla.components.support.test.any
@@ -179,16 +180,42 @@ class AwesomeBarFeatureTest {
     }
 
     @Test
-    fun `addHistoryProvider adds the limit of suggestions to be returned to suggestion provider`() {
+    fun `addHistoryProvider adds the limit of suggestions to be returned to suggestion provider if positive`() {
         val awesomeBar: AwesomeBar = mock()
 
         val feature = AwesomeBarFeature(awesomeBar, mock())
         feature.addHistoryProvider(
-            historyStorage = mock(), loadUrlUseCase = mock(), maxNumberOfResults = 42)
+            historyStorage = mock(), loadUrlUseCase = mock(), maxNumberOfSuggestions = 42)
 
         val provider = argumentCaptor<HistoryStorageSuggestionProvider>()
         verify(awesomeBar).addProviders(provider.capture())
         assertSame(42, provider.value.maxNumberOfSuggestions)
+    }
+
+    @Test
+    fun `addHistoryProvider does not add the limit of suggestions to be returned to suggestion provider if negative`() {
+        val awesomeBar: AwesomeBar = mock()
+
+        val feature = AwesomeBarFeature(awesomeBar, mock())
+        feature.addHistoryProvider(
+            historyStorage = mock(), loadUrlUseCase = mock(), maxNumberOfSuggestions = -1)
+
+        val provider = argumentCaptor<HistoryStorageSuggestionProvider>()
+        verify(awesomeBar).addProviders(provider.capture())
+        assertSame(DEFAULT_HISTORY_SUGGESTION_LIMIT, provider.value.maxNumberOfSuggestions)
+    }
+
+    @Test
+    fun `addHistoryProvider does not add the limit of suggestions to be returned to suggestion provider if 0`() {
+        val awesomeBar: AwesomeBar = mock()
+
+        val feature = AwesomeBarFeature(awesomeBar, mock())
+        feature.addHistoryProvider(
+            historyStorage = mock(), loadUrlUseCase = mock(), maxNumberOfSuggestions = 0)
+
+        val provider = argumentCaptor<HistoryStorageSuggestionProvider>()
+        verify(awesomeBar).addProviders(provider.capture())
+        assertSame(DEFAULT_HISTORY_SUGGESTION_LIMIT, provider.value.maxNumberOfSuggestions)
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,7 @@ permalink: /changelog/
   * 🌟️ Adds a new `maxNumberOfSuggestions` parameter to `HistoryStorageSuggestionProvider` as a way to specify a different number than the default of 20 for how many history results to be returned.
   * 🌟️ Adds a new `maxNumberOfSuggestions` parameter to `HistoryMetadataSuggestionProvider` as a way to specify a different number than the default of 5 for how many history results to be returned.
   * HistoryMetadataSuggestionProvider - only return pages user spent time on.
+  * `AwesomeBarFeature.addHistoryProvider` allows specifying a positive value for `maxNumberOfSuggestions`. If zero or a negative value is used the default number of history suggestions will be returned.
 
 * **concept-engine**
   * 🌟️ Adds a new `SitePermissionsStorage` interface that represents a common API to store site permissions.


### PR DESCRIPTION
loadWebsiteTest and loadWebsitesInMultipleTabsTest were failing because
AwesomeBarFeature was asking for a negative number of history suggestions.

Since this is the one point configuring different providers below I went with 
deciding here whether the default or a different number of history suggestions
should be returned.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
