### PR TITLE
For #9830: Do not request/use WRITE_EXTERNAL_STORAGE on Android 11 and above

### DIFF
--- a/components/feature/downloads/src/main/AndroidManifest.xml
+++ b/components/feature/downloads/src/main/AndroidManifest.xml
@@ -8,7 +8,8 @@
     package="mozilla.components.feature.downloads">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        tools:ignore="ScopedStorage" />
+        tools:ignore="ScopedStorage"
+        android:maxSdkVersion="28"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
 

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/manager/AndroidDownloadManager.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/manager/AndroidDownloadManager.kt
@@ -13,8 +13,10 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Build
+import android.os.Build.VERSION.SDK_INT
 import android.util.LongSparseArray
-import androidx.annotation.RequiresPermission
+import androidx.annotation.VisibleForTesting
 import androidx.core.content.getSystemService
 import androidx.core.net.toUri
 import androidx.core.util.set
@@ -46,7 +48,16 @@ class AndroidDownloadManager(
     private val downloadRequests = LongSparseArray<SystemRequest>()
     private var isSubscribedReceiver = false
 
-    override val permissions = arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE)
+    // Do not require WRITE_EXTERNAL_STORAGE permission on API 29 and above (using scoped storage)
+    override val permissions
+        get() = if (getSDKVersion() >= Build.VERSION_CODES.Q) {
+            arrayOf(INTERNET)
+        } else {
+            arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE)
+        }
+
+    @VisibleForTesting
+    internal fun getSDKVersion() = SDK_INT
 
     /**
      * Schedules a download through the [AndroidDownloadManager].
@@ -54,7 +65,6 @@ class AndroidDownloadManager(
      * @param cookie any additional cookie to add as part of the download request.
      * @return the id reference of the scheduled download.
      */
-    @RequiresPermission(allOf = [INTERNET, WRITE_EXTERNAL_STORAGE])
     override fun download(download: DownloadState, cookie: String): String? {
         val androidDownloadManager: SystemDownloadManager = applicationContext.getSystemService()!!
 
@@ -106,8 +116,9 @@ class AndroidDownloadManager(
     override fun onReceive(context: Context, intent: Intent) {
         val downloadID = intent.getStringExtra(EXTRA_DOWNLOAD_ID) ?: ""
         val download = store.state.downloads[downloadID]
-        val downloadStatus = intent.getSerializableExtra(AbstractFetchDownloadService.EXTRA_DOWNLOAD_STATUS)
-            as Status
+        val downloadStatus =
+            intent.getSerializableExtra(AbstractFetchDownloadService.EXTRA_DOWNLOAD_STATUS)
+                as Status
 
         if (download != null) {
             onDownloadStopped(download, downloadID, downloadStatus)

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/manager/AndroidDownloadManagerTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/manager/AndroidDownloadManagerTest.kt
@@ -9,6 +9,7 @@ import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.app.DownloadManager.ACTION_DOWNLOAD_COMPLETE
 import android.app.DownloadManager.Request
 import android.content.Intent
+import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.store.BrowserStore
@@ -24,6 +25,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 
@@ -92,6 +95,28 @@ class AndroidDownloadManagerTest {
 
         val id = downloadManager.download(invalidDownload)
         assertNull(id)
+    }
+
+    @Test
+    fun `GIVEN a device that supports scoped storage THEN permissions must not included file access`() {
+        val downloadManager = spy(AndroidDownloadManager(testContext, store))
+
+        doReturn(Build.VERSION_CODES.Q).`when`(downloadManager).getSDKVersion()
+        println(downloadManager.permissions.joinToString { it })
+        assertTrue(WRITE_EXTERNAL_STORAGE !in downloadManager.permissions)
+    }
+
+    @Test
+    fun `GIVEN a device does not supports scoped storage THEN permissions must be included file access`() {
+        val downloadManager = spy(AndroidDownloadManager(testContext, store))
+
+        doReturn(Build.VERSION_CODES.P).`when`(downloadManager).getSDKVersion()
+
+        assertTrue(WRITE_EXTERNAL_STORAGE in downloadManager.permissions)
+
+        doReturn(Build.VERSION_CODES.O_MR1).`when`(downloadManager).getSDKVersion()
+
+        assertTrue(WRITE_EXTERNAL_STORAGE in downloadManager.permissions)
     }
 
     @Test

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/manager/FetchDownloadManagerTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/manager/FetchDownloadManagerTest.kt
@@ -11,6 +11,7 @@ import android.app.DownloadManager.ACTION_DOWNLOAD_COMPLETE
 import android.app.DownloadManager.EXTRA_DOWNLOAD_ID
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.state.state.content.DownloadState
@@ -30,7 +31,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
@@ -99,6 +102,30 @@ class FetchDownloadManagerTest {
         verify(context).startService(any())
         notifyDownloadCompleted(id)
         assertTrue(downloadStopped)
+    }
+
+    @Test
+    fun `GIVEN a device that supports scoped storage THEN permissions must not included file access`() {
+        downloadManager =
+            spy(FetchDownloadManager(mock(), store, MockDownloadService::class, broadcastManager))
+
+        doReturn(Build.VERSION_CODES.Q).`when`(downloadManager).getSDKVersion()
+
+        assertTrue(WRITE_EXTERNAL_STORAGE !in downloadManager.permissions)
+    }
+
+    @Test
+    fun `GIVEN a device does not supports scoped storage THEN permissions must be included file access`() {
+        downloadManager =
+            spy(FetchDownloadManager(mock(), store, MockDownloadService::class, broadcastManager))
+
+        doReturn(Build.VERSION_CODES.P).`when`(downloadManager).getSDKVersion()
+
+        assertTrue(WRITE_EXTERNAL_STORAGE in downloadManager.permissions)
+
+        doReturn(Build.VERSION_CODES.O_MR1).`when`(downloadManager).getSDKVersion()
+
+        assertTrue(WRITE_EXTERNAL_STORAGE in downloadManager.permissions)
     }
 
     @Test


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
