### PR TITLE
Handle PlacesExceptions when reading history metadata

### DIFF
--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
@@ -244,19 +244,27 @@ open class PlacesHistoryStorage(
     }
 
     override suspend fun getLatestHistoryMetadataForUrl(url: String): HistoryMetadata? {
-        return places.reader().getLatestHistoryMetadataForUrl(url)?.into()
+        return handlePlacesExceptions("getLatestHistoryMetadataForUrl", default = null) {
+            places.reader().getLatestHistoryMetadataForUrl(url)?.into()
+        }
     }
 
     override suspend fun getHistoryMetadataSince(since: Long): List<HistoryMetadata> {
-        return places.reader().getHistoryMetadataSince(since).into()
+        return handlePlacesExceptions("getHistoryMetadataSince", default = emptyList()) {
+            places.reader().getHistoryMetadataSince(since).into()
+        }
     }
 
     override suspend fun getHistoryMetadataBetween(start: Long, end: Long): List<HistoryMetadata> {
-        return places.reader().getHistoryMetadataBetween(start, end).into()
+        return handlePlacesExceptions("getHistoryMetadataBetween", default = emptyList()) {
+            places.reader().getHistoryMetadataBetween(start, end).into()
+        }
     }
 
     override suspend fun queryHistoryMetadata(query: String, limit: Int): List<HistoryMetadata> {
-        return places.reader().queryHistoryMetadata(query, limit).into()
+        return handlePlacesExceptions("queryHistoryMetadata", default = emptyList()) {
+            places.reader().queryHistoryMetadata(query, limit).into()
+        }
     }
 
     override suspend fun noteHistoryMetadataObservation(

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesStorage.kt
@@ -78,7 +78,10 @@ abstract class PlacesStorage(
     }
 
     /**
-     * Runs [block] described by [operation], ignoring non-fatal exceptions.
+     * Runs [block] described by [operation], ignoring and logging non-fatal exceptions.
+     *
+     * @param operation the name of the operation to run.
+     * @param block the operation to run.
      */
     protected inline fun handlePlacesExceptions(operation: String, block: () -> Unit) {
         try {
@@ -88,6 +91,31 @@ abstract class PlacesStorage(
         } catch (e: PlacesException) {
             crashReporter?.submitCaughtException(e)
             logger.warn("Ignoring PlacesException while running $operation", e)
+        }
+    }
+
+    /**
+     * Runs [block] described by [operation] to return a result of type [T], ignoring and
+     * logging non-fatal exceptions. In case of a non-fatal exception, the provided
+     * [default] value is returned.
+     *
+     * @param operation the name of the operation to run.
+     * @param block the operation to run.
+     * @param default the default value to return in case of errors.
+     */
+    inline fun <T> handlePlacesExceptions(
+        operation: String,
+        default: T,
+        block: () -> T
+    ): T {
+        return try {
+            block()
+        } catch (e: InternalPanic) {
+            throw e
+        } catch (e: PlacesException) {
+            crashReporter?.submitCaughtException(e)
+            logger.warn("Ignoring PlacesException while running $operation", e)
+            default
         }
     }
 

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
@@ -1158,6 +1158,14 @@ class PlacesHistoryStorageTest {
         }
     }
 
+    @Test
+    fun `safe read from places`() = runBlocking {
+        val result = history.handlePlacesExceptions("test", default = emptyList<HistoryMetadata>()) {
+            throw PlacesException("test")
+        }
+        assertEquals(emptyList<HistoryMetadata>(), result)
+    }
+
     private fun assertHistoryMetadataRecord(
         expectedKey: HistoryMetadataKey,
         expectedTotalViewTime: Int,


### PR DESCRIPTION
@grigoryk and I recently fixed a few cases that caused recording of invalid metadata (inflated view times that don't fit into an i32 integer when reading them back). Unfortunately, we have users that have this invalid data persisted and are now experiencing crashes (we just enabled this UI feature in Nightly): 

https://github.com/mozilla-mobile/fenix/issues/21506
https://sentry.prod.mozaws.net/operations/firefox-nightly/issues/12345511/

In order to get us unstuck and stop the crashes, let's log those exceptions instead, as we do for writes. We do need to land some data cleanup code this week though so we don't spam Sentry when this goes into beta. Luckily, metadata is relatively short-lived (2 weeks), and if we handled all cases we shouldn't be seeing this going forward. However, metadata reads should really never cause the app to crash so this seems fine to keep either way. 

So let's land as a short-term fix and discuss data cleanup early next week. Long term we also have:
https://github.com/mozilla/application-services/issues/4391