### PR TITLE
For #10633 - toDisplayUrl - don't crash for empty strings

### DIFF
--- a/components/support/utils/src/main/java/mozilla/components/support/utils/URLStringUtils.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/URLStringUtils.kt
@@ -107,7 +107,10 @@ object URLStringUtils {
     ): CharSequence {
         val strippedText = maybeStripTrailingSlash(maybeStripUrlProtocol(originalUrl))
 
-        return if (textDirectionHeuristic.isRtl(strippedText, 0, 1)) {
+        return if (
+            strippedText.isNotBlank() &&
+            textDirectionHeuristic.isRtl(strippedText, 0, 1)
+        ) {
             "\u200E" + strippedText
         } else {
             strippedText

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/URLStringUtilsTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/URLStringUtilsTest.kt
@@ -189,6 +189,13 @@ class URLStringUtilsTest {
         URLStringUtils.toDisplayUrl("http://www.mozilla.org/1", textHeuristic)
         verify(textHeuristic).isRtl("mozilla.org/1", 0, 1)
     }
+
+    @Test
+    fun toDisplayUrlHandlesBlankStrings() {
+        assertEquals("", URLStringUtils.toDisplayUrl(""))
+
+        assertEquals("  ", URLStringUtils.toDisplayUrl("  "))
+    }
 }
 
 /**


### PR DESCRIPTION
"isRtl" would try to iterate through the provided String and crash if that is
empty so we need our own before check.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
