### PR TITLE
Update GeckoView (Nightly) to 94.0.20210930095024

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -31,7 +31,7 @@ object Versions {
 
     const val mozilla_appservices = "85.2.0"
 
-    const val mozilla_glean = "41.1.0"
+    const val mozilla_glean = "41.1.1"
 
     const val material = "1.2.1"
 

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -9,7 +9,7 @@ object Gecko {
     /**
      * GeckoView Version.
      */
-    const val version = "94.0.20210929094607"
+    const val version = "94.0.20210930095024"
 
     /**
      * GeckoView channel


### PR DESCRIPTION
Updates to today's Nightly.
Closes #11052 (that PR's branch should be deleted so future updates are created automatically again)

Also updates to the bundled Glean version, which fixes an issue with excessive logging from Rust.