### PR TITLE
Issue #11066: Make optimized load url case observable in middlewares

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -837,6 +837,17 @@ sealed class EngineAction : BrowserAction() {
     ) : EngineAction(), ActionWithTab
 
     /**
+     * Indicates to observers that a [LoadUrlAction] was shortcutted and a direct
+     * load on the engine occurred instead.
+     */
+    data class OptimizedLoadUrlTriggeredAction(
+        override val tabId: String,
+        val url: String,
+        val flags: EngineSession.LoadUrlFlags = EngineSession.LoadUrlFlags.none(),
+        val additionalHeaders: Map<String, String>? = null
+    ) : EngineAction(), ActionWithTab
+
+    /**
      * Loads [data] in the tab with the given [tabId].
      */
     data class LoadDataAction(

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/EngineStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/EngineStateReducer.kt
@@ -42,6 +42,9 @@ internal object EngineStateReducer {
         is EngineAction.UpdateEngineSessionInitializingAction -> state.copyWithEngineState(action.tabId) {
             it.copy(initializing = action.initializing)
         }
+        is EngineAction.OptimizedLoadUrlTriggeredAction -> {
+            state
+        }
         is EngineAction.SuspendEngineSessionAction,
         is EngineAction.CreateEngineSessionAction,
         is EngineAction.LoadDataAction,

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/EngineActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/EngineActionTest.kt
@@ -20,6 +20,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -128,5 +129,12 @@ class EngineActionTest {
 
         store.dispatch(EngineAction.UpdateEngineSessionInitializingAction(tab.id, true)).joinBlocking()
         assertTrue(engineState().initializing)
+    }
+
+    @Test
+    fun `OptimizedLoadUrlTriggeredAction - State is not changed`() {
+        val state = store.state
+        store.dispatch(EngineAction.OptimizedLoadUrlTriggeredAction(tab.id, "https://mozilla.org")).joinBlocking()
+        assertSame(store.state, state)
     }
 }

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
@@ -97,6 +97,14 @@ class SessionUseCases(
                     flags = flags,
                     additionalHeaders = additionalHeaders
                 )
+                store.dispatch(
+                    EngineAction.OptimizedLoadUrlTriggeredAction(
+                        loadSessionId,
+                        url,
+                        flags,
+                        additionalHeaders
+                    )
+                )
             } else {
                 store.dispatch(
                     EngineAction.LoadUrlAction(

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -72,24 +72,34 @@ class SessionUseCasesTest {
     fun loadUrlWithEngineSession() {
         useCases.loadUrl("https://getpocket.com")
         store.waitUntilIdle()
-
         middleware.assertNotDispatched(EngineAction.LoadUrlAction::class)
         verify(engineSession).loadUrl(url = "https://getpocket.com")
+        middleware.assertLastAction(EngineAction.OptimizedLoadUrlTriggeredAction::class) { action ->
+            assertEquals("mozilla", action.tabId)
+            assertEquals("https://getpocket.com", action.url)
+        }
 
         useCases.loadUrl("https://www.mozilla.org", LoadUrlFlags.select(LoadUrlFlags.EXTERNAL))
         store.waitUntilIdle()
-
         middleware.assertNotDispatched(EngineAction.LoadUrlAction::class)
         verify(engineSession).loadUrl(
             url = "https://www.mozilla.org",
             flags = LoadUrlFlags.select(LoadUrlFlags.EXTERNAL)
         )
+        middleware.assertLastAction(EngineAction.OptimizedLoadUrlTriggeredAction::class) { action ->
+            assertEquals("mozilla", action.tabId)
+            assertEquals("https://www.mozilla.org", action.url)
+            assertEquals(LoadUrlFlags.select(LoadUrlFlags.EXTERNAL), action.flags)
+        }
 
         useCases.loadUrl("https://firefox.com", store.state.selectedTabId)
         store.waitUntilIdle()
-
         middleware.assertNotDispatched(EngineAction.LoadUrlAction::class)
         verify(engineSession).loadUrl(url = "https://firefox.com")
+        middleware.assertLastAction(EngineAction.OptimizedLoadUrlTriggeredAction::class) { action ->
+            assertEquals("mozilla", action.tabId)
+            assertEquals("https://firefox.com", action.url)
+        }
 
         useCases.loadUrl.invoke(
             "https://developer.mozilla.org",
@@ -97,24 +107,31 @@ class SessionUseCasesTest {
             LoadUrlFlags.select(LoadUrlFlags.BYPASS_PROXY)
         )
         store.waitUntilIdle()
-
         middleware.assertNotDispatched(EngineAction.LoadUrlAction::class)
         verify(engineSession).loadUrl(
             url = "https://developer.mozilla.org",
             flags = LoadUrlFlags.select(LoadUrlFlags.BYPASS_PROXY)
         )
+        middleware.assertLastAction(EngineAction.OptimizedLoadUrlTriggeredAction::class) { action ->
+            assertEquals("mozilla", action.tabId)
+            assertEquals("https://developer.mozilla.org", action.url)
+            assertEquals(LoadUrlFlags.select(LoadUrlFlags.BYPASS_PROXY), action.flags)
+        }
 
         useCases.loadUrl.invoke(
             "https://www.mozilla.org/en-CA/firefox/browsers/mobile/",
             "bugzilla"
         )
         store.waitUntilIdle()
-
         middleware.assertNotDispatched(EngineAction.LoadUrlAction::class)
         verify(childEngineSession).loadUrl(
             url = "https://www.mozilla.org/en-CA/firefox/browsers/mobile/",
             parent = engineSession
         )
+        middleware.assertLastAction(EngineAction.OptimizedLoadUrlTriggeredAction::class) { action ->
+            assertEquals("bugzilla", action.tabId)
+            assertEquals("https://www.mozilla.org/en-CA/firefox/browsers/mobile/", action.url)
+        }
     }
 
     @Test


### PR DESCRIPTION
Idea is to make the optimized path observable in middlewares as well via a dedicated action. 