### PR TITLE
Close #10382: Handle exceptions thrown in RemoteTabsStorage

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,9 @@ permalink: /changelog/
   * HistoryMetadataSuggestionProvider - only return pages user spent time on.
   * `AwesomeBarFeature.addHistoryProvider` allows specifying a positive value for `maxNumberOfSuggestions`. If zero or a negative value is used the default number of history suggestions will be returned.
 
+* **browser-storage-sync**
+  * Adds `CrashReporting` to the `RemoteTabsStorage`.
+
 * **concept-engine**
   * 🌟️ Adds a new `SitePermissionsStorage` interface that represents a common API to store site permissions.
 


### PR DESCRIPTION
RemoteTabsStorage is the only storage layer that doesn't have the safety of WorkManager's error reporting to avoid crashes.

This change introduces `CrashReporting` to the constructor to catch and log exceptions on any future crashes.

Since we're cutting the release next week, I'm okay with with waiting until then. If we are however, introducing new app services upgrades (via https://github.com/mozilla-mobile/android-components/pull/10482 or https://github.com/mozilla-mobile/android-components/pull/10475), we should land this as well.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
