### PR TITLE
Close #9576 - Add custom lint rule that warns if `Fact.collect` is no…

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -143,6 +143,7 @@ object Dependencies {
 
     const val tools_lint = "com.android.tools.lint:lint:${Versions.lint}"
     const val tools_lintapi = "com.android.tools.lint:lint-api:${Versions.lint}"
+    const val tools_lintchecks = "com.android.tools.lint:lint-checks:${Versions.lint}"
     const val tools_linttests = "com.android.tools.lint:lint-tests:${Versions.lint}"
 
     const val tools_detekt_api = "io.gitlab.arturbosch.detekt:detekt-api:${Versions.detekt}"

--- a/components/tooling/lint/build.gradle
+++ b/components/tooling/lint/build.gradle
@@ -10,6 +10,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
   compileOnly Dependencies.tools_lintapi
+  compileOnly Dependencies.tools_lintchecks
 
   // Force the usage of /our/ Kotlin version and not what we get transitively from the lint
   // dependencies. Otherwise we end up with a warning that there are multiple versions on the

--- a/components/tooling/lint/src/main/java/mozilla/components/tooling/lint/FactCollectDetector.kt
+++ b/components/tooling/lint/src/main/java/mozilla/components/tooling/lint/FactCollectDetector.kt
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.tooling.lint
+
+import com.android.tools.lint.checks.DataFlowAnalyzer
+import com.android.tools.lint.detector.api.*
+import com.intellij.psi.PsiMethod
+import org.jetbrains.uast.*
+
+/**
+ * A custom lint check that warns if [Fact.collect()] is not called on a newly created [Fact] instance
+ */
+class FactCollectDetector : Detector(), SourceCodeScanner {
+
+    companion object {
+        private const val FULLY_QUALIFIED_FACT_CLASS_NAME =
+            "mozilla.components.support.base.facts.Fact"
+        private const val EXPECTED_METHOD_SIMPLE_NAME =
+            "collect" // The `Fact.collect` extension method
+
+        private val IMPLEMENTATION = Implementation(
+            FactCollectDetector::class.java,
+            Scope.JAVA_FILE_SCOPE
+        )
+
+        val ISSUE_FACT_COLLECT_CALLED: Issue = Issue
+            .create(
+                id = "FactCollect",
+                briefDescription = "Fact created but not collected",
+                explanation = """
+                An instance of `Fact` was created but not collected. You must call 
+                `collect()` on the instance to actually process it.
+            """.trimIndent(),
+                category = Category.CORRECTNESS,
+                priority = 6,
+                severity = Severity.ERROR,
+                implementation = IMPLEMENTATION
+            )
+    }
+
+    override fun getApplicableConstructorTypes(): List<String> {
+        return listOf(FULLY_QUALIFIED_FACT_CLASS_NAME)
+    }
+
+    override fun visitConstructor(
+        context: JavaContext,
+        node: UCallExpression,
+        constructor: PsiMethod
+    ) {
+        var isCollectCalled = false
+        var escapes = false
+        val visitor = object : DataFlowAnalyzer(setOf(node)) {
+            override fun receiver(call: UCallExpression) {
+                if (call.methodName == EXPECTED_METHOD_SIMPLE_NAME) {
+                    isCollectCalled = true
+                }
+            }
+
+            override fun argument(call: UCallExpression, reference: UElement) {
+                escapes = true
+            }
+
+            override fun field(field: UElement) {
+                escapes = true
+            }
+
+            override fun returns(expression: UReturnExpression) {
+                escapes = true
+            }
+        }
+        val method = node.getParentOfType<UMethod>(UMethod::class.java, true) ?: return
+        method.accept(visitor)
+        if (!isCollectCalled && !escapes) {
+            reportUsage(context, node)
+        }
+    }
+
+    private fun reportUsage(context: JavaContext, node: UCallExpression) {
+        context.report(
+            issue = ISSUE_FACT_COLLECT_CALLED,
+            scope = node,
+            location = context.getCallLocation(
+                call = node,
+                includeReceiver = true,
+                includeArguments = false
+            ),
+            message = "Fact created but not shown: did you forget to call `collect()` ?"
+        )
+    }
+}

--- a/components/tooling/lint/src/main/java/mozilla/components/tooling/lint/LintIssueRegistry.kt
+++ b/components/tooling/lint/src/main/java/mozilla/components/tooling/lint/LintIssueRegistry.kt
@@ -17,6 +17,7 @@ class LintIssueRegistry : IssueRegistry() {
         LintLogChecks.ISSUE_LOG_USAGE,
         AndroidSrcXmlDetector.ISSUE_XML_SRC_USAGE,
         TextViewAndroidSrcXmlDetector.ISSUE_XML_SRC_USAGE,
-        ImageViewAndroidTintXmlDetector.ISSUE_XML_SRC_USAGE
+        ImageViewAndroidTintXmlDetector.ISSUE_XML_SRC_USAGE,
+        FactCollectDetector.ISSUE_FACT_COLLECT_CALLED
     )
 }

--- a/components/tooling/lint/src/test/java/mozilla/components/tooling/lint/FactCollectDetectorTest.kt
+++ b/components/tooling/lint/src/test/java/mozilla/components/tooling/lint/FactCollectDetectorTest.kt
@@ -1,0 +1,215 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.tooling.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/**
+ * Tests for the [FactCollectDetector] custom lint check.
+ */
+@RunWith(JUnit4::class)
+class FactCollectDetectorTest {
+
+    private val factClassfileStub = kotlin(
+        """
+        package mozilla.components.support.base.facts
+
+        data class Fact(
+            val component: Component,
+            val action: Action,
+            val item: String,
+            val value: String? = null,
+            val metadata: Map<String, Any>? = null
+        )
+
+        fun Fact.collect() = Facts.collect(this)
+        """
+    ).indented()
+
+    @Test
+    fun `should report when collect is not invoked on Fact instance`() {
+        lint()
+            .files(
+                kotlin(
+                    """
+                    package test
+
+                    import mozilla.components.support.base.facts.Fact
+                    import mozilla.components.support.base.facts.collect
+                    
+                    private fun emitAwesomebarFact(
+                        action: Action,
+                        item: String,
+                        value: String? = null,
+                        metadata: Map<String, Any>? = null
+                    ) {
+                        Fact(
+                            Component.BROWSER_AWESOMEBAR,
+                            action,
+                            item,
+                            value,
+                            metadata
+                        )
+                    }
+                    """
+                ).indented(), factClassfileStub
+            )
+            .issues(FactCollectDetector.ISSUE_FACT_COLLECT_CALLED)
+            .run()
+            .expect(
+                """
+                src/test/test.kt:12: Error: Fact created but not shown: did you forget to call collect() ? [FactCollect]
+                    Fact(
+                    ~~~~
+                1 errors, 0 warnings
+            """.trimIndent()
+            )
+    }
+
+    @Test
+    fun `should pass when collect is invoked on Fact instance`() {
+        lint()
+            .files(
+                kotlin(
+                    """
+                    package test
+
+                    import mozilla.components.support.base.facts.Fact
+                    import mozilla.components.support.base.facts.collect
+                    
+                    private fun emitAwesomebarFact(
+                        action: Action,
+                        item: String,
+                        value: String? = null,
+                        metadata: Map<String, Any>? = null
+                    ) {
+                        Fact(
+                            Component.BROWSER_AWESOMEBAR,
+                            action,
+                            item,
+                            value,
+                            metadata
+                        ).collect()
+                    }
+                    """
+                ).indented(), factClassfileStub
+            )
+            .issues(FactCollectDetector.ISSUE_FACT_COLLECT_CALLED)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `should pass when an instance escapes through a return statement`() {
+        lint()
+            .files(
+                kotlin(
+                    """
+                    package test
+
+                    import mozilla.components.support.base.facts.Fact
+                    import mozilla.components.support.base.facts.collect
+                    
+                    private fun createFact(
+                        action: Action,
+                        item: String,
+                        value: String? = null,
+                        metadata: Map<String, Any>? = null
+                    ): Fact {
+                        return Fact(
+                            Component.BROWSER_AWESOMEBAR,
+                            action,
+                            item,
+                            value,
+                            metadata
+                        )
+                    }
+                    """
+                ).indented(), factClassfileStub
+            )
+            .issues(FactCollectDetector.ISSUE_FACT_COLLECT_CALLED)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `should pass when an instance escapes through a method parameter`() {
+        lint()
+            .files(
+                kotlin(
+                    """
+                    package test
+
+                    import mozilla.components.support.base.facts.Fact
+                    import mozilla.components.support.base.facts.collect
+                    
+                    private fun createFact(
+                        action: Action,
+                        item: String,
+                        value: String? = null,
+                        metadata: Map<String, Any>? = null
+                    ) {
+                        val fact = Fact(
+                            Component.BROWSER_AWESOMEBAR,
+                            action,
+                            item,
+                            value,
+                            metadata
+                        )
+                        method(fact)
+                    }
+
+                    private fun method(parameter: Fact) {
+                        
+                    }
+                    """
+                ).indented(), factClassfileStub
+            )
+            .issues(FactCollectDetector.ISSUE_FACT_COLLECT_CALLED)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `should pass when an instance escapes through a field assignment`() {
+        lint()
+            .files(
+                kotlin(
+                    """
+                    package test
+
+                    import mozilla.components.support.base.facts.Fact
+                    import mozilla.components.support.base.facts.collect
+
+                    class FactSender {
+                        private var fact: Fact? = null
+                    
+                        private fun createFact(
+                            action: Action,
+                            item: String,
+                            value: String? = null,
+                            metadata: Map<String, Any>? = null
+                        ) {
+                            fact = Fact(
+                                Component.BROWSER_AWESOMEBAR,
+                                action,
+                                item,
+                                value,
+                                metadata
+                            )
+                        }
+                    }
+                    """
+                ).indented(), factClassfileStub
+            )
+            .issues(FactCollectDetector.ISSUE_FACT_COLLECT_CALLED)
+            .run()
+            .expectClean()
+    }
+}


### PR DESCRIPTION
…t called on a newly created `Fact` instance



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
