### PR TITLE
Ensure we notice and repair a missing or expired push endpoint.

### DIFF
--- a/components/feature/accounts-push/src/main/java/mozilla/components/feature/accounts/push/FxaPushSupportFeature.kt
+++ b/components/feature/accounts-push/src/main/java/mozilla/components/feature/accounts/push/FxaPushSupportFeature.kt
@@ -163,6 +163,7 @@ internal class AccountObserver(
         // See https://github.com/mozilla-mobile/android-components/issues/8766
         GlobalScope.launch(Dispatchers.Main) {
             account.deviceConstellation().registerDeviceObserver(constellationObserver, lifecycleOwner, autoPause)
+            account.deviceConstellation().refreshDevices()
         }
     }
 

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
@@ -125,6 +125,7 @@ class FxaDeviceConstellation(
         owner: LifecycleOwner,
         autoPause: Boolean
     ) {
+        logger.debug("registering device observer")
         deviceObserverRegistry.register(observer, owner, autoPause)
     }
 

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
@@ -211,7 +211,9 @@ class FxaDeviceConstellation(
 
             // Find the current device.
             val currentDevice = allDevices.find { it.isCurrentDevice }?.also {
-                // Check if our current device's push subscription needs to be renewed.
+                // If our current device's push subscription needs to be renewed, then we
+                // possibly missed some push notifications, so check for that here.
+                // (This doesn't actually perform the renewal, FxaPushSupportFeature does that.)
                 if (it.subscription == null || it.subscriptionExpired) {
                     logger.info("Current device needs push endpoint registration, so checking for missed commands")
                     pollForCommands()

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -19,7 +19,6 @@ import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.AuthFlowError
 import mozilla.components.concept.sync.AuthFlowUrl
 import mozilla.components.concept.sync.AuthType
-import mozilla.components.concept.sync.DeviceCapability
 import mozilla.components.concept.sync.DeviceConfig
 import mozilla.components.concept.sync.InFlightMigrationState
 import mozilla.components.concept.sync.OAuthAccount

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -533,15 +533,11 @@ open class FxaAccountManager(
             is Event.Progress.CompletedAuthentication -> {
                 notifyObservers { onAuthenticated(account, via.authType) }
                 refreshProfile(ignoreCache = false)
-                // Unconditionally call `refreshDevices()` as it repairs push expiry.
-                account.deviceConstellation().refreshDevices()
                 Unit
             }
             Event.Progress.RecoveredFromAuthenticationProblem -> {
                 notifyObservers { onAuthenticated(account, AuthType.Recovered) }
                 refreshProfile(ignoreCache = true)
-                // Unconditionally call `refreshDevices()` as it repairs push expiry.
-                account.deviceConstellation().refreshDevices()
                 Unit
             }
             else -> Unit

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -895,8 +895,9 @@ class FxaAccountManagerTest {
         assertEquals(mockAccount, manager.authenticatedAccount())
         assertEquals(profile, manager.accountProfile())
 
-        // Assert that we don't refresh device state for non-SEND_TAB enabled devices.
-        verify(constellation, never()).refreshDevices()
+        // Assert that we do refresh device state for non-SEND_TAB enabled devices (because this
+        // refresh also checks the current device state)
+        verify(constellation, times(1)).refreshDevices()
 
         // Make sure 'logoutAsync' clears out state and fires correct observers.
         reset(accountObserver)

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -481,9 +481,6 @@ class FxaAccountManagerTest {
         // Assert that ensureCapabilities fired, but not the device initialization (since we're restoring).
         verify(constellation).finalizeDevice(eq(AuthType.Existing), any())
 
-        // Assert that we refresh device state.
-        verify(constellation).refreshDevices()
-
         // Assert that persistence callback is interacting with the storage layer.
         account.persistenceCallback!!.persist("test")
         verify(accountStorage).write("test")
@@ -894,10 +891,6 @@ class FxaAccountManagerTest {
 
         assertEquals(mockAccount, manager.authenticatedAccount())
         assertEquals(profile, manager.accountProfile())
-
-        // Assert that we do refresh device state for non-SEND_TAB enabled devices (because this
-        // refresh also checks the current device state)
-        verify(constellation, times(1)).refreshDevices()
 
         // Make sure 'logoutAsync' clears out state and fires correct observers.
         reset(accountObserver)

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -1366,7 +1366,6 @@ class FxaAccountManagerTest {
         // During recovery, only 'sign-in' finalize device call should have been made.
         verify(constellation, times(1)).finalizeDevice(eq(AuthType.Signin), any())
         verify(constellation, never()).finalizeDevice(eq(AuthType.Recovered), any())
-        verify(constellation, times(1)).refreshDevices()
 
         assertEquals(mockAccount, manager.authenticatedAccount())
 


### PR DESCRIPTION
The core problem is that the device constellation's observer is registered
after we've updated the devices, so the code that checks if re-subscribing is
necessary is never hit.

The easiest way of fixing this was to move the `refreshDevices` call to the
account state state-machine, rather than the authentication state-machine,
meaning we can ensure the `onAuthenticated` notification is delivered before
we refresh the devices.

Note that I also removed the special-case for "SEND_TAB" devices - push is
also used for account-related notifications, such as being disconnected.

Sadly, I failed to work out how to test this - I'd welcome advice here. It can be verified via logcat:

Note the new log message in FxaDeviceConstellation's `registerDeviceObserver`:

> logger.debug("registering device observer")

Without the rest of this patch, you will see these entries:

> 2021-09-01 11:01:58.739 22342-22403/org.mozilla.fenix.debug I/FxaDeviceConstellation: Refreshing device list...
> ...
> 2021-09-01 11:01:59.412 22342-22403/org.mozilla.fenix.debug I/FxaDeviceConstellation: Refreshed device list; saw 4 device(s).
> ...
> 2021-09-01 11:01:59.435 22342-22342/org.mozilla.fenix.debug D/FxaDeviceConstellation: registering device observer

So the device list is refreshed before FxaDeviceConstellation has registered its observer - so it never sees `onDevicesUpdated`. With the rest of the patch, the order changes:

> 2021-09-01 11:10:33.647 22701-22701/org.mozilla.fenix.debug D/FxaDeviceConstellation: registering device observer
> ...
> 2021-09-01 11:10:34.366 22701-22773/org.mozilla.fenix.debug I/FxaDeviceConstellation: Refreshing device list...
> ... 

So FxaDeviceConstellation will notice the expired subscription and update.
