### PR TITLE
For #11124 - Limit suggestion text length in the Awesomebar composable.

### DIFF
--- a/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/Suggestion.kt
+++ b/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/Suggestion.kt
@@ -35,6 +35,10 @@ import mozilla.components.compose.browser.awesomebar.AwesomeBarOrientation
 import mozilla.components.compose.browser.awesomebar.R
 import mozilla.components.concept.awesomebar.AwesomeBar
 
+// We only show one row of text, covering at max screen width.
+// Limit bigger texts that could cause slowdowns or even crashes.
+private const val SUGGESTION_TEXT_MAX_LENGTH = 100
+
 @Composable
 internal fun Suggestion(
     suggestion: AwesomeBar.Suggestion,
@@ -58,8 +62,8 @@ internal fun Suggestion(
             )
         }
         SuggestionTitleAndDescription(
-            title = suggestion.title,
-            description = suggestion.description,
+            title = suggestion.title?.take(SUGGESTION_TEXT_MAX_LENGTH),
+            description = suggestion.description?.take(SUGGESTION_TEXT_MAX_LENGTH),
             colors = colors,
             modifier = Modifier
                 .weight(1f)


### PR DESCRIPTION
Video for the fixed scenario which would otherwise crash Fenix:



https://user-images.githubusercontent.com/11428869/137082702-3e62df12-94de-4c90-9f49-4c782479dec1.mp4


Tried various modifiers and combinations of them to avoid cutting the suggestion's text but in the best case this would leave to multi second hangs so the best and fastest solution seems to be to just limit the text awesomebar works with.

Not sure this is really a bug in Compose or just a "don't do that" sort of thing but will open a ticket @ google also.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
