### PR TITLE
Closes #11051: NPE parsing search terms when placeholder is missing

### DIFF
--- a/components/feature/search/src/main/java/mozilla/components/feature/search/ext/SearchEngine.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/ext/SearchEngine.kt
@@ -108,7 +108,9 @@ fun SearchEngine.parseSearchTerms(url: Uri): String? {
 
     return if (searchResultsRoot == urlRoot) {
         val searchTerms = try {
-            url.getQueryParameter(this.searchParameterName)
+            this.searchParameterName?.let {
+                url.getQueryParameter(it)
+            }
         } catch (e: UnsupportedOperationException) {
             // Non-hierarchical url.
             null

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/ext/SearchEngineKtTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/ext/SearchEngineKtTest.kt
@@ -143,4 +143,21 @@ class SearchEngineKtTest {
             searchState.parseSearchTerms("https://www.ecosia.org/search?r=134s7&attr=moz-test&q=Another%20test&d=136697676793")
         )
     }
+
+    @Test
+    fun `GIVEN search engine parameter can not be found THEN search terms are never determined`() {
+        val invalidEngine = SearchEngine(
+            id = UUID.randomUUID().toString(),
+            name = "invalid",
+            icon = mock(),
+            type = SearchEngine.Type.CUSTOM,
+            resultUrls = listOf("https://mozilla.org/search/?q={invalid}")
+        )
+
+        val searchState = SearchState(
+            regionSearchEngines = listOf(invalidEngine)
+        )
+
+        assertNull(searchState.parseSearchTerms("https://mozilla.org/search/?q=test"))
+    }
 }


### PR DESCRIPTION
See https://github.com/mozilla-mobile/android-components/issues/11051#issuecomment-930305143.