### PR TITLE
Issue #10798 - Refactor getRepresentativeSnippet and getRepresentativeCharacter from browser-icons to support-ktx

### DIFF
--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/generator/DefaultIconGenerator.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/generator/DefaultIconGenerator.kt
@@ -11,7 +11,6 @@ import android.graphics.Bitmap.Config.ARGB_8888
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
-import android.net.Uri
 import android.util.TypedValue
 import androidx.annotation.ArrayRes
 import androidx.annotation.ColorInt
@@ -21,7 +20,8 @@ import androidx.core.content.ContextCompat
 import mozilla.components.browser.icons.Icon
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.browser.icons.R
-import mozilla.components.support.ktx.android.net.hostWithoutCommonPrefixes
+import mozilla.components.support.ktx.kotlin.getRepresentativeCharacter
+import mozilla.components.support.ktx.kotlin.getRepresentativeSnippet
 import kotlin.math.abs
 
 /**
@@ -50,7 +50,7 @@ class DefaultIconGenerator(
         val cornerRadius = cornerRadiusDimen?.let { context.resources.getDimension(it) } ?: 0f
         canvas.drawRoundRect(sizeRect, cornerRadius, cornerRadius, paint)
 
-        val character = getRepresentativeCharacter(request.url)
+        val character = request.url.getRepresentativeCharacter()
 
         // The text size is calculated dynamically based on the target icon size (1/8th). For an icon
         // size of 112dp we'd use a text size of 14dp (112 / 8).
@@ -90,7 +90,7 @@ class DefaultIconGenerator(
         val color = if (url.isEmpty()) {
             backgroundColors.getColor(0, 0)
         } else {
-            val snippet = getRepresentativeSnippet(url)
+            val snippet = url.getRepresentativeSnippet()
             val index = abs(snippet.hashCode() % backgroundColors.length())
 
             backgroundColors.getColor(index, 0)
@@ -98,44 +98,6 @@ class DefaultIconGenerator(
 
         backgroundColors.recycle()
         return color
-    }
-
-    /**
-     * Get the representative part of the URL. Usually this is the eTLD part of the host.
-     *
-     * For example this method will return "facebook.com" for "https://www.facebook.com/foobar".
-     */
-    private fun getRepresentativeSnippet(url: String): String {
-        val uri = Uri.parse(url)
-
-        val host = uri.hostWithoutCommonPrefixes
-        if (!host.isNullOrEmpty()) {
-            return host
-        }
-
-        val path = uri.path
-        if (!path.isNullOrEmpty()) {
-            return path
-        }
-
-        return url
-    }
-
-    /**
-     * Get a representative character for the given URL.
-     *
-     * For example this method will return "f" for "https://m.facebook.com/foobar".
-     */
-    internal fun getRepresentativeCharacter(url: String): String {
-        val snippet = getRepresentativeSnippet(url)
-
-        snippet.forEach { character ->
-            if (character.isLetterOrDigit()) {
-                return character.uppercase()
-            }
-        }
-
-        return "?"
     }
 
     companion object {

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/generator/DefaultIconGeneratorTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/generator/DefaultIconGeneratorTest.kt
@@ -21,56 +21,6 @@ import org.junit.runner.RunWith
 class DefaultIconGeneratorTest {
 
     @Test
-    fun getRepresentativeCharacter() = runBlocking {
-        val generator = DefaultIconGenerator()
-
-        assertEquals("M", generator.getRepresentativeCharacter("https://mozilla.org"))
-        assertEquals("W", generator.getRepresentativeCharacter("http://wikipedia.org"))
-        assertEquals("P", generator.getRepresentativeCharacter("http://plus.google.com"))
-        assertEquals("E", generator.getRepresentativeCharacter("https://en.m.wikipedia.org/wiki/Main_Page"))
-
-        // Stripping common prefixes
-        assertEquals("T", generator.getRepresentativeCharacter("http://www.theverge.com"))
-        assertEquals("F", generator.getRepresentativeCharacter("https://m.facebook.com"))
-        assertEquals("T", generator.getRepresentativeCharacter("https://mobile.twitter.com"))
-
-        // Special urls
-        assertEquals("?", generator.getRepresentativeCharacter("file:///"))
-        assertEquals("S", generator.getRepresentativeCharacter("file:///system/"))
-        assertEquals("P", generator.getRepresentativeCharacter("ftp://people.mozilla.org/test"))
-
-        // No values
-        assertEquals("?", generator.getRepresentativeCharacter(""))
-
-        // Rubbish
-        assertEquals("Z", generator.getRepresentativeCharacter("zZz"))
-        assertEquals("Ö", generator.getRepresentativeCharacter("ölkfdpou3rkjaslfdköasdfo8"))
-        assertEquals("?", generator.getRepresentativeCharacter("_*+*'##"))
-        assertEquals("ツ", generator.getRepresentativeCharacter("¯\\_(ツ)_/¯"))
-        assertEquals("ಠ", generator.getRepresentativeCharacter("ಠ_ಠ Look of Disapproval"))
-
-        // Non-ASCII
-        assertEquals("Ä", generator.getRepresentativeCharacter("http://www.ätzend.de"))
-        assertEquals("名", generator.getRepresentativeCharacter("http://名がドメイン.com"))
-        assertEquals("C", generator.getRepresentativeCharacter("http://√.com"))
-        assertEquals("SS", generator.getRepresentativeCharacter("http://ß.de"))
-        assertEquals("Ԛ", generator.getRepresentativeCharacter("http://ԛәлп.com/")) // cyrillic
-
-        // Punycode
-        assertEquals("X", generator.getRepresentativeCharacter("http://xn--tzend-fra.de")) // ätzend.de
-        assertEquals(
-            "X",
-            generator.getRepresentativeCharacter("http://xn--V8jxj3d1dzdz08w.com")
-        ) // 名がドメイン.com
-
-        // Numbers
-        assertEquals("1", generator.getRepresentativeCharacter("https://www.1and1.com/"))
-
-        // IP
-        assertEquals("1", generator.getRepresentativeCharacter("https://192.168.0.1"))
-    }
-
-    @Test
     fun pickColor() {
         val generator = DefaultIconGenerator()
         val res = testContext.resources

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
@@ -4,6 +4,8 @@
 
 package mozilla.components.support.ktx.kotlin
 
+import android.net.Uri
+import mozilla.components.support.ktx.android.net.hostWithoutCommonPrefixes
 import mozilla.components.support.utils.URLStringUtils
 import java.io.File
 import java.net.MalformedURLException
@@ -226,3 +228,41 @@ fun String.getDataUrlImageExtension(defaultExtension: String = "jpg"): String {
  */
 inline fun <C, R> C?.ifNullOrEmpty(defaultValue: () -> R): C where C : CharSequence, R : C =
     if (isNullOrEmpty()) defaultValue() else this
+
+/**
+ * Get the representative part of the URL. Usually this is the eTLD part of the host.
+ *
+ * For example this method will return "facebook.com" for "https://www.facebook.com/foobar".
+ */
+fun String.getRepresentativeSnippet(): String {
+    val uri = Uri.parse(this)
+
+    val host = uri.hostWithoutCommonPrefixes
+    if (!host.isNullOrEmpty()) {
+        return host
+    }
+
+    val path = uri.path
+    if (!path.isNullOrEmpty()) {
+        return path
+    }
+
+    return this
+}
+
+/**
+ * Get a representative character for the given URL.
+ *
+ * For example this method will return "f" for "https://m.facebook.com/foobar".
+ */
+fun String.getRepresentativeCharacter(): String {
+    val snippet = this.getRepresentativeSnippet()
+
+    snippet.forEach { character ->
+        if (character.isLetterOrDigit()) {
+            return character.uppercase()
+        }
+    }
+
+    return "?"
+}

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
@@ -158,12 +158,12 @@ class StringTest {
     }
 
     @Test
-
     fun sanitizeURL() {
         val expectedUrl = "http://mozilla.org"
         assertEquals(expectedUrl, "\nhttp://mozilla.org\n".sanitizeURL())
     }
 
+    @Test
     fun isResourceUrl() {
         assertTrue("resource://1232-abcd".isResourceUrl())
         assertFalse("mozilla.org".isResourceUrl())
@@ -232,5 +232,50 @@ class StringTest {
         val validResult = "notEmptyString"
 
         assertSame(validResult, nullString.ifNullOrEmpty { validResult })
+    }
+
+    @Test
+    fun `getRepresentativeCharacter returns the correct representative character for the given urls`() {
+        assertEquals("M", "https://mozilla.org".getRepresentativeCharacter())
+        assertEquals("W", "http://wikipedia.org".getRepresentativeCharacter())
+        assertEquals("P", "http://plus.google.com".getRepresentativeCharacter())
+        assertEquals("E", "https://en.m.wikipedia.org/wiki/Main_Page".getRepresentativeCharacter())
+
+        // Stripping common prefixes
+        assertEquals("T", "http://www.theverge.com".getRepresentativeCharacter())
+        assertEquals("F", "https://m.facebook.com".getRepresentativeCharacter())
+        assertEquals("T", "https://mobile.twitter.com".getRepresentativeCharacter())
+
+        // Special urls
+        assertEquals("?", "file:///".getRepresentativeCharacter())
+        assertEquals("S", "file:///system/".getRepresentativeCharacter())
+        assertEquals("P", "ftp://people.mozilla.org/test".getRepresentativeCharacter())
+
+        // No values
+        assertEquals("?", "".getRepresentativeCharacter())
+
+        // Rubbish
+        assertEquals("Z", "zZz".getRepresentativeCharacter())
+        assertEquals("Ö", "ölkfdpou3rkjaslfdköasdfo8".getRepresentativeCharacter())
+        assertEquals("?", "_*+*'##".getRepresentativeCharacter())
+        assertEquals("ツ", "¯\\_(ツ)_/¯".getRepresentativeCharacter())
+        assertEquals("ಠ", "ಠ_ಠ Look of Disapproval".getRepresentativeCharacter())
+
+        // Non-ASCII
+        assertEquals("Ä", "http://www.ätzend.de".getRepresentativeCharacter())
+        assertEquals("名", "http://名がドメイン.com".getRepresentativeCharacter())
+        assertEquals("C", "http://√.com".getRepresentativeCharacter())
+        assertEquals("SS", "http://ß.de".getRepresentativeCharacter())
+        assertEquals("Ԛ", "http://ԛәлп.com/".getRepresentativeCharacter()) // cyrillic
+
+        // Punycode
+        assertEquals("X", "http://xn--tzend-fra.de".getRepresentativeCharacter()) // ätzend.de
+        assertEquals("X", "http://xn--V8jxj3d1dzdz08w.com".getRepresentativeCharacter()) // 名がドメイン.com
+
+        // Numbers
+        assertEquals("1", "https://www.1and1.com/".getRepresentativeCharacter())
+
+        // IP
+        assertEquals("1", "https://192.168.0.1".getRepresentativeCharacter())
     }
 }


### PR DESCRIPTION
Fixes #10798


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
