### PR TITLE
Upgrade to A-S 84.0.0 (resolves push and places breaking changes)

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,7 +29,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "2.4"
 
-    const val mozilla_appservices = "83.0.0"
+    const val mozilla_appservices = "84.0.0"
 
     const val mozilla_glean = "39.0.3"
 

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Types.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Types.kt
@@ -166,7 +166,8 @@ internal fun mozilla.appservices.places.uniffi.HistoryMetadata.into(): HistoryMe
         createdAt = this.createdAt,
         updatedAt = this.updatedAt,
         totalViewTime = this.totalViewTime,
-        documentType = this.documentType.into()
+        documentType = this.documentType.into(),
+        previewImageUrl = this.previewImageUrl
     )
 }
 
@@ -190,7 +191,8 @@ internal fun HistoryMetadata.into(): mozilla.appservices.places.uniffi.HistoryMe
         createdAt = this.createdAt,
         updatedAt = this.updatedAt,
         totalViewTime = this.totalViewTime,
-        documentType = this.documentType.into()
+        documentType = this.documentType.into(),
+        previewImageUrl = this.previewImageUrl
     )
 }
 

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorageTest.kt
@@ -199,7 +199,7 @@ class PlacesBookmarksStorageTest {
             fail("Expected v0 database to be unsupported")
         } catch (e: PlacesException) {
             // This is a little brittle, but the places library doesn't have a proper error type for this.
-            assertEquals("Database version 0 is not supported", e.message)
+            assertEquals("Can not import from database version 0", e.message)
         }
     }
 

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
@@ -780,7 +780,7 @@ class PlacesHistoryStorageTest {
             fail("Expected v0 database to be unsupported")
         } catch (e: PlacesException) {
             // This is a little brittle, but the places library doesn't have a proper error type for this.
-            assertEquals("Database version 0 is not supported", e.message)
+            assertEquals("Can not import from database version 0", e.message)
         }
     }
 
@@ -793,7 +793,7 @@ class PlacesHistoryStorageTest {
             fail("Expected v23 database to be unsupported")
         } catch (e: PlacesException) {
             // This is a little brittle, but the places library doesn't have a proper error type for this.
-            assertEquals("Database version 23 is not supported", e.message)
+            assertEquals("Can not import from database version 23", e.message)
         }
     }
 

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryMetadataStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryMetadataStorage.kt
@@ -59,6 +59,7 @@ data class HistoryMetadataKey(
  * @property updatedAt The last time this record was updated.
  * @property totalViewTime Total time the user viewed the page associated with this record.
  * @property documentType The [DocumentType] of the page.
+ * @property previewImageUrl A preview image of the page (a.k.a. the hero image), if available.
  */
 data class HistoryMetadata(
     val key: HistoryMetadataKey,
@@ -66,7 +67,8 @@ data class HistoryMetadata(
     val createdAt: Long,
     val updatedAt: Long,
     val totalViewTime: Int,
-    val documentType: DocumentType
+    val documentType: DocumentType,
+    val previewImageUrl: String?
 )
 
 /**

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/CombinedHistorySuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/CombinedHistorySuggestionProviderTest.kt
@@ -32,7 +32,8 @@ class CombinedHistorySuggestionProviderTest {
         createdAt = System.currentTimeMillis(),
         updatedAt = System.currentTimeMillis(),
         totalViewTime = 10,
-        documentType = DocumentType.Regular
+        documentType = DocumentType.Regular,
+        previewImageUrl = null
     )
 
     @Test

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryMetadataSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryMetadataSuggestionProviderTest.kt
@@ -29,7 +29,8 @@ class HistoryMetadataSuggestionProviderTest {
         createdAt = System.currentTimeMillis(),
         updatedAt = System.currentTimeMillis(),
         totalViewTime = 10,
-        documentType = DocumentType.Regular
+        documentType = DocumentType.Regular,
+        previewImageUrl = null
     )
 
     @Test

--- a/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
@@ -13,12 +13,12 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
-import mozilla.appservices.push.CommunicationError
-import mozilla.appservices.push.CommunicationServerError
-import mozilla.appservices.push.CryptoError
-import mozilla.appservices.push.GeneralError
-import mozilla.appservices.push.JSONDeserializeError
-import mozilla.appservices.push.RequestError
+import mozilla.appservices.push.PushException.CommunicationException
+import mozilla.appservices.push.PushException.CommunicationServerException
+import mozilla.appservices.push.PushException.CryptoException
+import mozilla.appservices.push.PushException.GeneralException
+import mozilla.appservices.push.PushException.JSONDeserializeException
+import mozilla.appservices.push.PushException.RequestException
 import mozilla.components.concept.base.crash.CrashReporting
 import mozilla.components.concept.push.EncryptedPushMessage
 import mozilla.components.concept.push.PushError
@@ -370,12 +370,12 @@ class AutoPushFeature(
 internal inline fun exceptionHandler(crossinline onError: (PushError) -> Unit) = CoroutineExceptionHandler { _, e ->
     val isFatal = when (e) {
         is PushError.MalformedMessage,
-        is GeneralError,
-        is CryptoError,
-        is CommunicationError,
-        is JSONDeserializeError,
-        is RequestError,
-        is CommunicationServerError -> false
+        is GeneralException,
+        is CryptoException,
+        is CommunicationException,
+        is JSONDeserializeException,
+        is RequestException,
+        is CommunicationServerException -> false
         else -> true
     }
 

--- a/components/feature/push/src/main/java/mozilla/components/feature/push/ext/CoroutineScope.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/ext/CoroutineScope.kt
@@ -7,7 +7,7 @@ package mozilla.components.feature.push.ext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import mozilla.appservices.push.PushError
+import mozilla.appservices.push.PushException
 
 /**
  * Catches all fatal push errors to notify the callback before re-throwing.
@@ -19,7 +19,7 @@ internal fun CoroutineScope.launchAndTry(
     return launch {
         try {
             block()
-        } catch (e: PushError) {
+        } catch (e: PushException) {
             errorBlock(e)
 
             // rethrow

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureKtTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureKtTest.kt
@@ -9,11 +9,11 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.test.runBlockingTest
-import mozilla.appservices.push.CommunicationError
-import mozilla.appservices.push.CommunicationServerError
-import mozilla.appservices.push.CryptoError
-import mozilla.appservices.push.GeneralError
-import mozilla.appservices.push.MissingRegistrationTokenError
+import mozilla.appservices.push.PushException.CommunicationException
+import mozilla.appservices.push.PushException.CommunicationServerException
+import mozilla.appservices.push.PushException.CryptoException
+import mozilla.appservices.push.PushException.GeneralException
+import mozilla.appservices.push.PushException.MissingRegistrationTokenException
 import mozilla.components.concept.push.PushError
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -46,20 +46,20 @@ class AutoPushFeatureKtTest {
         scope.launch { throw PushError.MalformedMessage("test") }
         assertFalse(invoked)
 
-        scope.launch { throw GeneralError("test") }
+        scope.launch { throw GeneralException("test") }
         assertFalse(invoked)
 
-        scope.launch { throw CryptoError("test") }
+        scope.launch { throw CryptoException("test") }
         assertFalse(invoked)
 
-        scope.launch { throw CommunicationError("test") }
+        scope.launch { throw CommunicationException("test") }
         assertFalse(invoked)
 
-        scope.launch { throw CommunicationServerError("test") }
+        scope.launch { throw CommunicationServerException("test") }
         assertFalse(invoked)
 
         // An exception where we should invoke our callback.
-        scope.launch { throw MissingRegistrationTokenError() }
+        scope.launch { throw MissingRegistrationTokenException("") }
         assertTrue(invoked)
     }
 }

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureTest.kt
@@ -11,8 +11,8 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
-import mozilla.appservices.push.GeneralError
-import mozilla.appservices.push.MissingRegistrationTokenError
+import mozilla.appservices.push.PushException.GeneralException
+import mozilla.appservices.push.PushException.MissingRegistrationTokenException
 import mozilla.components.concept.base.crash.CrashReporting
 import mozilla.components.concept.push.EncryptedPushMessage
 import mozilla.components.concept.push.PushError
@@ -206,7 +206,7 @@ class AutoPushFeatureTest {
         assertFalse(errorInvoked)
 
         whenever(connection.isInitialized()).thenReturn(true)
-        whenever(connection.subscribe(anyString(), nullable())).thenAnswer { throw MissingRegistrationTokenError() }
+        whenever(connection.subscribe(anyString(), nullable())).thenAnswer { throw MissingRegistrationTokenException("") }
         whenever(subscription.scope).thenReturn("testScope")
 
         feature.subscribe(
@@ -282,7 +282,7 @@ class AutoPushFeatureTest {
         var invoked = false
         var errorInvoked = false
 
-        whenever(connection.unsubscribe(anyString())).thenAnswer { throw MissingRegistrationTokenError() }
+        whenever(connection.unsubscribe(anyString())).thenAnswer { throw MissingRegistrationTokenException("") }
 
         feature.unsubscribe(
             scope = "testScope",
@@ -479,7 +479,7 @@ class AutoPushFeatureTest {
             crashReporter = crashReporter
         )
 
-        whenever(connection.unsubscribe(any())).thenAnswer { throw GeneralError("test") }
+        whenever(connection.unsubscribe(any())).thenAnswer { throw GeneralException("test") }
 
         feature.unsubscribe("123") {}
 
@@ -498,7 +498,7 @@ class AutoPushFeatureTest {
             crashReporter = crashReporter
         )
 
-        whenever(connection.unsubscribe(any())).thenAnswer { throw MissingRegistrationTokenError() }
+        whenever(connection.unsubscribe(any())).thenAnswer { throw MissingRegistrationTokenException("") }
 
         feature.unsubscribe("123") {}
 

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/ConnectionKtTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/ConnectionKtTest.kt
@@ -57,7 +57,7 @@ class ConnectionKtTest {
             "scope"
         )
         val sub = response.toPushSubscriptionChanged()
-        assertEquals(response.channelID, sub.channelId)
+        assertEquals(response.channelId, sub.channelId)
         assertEquals(response.scope, sub.scope)
     }
 

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/RustPushConnectionTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/RustPushConnectionTest.kt
@@ -8,7 +8,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import mozilla.appservices.push.DispatchInfo
 import mozilla.appservices.push.KeyInfo
-import mozilla.appservices.push.PushAPI
+import mozilla.appservices.push.PushManager
 import mozilla.appservices.push.SubscriptionInfo
 import mozilla.appservices.push.SubscriptionResponse
 import mozilla.components.support.test.any
@@ -50,7 +50,7 @@ class RustPushConnectionTest {
     @Test
     fun `new token calls update if API is already initialized`() {
         val connection = createConnection()
-        val api: PushAPI = mock()
+        val api: PushManager = mock()
         connection.api = api
 
         runBlocking {
@@ -73,9 +73,9 @@ class RustPushConnectionTest {
     @Test
     fun `subscribe calls Rust API`() {
         val connection = createConnection()
-        val api: PushAPI = mock()
+        val api: PushManager = mock()
         val response = SubscriptionResponse(
-            channelID = "1234",
+            channelId = "1234",
             subscriptionInfo = SubscriptionInfo(
                 endpoint = "https://foo",
                 keys = KeyInfo(
@@ -113,7 +113,7 @@ class RustPushConnectionTest {
     @Test
     fun `unsubscribe calls Rust API`() {
         val connection = createConnection()
-        val api: PushAPI = mock()
+        val api: PushManager = mock()
         connection.api = api
 
         runBlocking {
@@ -135,7 +135,7 @@ class RustPushConnectionTest {
     @Test
     fun `unsubscribeAll calls Rust API`() {
         val connection = createConnection()
-        val api: PushAPI = mock()
+        val api: PushManager = mock()
         connection.api = api
 
         runBlocking {
@@ -148,7 +148,7 @@ class RustPushConnectionTest {
     @Test
     fun `containsSubscription returns true if a subscription exists`() {
         val connection = createConnection()
-        val api: PushAPI = mock()
+        val api: PushManager = mock()
         connection.api = api
 
         `when`(api.dispatchInfoForChid(ArgumentMatchers.anyString()))
@@ -174,7 +174,7 @@ class RustPushConnectionTest {
     @Test
     fun `verifyConnection calls Rust API`() {
         val connection = createConnection()
-        val api: PushAPI = mock()
+        val api: PushManager = mock()
         connection.api = api
 
         runBlocking {
@@ -196,7 +196,7 @@ class RustPushConnectionTest {
     @Test
     fun `decrypt calls Rust API`() {
         val connection = createConnection()
-        val api: PushAPI = mock()
+        val api: PushManager = mock()
         val dispatchInfo: DispatchInfo = mock()
         connection.api = api
 
@@ -225,7 +225,7 @@ class RustPushConnectionTest {
     @Test
     fun `empty body decrypts nothing`() {
         val connection = createConnection()
-        val api: PushAPI = mock()
+        val api: PushManager = mock()
         val dispatchInfo: DispatchInfo = mock()
         connection.api = api
 
@@ -259,7 +259,7 @@ class RustPushConnectionTest {
     @Test
     fun `close calls Rust API`() {
         val connection = createConnection()
-        val api: PushAPI = mock()
+        val api: PushManager = mock()
         connection.api = api
 
         runBlocking {

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/ext/CoroutineScopeKtTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/ext/CoroutineScopeKtTest.kt
@@ -9,36 +9,36 @@ package mozilla.components.feature.push.ext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
-import mozilla.appservices.push.AlreadyRegisteredError
-import mozilla.appservices.push.CommunicationError
-import mozilla.appservices.push.CommunicationServerError
-import mozilla.appservices.push.CryptoError
-import mozilla.appservices.push.GeneralError
-import mozilla.appservices.push.InternalPanic
-import mozilla.appservices.push.MissingRegistrationTokenError
-import mozilla.appservices.push.RecordNotFoundError
-import mozilla.appservices.push.StorageError
-import mozilla.appservices.push.StorageSqlError
-import mozilla.appservices.push.TranscodingError
-import mozilla.appservices.push.UrlParseError
+import mozilla.appservices.push.InternalException
+import mozilla.appservices.push.PushException.AlreadyRegisteredException
+import mozilla.appservices.push.PushException.CommunicationException
+import mozilla.appservices.push.PushException.CommunicationServerException
+import mozilla.appservices.push.PushException.CryptoException
+import mozilla.appservices.push.PushException.GeneralException
+import mozilla.appservices.push.PushException.MissingRegistrationTokenException
+import mozilla.appservices.push.PushException.RecordNotFoundException
+import mozilla.appservices.push.PushException.StorageException
+import mozilla.appservices.push.PushException.StorageSqlException
+import mozilla.appservices.push.PushException.TranscodingException
+import mozilla.appservices.push.PushException.UrlParseException
 import mozilla.components.feature.push.exceptionHandler
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
 class CoroutineScopeKtTest {
 
-    @Test(expected = InternalPanic::class)
+    @Test(expected = InternalException::class)
     fun `launchAndTry throws on unrecoverable Rust exceptions`() = runBlockingTest {
         CoroutineScope(coroutineContext).launchAndTry(
-            errorBlock = { throw InternalPanic("unit test") },
-            block = { throw MissingRegistrationTokenError() }
+            errorBlock = { throw InternalException("unit test") },
+            block = { throw MissingRegistrationTokenException("") }
         )
     }
 
     @Test(expected = ArithmeticException::class)
     fun `launchAndTry throws original exception`() = runBlockingTest {
         CoroutineScope(coroutineContext).launchAndTry(
-            errorBlock = { throw InternalPanic("unit test") },
+            errorBlock = { throw InternalException("unit test") },
             block = { throw ArithmeticException() }
         )
     }
@@ -46,57 +46,57 @@ class CoroutineScopeKtTest {
     @Test
     fun `launchAndTry should NOT throw on recoverable Rust exceptions`() = runBlockingTest {
         CoroutineScope(coroutineContext).launchAndTry(
-            { throw CryptoError("should not fail test") },
+            { throw CryptoException("should not fail test") },
             { assert(true) }
         ) + exceptionHandler {}
 
         CoroutineScope(coroutineContext).launchAndTry(
-            { throw CommunicationServerError("should not fail test") },
+            { throw CommunicationServerException("should not fail test") },
             { assert(true) }
         )
 
         CoroutineScope(coroutineContext).launchAndTry(
-            { throw CommunicationError("should not fail test") },
+            { throw CommunicationException("should not fail test") },
             { assert(true) }
         )
 
         CoroutineScope(coroutineContext).launchAndTry(
-            { throw AlreadyRegisteredError() },
+            { throw AlreadyRegisteredException("") },
             { assert(true) }
         )
 
         CoroutineScope(coroutineContext).launchAndTry(
-            { throw StorageError("should not fail test") },
+            { throw StorageException("should not fail test") },
             { assert(true) }
         )
 
         CoroutineScope(coroutineContext).launchAndTry(
-            { throw MissingRegistrationTokenError() },
+            { throw MissingRegistrationTokenException("") },
             { assert(true) }
         )
 
         CoroutineScope(coroutineContext).launchAndTry(
-            { throw StorageSqlError("should not fail test") },
+            { throw StorageSqlException("should not fail test") },
             { assert(true) }
         )
 
         CoroutineScope(coroutineContext).launchAndTry(
-            { throw TranscodingError("should not fail test") },
+            { throw TranscodingException("should not fail test") },
             { assert(true) }
         )
 
         CoroutineScope(coroutineContext).launchAndTry(
-            { throw RecordNotFoundError("should not fail test") },
+            { throw RecordNotFoundException("should not fail test") },
             { assert(true) }
         )
 
         CoroutineScope(coroutineContext).launchAndTry(
-            { throw UrlParseError("should not fail test") },
+            { throw UrlParseException("should not fail test") },
             { assert(true) }
         )
 
         CoroutineScope(coroutineContext).launchAndTry(
-            { throw GeneralError("should not fail test") },
+            { throw GeneralException("should not fail test") },
             { assert(true) }
         )
     }


### PR DESCRIPTION
fixes https://github.com/mozilla/application-services/issues/4425

Quick Summary: We are `uniffi`ing the push component 🎉 !  This PR is to get feedback on the impact on android components the upcoming breaking changes on https://github.com/mozilla/application-services/pull/4431 will have

NOTE: that PR is not merged yet, intentionally for two reasons:
- There is already a bunch of breaking changes on `application-services`'s main, we will probably cut a release to resolve those first
- To gather feedback here on the breaking changes there in case anything needs to change

## Summary of changes
- `PushAPI` is gone, replaced directly by `PushManager`
- `channelID` becomes `channelId` in all the API calls and types, looks like this aligns better with what android components does 😄!
- `PushError` becomes `PushException`, as so do all its variants
- `decrypt` returns a `List<Byte>` instead of a `ByteArray`, all I needed to add on the android components side is a `.toByteArray` and it works ok


~~To make the project build and tests to run on my local application-services, I had to fix the breaking changes in application services, I separated them into their own commit. **The only relevant commit for feedback is the second one!**~~ rebased this on top of the latest main with the fixes.

I can't add reviewers, but CC: @jonalmeida 
