### PR TITLE
For #10702 - New CombinedHistorySuggestionProvider

### DIFF
--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/CombinedHistorySuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/CombinedHistorySuggestionProvider.kt
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.awesomebar.provider
+
+import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import mozilla.components.browser.icons.BrowserIcons
+import mozilla.components.concept.awesomebar.AwesomeBar
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.storage.HistoryMetadata
+import mozilla.components.concept.storage.HistoryMetadataStorage
+import mozilla.components.concept.storage.HistoryStorage
+import mozilla.components.feature.session.SessionUseCases
+import java.util.UUID
+
+/**
+ * Return 5 history suggestions by default.
+ */
+const val DEFAULT_COMBINED_SUGGESTION_LIMIT = 5
+
+/**
+ * A [AwesomeBar.SuggestionProvider] implementation that combines suggestions from
+ * [HistoryMetadataSuggestionProvider] and [HistoryStorageSuggestionProvider].
+ * It will return suggestions using [HistoryMetadataSuggestionProvider] first,
+ * followed by suggestion from [HistoryStorageSuggestionProvider] up to the provided
+ * [maxNumberOfSuggestions].
+ *
+ * @param historyStorage an instance of the [HistoryStorage] used
+ * to query matching metadata records.
+ * @param historyMetadataStorage an instance of the [HistoryStorage] used
+ * to query matching metadata records.
+ * @param loadUrlUseCase the use case invoked to load the url when the
+ * user clicks on the suggestion.
+ * @param icons optional instance of [BrowserIcons] to load fav icons
+ * for [HistoryMetadata] URLs.
+ * @param engine optional [Engine] instance to call [Engine.speculativeConnect] for the
+ * highest scored suggestion URL.
+ * @param maxNumberOfSuggestions optional parameter to specify the maximum number of returned suggestions,
+ * defaults to [DEFAULT_COMBINED_SUGGESTION_LIMIT].
+ */
+@Suppress("LongParameterList")
+class CombinedHistorySuggestionProvider(
+    private val historyStorage: HistoryStorage,
+    private val historyMetadataStorage: HistoryMetadataStorage,
+    private val loadUrlUseCase: SessionUseCases.LoadUrlUseCase,
+    private val icons: BrowserIcons? = null,
+    internal val engine: Engine? = null,
+    @VisibleForTesting internal val maxNumberOfSuggestions: Int = DEFAULT_COMBINED_SUGGESTION_LIMIT
+) : AwesomeBar.SuggestionProvider {
+    override val id: String = UUID.randomUUID().toString()
+
+    override val shouldClearSuggestions: Boolean
+        get() = false
+
+    override suspend fun onInputChanged(text: String): List<AwesomeBar.Suggestion> = coroutineScope {
+        if (text.isBlank()) {
+            return@coroutineScope emptyList()
+        }
+
+        // Do both queries in parallel to optimize for speed.
+        val metadataSuggestions = async {
+            historyMetadataStorage
+                .queryHistoryMetadata(text, maxNumberOfSuggestions)
+                .filter { it.totalViewTime > 0 }
+                .into(this@CombinedHistorySuggestionProvider, icons, loadUrlUseCase)
+        }
+        val historySuggestions = async {
+            historyStorage.getSuggestions(text, maxNumberOfSuggestions)
+                .sortedByDescending { it.score }
+                .distinctBy { it.id }
+                .into(this@CombinedHistorySuggestionProvider, icons, loadUrlUseCase)
+        }
+
+        val combinedSuggestions = (metadataSuggestions.await() + historySuggestions.await())
+            .take(maxNumberOfSuggestions)
+        combinedSuggestions.firstOrNull()?.description?.let { url -> engine?.speculativeConnect(url) }
+
+        return@coroutineScope combinedSuggestions
+    }
+}

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/CombinedHistorySuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/CombinedHistorySuggestionProviderTest.kt
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.awesomebar.provider
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.storage.memory.InMemoryHistoryStorage
+import mozilla.components.concept.storage.DocumentType
+import mozilla.components.concept.storage.HistoryMetadata
+import mozilla.components.concept.storage.HistoryMetadataKey
+import mozilla.components.concept.storage.HistoryMetadataStorage
+import mozilla.components.concept.storage.PageVisit
+import mozilla.components.concept.storage.RedirectSource
+import mozilla.components.concept.storage.VisitType
+import mozilla.components.support.test.eq
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.anyInt
+import org.mockito.Mockito.doReturn
+
+@RunWith(AndroidJUnit4::class)
+class CombinedHistorySuggestionProviderTest {
+    private val historyEntry = HistoryMetadata(
+        key = HistoryMetadataKey("http://www.mozilla.com", null, null),
+        title = "mozilla",
+        createdAt = System.currentTimeMillis(),
+        updatedAt = System.currentTimeMillis(),
+        totalViewTime = 10,
+        documentType = DocumentType.Regular
+    )
+
+    @Test
+    fun `GIVEN history items exists WHEN onInputChanged is called with empty text THEN return empty suggestions list`() = runBlocking {
+        val storage: HistoryMetadataStorage = mock()
+        whenever(storage.queryHistoryMetadata("moz", DEFAULT_METADATA_SUGGESTION_LIMIT)).thenReturn(listOf(historyEntry))
+        val history = InMemoryHistoryStorage()
+        history.recordVisit("http://www.mozilla.com", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
+        val provider = CombinedHistorySuggestionProvider(history, storage, mock())
+
+        assertTrue(provider.onInputChanged("").isEmpty())
+        assertTrue(provider.onInputChanged("  ").isEmpty())
+    }
+
+    @Test
+    fun `GIVEN more suggestions asked than metadata items exist WHEN user changes input THEN return a combined list of suggestions`() = runBlocking {
+        val storage: HistoryMetadataStorage = mock()
+        doReturn(listOf(historyEntry)).`when`(storage).queryHistoryMetadata(eq("moz"), anyInt())
+        val history = InMemoryHistoryStorage()
+        history.recordVisit("http://www.mozilla.com/firefox", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
+        val provider = CombinedHistorySuggestionProvider(history, storage, mock())
+
+        val result = provider.onInputChanged("moz")
+
+        assertEquals(2, result.size)
+        assertEquals("http://www.mozilla.com", result[0].description)
+        assertEquals("http://www.mozilla.com/firefox", result[1].description)
+    }
+
+    @Test
+    fun `GIVEN fewer suggestions asked than metadata items exist WHEN user changes input THEN return suggestions only based on metadata items`() = runBlocking {
+        val storage: HistoryMetadataStorage = mock()
+        doReturn(listOf(historyEntry)).`when`(storage).queryHistoryMetadata(eq("moz"), anyInt())
+        val history = InMemoryHistoryStorage()
+        history.recordVisit("http://www.mozilla.com/firefox", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
+        val provider = CombinedHistorySuggestionProvider(history, storage, mock(), maxNumberOfSuggestions = 1)
+
+        val result = provider.onInputChanged("moz")
+
+        assertEquals(1, result.size)
+        assertEquals("http://www.mozilla.com", result[0].description)
+    }
+
+    @Test
+    fun `GIVEN only storage history items exist WHEN user changes input THEN return suggestions only based on storage items`() = runBlocking {
+        val storage: HistoryMetadataStorage = mock()
+        doReturn(emptyList<HistoryMetadata>()).`when`(storage).queryHistoryMetadata(eq("moz"), anyInt())
+        val history = InMemoryHistoryStorage()
+        history.recordVisit("http://www.mozilla.com/firefox", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
+        val provider = CombinedHistorySuggestionProvider(history, storage, mock(), maxNumberOfSuggestions = 1)
+
+        val result = provider.onInputChanged("moz")
+
+        assertEquals(1, result.size)
+        assertEquals("http://www.mozilla.com/firefox", result[0].description)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **browser-feature-awesomebar**:
+  * 🌟️ Adds `CombinedHistorySuggestionProvider` that combines the results from `HistoryMetadataSuggestionProvider` and `HistoryStorageSuggestionProvider` so that if not enough metadata history results are available then storage history results are added to return the requested maxNumberOfSuggestions of awesomeBar suggestions.
+
 * **browser-toolbar**
   * 🚒 Bug fixed [issue #10555](https://github.com/mozilla-mobile/android-components/issues/10555) - Prevent new touches from expanding a collapsed toolbar. Wait until there's a response from GeckoView on how the touch was handled to expand/collapse the toolbar.
   * 🌟️ Adds Long-click support to `Button` and gives `TwoStateButton` all the features of `BrowserMenuItemToolbar.TwoStateButton`


### PR DESCRIPTION
This combines the results from `HistoryMetadataSuggestionProvider` and
`HistoryStorageSuggestionProvider` so that if not enough metadata history
results are available then storage history results are added to return the
requested maxNumberOfSuggestions of awesomeBar suggestions.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
