### PR TITLE
Improve BrowserToolbar TwoStateButton

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -384,6 +384,7 @@ class BrowserToolbar @JvmOverloads constructor(
      * @param background A custom (stateful) background drawable resource to be used.
      * @param padding a custom [Padding] for this Button.
      * @param iconTintColorResource Optional ID of color resource to tint the icon.
+     * @param longClickListener Callback that will be invoked whenever the button is long-pressed.
      * @param listener Callback that will be invoked whenever the button is pressed
      */
     @Suppress("LongParameterList")
@@ -460,6 +461,7 @@ class BrowserToolbar @JvmOverloads constructor(
      * @param longClickListener Callback that will be invoked whenever the button is long-pressed.
      * @param listener Callback that will be invoked whenever the button is pressed.
      */
+    @Suppress("LongParameterList")
     open class TwoStateButton(
         val primaryImage: Drawable,
         val primaryContentDescription: String,
@@ -475,9 +477,9 @@ class BrowserToolbar @JvmOverloads constructor(
     ) : BrowserToolbar.Button(
         primaryImage,
         primaryContentDescription,
-        longClickListener=longClickListener,
+        background = background,
+        longClickListener = longClickListener,
         listener = listener,
-        background = background
     ) {
         var enabled: Boolean = false
             private set

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -445,6 +445,7 @@ class BrowserToolbar @JvmOverloads constructor(
      * @param secondaryImage: The drawable to be shown if the button is in the secondary/disabled state.
      * @param secondaryContentDescription: The content description to use if the button is in the secondary state.
      * @param isInPrimaryState: Lambda that returns whether this button should be in the primary or secondary state.
+     * @param disableInSecondaryState: Disable the button entirely when in the secondary state?
      * @param background A custom (stateful) background drawable resource to be used.
      * @param longClickListener Callback that will be invoked whenever the button is long-pressed.
      * @param listener Callback that will be invoked whenever the button is pressed.
@@ -455,6 +456,7 @@ class BrowserToolbar @JvmOverloads constructor(
         val secondaryImage: Drawable = primaryImage,
         val secondaryContentDescription: String = primaryContentDescription,
         val isInPrimaryState: () -> Boolean = { true },
+        val disableInSecondaryState: Boolean = true,
         background: Int = 0,
         longClickListener: (() -> Unit)? = null,
         listener: () -> Unit
@@ -475,9 +477,11 @@ class BrowserToolbar @JvmOverloads constructor(
             if (enabled) {
                 button.setImageDrawable(primaryImage)
                 button.contentDescription = primaryContentDescription
+                button.isEnabled = true
             } else {
                 button.setImageDrawable(secondaryImage)
                 button.contentDescription = secondaryContentDescription
+                button.isEnabled = !disableInSecondaryState
             }
         }
     }

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -386,6 +386,7 @@ class BrowserToolbar @JvmOverloads constructor(
         @DrawableRes background: Int = 0,
         val padding: Padding = DEFAULT_PADDING,
         @ColorRes iconTintColorResource: Int = NO_ID,
+        longClickListener: (() -> Unit)? = null,
         listener: () -> Unit
     ) : Toolbar.ActionButton(
         imageDrawable,
@@ -394,6 +395,7 @@ class BrowserToolbar @JvmOverloads constructor(
         background,
         padding,
         iconTintColorResource,
+        longClickListener,
         listener
     )
 

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -454,11 +454,13 @@ class BrowserToolbar @JvmOverloads constructor(
         private val disabledContentDescription: String,
         private val isEnabled: () -> Boolean = { true },
         background: Int = 0,
+        longClickListener: (() -> Unit)? = null,
         listener: () -> Unit
     ) : BrowserToolbar.Button(
         enabledImage,
         enabledContentDescription,
         listener = listener,
+        longClickListener=longClickListener,
         background = background
     ) {
         var enabled: Boolean = false
@@ -470,11 +472,11 @@ class BrowserToolbar @JvmOverloads constructor(
             val button = view as ImageButton
 
             if (enabled) {
-                button.setImageDrawable(disabledImage)
-                button.contentDescription = disabledContentDescription
-            } else {
                 button.setImageDrawable(enabledImage)
                 button.contentDescription = enabledContentDescription
+            } else {
+                button.setImageDrawable(disabledImage)
+                button.contentDescription = disabledContentDescription
             }
         }
     }

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -9,13 +9,16 @@ import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
+import android.view.View.NO_ID
 import android.view.ViewGroup
 import android.widget.ImageButton
+import android.widget.ImageView
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PRIVATE
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.content.ContextCompat
 import androidx.core.view.forEach
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -41,6 +44,11 @@ import kotlin.coroutines.CoroutineContext
 // https://github.com/mozilla-mobile/android-components/issues/5249
 const val MAX_URI_LENGTH = 25000
 
+internal fun ImageView.setTintResource(@ColorRes tintColorResource: Int) {
+    if (tintColorResource != NO_ID) {
+        imageTintList = ContextCompat.getColorStateList(context, tintColorResource)
+    }
+}
 /**
  * A customizable toolbar for browsers.
  *
@@ -445,6 +453,8 @@ class BrowserToolbar @JvmOverloads constructor(
      * @param secondaryImage: The drawable to be shown if the button is in the secondary/disabled state.
      * @param secondaryContentDescription: The content description to use if the button is in the secondary state.
      * @param isInPrimaryState: Lambda that returns whether this button should be in the primary or secondary state.
+     * @param primaryImageTintResource: Optional ID of color resource to tint the icon in the primary state.
+     * @param secondaryImageTintResource: ID of color resource to tint the icon in the secondary state.
      * @param disableInSecondaryState: Disable the button entirely when in the secondary state?
      * @param background A custom (stateful) background drawable resource to be used.
      * @param longClickListener Callback that will be invoked whenever the button is long-pressed.
@@ -456,6 +466,8 @@ class BrowserToolbar @JvmOverloads constructor(
         val secondaryImage: Drawable = primaryImage,
         val secondaryContentDescription: String = primaryContentDescription,
         val isInPrimaryState: () -> Boolean = { true },
+        @ColorRes val primaryImageTintResource: Int = NO_ID,
+        @ColorRes val secondaryImageTintResource: Int = primaryImageTintResource,
         val disableInSecondaryState: Boolean = true,
         background: Int = 0,
         longClickListener: (() -> Unit)? = null,
@@ -477,10 +489,12 @@ class BrowserToolbar @JvmOverloads constructor(
             if (enabled) {
                 button.setImageDrawable(primaryImage)
                 button.contentDescription = primaryContentDescription
+                button.setTintResource(primaryImageTintResource)
                 button.isEnabled = true
             } else {
                 button.setImageDrawable(secondaryImage)
                 button.contentDescription = secondaryContentDescription
+                button.setTintResource(secondaryImageTintResource)
                 button.isEnabled = !disableInSecondaryState
             }
         }

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -437,46 +437,47 @@ class BrowserToolbar @JvmOverloads constructor(
 
     /**
      * An action that either shows an active button or an inactive button based on the provided
-     * <code>isEnabled</code> lambda.
+     * <code>isInPrimaryState</code> lambda. All secondary characteristics default to their
+     * corresponding primary.
      *
-     * @param enabledImage The drawable to be show if the button is in the enabled stated.
-     * @param enabledContentDescription The content description to use if the button is in the enabled state.
-     * @param disabledImage The drawable to be show if the button is in the disabled stated.
-     * @param disabledContentDescription The content description to use if the button is in the enabled state.
-     * @param isEnabled Lambda that returns true of false to indicate whether this button should be enabled/disabled.
+     * @param primaryImage: The drawable to be shown if the button is in the primary/enabled state
+     * @param primaryContentDescription: The content description to use if the button is in the primary state.
+     * @param secondaryImage: The drawable to be shown if the button is in the secondary/disabled state.
+     * @param secondaryContentDescription: The content description to use if the button is in the secondary state.
+     * @param isInPrimaryState: Lambda that returns whether this button should be in the primary or secondary state.
      * @param background A custom (stateful) background drawable resource to be used.
-     * @param listener Callback that will be invoked whenever the checked state changes.
+     * @param longClickListener Callback that will be invoked whenever the button is long-pressed.
+     * @param listener Callback that will be invoked whenever the button is pressed.
      */
     open class TwoStateButton(
-        private val enabledImage: Drawable,
-        private val enabledContentDescription: String,
-        private val disabledImage: Drawable,
-        private val disabledContentDescription: String,
-        private val isEnabled: () -> Boolean = { true },
+        val primaryImage: Drawable,
+        val primaryContentDescription: String,
+        val secondaryImage: Drawable = primaryImage,
+        val secondaryContentDescription: String = primaryContentDescription,
+        val isInPrimaryState: () -> Boolean = { true },
         background: Int = 0,
         longClickListener: (() -> Unit)? = null,
         listener: () -> Unit
     ) : BrowserToolbar.Button(
-        enabledImage,
-        enabledContentDescription,
-        listener = listener,
+        primaryImage,
+        primaryContentDescription,
         longClickListener=longClickListener,
+        listener = listener,
         background = background
     ) {
         var enabled: Boolean = false
             private set
 
         override fun bind(view: View) {
-            enabled = isEnabled.invoke()
+            enabled = isInPrimaryState.invoke()
 
             val button = view as ImageButton
-
             if (enabled) {
-                button.setImageDrawable(enabledImage)
-                button.contentDescription = enabledContentDescription
+                button.setImageDrawable(primaryImage)
+                button.contentDescription = primaryContentDescription
             } else {
-                button.setImageDrawable(disabledImage)
-                button.contentDescription = disabledContentDescription
+                button.setImageDrawable(secondaryImage)
+                button.contentDescription = secondaryContentDescription
             }
         }
     }

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -646,13 +646,13 @@ class BrowserToolbarTest {
         var reloadPageAction = BrowserToolbar.TwoStateButton(reloadImage, "reload", stopImage, "stop") {}
         assertFalse(reloadPageAction.enabled)
         reloadPageAction.bind(view)
-        verify(view).setImageDrawable(stopImage)
-        verify(view).contentDescription = "stop"
+        verify(view).setImageDrawable(reloadImage)
+        verify(view).contentDescription = "reload"
 
         reloadPageAction = BrowserToolbar.TwoStateButton(reloadImage, "reload", stopImage, "stop", { false }) {}
         reloadPageAction.bind(view)
         verify(view).setImageDrawable(stopImage)
-        verify(view).contentDescription = "reload"
+        verify(view).contentDescription = "stop"
     }
 
     @Test

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -232,6 +232,7 @@ interface Toolbar {
      * @param visible Lambda that returns true or false to indicate whether this button should be shown.
      * @param padding A optional custom padding.
      * @param iconTintColorResource Optional ID of color resource to tint the icon.
+     * @param longClickListener Callback that will be invoked whenever the button is long-pressed.
      * @param listener Callback that will be invoked whenever the button is pressed
      */
     @Suppress("LongParameterList")

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -242,6 +242,7 @@ interface Toolbar {
         private val background: Int = 0,
         private val padding: Padding? = null,
         @ColorRes val iconTintColorResource: Int = ViewGroup.NO_ID,
+        private val longClickListener: (() -> Unit)? = null,
         private val listener: () -> Unit
     ) : Action {
 
@@ -250,6 +251,11 @@ interface Toolbar {
             imageButton.contentDescription = contentDescription
             imageButton.setTintResource(iconTintColorResource)
             imageButton.setOnClickListener { listener.invoke() }
+            imageButton.setOnLongClickListener {
+                longClickListener?.invoke()
+                true
+            }
+            imageButton.isLongClickable = longClickListener != null
 
             val backgroundResource = if (background == 0) {
                 parent.context.theme.resolveAttribute(android.R.attr.selectableItemBackgroundBorderless)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ permalink: /changelog/
 
 * **browser-toolbar**
   * 🚒 Bug fixed [issue #10555](https://github.com/mozilla-mobile/android-components/issues/10555) - Prevent new touches from expanding a collapsed toolbar. Wait until there's a response from GeckoView on how the touch was handled to expand/collapse the toolbar.
+  * 🌟️ Adds Long-click support to `Button` and gives `TwoStateButton` all the features of `BrowserMenuItemToolbar.TwoStateButton`
 
 * **support-test**
   * ⚠️  Deprecation: `createTestCoroutinesDispatcher()` should be replaced with the preferred `TestCoroutineDispatcher()` from the `kotlinx-coroutines-test` library.

--- a/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/ToolbarActivity.kt
+++ b/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/ToolbarActivity.kt
@@ -145,11 +145,19 @@ class ToolbarActivity : AppCompatActivity() {
         // Add a "reload" browser action that simulates reloading the current page
         // //////////////////////////////////////////////////////////////////////////////////////////
 
-        val reload = BrowserToolbar.Button(
-            resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_refresh)!!,
-            "Reload"
+        val reload = BrowserToolbar.TwoStateButton(
+            primaryImage =resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_refresh)!!,
+            primaryContentDescription = "Reload",
+            secondaryImage = resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_stop)!!,
+            secondaryContentDescription = "Stop",
+            isInPrimaryState = { loading.value != true },
+            disableInSecondaryState = false
         ) {
-            simulateReload()
+            if (loading.value == true) {
+                job?.cancel()
+            } else {
+                simulateReload()
+            }
         }
         binding.toolbar.addBrowserAction(reload)
 

--- a/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/ToolbarActivity.kt
+++ b/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/ToolbarActivity.kt
@@ -146,7 +146,7 @@ class ToolbarActivity : AppCompatActivity() {
         // //////////////////////////////////////////////////////////////////////////////////////////
 
         val reload = BrowserToolbar.TwoStateButton(
-            primaryImage =resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_refresh)!!,
+            primaryImage = resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_refresh)!!,
             primaryContentDescription = "Reload",
             secondaryImage = resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_stop)!!,
             secondaryContentDescription = "Stop",


### PR DESCRIPTION
These changes will be used in code I will be submitting for mozilla-mobile/fenix#4134

The added `setTintResource` function is not ideal and the 3 copies of that function spread throughout the codebase should probably be centralized. (Currently also in `/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt` and `/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageText.kt`). I am unsure as to the best place to do this.

The arguments are reordered from `BrowserMenuItemToolbar.TwoStateButton` to try to be non-breaking to the previous version of `TwoStateButton`. For consistency's sake maybe I shouldn't do that?

No tests were added except for the modification of the sample since the code is fairly simple and much easier to visually check than to automate. I am unsure how to properly test this without just testing my implementation details.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
