### PR TITLE
Bug 1728594 - fix a SmartBlock regression breaking some links

### DIFF
--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/manifest.json
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Mozilla Android Components - Web Compatibility Interventions",
   "description": "Urgent post-release fixes for web compatibility.",
-  "version": "26.0.0",
+  "version": "26.1.0",
   "applications": {
     "gecko": {
       "id": "webcompat@mozilla.org",

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/shims/google-analytics-and-tag-manager.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/shims/google-analytics-and-tag-manager.js
@@ -154,6 +154,7 @@ if (window[window.GoogleAnalyticsObject || "ga"]?.loaded === undefined) {
   if (Array.isArray(dl)) {
     const push = o => {
       setTimeout(() => run(o?.eventCallback), 1);
+      return true;
     };
     dl.push = push;
     dl.forEach(o => push(o));


### PR DESCRIPTION
This is a fix for a regression in Firefox 92 (and due for 93). If possible, could we make sure it gets into 93 on Android as well? It's a trivial patch, and fixes links on quite a few pages in private browsing and strict anti-tracking mode (involving Google Tag Manager).