### PR TITLE
Catch and log history metadata write exceptions

### DIFF
--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
@@ -260,10 +260,14 @@ open class PlacesHistoryStorage(
         key: HistoryMetadataKey,
         observation: HistoryMetadataObservation
     ) {
-        places.writer().noteHistoryMetadataObservation(key.into(), observation.into())
+        handlePlacesExceptions("noteHistoryMetadataObservation") {
+            places.writer().noteHistoryMetadataObservation(key.into(), observation.into())
+        }
     }
 
     override suspend fun deleteHistoryMetadataOlderThan(olderThan: Long) {
-        places.writer().deleteHistoryMetadataOlderThan(olderThan)
+        handlePlacesExceptions("deleteHistoryMetadataOlderThan") {
+            places.writer().deleteHistoryMetadataOlderThan(olderThan)
+        }
     }
 }


### PR DESCRIPTION
Similar to regular history writes we also want to catch and log failures writing metadata.