### PR TITLE
For #10668 - On screen indicators for toolbar translation and vertical clipping

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -4,12 +4,17 @@
 
 package mozilla.components.browser.engine.gecko
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
+import android.graphics.drawable.GradientDrawable.Orientation.LEFT_RIGHT
 import android.util.AttributeSet
+import android.view.Gravity
 import android.widget.FrameLayout
+import android.widget.TextView
 import androidx.annotation.VisibleForTesting
 import androidx.core.view.ViewCompat
 import mozilla.components.browser.engine.gecko.selection.GeckoSelectionActionDelegate
@@ -29,6 +34,14 @@ class GeckoEngineView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr), EngineView {
+    private val clippingValueIndicator = TextView(context).apply {
+        layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT, Gravity.TOP or Gravity.RIGHT)
+        background = GradientDrawable(
+            LEFT_RIGHT, intArrayOf(Color.TRANSPARENT, Color.GRAY)
+        )
+        textAlignment = TEXT_ALIGNMENT_TEXT_END
+    }
+
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal var geckoView = object : NestedGeckoView(context) {
 
@@ -94,6 +107,7 @@ class GeckoEngineView @JvmOverloads constructor(
 
     init {
         addView(geckoView)
+        addView(clippingValueIndicator)
     }
 
     /**
@@ -170,7 +184,9 @@ class GeckoEngineView @JvmOverloads constructor(
 
     override fun getInputResultDetail() = geckoView.inputResultDetail
 
+    @SuppressLint("SetTextI18n")
     override fun setVerticalClipping(clippingHeight: Int) {
+        clippingValueIndicator.text = "vertical clipping -> $clippingHeight"
         geckoView.setVerticalClipping(clippingHeight)
     }
 


### PR DESCRIPTION
Just for debugging.
The values are set as close to where they're used as possible and allow us to
follow them in real time based on the on-screen gestures or to verify the end
value is the expected one.


https://user-images.githubusercontent.com/11428869/126629080-33d0367c-4201-4432-8859-f0b2effd70e3.mp4





### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
