### PR TITLE
Draft for autofill save UI

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -11,7 +11,7 @@ object Versions {
     const val coroutines = "1.5.0"
 
     const val junit = "4.12"
-    const val robolectric = "4.1"
+    const val robolectric = "4.6.1"
     const val mockito = "3.11.2"
     const val maven_ant_tasks = "2.1.3"
 

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/AbstractAutofillService.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/AbstractAutofillService.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import mozilla.components.concept.storage.Login
+import mozilla.components.concept.storage.LoginEntry
 import mozilla.components.feature.autofill.handler.FillRequestHandler
 import mozilla.components.feature.autofill.handler.MAX_LOGINS
 import mozilla.components.feature.autofill.structure.ParsedStructure
@@ -81,13 +81,12 @@ abstract class AbstractAutofillService : AutofillService() {
         @OptIn(DelicateCoroutinesApi::class)
         GlobalScope.launch(Dispatchers.IO) {
             val lookupDomain = parsedStructure.getLookupDomain(configuration.publicSuffixList)
-            val loginEntry = Login(
-                guid = "",
+            val loginEntry = LoginEntry(
                 origin = "https://$lookupDomain",
                 username = username!!,
                 password = password!!,
                 httpRealm = "https://$lookupDomain"
-            ).toEntry()
+            )
             configuration.storage.addOrUpdate(loginEntry)
         }
 

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/fill/LoginFillResponseBuilder.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/fill/LoginFillResponseBuilder.kt
@@ -63,15 +63,15 @@ internal data class LoginFillResponseBuilder(
 }
 
 @RequiresApi(Build.VERSION_CODES.O)
-internal fun FillResponse.Builder.handleSaveInfo(ps: ParsedStructure) {
-    val ids = arrayOf(ps.usernameId, ps.passwordId).filterNotNull()
+internal fun FillResponse.Builder.handleSaveInfo(structure: ParsedStructure) {
+    val ids = arrayOf(structure.usernameId, structure.passwordId).filterNotNull()
     if (ids.isNotEmpty()) {
         setSaveInfo(
             SaveInfo.Builder(
                 SaveInfo.SAVE_DATA_TYPE_USERNAME or SaveInfo.SAVE_DATA_TYPE_PASSWORD,
                 ids.toTypedArray()
             ).also {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && ps.passwordId == null) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && structure.passwordId == null) {
                     // Continue workflow until password field is reached
                     it.setFlags(SaveInfo.FLAG_DELAY_SAVE)
                 }

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/structure/ParsedStructure.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/structure/ParsedStructure.kt
@@ -25,7 +25,9 @@ internal data class ParsedStructure(
     val usernameId: AutofillId? = null,
     val passwordId: AutofillId? = null,
     val webDomain: String? = null,
-    val packageName: String
+    val packageName: String,
+    val username: String?,
+    val password: String?
 ) : Parcelable
 
 /**

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/structure/ParsedStructureBuilder.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/structure/ParsedStructureBuilder.kt
@@ -9,6 +9,7 @@ import android.view.View
 import androidx.annotation.RequiresApi
 
 @RequiresApi(Build.VERSION_CODES.O)
+@Suppress("LargeClass")
 internal class ParsedStructureBuilder<ViewNode, AutofillId>(
     private val navigator: AutofillNodeNavigator<ViewNode, AutofillId>
 ) {
@@ -63,15 +64,25 @@ internal class ParsedStructureBuilder<ViewNode, AutofillId>(
         return getAutofillIdForKeywords(rootNode, listOf(View.AUTOFILL_HINT_PASSWORD, "password"))
     }
 
-    private fun getAutofillIdForKeywords(rootNode: ViewNode?, keywords: Collection<String>): Pair<AutofillId?, String?>? {
+    private fun getAutofillIdForKeywords(
+        rootNode: ViewNode?,
+        keywords: Collection<String>
+    ): Pair<AutofillId?, String?>? {
         return checkForNamedTextField(rootNode, keywords)
             ?: checkForConsecutiveLabelAndField(rootNode, keywords)
             ?: checkForNestedLayoutAndField(rootNode, keywords)
     }
 
-    private fun checkForNamedTextField(rootNode: ViewNode?, keywords: Collection<String>): Pair<AutofillId?, String?>? {
+    private fun checkForNamedTextField(
+        rootNode: ViewNode?,
+        keywords: Collection<String>
+    ): Pair<AutofillId?, String?>? {
         return navigator.findFirst(rootNode) { node: ViewNode ->
-            if (isAutoFillableEditText(node, keywords) || isAutoFillableInputField(node, keywords)) {
+            if (isAutoFillableEditText(node, keywords) || isAutoFillableInputField(
+                    node,
+                    keywords
+                )
+            ) {
                 navigator.autofillId(node) to navigator.currentText(node)
             } else {
                 null
@@ -79,7 +90,10 @@ internal class ParsedStructureBuilder<ViewNode, AutofillId>(
         }
     }
 
-    private fun checkForConsecutiveLabelAndField(rootNode: ViewNode?, keywords: Collection<String>): Pair<AutofillId?, String?>? {
+    private fun checkForConsecutiveLabelAndField(
+        rootNode: ViewNode?,
+        keywords: Collection<String>
+    ): Pair<AutofillId?, String?>? {
         return navigator.findFirst(rootNode) { node: ViewNode ->
             val childNodes = navigator.childNodes(node)
             // check for consecutive views with keywords followed by possible fill locations
@@ -99,7 +113,8 @@ internal class ParsedStructureBuilder<ViewNode, AutofillId>(
         }
     }
 
-    private fun checkForNestedLayoutAndField(rootNode: ViewNode?, keywords: Collection<String>): Pair<AutofillId?, String?>? {
+    private fun checkForNestedLayoutAndField(rootNode: ViewNode?, keywords: Collection<String>):
+        Pair<AutofillId?, String?>? {
         return navigator.findFirst(rootNode) { node: ViewNode ->
             val childNodes = navigator.childNodes(node)
 
@@ -120,7 +135,8 @@ internal class ParsedStructureBuilder<ViewNode, AutofillId>(
         }
     }
 
-    private fun checkForAdjacentFields(rootNode: ViewNode?): Pair<Pair<AutofillId?, String?>?, Pair<AutofillId?, String?>?>? {
+    private fun checkForAdjacentFields(rootNode: ViewNode?):
+        Pair<Pair<AutofillId?, String?>?, Pair<AutofillId?, String?>?>? {
         return navigator.findFirst(rootNode) { node: ViewNode ->
 
             val childNodes = navigator.childNodes(node)
@@ -136,7 +152,9 @@ internal class ParsedStructureBuilder<ViewNode, AutofillId>(
             }
 
             val inputFields = firstFewNodes.filter {
-                navigator.isEditText(it) && navigator.autofillId(it) != null && navigator.isVisible(it)
+                navigator.isEditText(it) && navigator.autofillId(it) != null && navigator.isVisible(
+                    it
+                )
             }
 
             // we must have a minimum of two EditText boxes in order to have a pair.
@@ -148,8 +166,9 @@ internal class ParsedStructureBuilder<ViewNode, AutofillId>(
                 val prevNode = inputFields[i - 1]
                 val currentNode = inputFields[i]
                 if (navigator.isPasswordField(currentNode) && navigator.isPasswordField(prevNode).not()) {
-                    return@findFirst (navigator.autofillId(prevNode) to navigator.currentText(prevNode)) to
-                        (navigator.autofillId(currentNode) to navigator.currentText(currentNode))
+                    return@findFirst (
+                        navigator.autofillId(prevNode) to navigator.currentText(prevNode)
+                        ) to (navigator.autofillId(currentNode) to navigator.currentText(currentNode))
                 }
             }
 
@@ -193,8 +212,8 @@ internal class ParsedStructureBuilder<ViewNode, AutofillId>(
         val hints = navigator.clues(node)
         keywords.forEach { keyword ->
             hints.forEach { hint ->
-                if (hint.map { it.uppercase() } == keyword.map { it.uppercase() }) {
-//                if (hint.contains(keyword, true)) {
+//                if (hint.map { it.uppercase() } == keyword.map { it.uppercase() }) {
+                if (hint.contains(keyword, true)) {
                     return true
                 }
             }

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/structure/ViewNodeNavigator.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/structure/ViewNodeNavigator.kt
@@ -48,7 +48,9 @@ internal interface AutofillNodeNavigator<Node, Id> {
         usernameId: Id?,
         passwordId: Id?,
         webDomain: String?,
-        packageName: String
+        packageName: String,
+        username: String?,
+        password: String?
     ): ParsedStructure
 
     private fun <T> findFirstRoots(transform: (Node) -> T?): T? {
@@ -174,13 +176,17 @@ internal class ViewNodeNavigator(
         usernameId: AutofillId?,
         passwordId: AutofillId?,
         webDomain: String?,
-        packageName: String
+        packageName: String,
+        username: String?,
+        password: String?
     ): ParsedStructure {
         return ParsedStructure(
             usernameId,
             passwordId,
             webDomain,
-            packageName
+            packageName,
+            username,
+            password
         )
     }
 }

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/structure/ViewNodeNavigator.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/structure/ViewNodeNavigator.kt
@@ -44,6 +44,7 @@ internal interface AutofillNodeNavigator<Node, Id> {
     fun isButton(node: Node): Boolean
     fun isFocused(node: Node): Boolean
     fun isVisible(node: Node): Boolean
+    @Suppress("LongParameterList")
     fun build(
         usernameId: Id?,
         passwordId: Id?,

--- a/components/feature/autofill/src/test/java/mozilla/components/feature/autofill/test/DOMNavigator.kt
+++ b/components/feature/autofill/src/test/java/mozilla/components/feature/autofill/test/DOMNavigator.kt
@@ -105,13 +105,17 @@ internal class DOMNavigator(
         usernameId: AutofillId?,
         passwordId: AutofillId?,
         webDomain: String?,
-        packageName: String
+        packageName: String,
+        username: String?,
+        password: String?
     ): ParsedStructure {
         return ParsedStructure(
             usernameId,
             passwordId,
             webDomain,
-            packageName
+            packageName,
+            username,
+            password
         )
     }
 }


### PR DESCRIPTION
Draft for #11145 (Android Autofill: Save credentials)

How should we tackle saving credentials when an app (e.g. Twitter) has multiple screens to implement autofill workflow (for example, one for username and the other one for password)? Starting from API 29 we can set `FLAG_DELAY_SAVE` flag. 
This is because `Login` object requires both username and password.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
