### PR TITLE
Update lastAccess of selected tab when restoring

### DIFF
--- a/components/feature/session/src/main/java/mozilla/components/feature/session/middleware/LastAccessMiddleware.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/middleware/LastAccessMiddleware.kt
@@ -57,6 +57,11 @@ class LastAccessMiddleware : Middleware<BrowserState, BrowserAction> {
                     context.dispatchUpdateActionForId(action.tab.id)
                 }
             }
+            is TabListAction.RestoreAction -> {
+                action.selectedTabId?.let {
+                    context.dispatchUpdateActionForId(it)
+                }
+            }
             is ContentAction.UpdateUrlAction -> {
                 if (action.sessionId == context.state.selectedTabId) {
                     context.dispatchUpdateActionForId(action.sessionId)


### PR DESCRIPTION
We update `lastAccess` whenever we select a tab.  Recently we added the missing case handling deletion, but restoring also selects, so let's handle it :).