### PR TITLE
Upgrades appservices to 86.0.1 with only logins log change

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,7 +29,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "2.4"
 
-    const val mozilla_appservices = "86.0.0"
+    const val mozilla_appservices = "86.0.1"
 
     const val mozilla_glean = "42.0.1"
 


### PR DESCRIPTION
This version of application services has exactly one change, which lowers the log level of some errors from "error" to "warn" to prevent them from showing up in Sentry. (you can verify the diff: (https://github.com/mozilla/application-services/compare/v86.0.0...v86.0.1)

This release was cut to get that change into this Beta cycle, there is a slightly larger release (which also includes this change) open in #11181 , but that can wait until the next cycle

cc: @bendk @grigoryk @csadilek 

Changelog: 
# v86.0.1 (_2021-10-28_)

[Full Changelog](https://github.com/mozilla/application-services/compare/v86.0.0...v86.0.1)
## Logins
### What's Changed
- Downgraded the log level of some logs, so now they should not show up in Sentry.
