### PR TITLE
For #10588 - `ERROR_SECURITY_SSL` no longer shows Advanced button

### DIFF
--- a/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
+++ b/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
@@ -36,7 +36,7 @@ object ErrorPages {
         )
 
         val showSSLAdvanced: String = when (errorType) {
-            ErrorType.ERROR_SECURITY_SSL, ErrorType.ERROR_SECURITY_BAD_CERT -> true
+            ErrorType.ERROR_SECURITY_BAD_CERT -> true
             else -> false
         }.toString()
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
 
+* **browser-errorpages**:
+  * `ErrorType.ERROR_SECURITY_SSL` will now no longer display `Advanced` button on the SSL Error Page.
+
 * **browser-state**:
   * 🌟️ Adds a new `lastMediaAccess` in `TabSessionState` as an easy way to check the timestamp of when media last started playing on a particular webpage. The value will be 0 if no media was started. To observe the media playback and updating this property one needs to add a new `LastMediaAccessMiddleware` to `BrowserStore`.
 


### PR DESCRIPTION
For https://github.com/mozilla-mobile/android-components/issues/10588
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes no tests as it's only a minor change.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

![image](https://user-images.githubusercontent.com/60002907/125446759-80ed229e-45f0-40e7-84bc-e60b3d4f22e1.png)

