### PR TITLE
Close #11234: Re-introduce close support in TabsFeature

### DIFF
--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsAdapter.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsAdapter.kt
@@ -23,7 +23,6 @@ typealias ViewHolderProvider = (ViewGroup) -> TabViewHolder
  * @param viewHolderProvider a function that creates a [TabViewHolder].
  * @param styling the default styling for the [TabsTrayStyling].
  * @param delegate a delegate to handle interactions in the tabs tray.
- * @param onCloseTray a callback invoked when the last tab is closed.
  */
 open class TabsAdapter(
     thumbnailLoader: ImageLoader? = null,
@@ -35,10 +34,8 @@ open class TabsAdapter(
     },
     private val styling: TabsTrayStyling = TabsTrayStyling(),
     private val delegate: TabsTray.Delegate,
-    private val onCloseTray: () -> Unit = {}
 ) : ListAdapter<TabSessionState, TabViewHolder>(DiffCallback), TabsTray {
 
-    private var previouslyOpened: Boolean = false
     private var selectedTabId: String? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TabViewHolder {
@@ -74,13 +71,7 @@ open class TabsAdapter(
     }
 
     override fun updateTabs(tabs: List<TabSessionState>, selectedTabId: String?) {
-        if (tabs.isEmpty() && previouslyOpened) {
-            onCloseTray.invoke()
-            return
-        }
-
         this.selectedTabId = selectedTabId
-        this.previouslyOpened = true
 
         submitList(tabs)
     }

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsFeature.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsFeature.kt
@@ -16,18 +16,21 @@ import mozilla.components.support.base.feature.LifecycleAwareFeature
  *
  * @param defaultTabsFilter A tab filter that is used for the initial presenting of tabs that will be used by
  * [TabsFeature.filterTabs] by default as well.
+ * @param onCloseTray a callback invoked when the last tab is closed.
  */
 @Suppress("LongParameterList")
 class TabsFeature(
     private val tabsTray: TabsTray,
     private val store: BrowserStore,
+    private val onCloseTray: () -> Unit = {},
     private val defaultTabsFilter: (TabSessionState) -> Boolean = { true }
 ) : LifecycleAwareFeature {
     @VisibleForTesting
     internal var presenter = TabsTrayPresenter(
         tabsTray,
         store,
-        defaultTabsFilter
+        defaultTabsFilter,
+        onCloseTray
     )
 
     override fun start() {

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/TabsTrayFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/TabsTrayFragment.kt
@@ -59,6 +59,7 @@ class TabsTrayFragment : Fragment(), UserInteractionHandler {
             feature = TabsFeature(
                 tabsTray = tabsAdapter,
                 store = components.store,
+                onCloseTray = ::closeTabsTray
             ),
             owner = this,
             view = view
@@ -94,9 +95,6 @@ class TabsTrayFragment : Fragment(), UserInteractionHandler {
                 override fun onTabClosed(tab: TabSessionState, source: String?) {
                     removeUseCase.invoke(tab.id)
                 }
-            },
-            onCloseTray = {
-                closeTabsTray()
             }
         )
     }


### PR DESCRIPTION
This fixes the perma-fail tests in https://github.com/mozilla-mobile/reference-browser/issues/1705

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
