### PR TITLE
Change the branch name in l10n.toml back to main

### DIFF
--- a/l10n.toml
+++ b/l10n.toml
@@ -113,7 +113,7 @@ locales = [
 # Expose the following branches to localization
 # Changes to this list should be announced to the l10n team ahead of time.
 branches = [
-    "master",
+    "main",
 ]
 
 [env]


### PR DESCRIPTION
This patch sets the branch configuration in `l10n.toml` back to `main`. We initially changed this as part of the branch rename PR but the l10n tooling changed it back - it needed one more change in the tooling.