### PR TITLE
 Add 'Add-ons' visibility flag in WebExtensionBrowserMenuBuilder

### DIFF
--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilderTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilderTest.kt
@@ -143,7 +143,7 @@ class WebExtensionBrowserMenuBuilderTest {
     }
 
     @Test
-    fun `web extension submenu is added at the top when usingBottomToolbar is true with no placeholde for submenu`() {
+    fun `web extension submenu is added at the top when usingBottomToolbar is true with no placeholder for submenu`() {
         val browserAction = WebExtensionBrowserAction("browser_action", true, mock(), "", 0, 0) {}
         val pageAction = WebExtensionBrowserAction("page_action", true, mock(), "", 0, 0) {}
 
@@ -401,6 +401,99 @@ class WebExtensionBrowserMenuBuilderTest {
         assertNotNull(backMenuItem)
         assertEquals("page_action", subMenuExtItemPageAction!!.action.title)
         assertNotNull(addOnsManagerMenuItem)
+    }
+
+    @Test
+    fun `GIVEN showAddonsInMenu with value true WHEN the menu is built THEN the Add-ons item is added at the bottom`() {
+        val pageAction = WebExtensionBrowserAction("page_action", true, mock(), "", 0, 0) {}
+
+        val extensions = mapOf(
+            "id" to WebExtensionState(
+                "id",
+                "url",
+                "name",
+                true,
+                browserAction = null,
+                pageAction = pageAction
+            )
+        )
+        val store = BrowserStore(BrowserState(extensions = extensions))
+
+        // 2 items initially on the main menu
+        val items = listOf(
+            mockMenuItem(),
+            mockMenuItem()
+        )
+
+        val builder =
+            WebExtensionBrowserMenuBuilder(
+                items,
+                store = store,
+                showAddonsInMenu = true
+            )
+
+        val menu = builder.build(testContext)
+        val anchor = ImageButton(testContext)
+        val popup = menu.show(anchor)
+
+        val recyclerView: RecyclerView = popup.contentView.findViewById(R.id.mozac_browser_menu_recyclerView)
+        assertNotNull(recyclerView)
+
+        val recyclerAdapter = recyclerView.adapter as BrowserMenuAdapter
+        assertNotNull(recyclerAdapter)
+
+        // main menu should have 3 items and the last one should be the "Add-ons" item
+        assertEquals(3, recyclerAdapter.itemCount)
+
+        val lastItem = recyclerAdapter.visibleItems[2]
+        assert(lastItem is ParentBrowserMenuItem && lastItem.label == "Add-ons")
+    }
+
+    @Test
+    fun `GIVEN showAddonsInMenu with value false WHEN the menu is built THEN the Add-ons item is not added`() {
+        val pageAction = WebExtensionBrowserAction("page_action", true, mock(), "", 0, 0) {}
+
+        val extensions = mapOf(
+            "id" to WebExtensionState(
+                "id",
+                "url",
+                "name",
+                true,
+                browserAction = null,
+                pageAction = pageAction
+            )
+        )
+        val store = BrowserStore(BrowserState(extensions = extensions))
+
+        // 2 items initially on the main menu
+        val items = listOf(
+            mockMenuItem(),
+            mockMenuItem()
+        )
+
+        val builder =
+            WebExtensionBrowserMenuBuilder(
+                items,
+                store = store,
+                showAddonsInMenu = false
+            )
+
+        val menu = builder.build(testContext)
+        val anchor = ImageButton(testContext)
+        val popup = menu.show(anchor)
+
+        val recyclerView: RecyclerView = popup.contentView.findViewById(R.id.mozac_browser_menu_recyclerView)
+        assertNotNull(recyclerView)
+
+        val recyclerAdapter = recyclerView.adapter as BrowserMenuAdapter
+        assertNotNull(recyclerAdapter)
+
+        // main menu should have 2 items
+        assertEquals(2, recyclerAdapter.itemCount)
+
+        recyclerAdapter.visibleItems.forEach { item ->
+            assert(item !is ParentBrowserMenuItem)
+        }
     }
 
     private fun mockMenuItem() = object : BrowserMenuItem {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,9 @@ permalink: /changelog/
 * **feature-search**
   * Updated the icon of the bing search engine.
 
+* **browser-menu**
+  * Adds `showAddonsInMenu` in WebExtensionBrowserMenuBuilder to allow the option of removing `Add-ons` item even if another extensions are displayed
+
 * **feature-privatemode**
   * Adds `clearFlagOnStop = true` in SecureWindowFeature to allow the option of keeping `FLAG_SECURE` when calling `stop()`
 


### PR DESCRIPTION
For #10559
 Adds `showAddonsInMenu` in WebExtensionBrowserMenuBuilder to allow the option of removing `Add-ons`
item even if another extensions are displayed
Add unit tests to test if 'Add-ons' item visibility is updated properly

### Context
Implement a [browser menu](https://www.figma.com/file/2V6wgf9fRFdYfLaf5c3oPj/MVP?node-id=902%3A3557) with "Report site issue" extension but without "Add-ons"

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
