### PR TITLE
For #7249 - Fix permissions matching, avoid warnings

### DIFF
--- a/components/feature/search/src/main/assets/extensions/ads/manifest.template.json
+++ b/components/feature/search/src/main/assets/extensions/ads/manifest.template.json
@@ -406,7 +406,8 @@
     "https://www.google.cat/search*",
     "https://www.baidu.com/*",
     "https://m.baidu.com/*",
-    "https://*search.yahoo.com/search*",
+    "https://search.yahoo.com/search*",
+    "https://*.search.yahoo.com/search*",
     "https://www.bing.com/search*",
     "https://duckduckgo.com/*"
   ]

--- a/components/feature/search/src/main/assets/extensions/search/manifest.template.json
+++ b/components/feature/search/src/main/assets/extensions/search/manifest.template.json
@@ -407,7 +407,8 @@
     "https://www.google.cat/search*",
     "https://www.baidu.com/*",
     "https://m.baidu.com/*",
-    "https://*search.yahoo.com/search*",
+    "https://search.yahoo.com/search*",
+    "https://*.search.yahoo.com/search*",
     "https://www.bing.com/search*",
     "https://duckduckgo.com/*"
   ]


### PR DESCRIPTION
For yahoo we need to match all country codes which are each a subdomain,
eg: "uk.search.yahoo.com"
and we also need to support just "search.yahoo.com".

Previously there was a warning about "*" in "*search.yahoo.com" which seems
resolved by using "\*.search.yahoo.com" and "search.yahoo.com" separately.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
