### PR TITLE
Closes #10834: Add BrowserIcons.Loader() composable function to load website icons in Jetpack Compose code.

### DIFF
--- a/components/browser/icons/build.gradle
+++ b/components/browser/icons/build.gradle
@@ -31,6 +31,14 @@ android {
             resources.srcDirs += ['src/test/resources']
         }
     }
+
+    buildFeatures {
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = Versions.compose_version
+    }
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
@@ -54,6 +62,8 @@ dependencies {
     implementation Dependencies.androidx_annotation
     implementation Dependencies.androidx_core_ktx
     implementation Dependencies.androidx_palette
+    implementation Dependencies.androidx_compose_ui
+    implementation Dependencies.androidx_compose_material
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
     implementation Dependencies.thirdparty_disklrucache

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/compose/IconLoaderScope.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/compose/IconLoaderScope.kt
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import mozilla.components.browser.icons.BrowserIcons
+
+/**
+ * The scope of a [BrowserIcons.Loader] block.
+ */
+interface IconLoaderScope {
+    val state: MutableState<IconLoaderState>
+}
+
+/**
+ * Renders the inner [content] block once an icon was loaded.
+ */
+@Composable
+fun IconLoaderScope.WithIcon(
+    content: @Composable (icon: IconLoaderState.Icon) -> Unit
+) {
+    WithInternalState {
+        val state = state.value
+        if (state is IconLoaderState.Icon) {
+            content(state)
+        }
+    }
+}
+
+/**
+ * Renders the inner [content] block until an icon was loaded.
+ */
+@Composable
+fun IconLoaderScope.Placeholder(
+    content: @Composable () -> Unit
+) {
+    WithInternalState {
+        val state = state.value
+        if (state is IconLoaderState.Loading) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun IconLoaderScope.WithInternalState(
+    content: @Composable InternalIconLoaderScope.() -> Unit
+) {
+    val internalScope = this as InternalIconLoaderScope
+    internalScope.content()
+}
+
+internal class InternalIconLoaderScope(
+    override val state: MutableState<IconLoaderState> = mutableStateOf(IconLoaderState.Loading)
+) : IconLoaderScope

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/compose/IconLoaderState.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/compose/IconLoaderState.kt
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.compose
+
+import androidx.compose.ui.graphics.painter.Painter
+import mozilla.components.browser.icons.BrowserIcons
+import mozilla.components.browser.icons.Icon.Source
+
+/**
+ * The state an [IconLoaderScope] is in.
+ */
+sealed class IconLoaderState {
+    /**
+     * The [BrowserIcons.Loader] is currently loading the icon.
+     */
+    object Loading : IconLoaderState()
+
+    /**
+     * The [BrowserIcons.Loader] has completed loading the icon and it is available through the
+     * attached [painter].
+     *
+     * @property painter The loaded or generated icon as a [Painter].
+     * @property color The dominant color of the icon. Will be null if no color could be extracted.
+     * @property source The source of the icon.
+     * @property maskable True if the icon represents as full-bleed icon that can be cropped to other shapes.
+     */
+    data class Icon(
+        val painter: Painter,
+        val color: Int?,
+        val source: Source,
+        val maskable: Boolean
+    ) : IconLoaderState()
+}

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/compose/Loader.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/compose/Loader.kt
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import mozilla.components.browser.icons.BrowserIcons
+import mozilla.components.browser.icons.IconRequest
+
+/**
+ * Loads an icon for the given [url] (or generates one) and makes it available to the inner
+ * [IconLoaderScope].
+ *
+ * The loaded image will be available through the [WithIcon] composable. While the icon is still
+ * loading [Placeholder] will get rendered.
+ *
+ * @param url The URL of the website an icon should be loaded for. Note that this is the URL of the
+ * website the icon is *for* (e.g. https://github.com) and not the URL of the icon itself (e.g.
+ * https://github.com/favicon.ico)
+ * @param size The preferred size of the icon that should be loaded.
+ * @param isPrivate Whether or not a private request (like in private browsing) should be used to
+ * download the icon (if needed).
+ */
+@Composable
+fun BrowserIcons.Loader(
+    url: String,
+    size: IconRequest.Size = IconRequest.Size.DEFAULT,
+    isPrivate: Boolean = false,
+    content: @Composable IconLoaderScope.() -> Unit
+) {
+    val request = IconRequest(url, size, emptyList(), null, isPrivate)
+    val scope = remember(request) { InternalIconLoaderScope() }
+
+    LaunchedEffect(request) {
+        val icon = loadIcon(request).await()
+        scope.state.value = IconLoaderState.Icon(
+            BitmapPainter(icon.bitmap.asImageBitmap()),
+            icon.color,
+            icon.source,
+            icon.maskable
+        )
+    }
+
+    scope.content()
+}


### PR DESCRIPTION
Using a similar API as the `ImageLoader()` composable (#10838), this patch introduces Jetpack Compose bindings to load website icons using the `BrowserIcons.Loader()` function.

Example:

```Kotlin
components.icons.Loader(
    url = "https://www.mozilla.org"
) {
    Placeholder {
        Text("Loading icon...")
    }
    WithIcon { icon ->
        Image(icon.painter, contentDescription = null)

        // icon.color
        // icon.maskable
        // icon.source
    }
}
```