### PR TITLE
Close #10601: Add lastAccess to Tab in TabsTray

### DIFF
--- a/components/concept/tabstray/src/main/java/mozilla/components/concept/tabstray/Tab.kt
+++ b/components/concept/tabstray/src/main/java/mozilla/components/concept/tabstray/Tab.kt
@@ -18,6 +18,7 @@ import mozilla.components.concept.engine.mediasession.MediaSession
  * @property thumbnail Current thumbnail of the tab (or null)
  * @property playbackState Current media session playback state for the tab (or null)
  * @property controller Current media session controller for the tab (or null)
+ * @property lastAccess The last time this tab was selected.
  */
 data class Tab(
     val id: String,
@@ -27,5 +28,6 @@ data class Tab(
     val icon: Bitmap? = null,
     val thumbnail: Bitmap? = null,
     val playbackState: MediaSession.PlaybackState? = null,
-    val controller: MediaSession.Controller? = null
+    val controller: MediaSession.Controller? = null,
+    val lastAccess: Long = 0L
 )

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/ext/TabSessionState.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/ext/TabSessionState.kt
@@ -15,5 +15,6 @@ internal fun TabSessionState.toTab() = Tab(
     content.icon,
     content.thumbnail,
     mediaSessionState?.playbackState,
-    mediaSessionState?.controller
+    mediaSessionState?.controller,
+    lastAccess
 )

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
   * 🌟️ New `AdsTelemetry` based on a web extension that identify whether there are ads in search results of particular providers for which a (Component.FEATURE_SEARCH to SERP_SHOWN_WITH_ADDS) Fact will be emitted and whether an ad was clicked for which a (Component.FEATURE_SEARCH to SERP_ADD_CLICKED) Fact will be emitted if the `AdsTelemetryMiddleware` is set for `BrowserStore`.
   * 🌟️ New `InContentTelemetry` based on a web extension that identify follow-on and organic web searches for which a (Component.FEATURE_SEARCH to IN_CONTENT_SEARCH) Fact will be emitted.
 
+* **feature-tabs**
+  * Adds `lastAccess` to the `Tab` data class that is used in `TabsTray`.
+
 # 91.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v91.0.0...master)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/138?closed=1)


### PR DESCRIPTION
We need to expose the `lastAccess` field to the TabsTray so that we can use it for UI-base filtering.

@csadilek you might be interested in this.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
