### PR TITLE
Issue #11071: Fix TabIntentProcessorTest

### DIFF
--- a/components/feature/intent/src/test/java/mozilla/components/feature/intent/processing/TabIntentProcessorTest.kt
+++ b/components/feature/intent/src/test/java/mozilla/components/feature/intent/processing/TabIntentProcessorTest.kt
@@ -90,7 +90,7 @@ class TabIntentProcessorTest {
 
         sessionUseCases = SessionUseCases(store)
         tabsUseCases = TabsUseCases(store)
-        searchUseCases = SearchUseCases(store, tabsUseCases)
+        searchUseCases = SearchUseCases(store, tabsUseCases, sessionUseCases)
     }
 
     @Test


### PR DESCRIPTION
Looks like #11107 did not build `feature-intent` and therefore missed this build error in the tests.