### PR TITLE
Close #10827 show the toolbar Highlight (blue dot) when tracking protection is off for a site

### DIFF
--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarPresenter.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarPresenter.kt
@@ -88,7 +88,9 @@ class ToolbarPresenter(
 
     private fun updateHighlight(tab: SessionState) {
         toolbar.highlight = when {
-            tab.content.permissionHighlights.permissionsChanged -> Highlight.PERMISSIONS_CHANGED
+            tab.content.permissionHighlights.permissionsChanged ||
+                tab.trackingProtection.ignoredOnTrackingProtection
+            -> Highlight.PERMISSIONS_CHANGED
             else -> Highlight.NONE
         }
     }

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarPresenterTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarPresenterTest.kt
@@ -470,11 +470,18 @@ class ToolbarPresenterTest {
 
         verify(toolbar).highlight = Toolbar.Highlight.PERMISSIONS_CHANGED
 
+        store.dispatch(TrackingProtectionAction.ToggleExclusionListAction("tab", true))
+            .joinBlocking()
+
+        testDispatcher.advanceUntilIdle()
+
+        verify(toolbar, times(2)).highlight = Toolbar.Highlight.PERMISSIONS_CHANGED
+
         store.dispatch(UpdatePermissionHighlightsStateAction.Reset("tab")).joinBlocking()
 
         testDispatcher.advanceUntilIdle()
 
-        verify(toolbar, times(2)).highlight = Toolbar.Highlight.NONE
+        verify(toolbar).highlight = Toolbar.Highlight.NONE
     }
 
     @Test


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
