### PR TITLE
Update context menu candidates and layout

### DIFF
--- a/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuFeature.kt
+++ b/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuFeature.kt
@@ -42,14 +42,17 @@ internal const val FRAGMENT_TAG = "mozac_feature_contextmenu_dialog"
  * @property engineView The [EngineView]] this feature component should show context menus for.
  * @param tabId Optional id of a tab. Instead of showing context menus for the currently selected tab this feature will
  * show only context menus for this tab if an id is provided.
+ * @param additionalNote which it will be attached to the bottom of context menu but for a specific [HitResult]
  */
+@Suppress("LongParameterList")
 class ContextMenuFeature(
     private val fragmentManager: FragmentManager,
     private val store: BrowserStore,
     private val candidates: List<ContextMenuCandidate>,
     private val engineView: EngineView,
     private val useCases: ContextMenuUseCases,
-    private val tabId: String? = null
+    private val tabId: String? = null,
+    private val additionalNote: (HitResult) -> String? = { null }
 ) : LifecycleAwareFeature {
     private var scope: CoroutineScope? = null
 
@@ -104,7 +107,7 @@ class ContextMenuFeature(
         // We know that we are going to show a context menu. Now is the time to perform the haptic feedback.
         engineView.asView().performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
 
-        val fragment = ContextMenuFragment.create(tab, hitResult.getLink(), ids, labels)
+        val fragment = ContextMenuFragment.create(tab, hitResult.getLink(), ids, labels, additionalNote(hitResult))
         fragment.feature = this
         fragment.show(fragmentManager, FRAGMENT_TAG)
     }

--- a/components/feature/contextmenu/src/main/res/layout/mozac_feature_contextmenu_dialog.xml
+++ b/components/feature/contextmenu/src/main/res/layout/mozac_feature_contextmenu_dialog.xml
@@ -2,8 +2,23 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/recyclerView"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingBottom="16dp" />
+    android:orientation="vertical">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingBottom="16dp" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/additional_note"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        style="@style/Mozac.Dialog.AdditionalNote"
+        android:padding="24dp"
+        android:visibility="gone" />
+</LinearLayout>

--- a/components/feature/contextmenu/src/main/res/values/colors.xml
+++ b/components/feature/contextmenu/src/main/res/values/colors.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <color name="mozac_additional_note_background">#1D1133</color>
+    <color name="mozac_additional_note_text_color">#BFBFC9</color>
+</resources>

--- a/components/feature/contextmenu/src/main/res/values/style.xml
+++ b/components/feature/contextmenu/src/main/res/values/style.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <style name="Mozac.Dialog.AdditionalNote" parent="Widget.MaterialComponents.TextView">
+        <item name="android:layout_width">48dp</item>
+        <item name="android:layout_height">48dp</item>
+        <item name="android:textSize">14sp</item>
+        <item name="android:background">@color/mozac_additional_note_background</item>
+        <item name="android:textColor">@color/mozac_additional_note_text_color</item>
+        <item name="android:lineSpacingExtra">3dp</item>
+    </style>
+</resources>

--- a/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuFragmentTest.kt
+++ b/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuFragmentTest.kt
@@ -31,8 +31,9 @@ class ContextMenuFragmentTest {
         val labels = listOf("Item A", "Item B", "Item C")
         val title = "Hello World"
         val tab = createTab("https://www.mozilla.org")
+        val additionalNote = "Additional note"
 
-        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels, additionalNote))
         doReturn(testContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
@@ -49,8 +50,9 @@ class ContextMenuFragmentTest {
         val labels = listOf("Item A", "Item B", "Item C")
         val title = "Hello World"
         val tab = createTab("https://www.mozilla.org")
+        val additionalNote = "Additional note"
 
-        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels, additionalNote))
 
         val inflater = LayoutInflater.from(testContext)
         val view = fragment.createDialogTitleView(inflater)
@@ -67,8 +69,9 @@ class ContextMenuFragmentTest {
         val labels = listOf("Item A", "Item B", "Item C")
         val title = "Hello World"
         val tab = createTab("https://www.mozilla.org")
+        val additionalNote = "Additional note"
 
-        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels, additionalNote))
 
         val inflater = LayoutInflater.from(testContext)
         val view = fragment.createDialogTitleView(inflater)
@@ -88,8 +91,10 @@ class ContextMenuFragmentTest {
         val labels = listOf("Item A", "Item B", "Item C")
         val title = "Hello World"
         val tab = createTab("https://www.mozilla.org")
+        val additionalNote = "Additional note"
 
-        val fragment = ContextMenuFragment.create(tab, title, ids, labels)
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels, additionalNote))
+        doReturn(testContext).`when`(fragment).requireContext()
 
         val inflater = LayoutInflater.from(testContext)
         val view = fragment.createDialogContentView(inflater)
@@ -118,8 +123,10 @@ class ContextMenuFragmentTest {
         val labels = listOf("Item A", "Item B", "Item C")
         val title = "Hello World"
         val tab = createTab("https://www.mozilla.org")
+        val additionalNote = "Additional note"
 
-        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels, additionalNote))
+        doReturn(testContext).`when`(fragment).requireContext()
         doNothing().`when`(fragment).dismiss()
 
         val inflater = LayoutInflater.from(testContext)
@@ -140,10 +147,11 @@ class ContextMenuFragmentTest {
         val labels = listOf("Item A", "Item B", "Item C")
         val title = "Hello World"
         val tab = createTab("https://www.mozilla.org")
+        val additionalNote = "Additional note"
 
         val feature: ContextMenuFeature = mock()
 
-        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels, additionalNote))
         fragment.feature = feature
         doNothing().`when`(fragment).dismiss()
 
@@ -159,11 +167,12 @@ class ContextMenuFragmentTest {
         val labels = listOf("Item A", "Item B", "Item C")
         val tab = createTab("https://www.mozilla.org")
         val titleString = "test title"
+        val additionalNote = "Additional note"
 
         val hitResult = HitResult.IMAGE("https://www.mozilla.org", titleString)
         val title = hitResult.getLink()
 
-        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels, additionalNote))
 
         assertEquals(titleString, fragment.title)
     }
@@ -174,11 +183,12 @@ class ContextMenuFragmentTest {
         val labels = listOf("Item A", "Item B", "Item C")
         val tab = createTab("https://www.mozilla.org")
         val titleString = " "
+        val additionalNote = "Additional note"
 
         val hitResult = HitResult.IMAGE("https://www.mozilla.org", titleString)
         val title = hitResult.getLink()
 
-        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels, additionalNote))
 
         assertEquals("https://www.mozilla.org", fragment.title)
     }
@@ -188,11 +198,12 @@ class ContextMenuFragmentTest {
         val ids = listOf("A", "B", "C")
         val labels = listOf("Item A", "Item B", "Item C")
         val tab = createTab("https://www.mozilla.org")
+        val additionalNote = "Additional note"
 
         val hitResult = HitResult.IMAGE("https://www.mozilla.org")
         val title = hitResult.getLink()
 
-        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels, additionalNote))
 
         assertEquals("https://www.mozilla.org", fragment.title)
     }
@@ -202,11 +213,12 @@ class ContextMenuFragmentTest {
         val ids = listOf("A", "B", "C")
         val labels = listOf("Item A", "Item B", "Item C")
         val tab = createTab("https://www.mozilla.org")
+        val additionalNote = "Additional note"
 
         val hitResult = HitResult.IMAGE_SRC("https://www.mozilla.org", "https://another.com")
         val title = hitResult.getLink()
 
-        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels, additionalNote))
 
         assertEquals("https://another.com", fragment.title)
     }
@@ -216,11 +228,12 @@ class ContextMenuFragmentTest {
         val ids = listOf("A", "B", "C")
         val labels = listOf("Item A", "Item B", "Item C")
         val tab = createTab("https://www.mozilla.org")
+        val additionalNote = "Additional note"
 
         val hitResult = HitResult.UNKNOWN("https://www.mozilla.org")
         val title = hitResult.getLink()
 
-        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels, additionalNote))
 
         assertEquals("https://www.mozilla.org", fragment.title)
     }
@@ -231,11 +244,12 @@ class ContextMenuFragmentTest {
         val labels = listOf("Item A", "Item B", "Item C")
         val tab = createTab("https://www.mozilla.org")
         val titleString = " "
+        val additionalNote = "Additional note"
 
         val hitResult = HitResult.AUDIO("https://www.mozilla.org", titleString)
         val title = hitResult.getLink()
 
-        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels, additionalNote))
 
         assertEquals("https://www.mozilla.org", fragment.title)
     }
@@ -245,11 +259,12 @@ class ContextMenuFragmentTest {
         val ids = listOf("A", "B", "C")
         val labels = listOf("Item A", "Item B", "Item C")
         val tab = createTab("https://www.mozilla.org")
+        val additionalNote = "Additional note"
 
         val hitResult = HitResult.AUDIO("https://www.mozilla.org")
         val title = hitResult.getLink()
 
-        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels, additionalNote))
 
         assertEquals("https://www.mozilla.org", fragment.title)
     }
@@ -260,11 +275,12 @@ class ContextMenuFragmentTest {
         val labels = listOf("Item A", "Item B", "Item C")
         val tab = createTab("https://www.mozilla.org")
         val titleString = " "
+        val additionalNote = "Additional note"
 
         val hitResult = HitResult.VIDEO("https://www.mozilla.org", titleString)
         val title = hitResult.getLink()
 
-        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels, additionalNote))
 
         assertEquals("https://www.mozilla.org", fragment.title)
     }
@@ -274,11 +290,12 @@ class ContextMenuFragmentTest {
         val ids = listOf("A", "B", "C")
         val labels = listOf("Item A", "Item B", "Item C")
         val tab = createTab("https://www.mozilla.org")
+        val additionalNote = "Additional note"
 
         val hitResult = HitResult.VIDEO("https://www.mozilla.org")
         val title = hitResult.getLink()
 
-        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels, additionalNote))
 
         assertEquals("https://www.mozilla.org", fragment.title)
     }
@@ -288,11 +305,12 @@ class ContextMenuFragmentTest {
         val ids = listOf("A", "B", "C")
         val labels = listOf("Item A", "Item B", "Item C")
         val tab = createTab("https://www.mozilla.org")
+        val additionalNote = "Additional note"
 
         val hitResult = HitResult.EMAIL("https://www.mozilla.org")
         val title = hitResult.getLink()
 
-        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels, additionalNote))
 
         assertEquals("about:blank", fragment.title)
     }
@@ -302,11 +320,12 @@ class ContextMenuFragmentTest {
         val ids = listOf("A", "B", "C")
         val labels = listOf("Item A", "Item B", "Item C")
         val tab = createTab("https://www.mozilla.org")
+        val additionalNote = "Additional note"
 
         val hitResult = HitResult.GEO("https://www.mozilla.org")
         val title = hitResult.getLink()
 
-        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels, additionalNote))
 
         assertEquals("about:blank", fragment.title)
     }
@@ -316,11 +335,12 @@ class ContextMenuFragmentTest {
         val ids = listOf("A", "B", "C")
         val labels = listOf("Item A", "Item B", "Item C")
         val tab = createTab("https://www.mozilla.org")
+        val additionalNote = "Additional note"
 
         val hitResult = HitResult.PHONE("https://www.mozilla.org")
         val title = hitResult.getLink()
 
-        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels, additionalNote))
 
         assertEquals("about:blank", fragment.title)
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,9 @@ permalink: /changelog/
   * 🌟️ Adds icons: mozac_ic_add_to_home_screen, mozac_ic_help, mozac_ic_shield, mozac_ic_shield_disabled
   * 🌟️ Update icons: mozac_ic_home, mozac_ic_settings, mozac_ic_clear
 
+* **feature-contextmenu**:
+  * 🌟️ Adds `additionalNote` which it will be attached to the bottom of context menu but for a specific `HitResult`
+
 # 93.0.0-SNAPSHOT (In Development)
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v92.0.0...main)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/140?closed=1)


### PR DESCRIPTION
#### For #10822

Add 'createShareLinkCandidateForLink' and 'createCopyLinkCandidateForLink' methods in order to be able
to display 'Share link' and 'Copy Link' candidates only for plain text context menu

Update context menu layout and add an additional note - For that a new flag was added
Update unit tests



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
