### PR TITLE
Closes #10996: Support adding tab with history metadata

### DIFF
--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
@@ -132,6 +132,12 @@ class TabsUseCases(
          * @param flags the [LoadUrlFlags] to use when loading the provided URL.
          * @param contextId the session context id to use for this tab.
          * @param engineSession (optional) engine session to use for this tab.
+         * @param source The [SessionState.Source] of the new tab.
+         * @param searchTerms The search terms of this new tab if it represents an active
+         * search (result) page.
+         * @param private Whether or not the new tab should be private.
+         * @param historyMetadata the [HistoryMetadataKey] of the new tab in case this tab
+         * was opened from history.
          * @return The ID of the created tab.
          */
         @Suppress("LongParameterList")
@@ -145,7 +151,8 @@ class TabsUseCases(
             engineSession: EngineSession? = null,
             source: SessionState.Source = SessionState.Source.Internal.NewTab,
             searchTerms: String = "",
-            private: Boolean = false
+            private: Boolean = false,
+            historyMetadata: HistoryMetadataKey? = null
         ): String {
             val tab = createTab(
                 url = url,
@@ -155,7 +162,8 @@ class TabsUseCases(
                 parent = parentId?.let { store.state.findTab(it) },
                 engineSession = engineSession,
                 searchTerms = searchTerms,
-                initialLoadFlags = flags
+                initialLoadFlags = flags,
+                historyMetadata = historyMetadata
             )
 
             store.dispatch(TabListAction.AddTabAction(tab, select = selectTab))

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
@@ -226,6 +226,28 @@ class TabsUseCasesTest {
     }
 
     @Test
+    fun `AddNewTabUseCase uses provided history metadata`() {
+        val historyMetadata = HistoryMetadataKey(
+            "https://www.mozilla.org",
+            searchTerm = "test",
+            referrerUrl = "http://firefox.com"
+        )
+
+        tabsUseCases.addTab.invoke(
+            "https://www.mozilla.org",
+            flags = LoadUrlFlags.external(),
+            startLoading = true,
+            historyMetadata = historyMetadata
+        )
+
+        store.waitUntilIdle()
+
+        assertEquals(1, store.state.tabs.size)
+        assertEquals("https://www.mozilla.org", store.state.tabs[0].content.url)
+        assertEquals(historyMetadata, store.state.tabs[0].historyMetadata)
+    }
+
+    @Test
     @Suppress("DEPRECATION")
     fun `AddNewPrivateTabUseCase will not load URL if flag is set to false`() {
         tabsUseCases.addPrivateTab("https://www.mozilla.org", startLoading = false)


### PR DESCRIPTION
See #10996. I thought about adding validations e.g. should we throw if the url != historymetadata.url, but it felt like an overkill to do that and crash because of it.