### PR TITLE
Add a default to task-priority to fix issues when forks are named differently

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -135,6 +135,11 @@ task-priority:
     by-project:
         "android-components": highest
         "staging-android-components": low
+        # This handles cases where a fork may end up not being named
+        # as one of the explicit names above. Ideally anything forked
+        # from "android-components" would inherit its setting, but
+        # "low" is the safer default
+        default: low
 
 taskgraph:
     register: ac_taskgraph:register


### PR DESCRIPTION
Otherwise we get errors such as:
```[task 2021-08-08T11:27:10.405Z] Exception: No project matching 'mozilla-android-components' nor 'default' found while determining item Graph Config```