### PR TITLE
Close #11108: Remove internal DiffUtil from TabsTray

### DIFF
--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabsAdapterTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabsAdapterTest.kt
@@ -72,19 +72,6 @@ class TabsAdapterTest {
             )
         )
         assertEquals(2, adapter.itemCount)
-
-        adapter.updateTabs(
-            Tabs(
-                list = listOf(
-                    Tab("A", "https://www.mozilla.org"),
-                    Tab("B", "https://www.firefox.com"),
-                    Tab("C", "https://getpocket.com")
-                ),
-                selectedIndex = 0
-            )
-        )
-
-        assertEquals(3, adapter.itemCount)
     }
 
     @Test
@@ -105,23 +92,6 @@ class TabsAdapterTest {
         adapter.onBindViewHolder(holder, 0)
 
         verify(holder).bind(tab, true, adapter.styling, adapter)
-    }
-
-    @Test
-    fun `underlying adapter is notified about data set changes`() {
-        val adapter = spy(TabsAdapter())
-
-        adapter.onTabsInserted(27, 101)
-        verify(adapter).notifyItemRangeInserted(27, 101)
-
-        adapter.onTabsRemoved(11, 202)
-        verify(adapter).notifyItemRangeRemoved(11, 202)
-
-        adapter.onTabsMoved(13, 23)
-        verify(adapter).notifyItemMoved(13, 23)
-
-        adapter.onTabsChanged(42, 78)
-        verify(adapter).notifyItemRangeChanged(42, 78)
     }
 
     @Test

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/ext/TabsAdapterKtTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/ext/TabsAdapterKtTest.kt
@@ -4,11 +4,14 @@
 
 package mozilla.components.browser.tabstray.ext
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.tabstray.TabsAdapter
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class TabsAdapterKtTest {
 
     @Test

--- a/components/concept/tabstray/src/main/java/mozilla/components/concept/tabstray/TabsTray.kt
+++ b/components/concept/tabstray/src/main/java/mozilla/components/concept/tabstray/TabsTray.kt
@@ -44,24 +44,40 @@ interface TabsTray : Observable<TabsTray.Observer> {
      * Called after updateTabs() when <code>count</code> number of tabs are inserted at the
      * given position.
      */
-    fun onTabsInserted(position: Int, count: Int)
+    @Deprecated(
+        "We no longer support diff updates. Use alternatives like DiffUtil and ListAdapter directly.",
+        ReplaceWith("Unit")
+    )
+    fun onTabsInserted(position: Int, count: Int) = Unit
 
     /**
      * Called after updateTabs() when <code>count</code> number of tabs are removed from
      * the given position.
      */
-    fun onTabsRemoved(position: Int, count: Int)
+    @Deprecated(
+        "We no longer support diff updates. Use alternatives like DiffUtil and ListAdapter directly.",
+        ReplaceWith("Unit")
+    )
+    fun onTabsRemoved(position: Int, count: Int) = Unit
 
     /**
      * Called after updateTabs() when a tab changes it position.
      */
-    fun onTabsMoved(fromPosition: Int, toPosition: Int)
+    @Deprecated(
+        "We no longer support diff updates. Use alternatives like DiffUtil and ListAdapter directly.",
+        ReplaceWith("Unit")
+    )
+    fun onTabsMoved(fromPosition: Int, toPosition: Int) = Unit
 
     /**
      * Called after updateTabs() when <code>count</code> number of tabs are updated at the
      * given position.
      */
-    fun onTabsChanged(position: Int, count: Int)
+    @Deprecated(
+        "We no longer support diff updates. Use alternatives like DiffUtil and ListAdapter directly.",
+        ReplaceWith("Unit")
+    )
+    fun onTabsChanged(position: Int, count: Int) = Unit
 
     /**
      * Called when binding a new item to get if it should be shown as selected or not.
@@ -71,5 +87,6 @@ interface TabsTray : Observable<TabsTray.Observer> {
     /**
      * Convenience method to cast the implementation of this interface to an Android View object.
      */
+    @Deprecated("Will be removed in a future release.", ReplaceWith(""))
     fun asView(): View = this as View
 }

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsFeature.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsFeature.kt
@@ -20,7 +20,7 @@ import mozilla.components.support.base.feature.LifecycleAwareFeature
  */
 @Suppress("LongParameterList")
 class TabsFeature(
-    tabsTray: TabsTray,
+    private val tabsTray: TabsTray,
     private val store: BrowserStore,
     selectTabUseCase: TabsUseCases.SelectTabUseCase,
     removeTabUseCase: TabsUseCases.RemoveTabUseCase,
@@ -63,6 +63,6 @@ class TabsFeature(
         presenter.tabsFilter = tabsFilter
 
         val state = store.state
-        presenter.updateTabs(state.toTabs(tabsFilter))
+        tabsTray.updateTabs(state.toTabs(tabsFilter))
     }
 }

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenter.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenter.kt
@@ -4,8 +4,6 @@
 
 package mozilla.components.feature.tabs.tabstray
 
-import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListUpdateCallback
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
@@ -50,79 +48,9 @@ class TabsTrayPresenter(
                     closeTabsTray.invoke()
                 }
 
-                updateTabs(tabs)
-            }
-    }
-
-    internal fun updateTabs(tabs: Tabs) {
-        val currentTabs = this.tabs
-
-        if (currentTabs == null) {
-            this.tabs = tabs
-            if (tabs.list.isNotEmpty()) {
                 tabsTray.updateTabs(tabs)
-                tabsTray.onTabsInserted(0, tabs.list.size)
+
+                this.tabs = tabs
             }
-            return
-        } else {
-            calculateDiffAndUpdateTabsTray(currentTabs, tabs)
-        }
-    }
-
-    /**
-     * Calculates a diff between the last know state and the new state. After that it updates the
-     * tab tray with the new data and notifies it about what changes happened so that it can animate
-     * those changes.
-     */
-    private fun calculateDiffAndUpdateTabsTray(currentTabs: Tabs, updatedTabs: Tabs) {
-        val result = DiffUtil.calculateDiff(DiffCallback(currentTabs, updatedTabs), true)
-
-        this.tabs = updatedTabs
-
-        tabsTray.updateTabs(updatedTabs)
-
-        result.dispatchUpdatesTo(object : ListUpdateCallback {
-            override fun onChanged(position: Int, count: Int, payload: Any?) {
-                tabsTray.onTabsChanged(position, count)
-            }
-
-            override fun onMoved(fromPosition: Int, toPosition: Int) {
-                tabsTray.onTabsMoved(fromPosition, toPosition)
-            }
-
-            override fun onInserted(position: Int, count: Int) {
-                tabsTray.onTabsInserted(position, count)
-            }
-
-            override fun onRemoved(position: Int, count: Int) {
-                tabsTray.onTabsRemoved(position, count)
-            }
-        })
-    }
-}
-
-internal class DiffCallback(
-    private val currentTabs: Tabs,
-    private val updatedTabs: Tabs
-) : DiffUtil.Callback() {
-    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
-        currentTabs.list[oldItemPosition].id == updatedTabs.list[newItemPosition].id
-
-    override fun getOldListSize(): Int = currentTabs.list.size
-
-    override fun getNewListSize(): Int = updatedTabs.list.size
-
-    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        if (oldItemPosition == currentTabs.selectedIndex && newItemPosition != updatedTabs.selectedIndex) {
-            // This item was previously selected and is not selected anymore (-> changed).
-            return false
-        }
-
-        if (newItemPosition == updatedTabs.selectedIndex && oldItemPosition != currentTabs.selectedIndex) {
-            // This item was not selected previously and is now selected (-> changed).
-            return false
-        }
-
-        return updatedTabs.list[newItemPosition] == currentTabs.list[oldItemPosition]
     }
 }

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsFeatureTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsFeatureTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.tabs.tabstray
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.tabstray.Tabs
+import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
@@ -103,12 +104,13 @@ class TabsFeatureTest {
     fun filterTabs() {
         val store = BrowserStore()
         val presenter: TabsTrayPresenter = mock()
+        val tabsTray: TabsTray = mock()
         val interactor: TabsTrayInteractor = mock()
         val selectTabUseCase: TabsUseCases.SelectTabUseCase = mock()
         val removeTabUseCase: TabsUseCases.RemoveTabUseCase = mock()
         val tabsFeature = spy(
             TabsFeature(
-                mock(),
+                tabsTray,
                 store,
                 selectTabUseCase,
                 removeTabUseCase,
@@ -125,7 +127,7 @@ class TabsFeatureTest {
         tabsFeature.filterTabs(filter)
 
         verify(presenter).tabsFilter = filter
-        verify(presenter).updateTabs(Tabs(emptyList(), -1))
+        verify(tabsTray).updateTabs(Tabs(emptyList(), -1))
     }
 
     @Test

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
@@ -120,8 +120,6 @@ class TabsTrayPresenterTest {
 
         assertEquals(3, tabsTray.updateTabs!!.list.size)
 
-        verify(tabsTray).onTabsInserted(2, 1)
-
         presenter.stop()
     }
 
@@ -155,13 +153,11 @@ class TabsTrayPresenterTest {
         testDispatcher.advanceUntilIdle()
 
         assertEquals(1, tabsTray.updateTabs!!.list.size)
-        verify(tabsTray).onTabsRemoved(0, 1)
 
         store.dispatch(TabListAction.RemoveTabAction("b")).joinBlocking()
         testDispatcher.advanceUntilIdle()
 
         assertEquals(0, tabsTray.updateTabs!!.list.size)
-        verify(tabsTray, times(2)).onTabsRemoved(0, 1)
 
         presenter.stop()
     }
@@ -196,8 +192,6 @@ class TabsTrayPresenterTest {
         testDispatcher.advanceUntilIdle()
 
         assertEquals(0, tabsTray.updateTabs!!.list.size)
-
-        verify(tabsTray).onTabsRemoved(0, 2)
 
         presenter.stop()
     }
@@ -236,9 +230,6 @@ class TabsTrayPresenterTest {
 
         println("Selection: " + store.state.selectedTabId)
         assertEquals(3, tabsTray.updateTabs!!.selectedIndex)
-
-        verify(tabsTray).onTabsChanged(0, 1)
-        verify(tabsTray).onTabsChanged(3, 1)
     }
 
     @Test
@@ -348,7 +339,7 @@ class TabsTrayPresenterTest {
             )
         ).toTabs()
 
-        presenter.updateTabs(tabs)
+        tabsTray.updateTabs(tabs)
         testDispatcher.advanceUntilIdle()
 
         verify(tabsTray).updateTabs(tabs)
@@ -411,14 +402,6 @@ private class MockedTabsTray : TabsTray {
     override fun updateTabs(tabs: Tabs) {
         updateTabs = tabs
     }
-
-    override fun onTabsInserted(position: Int, count: Int) {}
-
-    override fun onTabsRemoved(position: Int, count: Int) {}
-
-    override fun onTabsMoved(fromPosition: Int, toPosition: Int) {}
-
-    override fun onTabsChanged(position: Int, count: Int) {}
 
     override fun register(observer: TabsTray.Observer) {}
 


### PR DESCRIPTION
The diff here looks intimidating, but the essential changes are:
```diff
diff --git a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsFeature.kt b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsFeature.kt
index 2827b62460..db38e15bc8 100644
--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsFeature.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsFeature.kt
@@ -20,7 +20,7 @@ import mozilla.components.support.base.feature.LifecycleAwareFeature
  */
 @Suppress("LongParameterList")
 class TabsFeature(
-    tabsTray: TabsTray,
+    private val tabsTray: TabsTray,
     private val store: BrowserStore,
     selectTabUseCase: TabsUseCases.SelectTabUseCase,
     removeTabUseCase: TabsUseCases.RemoveTabUseCase,
@@ -63,6 +63,6 @@ class TabsFeature(
         presenter.tabsFilter = tabsFilter
 
         val state = store.state
-        presenter.updateTabs(state.toTabs(tabsFilter))
+        tabsTray.updateTabs(state.toTabs(tabsFilter))
     }
 }
diff --git a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenter.kt b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenter.kt
index bbc5500828..17c78e447f 100644
--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenter.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenter.kt
@@ -50,7 +50,7 @@ class TabsTrayPresenter(
                     closeTabsTray.invoke()
                 }
 
-                updateTabs(tabs)
+                tabsTray.updateTabs(tabs)
             }
     }

```

We are now delegating the diff checks for the tray, directly to the consuming `TabsTray` to calculate, so that we no longer need to handle this in the feature any more. An example of what this would look like for non-Fenix consumers is quite straight-forward too (see sample-browser changes).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
