### PR TITLE
For #11209 - Stable tabs tray

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TabListReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TabListReducer.kt
@@ -98,16 +98,16 @@ internal object TabListReducer {
                         if (it.parentId == tabToRemove.id) it.copy(parentId = tabToRemove.parentId) else it
                     }
 
-                    val updatedSelection = if (action.selectParentIfExists && tabToRemove.parentId != null) {
+                    val updatedSelection: String? = if (tabToRemove.id != state.selectedTabId) {
+                        // The selected tab is not affected and can stay the same
+                        state.selectedTabId
+                    } else if (action.selectParentIfExists && tabToRemove.parentId != null) {
                         // The parent tab should be selected if one exists
                         tabToRemove.parentId
-                    } else if (state.selectedTabId == tabToRemove.id) {
+                    } else {
                         // The selected tab was removed and we need to find a new one
                         val previousIndex = state.tabs.indexOf(tabToRemove)
                         findNewSelectedTabId(updatedTabList, tabToRemove.content.private, previousIndex)
-                    } else {
-                        // The selected tab is not affected and can stay the same
-                        state.selectedTabId
                     }
 
                     state.copy(

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TabListReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TabListReducer.kt
@@ -101,8 +101,11 @@ internal object TabListReducer {
                     val updatedSelection: String? = if (tabToRemove.id != state.selectedTabId) {
                         // The selected tab is not affected and can stay the same
                         state.selectedTabId
-                    } else if (action.selectParentIfExists && tabToRemove.parentId != null) {
-                        // The parent tab should be selected if one exists
+                    } else if ((action.selectParentIfExists && tabToRemove.parentId != null) &&
+                        (state.findTab(tabToRemove.parentId)?.content?.private == tabToRemove.content.private)
+                    ) {
+                        // The parent tab should be selected if one exists.
+                        // Only if the parent is of the same type as the just removed tab (private or normal).
                         tabToRemove.parentId
                     } else {
                         // The selected tab was removed and we need to find a new one

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/reducer/TabListReducerTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/reducer/TabListReducerTest.kt
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.reducer
+
+import mozilla.components.browser.state.action.TabListAction
+import mozilla.components.browser.state.selector.findTab
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+private val tab1 = TabSessionState(id = "tab1", content = mock())
+private val tab2 = TabSessionState(id = "tab2", content = mock(), parentId = tab1.id)
+private val tab3 = TabSessionState(id = "tab3", content = mock(), parentId = tab2.id)
+private val tab4 = TabSessionState(id = "tab4", content = mock(), parentId = tab3.id)
+
+class TabListReducerTest {
+    @Test
+    fun `GIVEN a tab which doesn't exist in state WHEN RemoveTabAction is called for it THEN the state is not updated`() {
+        val state = BrowserState(tabs = listOf(tab3))
+
+        var result = TabListReducer.reduce(state, TabListAction.RemoveTabAction("random1", true))
+        assertSame(state, result)
+
+        result = TabListReducer.reduce(state, TabListAction.RemoveTabAction("random2", false))
+        assertSame(state, result)
+    }
+
+    @Test
+    fun `GIVEN a list of tabs WHEN RemoveTabAction is called for one THEN return all but the one removed`() {
+        val initialTabs = listOf(tab1, tab2, tab3, tab4)
+        val state = BrowserState(initialTabs)
+
+        var result = TabListReducer.reduce(state, TabListAction.RemoveTabAction(tab3.id, true))
+        // Verifying the ids since the tabs are reparented so object equality fails.
+        assertEquals((initialTabs - tab3).map { it.id }, result.tabs.map { it.id })
+
+        result = TabListReducer.reduce(state, TabListAction.RemoveTabAction(tab2.id, false))
+        assertEquals((initialTabs - tab2).map { it.id }, result.tabs.map { it.id })
+    }
+
+    @Test
+    fun `GIVEN a tab is the parent of other WHEN RemoveTabAction is called for the parent THEN reparent other to it's grandparent`() {
+        val initialTabs = listOf(tab1, tab2, tab3, tab4)
+        val state = BrowserState(initialTabs)
+
+        var result = TabListReducer.reduce(state, TabListAction.RemoveTabAction(tab3.id, true))
+        assertEquals(tab2.id, result.findTab(tab4.id)!!.parentId)
+
+        result = TabListReducer.reduce(state, TabListAction.RemoveTabAction(tab2.id, false))
+        assertEquals(tab1.id, result.findTab(tab3.id)!!.parentId)
+    }
+
+    @Test
+    fun `GIVEN a tab with no parent WHEN RemoveTabAction is called for it THEN don't reparent any`() {
+        val noParentTab = TabSessionState(content = mock())
+        val initialTabs = listOf(tab1, tab2, noParentTab, tab3, tab4)
+        val state = BrowserState(initialTabs)
+
+        var result = TabListReducer.reduce(state, TabListAction.RemoveTabAction(noParentTab.id, true))
+        assertEquals(tab1.id, result.findTab(tab2.id)!!.parentId)
+        assertEquals(tab2.id, result.findTab(tab3.id)!!.parentId)
+        assertEquals(tab3.id, result.findTab(tab4.id)!!.parentId)
+
+        result = TabListReducer.reduce(state, TabListAction.RemoveTabAction(noParentTab.id, false))
+        assertEquals(tab1.id, result.findTab(tab2.id)!!.parentId)
+        assertEquals(tab2.id, result.findTab(tab3.id)!!.parentId)
+        assertEquals(tab3.id, result.findTab(tab4.id)!!.parentId)
+    }
+
+    @Test
+    fun `GIVEN a list of tabs WHEN RemoveTabAction is called for other than the selected one THEN keep the selection`() {
+        val initialTabs = listOf(tab1, tab2, tab3, tab4)
+        val state = BrowserState(initialTabs, selectedTabId = tab2.id)
+
+        var result = TabListReducer.reduce(state, TabListAction.RemoveTabAction(tab1.id, true))
+        assertEquals(tab2.id, result.selectedTabId)
+
+        result = TabListReducer.reduce(state, TabListAction.RemoveTabAction(tab1.id, false))
+        assertEquals(tab2.id, result.selectedTabId)
+    }
+
+    @Test
+    fun `GIVEN a list of tabs WHEN RemoveTabAction is called for the currently selected one with selectParentIfExists THEN select the parent`() {
+        val initialTabs = listOf(tab1, tab2, tab3, tab4)
+        val state = BrowserState(initialTabs, selectedTabId = tab3.id)
+
+        val result = TabListReducer.reduce(state, TabListAction.RemoveTabAction(tab3.id, true))
+
+        assertEquals(tab2.id, result.selectedTabId)
+    }
+
+    @Test
+    fun `GIVEN a list of tabs WHEN RemoveTabAction is called for the currently selected one with selectParentIfExists false THEN select another`() {
+        val initialTabs = listOf(tab1, tab2, tab3, tab4)
+        val state = BrowserState(initialTabs, selectedTabId = tab3.id)
+
+        val result = TabListReducer.reduce(state, TabListAction.RemoveTabAction(tab3.id, false))
+
+        assertNotEquals(tab2.id, result.selectedTabId)
+    }
+
+    @Test
+    fun `GIVEN a list of tabs WHEN RemoveTabAction is called for the currently selected one no parent and selectParentIfExists THEN select another`() {
+        val noParentTab = TabSessionState(content = mock())
+        val initialTabs = listOf(tab1, tab2, noParentTab, tab3, tab4)
+        val state = BrowserState(initialTabs, selectedTabId = noParentTab.id)
+
+        val result = TabListReducer.reduce(state, TabListAction.RemoveTabAction(noParentTab.id, false))
+
+        assertNotNull(result.selectedTabId)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@ permalink: /changelog/
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
 * **browser-state**
-  *  🚒 Bug fixed [issue #11209](https://github.com/mozilla-mobile/android-components/issues/11209) - Keep the selected tab selected when others are removed.
+  *  🚒 Bug fixed [issue #11209](https://github.com/mozilla-mobile/android-components/issues/11209) - Keep the selected tab selected when others are removed and stay in the same mode (private / normal) when removing the currently selected tab.
 
 * **browser-engine-gecko**:
   * Removes deprecated `GeckoLoginDelegateWrapper`. Please use `GeckoAutocompleteStorageDelegate`. [#11311](https://github.com/mozilla-mobile/android-components/issues/11311)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **browser-state**
+  *  🚒 Bug fixed [issue #11209](https://github.com/mozilla-mobile/android-components/issues/11209) - Keep the selected tab selected when others are removed.
+
 * **browser-engine-gecko**:
   * Removes deprecated `GeckoLoginDelegateWrapper`. Please use `GeckoAutocompleteStorageDelegate`. [#11311](https://github.com/mozilla-mobile/android-components/issues/11311)
   * Added setting for HTTPS-Only mode [#5935](https://github.com/mozilla-mobile/focus-android/issues/5935)


### PR DESCRIPTION
Keep the selected tab selected when others are removed and stay in the same mode (private / normal) when removing the currently selected tab.



https://user-images.githubusercontent.com/11428869/139903014-88150380-8ff7-4798-8c63-666e75a428cf.mov



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
