### PR TITLE
For #9554: Use WindowInsetsControllerCompat to avoid null controllers.

### DIFF
--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/Window.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/Window.kt
@@ -8,7 +8,6 @@ import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.view.Window
 import androidx.annotation.ColorInt
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import mozilla.components.support.utils.ColorUtils.isDark
 
@@ -17,7 +16,7 @@ import mozilla.components.support.utils.ColorUtils.isDark
  * If the color is light enough, a light status bar with dark icons will be used.
  */
 fun Window.setStatusBarTheme(@ColorInt color: Int) {
-    getWindowInsetsController()?.isAppearanceLightStatusBars =
+    getWindowInsetsController().isAppearanceLightStatusBars =
         isDark(color)
     statusBarColor = color
 }
@@ -27,7 +26,7 @@ fun Window.setStatusBarTheme(@ColorInt color: Int) {
  * If the color is light enough, a light navigation bar with dark icons will be used.
  */
 fun Window.setNavigationBarTheme(@ColorInt color: Int) {
-    getWindowInsetsController()?.isAppearanceLightNavigationBars =
+    getWindowInsetsController().isAppearanceLightNavigationBars =
         isDark(color)
 
     if (SDK_INT >= Build.VERSION_CODES.P) {
@@ -39,6 +38,6 @@ fun Window.setNavigationBarTheme(@ColorInt color: Int) {
 /**
  * Retrieves a {@link WindowInsetsControllerCompat} for the top-level window decor view.
  */
-fun Window.getWindowInsetsController(): WindowInsetsControllerCompat? {
-    return ViewCompat.getWindowInsetsController(this.decorView)
+fun Window.getWindowInsetsController(): WindowInsetsControllerCompat {
+    return WindowInsetsControllerCompat(this, this.decorView)
 }


### PR DESCRIPTION
This issue came up on implementing some other features that needed a `WindowInsetsControllerCompat`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
