### PR TITLE
Adds UAIDNotRecognizedException to non-fatal list

### DIFF
--- a/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
@@ -19,6 +19,7 @@ import mozilla.appservices.push.PushException.CryptoException
 import mozilla.appservices.push.PushException.GeneralException
 import mozilla.appservices.push.PushException.JSONDeserializeException
 import mozilla.appservices.push.PushException.RequestException
+import mozilla.appservices.push.PushException.UAIDNotRecognizedException
 import mozilla.components.concept.base.crash.CrashReporting
 import mozilla.components.concept.push.EncryptedPushMessage
 import mozilla.components.concept.push.PushError
@@ -375,6 +376,7 @@ internal inline fun exceptionHandler(crossinline onError: (PushError) -> Unit) =
         is CommunicationException,
         is JSONDeserializeException,
         is RequestException,
+        is UAIDNotRecognizedException,
         is CommunicationServerException -> false
         else -> true
     }


### PR DESCRIPTION
I was keeping an eye on sentry for any push related errors following uniffication, I noticed https://sentry.prod.mozaws.net/operations/firefox-nightly/issues/12985857/?query=is%3Aunresolved%20push

Which looked odd, because the logic didn't change at all recently. What it ended up being is that the same error used to be reported under `CommunicationException`, which is marked as non-fatal - but I recently moved it out into its own error to be able to auto-recover on `verifyConnection` calls. This PR adds the new error into the non-fatal list.

The best way to handle this going forward though, is to probably catch this in the `subscribe` call in fenix/android components and re-trigger the connection verification flow
