### PR TITLE
Issue #10922: AwesomeBar(): Use description as fallback if suggestion has no title (like BrowserAwesomeBar).

### DIFF
--- a/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/Suggestion.kt
+++ b/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/Suggestion.kt
@@ -83,7 +83,11 @@ private fun SuggestionTitleAndDescription(
         modifier = modifier
     ) {
         Text(
-            text = title ?: "",
+            text = if (title.isNullOrEmpty()) {
+                description ?: ""
+            } else {
+                title
+            },
             color = colors.title,
             fontSize = 15.sp,
             maxLines = 1,


### PR DESCRIPTION
Another small patch for Fenix. We use the same behavior in `BrowserAwesomeBar`.