### PR TITLE
Close #11017: Update lastAccess on RestoreAction

### DIFF
--- a/components/feature/session/src/main/java/mozilla/components/feature/session/middleware/LastAccessMiddleware.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/middleware/LastAccessMiddleware.kt
@@ -57,6 +57,15 @@ class LastAccessMiddleware : Middleware<BrowserState, BrowserAction> {
                     context.dispatchUpdateActionForId(action.tab.id)
                 }
             }
+            is TabListAction.RestoreAction -> {
+                // If the session is restored from a collection or undo, we fire this action.
+                // For restoration from disk, we use a different use case that does not invoke this action, so we
+                // do not need to consider the case of updating lastAccess even if they have not been recently accessed
+                // by the user.
+                action.tabs.forEach { tab ->
+                    context.dispatchUpdateActionForId(tab.id)
+                }
+            }
             is ContentAction.UpdateUrlAction -> {
                 if (action.sessionId == context.state.selectedTabId) {
                     context.dispatchUpdateActionForId(action.sessionId)


### PR DESCRIPTION
I thought about landing this as a separate middleware directly in Fenix, but after mulling it over, it made sense to have this live in the `LastAccessMiddleware` as part of the other actions we perform. I'm fine with moving it back there if someone feels more strongly about it.

Another consideration I made was whether to avoid the n actions we fire for each restored tab. An approach would be to modify the `action.tabs` with the new `lastAccess` and then dispatch a new `RestoreAction`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
