### PR TITLE
Remove unnecessary `readScope` from PlacesStorage

### DIFF
--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorage.kt
@@ -34,9 +34,7 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
      * @return The populated root starting from the guid.
      */
     override suspend fun getTree(guid: String, recursive: Boolean): BookmarkNode? {
-        return withContext(readScope.coroutineContext) {
-            reader.getBookmarksTree(guid, recursive)?.asBookmarkNode()
-        }
+        return reader.getBookmarksTree(guid, recursive)?.asBookmarkNode()
     }
 
     /**
@@ -46,9 +44,7 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
      * @return The bookmark node or null if it does not exist.
      */
     override suspend fun getBookmark(guid: String): BookmarkNode? {
-        return withContext(readScope.coroutineContext) {
-            reader.getBookmark(guid)?.asBookmarkNode()
-        }
+        return reader.getBookmark(guid)?.asBookmarkNode()
     }
 
     /**
@@ -58,9 +54,7 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
      * @return The list of bookmarks that match the URL
      */
     override suspend fun getBookmarksWithUrl(url: String): List<BookmarkNode> {
-        return withContext(readScope.coroutineContext) {
-            reader.getBookmarksWithURL(url).map { it.asBookmarkNode() }
-        }
+        return reader.getBookmarksWithURL(url).map { it.asBookmarkNode() }
     }
 
     /**
@@ -71,9 +65,7 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
      * @return The list of matching bookmark nodes up to the limit number of items.
      */
     override suspend fun searchBookmarks(query: String, limit: Int): List<BookmarkNode> {
-        return withContext(readScope.coroutineContext) {
-            reader.searchBookmarks(query, limit).map { it.asBookmarkNode() }
-        }
+        return reader.searchBookmarks(query, limit).map { it.asBookmarkNode() }
     }
 
     /**
@@ -89,15 +81,13 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
         maxAge: Long?,
         @VisibleForTesting currentTime: Long
     ): List<BookmarkNode> {
-        return withContext(readScope.coroutineContext) {
-            val threshold = if (maxAge != null) {
-                currentTime - maxAge
-            } else {
-                0
-            }
-            reader.getRecentBookmarks(limit).filter { it.dateAdded >= threshold }
-                .map { it.asBookmarkNode() }
+        val threshold = if (maxAge != null) {
+            currentTime - maxAge
+        } else {
+            0
         }
+        return reader.getRecentBookmarks(limit).filter { it.dateAdded >= threshold }
+            .map { it.asBookmarkNode() }
     }
 
     /**

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesStorage.kt
@@ -7,7 +7,6 @@ package mozilla.components.browser.storage.sync
 import android.content.Context
 import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.withContext
@@ -38,7 +37,6 @@ abstract class PlacesStorage(
             ).asCoroutineDispatcher()
         )
     }
-    internal val readScope by lazy { CoroutineScope(Dispatchers.IO) }
     private val storageDir by lazy { context.filesDir }
 
     abstract val logger: Logger
@@ -73,7 +71,6 @@ abstract class PlacesStorage(
      */
     override fun cleanup() {
         writeScope.coroutineContext.cancelChildren()
-        readScope.coroutineContext.cancelChildren()
         places.close()
     }
 


### PR DESCRIPTION
All of the 'read' functions that are present in the variants of this
class are already 'suspend'. Declaring a specific dispatcher and
switching to it is harmless and ensures that we'll always end up doing
this work on a dispatchers.io, but all of the consumers are already
expected to invoke 'reader' methods on a worker thread (e.g.
dispatchers.io). Also, there are no special requirements for reading
from places - e.g. it can be done concurrently from different threads.

Contrast this with writing to places - _that_ needs to be sequential,
and so we maintain a `writeScope` to ensure work happens on a
single-threaded dispatcher.

So, the read scope is basically an unnecessary overhead and a tiny bit
of extra complexity we don't need.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
