### PR TITLE
Add Firefox Focus packages to known browsers list

### DIFF
--- a/components/support/utils/src/main/java/mozilla/components/support/utils/Browsers.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/Browsers.kt
@@ -50,6 +50,11 @@ class Browsers private constructor(
         FENIX_PREVIEW("org.mozilla.fenix"),
         FENIX_DEBUG("org.mozilla.fenix.debug"),
 
+        FIREFOX_FOCUS_DEBUG("org.mozilla.focus.debug"),
+        FIREFOX_FOCUS_NIGHTLY("org.mozilla.focus.nightly"),
+        FIREFOX_FOCUS_BETA("org.mozilla.focus.beta"),
+        FIREFOX_FOCUS("org.mozilla.focus"),
+
         REFERENCE_BROWSER("org.mozilla.reference.browser"),
         REFERENCE_BROWSER_DEBUG("org.mozilla.reference.browser.debug"),
 
@@ -202,6 +207,17 @@ class Browsers private constructor(
             browsers.containsKey(KnownBrowser.FIREFOX_FDROID.packageName) ->
                 browsers[KnownBrowser.FIREFOX_FDROID.packageName]
 
+            browsers.containsKey(KnownBrowser.FIREFOX_FOCUS.packageName) ->
+                browsers[KnownBrowser.FIREFOX_FOCUS.packageName]
+
+            browsers.containsKey(KnownBrowser.FIREFOX_FOCUS_DEBUG.packageName) ->
+                browsers[KnownBrowser.FIREFOX_FOCUS_DEBUG.packageName]
+
+            browsers.containsKey(KnownBrowser.FIREFOX_FOCUS_BETA.packageName) ->
+                browsers[KnownBrowser.FIREFOX_FOCUS_BETA.packageName]
+
+            browsers.containsKey(KnownBrowser.FIREFOX_FOCUS_NIGHTLY.packageName) ->
+                browsers[KnownBrowser.FIREFOX_FOCUS_NIGHTLY.packageName]
             else -> null
         }
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **support-utils**
+  * 🌟️️ **Add Firefox Focus packages to known browsers list
+
 * **concept-tabstray**
   * ⚠️ **This is a breaking change**: This component will be removed in future release.
      * Instead use the `TabsTray` interface from `browser-tabstray`.


### PR DESCRIPTION
For #11201
Add Firefox Focus packages to known browsers list

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
