### PR TITLE
Issue #11072: AwesomeBar(): Allow grouping suggestion providers in groups with optional titles

### DIFF
--- a/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/AwesomeBar.kt
+++ b/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/AwesomeBar.kt
@@ -37,19 +37,56 @@ fun AwesomeBar(
     onAutoComplete: (AwesomeBar.Suggestion) -> Unit,
     onScroll: () -> Unit = {}
 ) {
+    AwesomeBar(
+        text = text,
+        colors = colors,
+        groups = listOf(
+            AwesomeBar.SuggestionProviderGroup(
+                providers = providers
+            )
+        ),
+        orientation = orientation,
+        onSuggestionClicked = { _, suggestion -> onSuggestionClicked(suggestion) },
+        onAutoComplete = { _, suggestion -> onAutoComplete(suggestion) },
+        onScroll = onScroll
+    )
+}
+
+/**
+ * An awesome bar displaying suggestions in groups from the list of provided [AwesomeBar.SuggestionProviderGroup]s.
+ *
+ * @param text The text entered by the user and for which the AwesomeBar should show suggestions for.
+ * @param colors The color scheme the AwesomeBar will use for the UI.
+ * @param groups The list of groups of suggestion providers to query whenever the [text] changes.
+ * @param orientation Whether the AwesomeBar is oriented to the top or the bottom of the screen.
+ * @param onSuggestionClicked Gets invoked whenever the user clicks on a suggestion in the AwesomeBar.
+ * @param onAutoComplete Gets invoked when the user clicks on the "autocomplete" icon of a suggestion.
+ * @param onScroll Gets invoked at the beginning of the user performing a scroll gesture.
+ */
+@Composable
+fun AwesomeBar(
+    text: String,
+    colors: AwesomeBarColors = AwesomeBarDefaults.colors(),
+    groups: List<AwesomeBar.SuggestionProviderGroup>,
+    orientation: AwesomeBarOrientation = AwesomeBarOrientation.TOP,
+    onSuggestionClicked: (AwesomeBar.SuggestionProviderGroup, AwesomeBar.Suggestion) -> Unit,
+    onAutoComplete: (AwesomeBar.SuggestionProviderGroup, AwesomeBar.Suggestion) -> Unit,
+    onScroll: () -> Unit = {}
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .testTag("mozac.awesomebar")
             .background(colors.background)
     ) {
-        val fetcher = remember(providers) { SuggestionFetcher(providers) }
+        val fetcher = remember(groups) { SuggestionFetcher(groups) }
 
         LaunchedEffect(text, fetcher) {
             fetcher.fetch(text)
         }
 
         Suggestions(
+            groups,
             fetcher.state.value,
             colors,
             orientation,

--- a/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/AwesomeBarColors.kt
+++ b/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/AwesomeBarColors.kt
@@ -13,5 +13,6 @@ data class AwesomeBarColors(
     val background: Color,
     val title: Color,
     val description: Color,
-    val autocompleteIcon: Color
+    val autocompleteIcon: Color,
+    val groupTitle: Color
 )

--- a/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/AwesomeBarDefaults.kt
+++ b/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/AwesomeBarDefaults.kt
@@ -27,11 +27,13 @@ object AwesomeBarDefaults {
         description: Color = MaterialTheme.colors.onBackground.copy(
             alpha = ContentAlpha.medium
         ),
-        autocompleteIcon: Color = MaterialTheme.colors.onSurface
+        autocompleteIcon: Color = MaterialTheme.colors.onSurface,
+        groupTitle: Color = MaterialTheme.colors.primary
     ) = AwesomeBarColors(
         background,
         title,
         description,
-        autocompleteIcon
+        autocompleteIcon,
+        groupTitle
     )
 }

--- a/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/Suggestion.kt
+++ b/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/Suggestion.kt
@@ -39,12 +39,12 @@ internal fun Suggestion(
     suggestion: AwesomeBar.Suggestion,
     colors: AwesomeBarColors,
     orientation: AwesomeBarOrientation,
-    onSuggestionClicked: (AwesomeBar.Suggestion) -> Unit,
-    onAutoComplete: (AwesomeBar.Suggestion) -> Unit
+    onSuggestionClicked: () -> Unit,
+    onAutoComplete: () -> Unit
 ) {
     Row(
         modifier = Modifier
-            .clickable { onSuggestionClicked(suggestion) }
+            .clickable { onSuggestionClicked() }
             .defaultMinSize(minHeight = 56.dp)
             .testTag("mozac.awesomebar.suggestion")
             .padding(start = 16.dp, top = 8.dp, bottom = 8.dp, end = 8.dp)
@@ -66,7 +66,7 @@ internal fun Suggestion(
         )
         if (suggestion.editSuggestion != null) {
             AutocompleteButton(
-                onAutoComplete = { onAutoComplete(suggestion) },
+                onAutoComplete = onAutoComplete,
                 orientation = orientation,
                 colors = colors,
                 modifier = Modifier.align(Alignment.CenterVertically)

--- a/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/SuggestionGroup.kt
+++ b/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/SuggestionGroup.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.compose.browser.awesomebar.internal
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import mozilla.components.compose.browser.awesomebar.AwesomeBarColors
+
+/**
+ * Renders a header for a group of suggestions.
+ */
+@Composable
+internal fun SuggestionGroup(
+    title: String,
+    colors: AwesomeBarColors
+) {
+    Text(
+        title,
+        color = colors.groupTitle,
+        modifier = Modifier
+            .padding(4.dp)
+    )
+}

--- a/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
+++ b/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
@@ -180,4 +180,18 @@ interface AwesomeBar {
          */
         fun onInputCancelled() = Unit
     }
+
+    /**
+     * A group of [SuggestionProvider]s.
+     *
+     * @property providers The list of [SuggestionProvider]s in this group.
+     * @property title An optional title for this group. The title may be rendered by an AwesomeBar
+     * implementation.
+     * @property id A unique ID for this group (uses a generated UUID by default)
+     */
+    data class SuggestionProviderGroup(
+        val providers: List<SuggestionProvider>,
+        val title: String? = null,
+        val id: String = UUID.randomUUID().toString()
+    )
 }


### PR DESCRIPTION
This allows us to define groups of suggestion providers that can be displayed with an optional header. It's still possible to just provide a list of suggestion providers, but internally we only deal with groups and will map that to a group with no header.