### PR TITLE
Allow updates to the ContentState for private mode

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -334,6 +334,11 @@ sealed class ContentAction : BrowserAction() {
     data class UpdateProgressAction(val sessionId: String, val progress: Int) : ContentAction()
 
     /**
+     * Updates the private state of the [ContentState] with the given [sessionId].
+     */
+    data class UpdatePrivateModeAction(val sessionId: String, val privateMode: Boolean) : ContentAction()
+
+    /**
      * Updates permissions highlights of the [ContentState] with the given [sessionId].
      */
     sealed class UpdatePermissionHighlightsStateAction : ContentAction() {

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
@@ -60,6 +60,9 @@ internal object ContentStateReducer {
             is ContentAction.UpdateProgressAction -> updateContentState(state, action.sessionId) {
                 it.copy(progress = action.progress)
             }
+            is ContentAction.UpdatePrivateModeAction -> updateContentState(state, action.sessionId) {
+                it.copy(private = action.privateMode)
+            }
             is ContentAction.UpdateTitleAction -> updateContentState(state, action.sessionId) {
                 it.copy(title = action.title)
             }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
@@ -217,6 +217,23 @@ class ContentActionTest {
     }
 
     @Test
+    fun `UpdatePrivateModeAction updates private mode`() {
+        assertFalse(tab.content.private)
+        assertFalse(otherTab.content.private)
+
+        store.dispatch(ContentAction.UpdatePrivateModeAction(tab.id, true)).joinBlocking()
+
+        assertTrue(tab.content.private)
+        assertFalse(otherTab.content.private)
+
+        store.dispatch(ContentAction.UpdatePrivateModeAction(tab.id, false)).joinBlocking()
+        store.dispatch(ContentAction.UpdatePrivateModeAction(otherTab.id, true)).joinBlocking()
+
+        assertFalse(tab.content.private)
+        assertTrue(otherTab.content.private)
+    }
+
+    @Test
     fun `UpdateSearchTermsAction updates URL`() {
         val searchTerms = "Hello World"
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * **feature-contextmenu**:
   * 🌟️ Adds `additionalNote` which it will be attached to the bottom of context menu but for a specific `HitResult`
 
+* **browser-state**:
+  * 🌟️ Adds support for updating `ContentState` when switching between private mode.
+
 # 93.0.0-SNAPSHOT (In Development)
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v92.0.0...main)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/140?closed=1)


### PR DESCRIPTION
For https://github.com/mozilla-mobile/fenix/issues/20654

This will allow us to toggle private mode using the homescreen mask button while home is visible behind the search dialog.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
