### PR TITLE
Update Flank to v21.08.0

### DIFF
--- a/taskcluster/docker/ui-tests/Dockerfile
+++ b/taskcluster/docker/ui-tests/Dockerfile
@@ -28,7 +28,7 @@ RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud
     && ${TEST_TOOLS}/google-cloud-sdk/install.sh --quiet \
     && ${TEST_TOOLS}/google-cloud-sdk/bin/gcloud --quiet components update
 
-# Flank v21.07.1
+# Flank v21.08.0
 RUN URL_FLANK_BIN="$($CURL --silent 'https://api.github.com/repos/Flank/flank/releases/latest' | jq -r '.assets[] | select(.browser_download_url | test("flank.jar")) .browser_download_url')" \
     && $CURL --output "${TEST_TOOLS}/flank.jar" "${URL_FLANK_BIN}" \
     && chmod +x "${TEST_TOOLS}/flank.jar"


### PR DESCRIPTION
https://github.com/Flank/flank/releases/tag/v21.08.0

21.08.0 supports an `executeWithRetry` in `ftl.client.google.AppDetailsKt` which is causing frequent `503` error timeouts in UI tests on Firebase. This is a result of our large APKs. Google is also rolling out a fix based on the current working theory that this is an internal deadline being exceeded in the next several days.