### PR TITLE
For #10614 - Run 'get-secret.py' with Python 3

### DIFF
--- a/automation/taskcluster/helper/get-secret.py
+++ b/automation/taskcluster/helper/get-secret.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
This script needs to run with Python 3 (as we no longer install the `taskcluster` module into the Python 2 env). It is currently causing all ui-tests to fail.

Fixes issue #10614 