### PR TITLE
Use new geckoview-omni package, which includes Glean directly

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -31,7 +31,7 @@ object Versions {
 
     const val mozilla_appservices = "83.0.0"
 
-    const val mozilla_glean = "39.0.3"
+    const val mozilla_glean = "40.1.0"
 
     const val material = "1.2.1"
 
@@ -151,7 +151,7 @@ object Dependencies {
     val mozilla_geckoview = "org.mozilla.geckoview:${Gecko.channel.artifactName}:${Gecko.version}"
     const val mozilla_fxa = "org.mozilla.appservices:fxaclient:${Versions.mozilla_appservices}"
     const val mozilla_nimbus = "org.mozilla.appservices:nimbus:${Versions.mozilla_appservices}"
-    const val mozilla_glean_forUnitTests = "org.mozilla.telemetry:glean-forUnitTests:${Versions.mozilla_glean}"
+    const val mozilla_glean_forUnitTests = "org.mozilla.telemetry:glean-native-forUnitTests:${Versions.mozilla_glean}"
     const val mozilla_sync_autofill = "org.mozilla.appservices:autofill:${Versions.mozilla_appservices}"
     const val mozilla_sync_logins = "org.mozilla.appservices:logins:${Versions.mozilla_appservices}"
     const val mozilla_places = "org.mozilla.appservices:places:${Versions.mozilla_appservices}"

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -23,7 +23,7 @@ object Gecko {
 enum class GeckoChannel(
     val artifactName: String
 ) {
-    NIGHTLY("geckoview-nightly"),
-    BETA("geckoview-beta"),
-    RELEASE("geckoview")
+    NIGHTLY("geckoview-nightly-omni"),
+    BETA("geckoview-beta-omni"),
+    RELEASE("geckoview-omni")
 }

--- a/components/service/glean/build.gradle
+++ b/components/service/glean/build.gradle
@@ -40,7 +40,7 @@ configurations {
 
 // Define library names and version constants.
 String GLEAN_LIBRARY = "org.mozilla.telemetry:glean:${Versions.mozilla_glean}"
-String GLEAN_LIBRARY_FORUNITTESTS = "org.mozilla.telemetry:glean-forUnitTests:${Versions.mozilla_glean}"
+String GLEAN_LIBRARY_FORUNITTESTS = "org.mozilla.telemetry:glean-native-forUnitTests:${Versions.mozilla_glean}"
 
 dependencies {
     implementation Dependencies.kotlin_stdlib

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,13 @@ permalink: /changelog/
 * **concept-storage**, **browser-storage-sync**
   * 🌟️ New API: `HistoryMetadataStorage.deleteHistoryMetadata`, allows removing specific metadata entries.
 
+* **browser-engine-gecko**:
+  * Switch to the `geckoview-omni` releases. `-omni` packages also ship the Glean Core native code.
+
+* **service-glean**
+  * 🆙 Updated Glean to version 40.1.0 ([changelog](https://github.com/mozilla/glean/releases/tag/v40.1.0))
+    * The Glean Core native code is now shipped through GeckoView
+
 # 93.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v92.0.0...v93.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/140?closed=1)


### PR DESCRIPTION
The native Glean core code is now shipped as part of GeckoView, within
the `-omni` packages.
The Glean Gradle plugin takes care that this all fits together nicely.
Downstream users will need to depend on the `glean-native` package for
tests now.

For now Android Components still needs to declare an explicit dependency
on `org.mozilla.telemetry:glean` as well.
service-glean needs to know what to reexport and some other components
depend on it directly to be able to use it. These might not depend on
geckoview, so have no other way to get that dependency.

Now here's the catch: Because GeckoView defines `org.mozilla.telemetry:glean` as a dependency,
consumers that transitively depend on GeckoView (through
`browser-engine-gecko`) will get the latest version of `org.mozilla.telemetry:glean` through it.
Gradle unifies the versions.
It would be problematic if a-c depends on a higher version, but that
should not happen (though we don't have any technical limitations on it
yet).
If Glean does a breaking change release and gets that into
mozilla-central, the version in a-c needs to be manually updated too.
For other releases it can be left untouched.

---

cc @agi for review as well.

I tested this configuration locally in Fenix already.
Still we should keep an eye on when this lands in Fenix to validate that everything works as expected.
Our automated tests should catch if anything is really off, but this is a big change for how we ship Glean so worth a close look.