### PR TITLE
RemoveAllPrivateTabsAction: Clear selectedTabId if no new selection is available.

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TabListReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TabListReducer.kt
@@ -186,9 +186,9 @@ internal object TabListReducer {
                 val updatedTabs = state.tabs.filterNot { it.content.private }
                 state.copy(
                     tabs = updatedTabs,
-                    selectedTabId = if (selectionAffected && updatedTabs.isNotEmpty()) {
+                    selectedTabId = if (selectionAffected) {
                         // If the selection is affected, select the last normal tab, if available.
-                        updatedTabs.last().id
+                        updatedTabs.lastOrNull()?.id
                     } else {
                         state.selectedTabId
                     }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/TabListActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/TabListActionTest.kt
@@ -4,6 +4,8 @@
 
 package mozilla.components.browser.state.action
 
+import mozilla.components.browser.state.selector.normalTabs
+import mozilla.components.browser.state.selector.privateTabs
 import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.SessionState
@@ -1076,5 +1078,108 @@ class TabListActionTest {
         assertEquals("https://www.example.org", store.state.tabs[1].content.url)
         assertEquals("https://getpocket.com", store.state.tabs[2].content.url)
         assertNull(store.state.selectedTabId)
+    }
+
+    @Test
+    fun `RemoveAllNormalTabsAction with private tab selected`() {
+        val store = BrowserStore(
+            BrowserState(
+                tabs = listOf(
+                    createTab(id = "a", url = "https://www.mozilla.org", private = true),
+                    createTab(id = "b", url = "https://www.example.org", private = false),
+                    createTab(id = "c", url = "https://www.firefox.com", private = false),
+                    createTab(id = "d", url = "https://getpocket.com", private = true)
+                ),
+                selectedTabId = "d"
+            )
+        )
+
+        store.dispatch(TabListAction.RemoveAllNormalTabsAction).joinBlocking()
+
+        assertEquals(0, store.state.normalTabs.size)
+        assertEquals(2, store.state.privateTabs.size)
+        assertEquals("d", store.state.selectedTabId)
+    }
+
+    @Test
+    fun `RemoveAllNormalTabsAction with normal tab selected`() {
+        val store = BrowserStore(
+            BrowserState(
+                tabs = listOf(
+                    createTab(id = "a", url = "https://www.mozilla.org", private = true),
+                    createTab(id = "b", url = "https://www.example.org", private = false),
+                    createTab(id = "c", url = "https://www.firefox.com", private = false),
+                    createTab(id = "d", url = "https://getpocket.com", private = true)
+                ),
+                selectedTabId = "b"
+            )
+        )
+
+        store.dispatch(TabListAction.RemoveAllNormalTabsAction).joinBlocking()
+
+        assertEquals(0, store.state.normalTabs.size)
+        assertEquals(2, store.state.privateTabs.size)
+        assertNull(store.state.selectedTabId)
+    }
+
+    @Test
+    fun `RemoveAllPrivateTabsAction with private tab selected`() {
+        val store = BrowserStore(
+            BrowserState(
+                tabs = listOf(
+                    createTab(id = "a", url = "https://www.mozilla.org", private = true),
+                    createTab(id = "b", url = "https://www.example.org", private = false),
+                    createTab(id = "c", url = "https://www.firefox.com", private = false),
+                    createTab(id = "d", url = "https://getpocket.com", private = true)
+                ),
+                selectedTabId = "d"
+            )
+        )
+
+        store.dispatch(TabListAction.RemoveAllPrivateTabsAction).joinBlocking()
+
+        assertEquals(2, store.state.normalTabs.size)
+        assertEquals(0, store.state.privateTabs.size)
+        assertEquals("c", store.state.selectedTabId)
+    }
+
+    @Test
+    fun `RemoveAllPrivateTabsAction with private tab selected and no normal tabs`() {
+        val store = BrowserStore(
+            BrowserState(
+                tabs = listOf(
+                    createTab(id = "a", url = "https://www.mozilla.org", private = true),
+                    createTab(id = "b", url = "https://getpocket.com", private = true)
+                ),
+                selectedTabId = "b"
+            )
+        )
+
+        store.dispatch(TabListAction.RemoveAllPrivateTabsAction).joinBlocking()
+
+        assertEquals(0, store.state.normalTabs.size)
+        assertEquals(0, store.state.privateTabs.size)
+        assertNull(store.state.selectedTabId)
+    }
+
+    @Test
+    fun `RemoveAllPrivateTabsAction with normal tab selected`() {
+        val store = BrowserStore(
+            BrowserState(
+                tabs = listOf(
+                    createTab(id = "a", url = "https://www.mozilla.org", private = true),
+                    createTab(id = "b", url = "https://www.example.org", private = false),
+                    createTab(id = "c", url = "https://www.firefox.com", private = false),
+                    createTab(id = "d", url = "https://getpocket.com", private = true)
+                ),
+                selectedTabId = "b"
+            )
+        )
+
+        store.dispatch(TabListAction.RemoveAllPrivateTabsAction).joinBlocking()
+
+        assertEquals(2, store.state.normalTabs.size)
+        assertEquals(0, store.state.privateTabs.size)
+        assertEquals("b", store.state.selectedTabId)
     }
 }


### PR DESCRIPTION
For https://github.com/mozilla-mobile/focus-android/issues/5299

When removing all private tabs with `RemoveAllPrivateTabsAction` and when there is no normal tab to select, then we kept the selection. This is obviously wrong and we net to set it to `null`. This caused a bug in Focus (For https://github.com/mozilla-mobile/focus-android/issues/5299) where we tried to render the selected tab, but it doesn't exist.