### PR TITLE
Closes #10682: Emit fact when history metadata suggestion is clicked

### DIFF
--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/HistoryMetadataSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/HistoryMetadataSuggestionProvider.kt
@@ -12,6 +12,7 @@ import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.storage.HistoryMetadata
 import mozilla.components.concept.storage.HistoryMetadataStorage
 import mozilla.components.concept.storage.HistoryStorage
+import mozilla.components.feature.awesomebar.facts.emitHistorySuggestionClickedFact
 import mozilla.components.feature.session.SessionUseCases
 import java.util.UUID
 
@@ -72,6 +73,7 @@ internal suspend fun Iterable<HistoryMetadata>.into(
             editSuggestion = result.key.url,
             onSuggestionClicked = {
                 loadUrlUseCase.invoke(result.key.url)
+                emitHistorySuggestionClickedFact()
             }
         )
     }


### PR DESCRIPTION
This will need to be uplifted to 94.

In https://github.com/mozilla-mobile/android-components/pull/10683 we already added this and "emitted the fact" for the new provider, but we lost it again in https://github.com/mozilla-mobile/android-components/pull/10707.

@Mugurell can you review and land this :). Then we can uplift after.

Background: We saw the telemetry trending down for this in beta, so double-checked and found this.