### PR TITLE
Change Move Tab API

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -153,19 +153,16 @@ sealed class TabListAction : BrowserAction() {
     data class AddMultipleTabsAction(val tabs: List<TabSessionState>) : TabListAction()
 
     /**
-     * Moves a set of tabIDs into a new position (maintaining internal ordering)
+     * Moves a tab into a new position
      *
-     * @property tabIds The IDs of the tabs to move.
-     * @property targetTabId A tab that the moved tabs will be moved next to
-     * @property placeAfter True if the moved tabs should be placed after the target,
-     * False for placing before the target. Irrelevant if the target is one of the tabs being moved,
-     * since then the whole list is moved to where the target was. Ordering of the moved tabs
-     * relative to each other is preserved.
+     * @property tabId The IDs of the tab to move.
+     * @property targetTabId The moved tab will replace the position of the target.
+     * Before/After determined by the original position of the moved tab,
+     * pushing the target towards the original tab's position.
      */
     data class MoveTabsAction(
-        val tabIds: List<String>,
+        val tabId: String,
         val targetTabId: String,
-        val placeAfter: Boolean,
     ) : TabListAction()
 
     /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TabListReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TabListReducer.kt
@@ -68,15 +68,11 @@ internal object TabListReducer {
                 if (tabTarget == null) {
                     state
                 } else {
-                    val targetPosition = state.tabs.indexOf(tabTarget) + (if (action.placeAfter) 1 else 0)
-                    val positionOffset = state.tabs.filterIndexed { index, tab ->
-                        (index < targetPosition && tab.id in action.tabIds)
-                    }.count()
-                    val finalPos = targetPosition - positionOffset
-                    val (movedTabs, unmovedTabs) = state.tabs.partition { it.id in action.tabIds }
-                    val updatedTabList = unmovedTabs.subList(0, finalPos) +
-                        movedTabs +
-                        unmovedTabs.subList(finalPos, unmovedTabs.size)
+                    val targetPosition = state.tabs.indexOf(tabTarget)
+                    val (movedTab, unmovedTabs) = state.tabs.partition { it.id == action.tabId }
+                    val updatedTabList = unmovedTabs.subList(0, targetPosition) +
+                        movedTab +
+                        unmovedTabs.subList(targetPosition, unmovedTabs.size)
 
                     state.copy(tabs = updatedTabList)
                 }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/TabListActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/TabListActionTest.kt
@@ -1189,10 +1189,10 @@ class TabListActionTest {
         val bMap = b.map { "<" + it.id + "," + it.content.url + ">\n" }
         assertEquals(str, aMap.toString(), bMap.toString())
     }
-    private fun dispatchJoinMoveAction(store: BrowserStore, tabIds: List<String>, targetTabId: String, placeAfter: Boolean) {
+    private fun dispatchJoinMoveAction(store: BrowserStore, tabId: String, targetTabId: String) {
         store.dispatch(
             TabListAction.MoveTabsAction(
-                tabIds, targetTabId, placeAfter
+                tabId, targetTabId
             )
         ).joinBlocking()
     }
@@ -1211,28 +1211,13 @@ class TabListActionTest {
             )
         )
 
-        dispatchJoinMoveAction(store, listOf("a"), "a", false)
-        assertSameTabs(store, tabList, "a to a-")
-        dispatchJoinMoveAction(store, listOf("a"), "a", true)
-        assertSameTabs(store, tabList, "a to a+")
-        dispatchJoinMoveAction(store, listOf("a"), "b", false)
-        assertSameTabs(store, tabList, "a to b-")
-
-        dispatchJoinMoveAction(store, listOf("a", "b"), "a", false)
-        assertSameTabs(store, tabList, "a,b to a-")
-        dispatchJoinMoveAction(store, listOf("a", "b"), "a", true)
-        assertSameTabs(store, tabList, "a,b to a+")
-        dispatchJoinMoveAction(store, listOf("a", "b"), "b", false)
-        assertSameTabs(store, tabList, "a,b to b-")
-        dispatchJoinMoveAction(store, listOf("a", "b"), "b", true)
-        assertSameTabs(store, tabList, "a,b to b+")
-        dispatchJoinMoveAction(store, listOf("a", "b"), "c", false)
-        assertSameTabs(store, tabList, "a,b to c-")
-
-        dispatchJoinMoveAction(store, listOf("c", "d"), "c", false)
-        assertSameTabs(store, tabList, "c,d to c-")
-        dispatchJoinMoveAction(store, listOf("c", "d"), "d", true)
-        assertSameTabs(store, tabList, "c,d to d+")
+        dispatchJoinMoveAction(store, "a", "a")
+        assertSameTabs(store, tabList, "a to a")
+        dispatchJoinMoveAction(store, "d", "d")
+        assertSameTabs(store, tabList, "d to d")
+        dispatchJoinMoveAction(store, "a", "b")
+        dispatchJoinMoveAction(store, "a", "b")
+        assertSameTabs(store, tabList, "a to b x2")
 
         val movedTabList = listOf(
             createTab(id = "b", url = "https://www.firefox.com"),
@@ -1240,49 +1225,18 @@ class TabListActionTest {
             createTab(id = "a", url = "https://www.mozilla.org"),
             createTab(id = "d", url = "https://www.example.org"),
         )
-        dispatchJoinMoveAction(store, listOf("a"), "d", false)
-        assertSameTabs(store, movedTabList, "a to d-")
-        dispatchJoinMoveAction(store, listOf("b", "c"), "a", true)
-        assertSameTabs(store, tabList, "b,c to a+")
+        dispatchJoinMoveAction(store, "a", "c")
+        assertSameTabs(store, movedTabList, "a to c")
+        dispatchJoinMoveAction(store, "a", "b")
+        assertSameTabs(store, tabList, "a back to b")
 
-        dispatchJoinMoveAction(store, listOf("a", "d"), "c", true)
-        assertSameTabs(store, movedTabList, "a,d to c+")
+        dispatchJoinMoveAction(store, "a", "b")
+        dispatchJoinMoveAction(store, "a", "c")
+        assertSameTabs(store, movedTabList, "a to b, to c")
 
-        dispatchJoinMoveAction(store, listOf("b", "c"), "d", false)
-        assertSameTabs(store, tabList, "b,c to d-")
+        dispatchJoinMoveAction(store, "a", "b")
+        assertSameTabs(store, tabList, "a back to b")
+
         assertEquals("a", store.state.selectedTabId)
-    }
-    @Test
-    fun `MoveTabsAction - Complex moves work`() {
-        val tabList = listOf(
-            createTab(id = "a", url = "https://www.mozilla.org"),
-            createTab(id = "b", url = "https://www.firefox.com"),
-            createTab(id = "c", url = "https://getpocket.com"),
-            createTab(id = "d", url = "https://www.example.org"),
-            createTab(id = "e", url = "https://www.mozilla.org/en-US/firefox/features/"),
-            createTab(id = "f", url = "https://www.mozilla.org/en-US/firefox/products/"),
-        )
-        val store = BrowserStore(
-            BrowserState(
-                tabs = tabList,
-                selectedTabId = "a"
-            )
-        )
-        dispatchJoinMoveAction(store, listOf("a", "b", "c", "d", "e", "f",), "a", false)
-        assertSameTabs(store, tabList, "all to a-")
-
-        val movedTabList = listOf(
-            createTab(id = "a", url = "https://www.mozilla.org"),
-            createTab(id = "c", url = "https://getpocket.com"),
-            createTab(id = "b", url = "https://www.firefox.com"),
-            createTab(id = "e", url = "https://www.mozilla.org/en-US/firefox/features/"),
-            createTab(id = "d", url = "https://www.example.org"),
-            createTab(id = "f", url = "https://www.mozilla.org/en-US/firefox/products/"),
-        )
-        dispatchJoinMoveAction(store, listOf("b", "e"), "d", false)
-        assertSameTabs(store, movedTabList, "b,e to d-")
-
-        dispatchJoinMoveAction(store, listOf("c", "d"), "b", true)
-        assertSameTabs(store, tabList, "c,d to b+")
     }
 }

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
@@ -485,23 +485,20 @@ class TabsUseCases(
         private val store: BrowserStore
     ) {
         /**
-         * Moves the tabs of [tabIds] next to [targetTabId], before/after based on [placeAfter]
+         * Moves a tab into a new position
          *
-         * @property tabIds The IDs of the tabs to move.
-         * @property targetTabId A tab that the moved tabs will be moved next to
-         * @property placeAfter True if the moved tabs should be placed after the target,
-         * False for placing before the target. Irrelevant if the target is one of the tabs being moved,
-         * since then the whole list is moved to where the target was. Ordering of the moved tabs
-         * relative to each other is preserved.
+         * @property tabId The IDs of the tab to move.
+         * @property targetTabId The moved tab will replace the position of the target.
+         * Before/After determined by the original position of the moved tab,
+         * pushing the target towards the original tab's position.
          */
         operator fun invoke(
-            tabIds: List<String>,
+            tabId: String,
             targetTabId: String,
-            placeAfter: Boolean
         ) {
             store.dispatch(
                 TabListAction.MoveTabsAction(
-                    tabIds, targetTabId, placeAfter
+                    tabId, targetTabId
                 )
             )
         }

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
@@ -523,11 +523,18 @@ class TabsUseCasesTest {
         assertEquals("https://mozilla.org", store.state.tabs[0].content.url)
         assertEquals("https://firefox.com", store.state.tabs[1].content.url)
 
+        // Check a swap
         val tab1Id = store.state.tabs[0].id
         val tab2Id = store.state.tabs[1].id
-        tabsUseCases.moveTabs(listOf(tab1Id), tab2Id, true)
+        tabsUseCases.moveTabs(tab1Id, tab2Id)
         store.waitUntilIdle()
         assertEquals("https://firefox.com", store.state.tabs[0].content.url)
         assertEquals("https://mozilla.org", store.state.tabs[1].content.url)
+
+        // Check a swap back
+        tabsUseCases.moveTabs(tab1Id, tab2Id)
+        store.waitUntilIdle()
+        assertEquals("https://mozilla.org", store.state.tabs[0].content.url)
+        assertEquals("https://firefox.com", store.state.tabs[1].content.url)
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,10 @@ permalink: /changelog/
 * [Dependencies](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Dependencies.kt)
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
-
+  
+* **BrowserAction**, **TabListReducer**, **TabsUseCases**:
+  * ⚠ Change API of MoveTabs (reordering) Action and UseCase
+  
 # 95.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v94.0.0...v95.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/142?closed=1)


### PR DESCRIPTION
EDIT: Hold on, don't merge this yet. I'm running into some animation issues that I might not be able to resolve without reverting to the before/after target setup despite its extra complications.

The UI for tab reordering isn't going to support multi-tab movement and is easier to code with a "Replace the target's position" design rather than the previous "Place before/after target". This means that before/after is determined based on the source tab's current position.

Since I don't think anyone else has used the API yet I'm replacing them. Tests are significantly simplified since without multi-tab movement there aren't as many cases to check.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
