### PR TITLE
[Don't merge] Use registerWithSyncManager for places (#10128)

### DIFF
--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Connection.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Connection.kt
@@ -27,12 +27,7 @@ const val DB_NAME = "places.sqlite"
  * Writer is always the same, as guaranteed by [PlacesApi].
  */
 internal interface Connection : Closeable {
-    /**
-     * This should be removed. See: https://github.com/mozilla/application-services/issues/1877
-     *
-     * @return raw internal handle that could be used for referencing underlying [PlacesApi]. Use it with SyncManager.
-     */
-    fun getHandle(): Long
+    fun registerWithSyncManager()
 
     fun reader(): PlacesReaderConnection
     fun writer(): PlacesWriterConnection
@@ -81,10 +76,10 @@ internal object RustPlacesConnection : Connection {
         cachedReader = api!!.openReader()
     }
 
-    override fun getHandle(): Long {
+    override fun registerWithSyncManager() {
         val api = safeGetApi()
         check(api != null) { "must call init first" }
-        return api.getHandle()
+        api.registerWithSyncManager()
     }
 
     override fun reader(): PlacesReaderConnection = synchronized(this) {

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorage.kt
@@ -209,15 +209,6 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
         return places.readPinnedSitesFromFennec(dbPath)
     }
 
-    /**
-     * This should be removed. See: https://github.com/mozilla/application-services/issues/1877
-     *
-     * @return raw internal handle that could be used for referencing underlying [PlacesApi]. Use it with SyncManager.
-     */
-    override fun getHandle(): Long {
-        throw NotImplementedError("Use registerWithSyncManager instead")
-    }
-
     override fun registerWithSyncManager() {
         places.registerWithSyncManager()
     }

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorage.kt
@@ -215,11 +215,10 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
      * @return raw internal handle that could be used for referencing underlying [PlacesApi]. Use it with SyncManager.
      */
     override fun getHandle(): Long {
-        return places.getHandle()
+        throw NotImplementedError("Use registerWithSyncManager instead")
     }
 
     override fun registerWithSyncManager() {
-        // See https://github.com/mozilla-mobile/android-components/issues/10128
-        throw NotImplementedError("Use getHandle instead")
+        places.registerWithSyncManager()
     }
 }

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
@@ -238,12 +238,11 @@ open class PlacesHistoryStorage(
      * @return raw internal handle that could be used for referencing underlying [PlacesApi]. Use it with SyncManager.
      */
     override fun getHandle(): Long {
-        return places.getHandle()
+        throw NotImplementedError("Use registerWithSyncManager instead")
     }
 
     override fun registerWithSyncManager() {
-        // See https://github.com/mozilla-mobile/android-components/issues/10128
-        throw NotImplementedError("Use getHandle instead")
+        return places.registerWithSyncManager()
     }
 
     override suspend fun getLatestHistoryMetadataForUrl(url: String): HistoryMetadata? {

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
@@ -232,15 +232,6 @@ open class PlacesHistoryStorage(
         return places.importVisitsFromFennec(dbPath)
     }
 
-    /**
-     * This should be removed. See: https://github.com/mozilla/application-services/issues/1877
-     *
-     * @return raw internal handle that could be used for referencing underlying [PlacesApi]. Use it with SyncManager.
-     */
-    override fun getHandle(): Long {
-        throw NotImplementedError("Use registerWithSyncManager instead")
-    }
-
     override fun registerWithSyncManager() {
         return places.registerWithSyncManager()
     }

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/RemoteTabsStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/RemoteTabsStorage.kt
@@ -86,10 +86,6 @@ open class RemoteTabsStorage(
         scope.coroutineContext.cancelChildren()
     }
 
-    override fun getHandle(): Long {
-        throw NotImplementedError("use registerWithSyncManager instead")
-    }
-
     override fun registerWithSyncManager() {
         return api.registerWithSyncManager()
     }

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
@@ -602,11 +602,6 @@ class PlacesHistoryStorageTest {
                 fail()
             }
 
-            override fun getHandle(): Long {
-                fail()
-                return 0L
-            }
-
             override fun importVisitsFromFennec(dbPath: String): JSONObject {
                 fail()
                 return JSONObject()
@@ -654,11 +649,6 @@ class PlacesHistoryStorageTest {
 
             override fun syncBookmarks(syncInfo: SyncAuthInfo) {}
 
-            override fun getHandle(): Long {
-                fail()
-                return 0L
-            }
-
             override fun importVisitsFromFennec(dbPath: String): JSONObject {
                 fail()
                 return JSONObject()
@@ -704,11 +694,6 @@ class PlacesHistoryStorageTest {
 
             override fun syncBookmarks(syncInfo: SyncAuthInfo) {
                 fail()
-            }
-
-            override fun getHandle(): Long {
-                fail()
-                return 0L
             }
 
             override fun importVisitsFromFennec(dbPath: String): JSONObject {
@@ -760,11 +745,6 @@ class PlacesHistoryStorageTest {
 
             override fun syncBookmarks(syncInfo: SyncAuthInfo) {
                 fail()
-            }
-
-            override fun getHandle(): Long {
-                fail()
-                return 0L
             }
 
             override fun importVisitsFromFennec(dbPath: String): JSONObject {

--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/Sync.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/Sync.kt
@@ -47,14 +47,7 @@ data class SyncAuthInfo(
  */
 interface SyncableStore {
     /**
-     * This should be removed. See: https://github.com/mozilla/application-services/issues/1877
-     *
-     * @return raw internal handle that could be used for referencing underlying [PlacesApi]. Use it with SyncManager.
-     */
-    fun getHandle(): Long
-
-    /**
-     * Registers this storage with a sync manager. Replaces [getHandle] for newer storage layers.
+     * Registers this storage with a sync manager.
      */
     fun registerWithSyncManager()
 }

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
@@ -329,9 +329,8 @@ internal class WorkManagerSyncWorker(
             // We're assuming all syncable stores live in Rust.
             // Currently `RustSyncManager` doesn't support non-Rust sync engines.
             when (it.key) {
-                // NB: History and Bookmarks will have the same handle.
-                SyncEngine.History -> RustSyncManager.setPlaces(it.value.lazyStore.value.getHandle())
-                SyncEngine.Bookmarks -> RustSyncManager.setPlaces(it.value.lazyStore.value.getHandle())
+                SyncEngine.History -> it.value.lazyStore.value.registerWithSyncManager()
+                SyncEngine.Bookmarks -> it.value.lazyStore.value.registerWithSyncManager()
 
                 // These stores don't expose `getHandle` (yay!), and instead are able to handle
                 // sync manager registration on their own.

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
@@ -331,9 +331,6 @@ internal class WorkManagerSyncWorker(
             when (it.key) {
                 SyncEngine.History -> it.value.lazyStore.value.registerWithSyncManager()
                 SyncEngine.Bookmarks -> it.value.lazyStore.value.registerWithSyncManager()
-
-                // These stores don't expose `getHandle` (yay!), and instead are able to handle
-                // sync manager registration on their own.
                 SyncEngine.CreditCards -> {
                     it.value.lazyStore.value.registerWithSyncManager()
 

--- a/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorage.kt
+++ b/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorage.kt
@@ -185,10 +185,6 @@ class AutofillCreditCardsAddressesStorage(
         conn.getStorage().registerWithSyncManager()
     }
 
-    override fun getHandle(): Long {
-        throw NotImplementedError("Use registerWithSyncManager instead")
-    }
-
     override fun close() {
         coroutineContext.cancel()
         conn.close()

--- a/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/SyncableLoginsStorage.kt
+++ b/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/SyncableLoginsStorage.kt
@@ -235,10 +235,6 @@ class SyncableLoginsStorage(
         conn.getStorage().registerWithSyncManager()
     }
 
-    override fun getHandle(): Long {
-        throw NotImplementedError("Use registerWithSyncManager instead")
-    }
-
     /**
      * @throws [CryptoException] invalid encryption key
      * @throws [LoginsStorageException] If DB isn't empty during an import; also, on unexpected errors


### PR DESCRIPTION
This one switches over to using `registerWithSyncManager` for places syncing.  It depends on ~mozilla/application-services#4627~ https://github.com/mozilla/application-services/pull/4634.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
