### PR TITLE
Issue #11135 - Fix photon colors to match color system

### DIFF
--- a/components/ui/colors/src/main/java/mozilla/components/ui/colors/PhotonColors.kt
+++ b/components/ui/colors/src/main/java/mozilla/components/ui/colors/PhotonColors.kt
@@ -29,7 +29,7 @@ object PhotonColors {
 
     // Green is primarily used for positive / success / update status in user interface.
     val Green05 = Color(0xFFE3FFF3)
-    val Green10 = Color(0xFFD1FEEE)
+    val Green10 = Color(0xFFD1FFEE)
     val Green20 = Color(0xFFB3FFE3)
     val Green30 = Color(0xFF87FFD1)
     val Green40 = Color(0xFF54FFBD)

--- a/components/ui/colors/src/main/res/values/photon_colors.xml
+++ b/components/ui/colors/src/main/res/values/photon_colors.xml
@@ -68,11 +68,11 @@
 	<color name="photonRed10">#ffffbdc5</color>
 	<color name="photonRed20">#ffff9aa2</color>
 	<color name="photonRed30">#ffff848b</color>
-	<color name="photonRed50">#ffff6a75</color>
-	<color name="photonRed60">#ffff4f5e</color>
-	<color name="photonRed70">#ffe22850</color>
-	<color name="photonRed80">#ffc50042</color>
-	<color name="photonRed90">#ff810220</color>
+	<color name="photonRed50">#ffff4f5e</color>
+	<color name="photonRed60">#ffe22850</color>
+	<color name="photonRed70">#ffc50042</color>
+	<color name="photonRed80">#ff810220</color>
+	<color name="photonRed90">#ff440306</color>
 
 	<!-- Yellow -->
 	<color name="photonYellow05">#ffffffcc</color>
@@ -129,7 +129,7 @@
 	<color name="photonInk40">#ff2b2156</color>
 	<color name="photonInk50">#ff291d4f</color>
 	<color name="photonInk60">#ff271948</color>
-	<color name="photonInk70">#ff251541</color>
+	<color name="photonInk70">#ff241541</color>
 	<color name="photonInk80">#ff20123a</color>
 	<color name="photonInk90">#ff1d1133</color>
 


### PR DESCRIPTION
Fixes #11135. Spoke with @brampitoyo and we acknowledge that some of the entries weren't entered correctly. I went through each of them to ensure we are getting everything aligned. We are still pulling the photon colors from https://www.figma.com/file/DyIIHvRgqt2EXfAVn1gV9c/Fx-Colors?node-id=90%3A0 as the source of truth.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
