### PR TITLE
Ensure we tell the autopush server about a new FCM token.

### DIFF
--- a/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/AutoPushObserverTest.kt
+++ b/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/AutoPushObserverTest.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.setMain
+import mozilla.components.concept.sync.ConstellationState
+import mozilla.components.concept.sync.Device
 import mozilla.components.concept.sync.DeviceConstellation
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.feature.push.AutoPushFeature
@@ -76,6 +78,11 @@ class AutoPushObserverTest {
 
         `when`(manager.authenticatedAccount()).thenReturn(account)
         `when`(account.deviceConstellation()).thenReturn(constellation)
+        val state: ConstellationState = mock()
+        val device: Device = mock()
+        `when`(constellation.state()).thenReturn(state)
+        `when`(state.currentDevice).thenReturn(device)
+        `when`(device.subscriptionExpired).thenReturn(true)
 
         observer.onSubscriptionChanged("test")
 

--- a/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/ConstellationObserverTest.kt
+++ b/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/ConstellationObserverTest.kt
@@ -8,8 +8,8 @@ package mozilla.components.feature.accounts.push
 
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.base.crash.CrashReporting
-import mozilla.components.concept.push.exceptions.SubscriptionException
 import mozilla.components.concept.sync.ConstellationState
 import mozilla.components.concept.sync.Device
 import mozilla.components.concept.sync.DeviceConstellation
@@ -20,7 +20,9 @@ import mozilla.components.feature.push.AutoPushSubscription
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.nullable
 import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.Before
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
@@ -28,6 +30,8 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.verifyNoMoreInteractions
+import org.mockito.stubbing.OngoingStubbing
 
 @RunWith(AndroidJUnit4::class)
 class ConstellationObserverTest {
@@ -38,53 +42,107 @@ class ConstellationObserverTest {
     private val device: Device = mock()
     private val context: Context = mock()
     private val account: OAuthAccount = mock()
+    private val constellation: DeviceConstellation = mock()
     private val crashReporter: CrashReporting = mock()
+
+    @Before
+    fun setup() {
+        `when`(state.currentDevice).thenReturn(device)
+        `when`(device.subscriptionExpired).thenReturn(false)
+        `when`(account.deviceConstellation()).thenReturn(constellation)
+        `when`(constellation.state()).thenReturn(state)
+    }
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
 
     @Test
-    fun `do nothing if subscription has not expired`() {
+    fun `first subscribe works`() = runBlocking {
         val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
 
-        observer.onDevicesUpdate(state)
-
         verifyNoInteractions(push)
 
-        `when`(state.currentDevice).thenReturn(device)
-        `when`(device.subscriptionExpired).thenReturn(false)
+        whenSubscribe()
 
         observer.onDevicesUpdate(state)
 
-        verifyNoInteractions(push)
+        verify(push).subscribe(eq("testScope"), any(), any(), any())
+        verifyNoMoreInteractions(push)
+        // We should have told the constellation of the new subscription.
+        verify(constellation).setDevicePushSubscription(any())
+
+        Unit
     }
 
     @Test
-    fun `do nothing if verifier is false`() {
+    fun `re-subscribe doesn't update constellation on same endpoint`() = runBlocking {
         val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
-
-        observer.onDevicesUpdate(state)
 
         verifyNoInteractions(push)
 
-        `when`(state.currentDevice).thenReturn(device)
+        whenAlreadySubscribed()
+        whenSubscribe()
+
+        observer.onDevicesUpdate(state)
+
+        verify(push).subscribe(eq("testScope"), any(), any(), any())
+        verifyNoMoreInteractions(push)
+        // We should not have told the constellation of the subscription as it matches
+        verify(constellation).state()
+        verifyNoMoreInteractions(constellation)
+        Unit
+    }
+
+    @Test
+    fun `re-subscribe update constellations on same endpoint if expired`() = runBlocking {
+        val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
+
+        verifyNoInteractions(push)
+
+        whenAlreadySubscribed(true)
+        whenSubscribe()
+
+        observer.onDevicesUpdate(state)
+
+        verify(push).subscribe(eq("testScope"), any(), any(), any())
+        verifyNoMoreInteractions(push)
+        // We should have told the constellation of the same end-point subscription to clear the
+        // expired flag on the server.
+        verify(constellation).setDevicePushSubscription(any())
+        Unit
+    }
+
+    // @Test
+    fun `notify crash reporter if subscribe error occurs`() {
+        val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
+
+        whenSubscribeError()
+        observer.onDevicesUpdate(state)
+
+        verify(crashReporter).recordCrashBreadcrumb(any())
+    }
+
+    @Test
+    fun `no FCM renewal if verifier is false`() {
+        val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
+
+        verifyNoInteractions(push)
+
         `when`(device.subscriptionExpired).thenReturn(true)
         `when`(verifier.allowedToRenew()).thenReturn(false)
 
-        verifyNoInteractions(push)
-
-        `when`(device.subscriptionExpired).thenReturn(true)
-
         observer.onDevicesUpdate(state)
 
-        verifyNoInteractions(push)
+        // The verifier prevents us fetching a new FCM token but doesn't prevent
+        // us calling .subscribe() on the push service.
+        verify(push).subscribe(eq("testScope"), any(), any(), any())
+        verifyNoMoreInteractions(push)
     }
 
     @Test
     fun `invoke registration renewal`() {
         val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
 
-        `when`(state.currentDevice).thenReturn(device)
         `when`(device.subscriptionExpired).thenReturn(true)
         `when`(verifier.allowedToRenew()).thenReturn(true)
 
@@ -94,61 +152,6 @@ class ConstellationObserverTest {
         verify(verifier).increment()
     }
 
-    /**
-     * Remove this test in the future. See [invoke registration renewal] test.
-     */
-    @Test
-    @Ignore("If we don't fix #7143, we may need this.")
-    fun `re-subscribe for push in onDevicesUpdate`() {
-        val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
-
-        `when`(state.currentDevice).thenReturn(device)
-        `when`(device.subscriptionExpired).thenReturn(true)
-        `when`(verifier.allowedToRenew()).thenReturn(true)
-
-        observer.onDevicesUpdate(state)
-
-        verify(push).unsubscribe(eq("testScope"), any(), any())
-        verify(push).subscribe(eq("testScope"), any(), any(), any())
-        verify(verifier).increment()
-    }
-
-    @Test
-    fun `notify crash reporter if old and new subscription matches`() {
-        val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
-        val constellation: DeviceConstellation = mock()
-        val state: ConstellationState = mock()
-        val device: Device = mock()
-        val subscription: DevicePushSubscription = mock()
-
-        `when`(account.deviceConstellation()).thenReturn(constellation)
-        `when`(state.currentDevice).thenReturn(device)
-        `when`(device.subscription).thenReturn(subscription)
-        `when`(subscription.endpoint).thenReturn("https://example.com/foobar")
-
-        observer.onSubscribe(state, testSubscription())
-
-        verify(crashReporter).submitCaughtException(any())
-    }
-
-    @Test
-    fun `notify crash reporter if re-subscribe error occurs`() {
-        val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
-
-        observer.onSubscribeError(mock())
-
-        verify(crashReporter).submitCaughtException(any<SubscriptionException>())
-    }
-
-    @Test
-    fun `notify crash reporter if un-subscribe error occurs`() {
-        val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
-
-        observer.onUnsubscribeError(mock())
-
-        verify(crashReporter).recordCrashBreadcrumb(any())
-    }
-
     private fun testSubscription() = AutoPushSubscription(
         scope = "testScope",
         endpoint = "https://example.com/foobar",
@@ -156,4 +159,33 @@ class ConstellationObserverTest {
         authKey = "",
         appServerKey = null
     )
+
+    @Suppress("UNCHECKED_CAST")
+    private fun whenSubscribe(): OngoingStubbing<Unit>? {
+        return `when`(push.subscribe(any(), nullable(), any(), any())).thenAnswer {
+
+            // Invoke the `onSubscribe` lambda with a fake subscription.
+            (it.arguments[3] as ((AutoPushSubscription) -> Unit)).invoke(
+                testSubscription()
+            )
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun whenSubscribeError(): OngoingStubbing<Unit>? {
+        return `when`(push.subscribe(any(), nullable(), any(), any())).thenAnswer {
+
+            // Invoke the `onSubscribeError` lambda with a fake exception.
+            (it.arguments[2] as ((Exception) -> Unit)).invoke(
+                IllegalStateException("test")
+            )
+        }
+    }
+
+    private fun whenAlreadySubscribed(expired: Boolean = false) {
+        val subscription: DevicePushSubscription = mock()
+        `when`(device.subscriptionExpired).thenReturn(expired)
+        `when`(device.subscription).thenReturn(subscription)
+        `when`(subscription.endpoint).thenReturn(testSubscription().endpoint)
+    }
 }


### PR DESCRIPTION
This should fix push for FxA.

I also made a number of other push cleanups - in particular,
we are far more aggressive about subscribing - we no longer
do it on login, but instead on every startup. Note that
the Rust component will not hit the server if a subscription
already exists, so this is still relatively fast, and will pick up
missing subscriptions)

This may not fix broken, non-FxA devices - they don't know they need a new
FCM token. It's not even clear if that's a thing though - but either
`renewRegistration` is not necessary, or it is and non FxA push
will remain broken.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
