### PR TITLE
Prepare 91.0.0 release

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -9,12 +9,12 @@ object Gecko {
     /**
      * GeckoView Version.
      */
-    const val version = "91.0.20210712093040"
+    const val version = "91.0.20210712122804"
 
     /**
      * GeckoView channel
      */
-    val channel = GeckoChannel.NIGHTLY
+    val channel = GeckoChannel.BETA
 }
 
 /**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,12 +4,12 @@ title: Changelog
 permalink: /changelog/
 ---
 
-# 91.0.0-SNAPSHOT (In Development)
-* [Commits](https://github.com/mozilla-mobile/android-components/compare/v90.0.0...master)
+# 91.0.0
+* [Commits](https://github.com/mozilla-mobile/android-components/compare/v91.0.0...master)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/138?closed=1)
-* [Dependencies](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Dependencies.kt)
-* [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
-* [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/.config.yml)
+* [Dependencies](https://github.com/mozilla-mobile/android-components/blob/v91.0.0/buildSrc/src/main/java/Dependencies.kt)
+* [Gecko](https://github.com/mozilla-mobile/android-components/blob/v90.0.0/buildSrc/src/main/java/Gecko.kt)
+* [Configuration](https://github.com/mozilla-mobile/android-components/blob/v91.0.0/.config.yml)
 
 * **browser-errorpages**:
   * `ErrorType.ERROR_SECURITY_SSL` will now no longer display `Advanced` button on the SSL Error Page.


### PR DESCRIPTION
This is for the new releases/91.0 branch and preparing for A-C 91.0.0:

- Switches to the now available GV 91 beta
- Updates changelog

The version (91.0.0) is already set correctly.