### PR TITLE
For #10609: Do not clear private tabs when a external browser task is removed.

### DIFF
--- a/components/feature/privatemode/src/main/java/mozilla/components/feature/privatemode/notification/AbstractPrivateNotificationService.kt
+++ b/components/feature/privatemode/src/main/java/mozilla/components/feature/privatemode/notification/AbstractPrivateNotificationService.kt
@@ -172,7 +172,7 @@ abstract class AbstractPrivateNotificationService : Service() {
     final override fun onBind(intent: Intent?): IBinder? = null
 
     final override fun onTaskRemoved(rootIntent: Intent) {
-        if (rootIntent.action in ignoreTaskActions) {
+        if (rootIntent.action in ignoreTaskActions || rootIntent.component?.className in ignoreTaskComponentClasses) {
             // The app may have multiple tasks (e.g. for PWAs). If tasks get removed that are not
             // the main browser task then we do not want to remove all private tabs here.
             // I am not sure whether we can reliably identify the main task since it can be launched
@@ -206,6 +206,12 @@ abstract class AbstractPrivateNotificationService : Service() {
         // passed to onTaskRemoved().
         private val ignoreTaskActions = listOf(
             "mozilla.components.feature.pwa.VIEW_PWA"
+        )
+
+        // List of Intent components classes that will get ignored when they are in the root intent
+        // that gets passed to onTaskRemoved().
+        private val ignoreTaskComponentClasses = listOf(
+            "org.mozilla.fenix.customtabs.ExternalAppBrowserActivity"
         )
     }
 }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
