### PR TITLE
For #10603 - Adds `createdAt` to `TabSessionState`

### DIFF
--- a/components/browser/session-storage/src/androidTest/java/mozilla/components/browser/session/storage/RestoringBrowsingSessionsTest.kt
+++ b/components/browser/session-storage/src/androidTest/java/mozilla/components/browser/session/storage/RestoringBrowsingSessionsTest.kt
@@ -255,4 +255,57 @@ class RestoringBrowsingSessionsTest {
             }
         }
     }
+
+    /**
+     * App: Firefox for Android (Fenix)
+     * Version: master branch (GeckoView Nightly), 2021-01-08
+     */
+    @Test
+    fun Fenix_Master_2021_01_8() {
+        runBlocking(Dispatchers.Main) {
+            val json = """
+                {"version":2,"selectedTabId":"7f4fd2c9-2bb1-4c23-a06c-7fbd2b78922f","sessionStateTuples":[{"session":{"url":"https://airhorner.com/","uuid":"0e556bb8-9120-48af-bc93-2bba0d4ec346","parentUuid":"","title":"The Air Horner","contextId":null,"readerMode":false,"lastAccess":1609784156118, "createdAt":1609784156118},"engineSession":{"GECKO_STATE":"{\"scrolldata\":{\"zoom\":{\"resolution\":1,\"displaySize\":{\"height\":1823,\"width\":1080}}},\"history\":{\"entries\":[{\"referrerInfo\":\"BBoSnxDOS9qmDeAnom1e0AAAAAAAAAAAwAAAAAAAAEYAAAAAAAEBAAAAAAEA\",\"persist\":true,\"cacheKey\":0,\"ID\":0,\"url\":\"https:\\/\\/airhorner.com\\/\",\"title\":\"The Air Horner\",\"loadReplace\":true,\"docIdentifier\":2147483649,\"loadReplace2\":true,\"partitionedPrincipalToInherit_base64\":\"eyIwIjp7IjAiOiJtb3otbnVsbHByaW5jaXBhbDp7YjRjZTU0NjItMGQ0Yy00MDc3LTgwMzctYjk2YTI5MGEyMDRifSJ9fQ==\",\"triggeringPrincipal_base64\":\"eyIwIjp7IjAiOiJtb3otbnVsbHByaW5jaXBhbDp7NmE1YzZhODItODdlNy00ODQ0LTljMWItYjY0ZWRiZTA1MDY1fSJ9fQ==\",\"principalToInherit_base64\":\"eyIwIjp7IjAiOiJtb3otbnVsbHByaW5jaXBhbDp7YjRjZTU0NjItMGQ0Yy00MDc3LTgwMzctYjk2YTI5MGEyMDRifSJ9fQ==\",\"resultPrincipalURI\":\"https:\\/\\/airhorner.com\\/\",\"hasUserInteraction\":false,\"originalURI\":\"http:\\/\\/airhorner.com\\/\",\"docshellUUID\":\"{16bc3b14-e47f-4839-b809-095f0b0f79b4}\"}],\"requestedIndex\":0,\"fromIdx\":-1,\"index\":1,\"userContextId\":0}}"}},{"session":{"url":"https://www.wikipedia.org/","uuid":"7f4fd2c9-2bb1-4c23-a06c-7fbd2b78922f","parentUuid":"","title":"","contextId":null,"readerMode":false,"lastAccess":0},"engineSession":{}}]}
+            """.trimIndent()
+
+            val engine = GeckoEngine(context)
+
+            assertTrue(
+                getFileForEngine(context, engine).writeString { json }
+            )
+
+            val storage = SessionStorage(context, engine)
+            val state = storage.restore()
+
+            assertNotNull(state)
+
+            assertEquals(2, state!!.tabs.size)
+            assertEquals("7f4fd2c9-2bb1-4c23-a06c-7fbd2b78922f", state.selectedTabId)
+
+            state.tabs[0].apply {
+                assertEquals("0e556bb8-9120-48af-bc93-2bba0d4ec346", id)
+                assertEquals("The Air Horner", title)
+                assertEquals("https://airhorner.com/", url)
+                assertNull(contextId)
+                assertNull(parentId)
+                assertFalse(readerState.active)
+                assertNull(readerState.activeUrl)
+                assertEquals(1609784156118, lastAccess)
+                assertEquals(1609784156118, createdAt)
+                assertNotNull(state)
+            }
+
+            state.tabs[1].apply {
+                assertEquals("7f4fd2c9-2bb1-4c23-a06c-7fbd2b78922f", id)
+                assertEquals("", title)
+                assertEquals("https://www.wikipedia.org/", url)
+                assertNull(contextId)
+                assertNull(parentId)
+                assertFalse(readerState.active)
+                assertNull(readerState.activeUrl)
+                assertEquals(0, lastAccess)
+                assertEquals(0, createdAt)
+                assertNotNull(state)
+            }
+        }
+    }
 }

--- a/components/browser/session-storage/src/main/java/mozilla/components/browser/session/storage/serialize/BrowserStateReader.kt
+++ b/components/browser/session-storage/src/main/java/mozilla/components/browser/session/storage/serialize/BrowserStateReader.kt
@@ -167,6 +167,7 @@ private fun JsonReader.tabSession(): RecoverableTab? {
     var title: String? = null
     var contextId: String? = null
     var lastAccess: Long? = null
+    var createdAt: Long? = null
     var lastMediaUrl: String? = null
     var lastMediaAccess: Long? = null
     var mediaSessionActive: Boolean? = null
@@ -193,6 +194,7 @@ private fun JsonReader.tabSession(): RecoverableTab? {
             Keys.SESSION_HISTORY_METADATA_SEARCH_TERM -> historyMetadataSearchTerm = nextStringOrNull()
             Keys.SESSION_HISTORY_METADATA_REFERRER_URL -> historyMetadataReferrerUrl = nextStringOrNull()
             Keys.SESSION_LAST_ACCESS -> lastAccess = nextLong()
+            Keys.SESSION_CREATED_AT -> createdAt = nextLong()
             Keys.SESSION_LAST_MEDIA_URL -> lastMediaUrl = nextString()
             Keys.SESSION_LAST_MEDIA_SESSION_ACTIVE -> mediaSessionActive = nextBoolean()
             Keys.SESSION_LAST_MEDIA_ACCESS -> lastMediaAccess = nextLong()
@@ -225,6 +227,7 @@ private fun JsonReader.tabSession(): RecoverableTab? {
         },
         private = false, // We never serialize private sessions
         lastAccess = lastAccess ?: 0,
+        createdAt = createdAt ?: 0,
         lastMediaAccessState = LastMediaAccessState(
             lastMediaUrl ?: "",
             lastMediaAccess = lastMediaAccess ?: 0,

--- a/components/browser/session-storage/src/main/java/mozilla/components/browser/session/storage/serialize/BrowserStateWriter.kt
+++ b/components/browser/session-storage/src/main/java/mozilla/components/browser/session/storage/serialize/BrowserStateWriter.kt
@@ -91,6 +91,9 @@ private fun JsonWriter.tab(
         name(Keys.SESSION_LAST_ACCESS)
         value(tab.lastAccess)
 
+        name(Keys.SESSION_CREATED_AT)
+        value(tab.createdAt)
+
         name(Keys.SESSION_LAST_MEDIA_URL)
         value(tab.lastMediaAccessState.lastMediaUrl)
 

--- a/components/browser/session-storage/src/main/java/mozilla/components/browser/session/storage/serialize/Keys.kt
+++ b/components/browser/session-storage/src/main/java/mozilla/components/browser/session/storage/serialize/Keys.kt
@@ -22,6 +22,7 @@ internal object Keys {
     const val SESSION_READER_MODE_ACTIVE_URL_KEY = "readerModeArticleUrl"
     const val SESSION_TITLE = "title"
     const val SESSION_LAST_ACCESS = "lastAccess"
+    const val SESSION_CREATED_AT = "createdAt"
     const val SESSION_LAST_MEDIA_URL = "lastMediaUrl"
     const val SESSION_LAST_MEDIA_ACCESS = "lastMediaAccess"
     const val SESSION_LAST_MEDIA_SESSION_ACTIVE = "mediaSessionActive"

--- a/components/browser/session-storage/src/test/java/mozilla/components/browser/session/storage/serialize/BrowserStateWriterReaderTest.kt
+++ b/components/browser/session-storage/src/test/java/mozilla/components/browser/session/storage/serialize/BrowserStateWriterReaderTest.kt
@@ -175,6 +175,60 @@ class BrowserStateWriterReaderTest {
         assertEquals(333L, restoredTab.lastMediaAccessState.lastMediaAccess)
         assertTrue(restoredTab.lastMediaAccessState.mediaSessionActive)
     }
+
+    @Test
+    fun `Read and write tab with createdAt`() {
+        val engineState = createFakeEngineState()
+        val engine = createFakeEngine(engineState)
+        val currentTime = System.currentTimeMillis()
+
+        val tab = createTab(
+            url = "https://www.mozilla.org",
+            title = "Mozilla",
+            contextId = "work",
+            createdAt = currentTime
+        )
+
+        val writer = BrowserStateWriter()
+        val reader = BrowserStateReader()
+
+        val file = AtomicFile(
+            File.createTempFile(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        )
+
+        assertTrue(writer.writeTab(tab, file))
+
+        val restoredTab = reader.readTab(engine, file)
+        assertNotNull(restoredTab!!)
+
+        assertEquals(currentTime, restoredTab.createdAt)
+    }
+
+    @Test
+    fun `Read and write tab without createdAt`() {
+        val engineState = createFakeEngineState()
+        val engine = createFakeEngine(engineState)
+
+        val tab = createTab(
+            url = "https://www.mozilla.org",
+            title = "Mozilla",
+            contextId = "work"
+        )
+
+        val writer = BrowserStateWriter()
+        val reader = BrowserStateReader()
+
+        val file = AtomicFile(
+            File.createTempFile(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        )
+
+        assertTrue(writer.writeTab(tab, file))
+
+        val restoredTab = reader.readTab(engine, file)
+        assertNotNull(restoredTab!!)
+
+        assertNotNull(restoredTab.createdAt)
+    }
 }
 
 private fun createFakeEngineState(): EngineSessionState {

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabSessionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabSessionState.kt
@@ -26,6 +26,7 @@ import java.util.UUID
  * @property readerState the [ReaderState] of this tab.
  * @property contextId the session context ID of this tab.
  * @property lastAccess The last time this tab was selected (requires LastAccessMiddleware).
+ * @property createdAt Timestamp of this tab's creation.
  * @property lastMediaAccessState - [LastMediaAccessState] detailing the tab state when media started playing.
  * Requires [LastMediaAccessMiddleware] to update the value when playback starts.
  */
@@ -40,6 +41,7 @@ data class TabSessionState(
     override val source: SessionState.Source = SessionState.Source.NONE,
     val parentId: String? = null,
     val lastAccess: Long = 0L,
+    val createdAt: Long = System.currentTimeMillis(),
     val lastMediaAccessState: LastMediaAccessState = LastMediaAccessState(),
     val readerState: ReaderState = ReaderState(),
     val historyMetadata: HistoryMetadataKey? = null
@@ -80,6 +82,7 @@ fun createTab(
     thumbnail: Bitmap? = null,
     contextId: String? = null,
     lastAccess: Long = 0L,
+    createdAt: Long = System.currentTimeMillis(),
     lastMediaAccessState: LastMediaAccessState = LastMediaAccessState(),
     source: SessionState.Source = SessionState.Source.NONE,
     engineSession: EngineSession? = null,
@@ -106,6 +109,7 @@ fun createTab(
         readerState = readerState,
         contextId = contextId,
         lastAccess = lastAccess,
+        createdAt = createdAt,
         lastMediaAccessState = lastMediaAccessState,
         source = source,
         engineState = EngineState(

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/recover/RecoverableTab.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/recover/RecoverableTab.kt
@@ -27,6 +27,7 @@ import mozilla.components.concept.storage.HistoryMetadataKey
  * @property state The [EngineSessionState] needed for restoring the previous state of this tab.
  * @property readerState The last [ReaderState] of the tab.
  * @property lastAccess The last time this tab was selected.
+ * @property createdAt Timestamp of the tab's creation.
  * @property lastMediaAccessState Details about the last time was playing in this tab.
  * @property private If tab was private.
  */
@@ -39,6 +40,7 @@ data class RecoverableTab(
     val state: EngineSessionState? = null,
     val readerState: ReaderState = ReaderState(),
     val lastAccess: Long = 0,
+    val createdAt: Long = 0,
     val lastMediaAccessState: LastMediaAccessState = LastMediaAccessState(),
     val private: Boolean = false,
     val historyMetadata: HistoryMetadataKey? = null
@@ -56,6 +58,7 @@ fun TabSessionState.toRecoverableTab() = RecoverableTab(
     state = engineState.engineSessionState,
     readerState = readerState,
     lastAccess = lastAccess,
+    createdAt = createdAt,
     lastMediaAccessState = lastMediaAccessState,
     private = content.private,
     historyMetadata = historyMetadata
@@ -73,6 +76,7 @@ fun RecoverableTab.toTabSessionState() = createTab(
     engineSessionState = state,
     readerState = readerState,
     lastAccess = lastAccess,
+    createdAt = createdAt,
     lastMediaAccessState = lastMediaAccessState,
     private = private
 )

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/ext/TabSessionStateTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/ext/TabSessionStateTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.tabs.ext
 import mozilla.components.browser.state.state.ContentState
 import mozilla.components.browser.state.state.LastMediaAccessState
 import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.browser.state.state.createTab
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -40,5 +41,16 @@ class TabSessionStateTest {
         )
 
         assertFalse(tab.hasMediaPlayed())
+    }
+
+    @Test
+    fun `WHEN creating a new TabSessionState THEN createAt is initialized with currentTimeMillis`() {
+        val currentTime = System.currentTimeMillis()
+
+        val newTab = TabSessionState(content = ContentState(url = "https://mozilla.org"))
+        val newTab2 = createTab(url = "https://mozilla.org")
+
+        assertTrue(currentTime <= newTab.createdAt)
+        assertTrue(currentTime <= newTab2.createdAt)
     }
 }


### PR DESCRIPTION
For https://github.com/mozilla-mobile/android-components/issues/10603
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR does not need [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md).
- [x] **Accessibility**: The code in this PR does not include any user facing features.

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
