### PR TITLE
Closes #10302: Android Autofill: Always show 'search' item.

### DIFF
--- a/components/feature/autofill/build.gradle
+++ b/components/feature/autofill/build.gradle
@@ -4,6 +4,7 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-parcelize'
 
 android {
     compileSdkVersion config.compileSdkVersion

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/handler/FillRequestHandler.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/handler/FillRequestHandler.kt
@@ -18,6 +18,7 @@ import mozilla.components.feature.autofill.response.dataset.LoginDatasetBuilder
 import mozilla.components.feature.autofill.response.fill.AuthFillResponseBuilder
 import mozilla.components.feature.autofill.response.fill.FillResponseBuilder
 import mozilla.components.feature.autofill.response.fill.LoginFillResponseBuilder
+import mozilla.components.feature.autofill.structure.ParsedStructure
 import mozilla.components.feature.autofill.structure.RawStructure
 import mozilla.components.feature.autofill.structure.getLookupDomain
 import mozilla.components.feature.autofill.structure.parseStructure
@@ -49,6 +50,13 @@ internal class FillRequestHandler(
         }
 
         val parsedStructure = parseStructure(context, structure) ?: return null
+        return handle(parsedStructure, forceUnlock)
+    }
+
+    suspend fun handle(
+        parsedStructure: ParsedStructure,
+        forceUnlock: Boolean = false
+    ): FillResponseBuilder {
         val lookupDomain = parsedStructure.getLookupDomain(configuration.publicSuffixList)
         val needsConfirmation = !configuration.verifier.hasCredentialRelationship(
             context,
@@ -60,15 +68,10 @@ internal class FillRequestHandler(
             .getByBaseDomain(lookupDomain)
             .take(MAX_LOGINS)
 
-        if (logins.isEmpty()) {
-            emitAutofillRequestFact(hasLogins = false)
-            return null
-        }
-
         return if (!configuration.lock.keepUnlocked() && !forceUnlock) {
             AuthFillResponseBuilder(parsedStructure)
         } else {
-            emitAutofillRequestFact(hasLogins = true, needsConfirmation)
+            emitAutofillRequestFact(hasLogins = logins.isNotEmpty(), needsConfirmation)
             LoginFillResponseBuilder(parsedStructure, logins, needsConfirmation)
         }
     }

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/fill/AuthFillResponseBuilder.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/fill/AuthFillResponseBuilder.kt
@@ -15,6 +15,7 @@ import androidx.annotation.RequiresApi
 import mozilla.components.feature.autofill.AutofillConfiguration
 import mozilla.components.feature.autofill.R
 import mozilla.components.feature.autofill.structure.ParsedStructure
+import mozilla.components.feature.autofill.ui.AbstractAutofillUnlockActivity
 
 internal data class AuthFillResponseBuilder(
     private val parsedStructure: ParsedStructure
@@ -40,6 +41,10 @@ internal data class AuthFillResponseBuilder(
         }
 
         val authIntent = Intent(context, configuration.unlockActivity)
+        authIntent.putExtra(
+            AbstractAutofillUnlockActivity.EXTRA_PARSED_STRUCTURE,
+            parsedStructure
+        )
 
         val intentSender: IntentSender = PendingIntent.getActivity(
             context,

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/structure/ParsedStructure.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/structure/ParsedStructure.kt
@@ -6,8 +6,10 @@ package mozilla.components.feature.autofill.structure
 
 import android.content.Context
 import android.os.Build
+import android.os.Parcelable
 import android.view.autofill.AutofillId
 import androidx.annotation.RequiresApi
+import kotlinx.parcelize.Parcelize
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import mozilla.components.support.utils.Browsers
 
@@ -18,12 +20,13 @@ import mozilla.components.support.utils.Browsers
  * https://github.com/mozilla-lockwise/lockwise-android/blob/d3c0511f73c34e8759e1bb597f2d3dc9bcc146f0/app/src/main/java/mozilla/lockbox/autofill/ParsedStructure.kt#L52
  */
 @RequiresApi(Build.VERSION_CODES.O)
+@Parcelize
 internal data class ParsedStructure(
     val usernameId: AutofillId? = null,
     val passwordId: AutofillId? = null,
     val webDomain: String? = null,
     val packageName: String
-)
+) : Parcelable
 
 /**
  * Try to find a domain in the [ParsedStructure] for looking up logins. This is either a "web domain"

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/ui/AbstractAutofillUnlockActivity.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/ui/AbstractAutofillUnlockActivity.kt
@@ -4,7 +4,6 @@
 
 package mozilla.components.feature.autofill.ui
 
-import android.app.assist.AssistStructure
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
@@ -22,7 +21,7 @@ import mozilla.components.feature.autofill.authenticator.Authenticator
 import mozilla.components.feature.autofill.authenticator.createAuthenticator
 import mozilla.components.feature.autofill.facts.emitAutofillLock
 import mozilla.components.feature.autofill.handler.FillRequestHandler
-import mozilla.components.feature.autofill.structure.toRawStructure
+import mozilla.components.feature.autofill.structure.ParsedStructure
 
 /**
  * Activity responsible for unlocking the autofill service by asking the user to verify with a
@@ -39,14 +38,14 @@ abstract class AbstractAutofillUnlockActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val structure: AssistStructure? = intent.getParcelableExtra(AutofillManager.EXTRA_ASSIST_STRUCTURE)
+        val parsedStructure = intent.getParcelableExtra<ParsedStructure>(EXTRA_PARSED_STRUCTURE)
 
         // While the user is asked to authenticate, we already try to build the fill response asynchronously.
-        val rawStructure = structure?.toRawStructure()
-        if (rawStructure != null) {
+        if (parsedStructure != null) {
             fillResponse = lifecycleScope.async(Dispatchers.IO) {
-                val builder = fillHandler.handle(rawStructure, forceUnlock = true)
-                builder?.build(this@AbstractAutofillUnlockActivity, configuration)
+                val builder = fillHandler.handle(parsedStructure, forceUnlock = true)
+                val result = builder.build(this@AbstractAutofillUnlockActivity, configuration)
+                result
             }
         }
 
@@ -95,5 +94,9 @@ abstract class AbstractAutofillUnlockActivity : FragmentActivity() {
             setResult(RESULT_CANCELED)
             finish()
         }
+    }
+
+    companion object {
+        const val EXTRA_PARSED_STRUCTURE = "parsed_structure"
     }
 }

--- a/components/feature/autofill/src/test/java/mozilla/components/feature/autofill/handler/FillRequestHandlerTest.kt
+++ b/components/feature/autofill/src/test/java/mozilla/components/feature/autofill/handler/FillRequestHandlerTest.kt
@@ -73,7 +73,9 @@ internal class FillRequestHandlerTest {
                 packageName = "com.twitter.android",
                 logins = emptyMap(),
                 assertThat = { builder ->
-                    assertNull(builder)
+                    assertNotNull(builder!!)
+                    assertEquals(0, builder.logins.size)
+                    assertEquals(false, builder.needsConfirmation)
                 }
             )
 
@@ -82,8 +84,9 @@ internal class FillRequestHandlerTest {
                 assertEquals(Component.FEATURE_AUTOFILL, component)
                 assertEquals(Action.SYSTEM, action)
                 assertEquals(AutofillFacts.Items.AUTOFILL_REQUEST, item)
-                assertEquals(1, metadata?.size)
+                assertEquals(2, metadata?.size)
                 assertEquals(false, metadata?.get(AutofillFacts.Metadata.HAS_MATCHING_LOGINS))
+                assertEquals(false, metadata?.get(AutofillFacts.Metadata.NEEDS_CONFIRMATION))
             }
         }
     }
@@ -171,7 +174,9 @@ internal class FillRequestHandlerTest {
             packageName = "org.chromium.webview_shell",
             logins = mapOf(credentials),
             assertThat = { builder ->
-                assertNull(builder)
+                assertNotNull(builder!!)
+                assertEquals(0, builder.logins.size)
+                assertEquals(false, builder.needsConfirmation)
             }
         )
     }


### PR DESCRIPTION
This patch will:
* Always return a response builder from `FillRequestHandler`. This will make sure that we
  always show at least the "search" item.
* Pass the parsed structure from the service to `AbstractAutofillUnlockActivity`. On my
  Android 12 phone, I do not see the original `AssistStructure` get passed along by the
  system. Instead we just pass the parsed structure manually along, which also means
  we do not have to parse it again.