### PR TITLE
For mozilla-mobile#10624 - Adds recoverable param to `RemoveAllTabsAction` to be used by UndoMiddleware.kt to prevent closed tabs from being recoverable

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -187,8 +187,9 @@ sealed class TabListAction : BrowserAction() {
 
     /**
      * Removes both private and normal [TabSessionState]s.
+     * @property recoverable Indicates whether removed tabs should be recoverable.
      */
-    object RemoveAllTabsAction : TabListAction()
+    data class RemoveAllTabsAction(val recoverable: Boolean = true) : TabListAction()
 
     /**
      * Removes all private [TabSessionState]s.

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/TabListActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/TabListActionTest.kt
@@ -579,7 +579,7 @@ class TabListActionTest {
         )
 
         val store = BrowserStore(state)
-        store.dispatch(TabListAction.RemoveAllTabsAction).joinBlocking()
+        store.dispatch(TabListAction.RemoveAllTabsAction()).joinBlocking()
 
         assertTrue(store.state.tabs.isEmpty())
         assertNull(store.state.selectedTabId)

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/TabsRemovedMiddlewareTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/TabsRemovedMiddlewareTest.kt
@@ -164,7 +164,7 @@ class TabsRemovedMiddlewareTest {
         val engineSession2 = linkEngineSession(store, tab2.id)
         val engineSession3 = linkEngineSession(store, tab3.id)
 
-        store.dispatch(TabListAction.RemoveAllTabsAction).joinBlocking()
+        store.dispatch(TabListAction.RemoveAllTabsAction()).joinBlocking()
         store.waitUntilIdle()
         dispatcher.advanceUntilIdle()
 

--- a/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/ThumbnailsMiddlewareTest.kt
+++ b/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/ThumbnailsMiddlewareTest.kt
@@ -85,7 +85,7 @@ class ThumbnailsMiddlewareTest {
             middleware = listOf(ThumbnailsMiddleware(thumbnailStorage))
         )
 
-        store.dispatch(TabListAction.RemoveAllTabsAction).joinBlocking()
+        store.dispatch(TabListAction.RemoveAllTabsAction()).joinBlocking()
         verify(thumbnailStorage).clearThumbnails()
     }
 

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadMiddlewareTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadMiddlewareTest.kt
@@ -356,7 +356,7 @@ class DownloadMiddlewareTest {
             middleware = listOf(downloadMiddleware)
         )
 
-        val actions = listOf(TabListAction.RemoveAllTabsAction, TabListAction.RemoveAllPrivateTabsAction)
+        val actions = listOf(TabListAction.RemoveAllTabsAction(), TabListAction.RemoveAllPrivateTabsAction)
 
         actions.forEach {
             store.dispatch(it).joinBlocking()

--- a/components/feature/recentlyclosed/src/test/java/mozilla/components/feature/recentlyclosed/RecentlyClosedMiddlewareTest.kt
+++ b/components/feature/recentlyclosed/src/test/java/mozilla/components/feature/recentlyclosed/RecentlyClosedMiddlewareTest.kt
@@ -228,7 +228,7 @@ class RecentlyClosedMiddlewareTest {
             middleware = listOf(UndoMiddleware(mainScope = scope), middleware)
         )
 
-        store.dispatch(TabListAction.RemoveAllTabsAction).joinBlocking()
+        store.dispatch(TabListAction.RemoveAllTabsAction()).joinBlocking()
         store.dispatch(UndoAction.ClearRecoverableTabs(store.state.undoHistory.tag)).joinBlocking()
 
         dispatcher.advanceUntilIdle()

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/middleware/undo/UndoMiddleware.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/middleware/undo/UndoMiddleware.kt
@@ -55,9 +55,11 @@ class UndoMiddleware(
             is TabListAction.RemoveAllPrivateTabsAction -> onTabsRemoved(
                 context, state.privateTabs, state.selectedTabId
             )
-            is TabListAction.RemoveAllTabsAction -> onTabsRemoved(
-                context, state.tabs, state.selectedTabId
-            )
+            is TabListAction.RemoveAllTabsAction -> {
+                if (action.recoverable) {
+                    onTabsRemoved(context, state.tabs, state.selectedTabId)
+                }
+            }
             is TabListAction.RemoveTabAction -> state.findTab(action.tabId)?.let {
                 onTabsRemoved(context, listOf(it), state.selectedTabId)
             }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
@@ -213,7 +213,7 @@ class SessionFeatureTest {
         verify(view).render(engineSession)
         verify(view, never()).release()
 
-        store.dispatch(TabListAction.RemoveAllTabsAction).joinBlocking()
+        store.dispatch(TabListAction.RemoveAllTabsAction()).joinBlocking()
         verify(view).release()
     }
 

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -292,7 +292,7 @@ class SessionUseCasesTest {
         var createdTab: TabSessionState? = null
         var tabCreatedForUrl: String? = null
 
-        store.dispatch(TabListAction.RemoveAllTabsAction).joinBlocking()
+        store.dispatch(TabListAction.RemoveAllTabsAction()).joinBlocking()
 
         val loadUseCase = SessionUseCases.DefaultLoadUrlUseCase(store) { url ->
             tabCreatedForUrl = url
@@ -316,7 +316,7 @@ class SessionUseCasesTest {
         var createdTab: TabSessionState? = null
         var tabCreatedForUrl: String? = null
 
-        store.dispatch(TabListAction.RemoveAllTabsAction).joinBlocking()
+        store.dispatch(TabListAction.RemoveAllTabsAction()).joinBlocking()
         store.waitUntilIdle()
 
         val loadUseCase = SessionUseCases.LoadDataUseCase(store) { url ->

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
@@ -255,8 +255,12 @@ class TabsUseCases(
     class RemoveAllTabsUseCase internal constructor(
         private val store: BrowserStore
     ) {
-        operator fun invoke() {
-            store.dispatch(TabListAction.RemoveAllTabsAction)
+        /**
+         * Removes all tabs.
+         * @param recoverable Indicates whether removed tabs should be recoverable.
+         */
+        operator fun invoke(recoverable: Boolean = true) {
+            store.dispatch(TabListAction.RemoveAllTabsAction(recoverable))
         }
     }
 

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
@@ -192,7 +192,7 @@ class TabsTrayPresenterTest {
 
         assertEquals(2, tabsTray.updateTabs!!.list.size)
 
-        store.dispatch(TabListAction.RemoveAllTabsAction).joinBlocking()
+        store.dispatch(TabListAction.RemoveAllTabsAction()).joinBlocking()
         testDispatcher.advanceUntilIdle()
 
         assertEquals(0, tabsTray.updateTabs!!.list.size)
@@ -270,7 +270,7 @@ class TabsTrayPresenterTest {
 
         assertFalse(closed)
 
-        store.dispatch(TabListAction.RemoveAllTabsAction).joinBlocking()
+        store.dispatch(TabListAction.RemoveAllTabsAction()).joinBlocking()
         testDispatcher.advanceUntilIdle()
 
         assertTrue(closed)


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
