### PR TITLE
Closes #3784: Properly distinguish between source and target of redirects

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -708,7 +708,7 @@ class GeckoEngineSession(
                     RedirectSource.PERMANENT
                 flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE != 0 ->
                     RedirectSource.TEMPORARY
-                else -> RedirectSource.NOT_A_SOURCE
+                else -> null
             }
 
             val delegate = settings.historyTrackingDelegate ?: return GeckoResult.fromValue(false)

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -682,26 +682,26 @@ class GeckoEngineSession(
 
             val isReload = lastVisitedURL?.let { it == url } ?: false
 
-            val visitType = if (isReload) {
-                VisitType.RELOAD
-            } else {
-                // Note the difference between `VISIT_REDIRECT_PERMANENT`,
-                // `VISIT_REDIRECT_TEMPORARY`, `VISIT_REDIRECT_SOURCE`, and
-                // `VISIT_REDIRECT_SOURCE_PERMANENT`.
-                //
-                // The former two indicate if the visited page is the *target*
-                // of a redirect; that is, another page redirected to it.
-                //
-                // The latter two indicate if the visited page is the *source*
-                // of a redirect: it's redirecting to another page, because the
-                // server returned an HTTP 3xy status code.
-                if (flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_PERMANENT != 0) {
+            // Note the difference between `VISIT_REDIRECT_PERMANENT`,
+            // `VISIT_REDIRECT_TEMPORARY`, `VISIT_REDIRECT_SOURCE`, and
+            // `VISIT_REDIRECT_SOURCE_PERMANENT`.
+            //
+            // The former two indicate if the visited page is the *target*
+            // of a redirect; that is, another page redirected to it.
+            //
+            // The latter two indicate if the visited page is the *source*
+            // of a redirect: it's redirecting to another page, because the
+            // server returned an HTTP 3xy status code.
+            //
+            // So, we mark the **source** redirects as actual redirects, while treating **target**
+            // redirects as normal visits.
+            val visitType = when {
+                isReload -> VisitType.RELOAD
+                flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE_PERMANENT != 0 ->
                     VisitType.REDIRECT_PERMANENT
-                } else if (flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_TEMPORARY != 0) {
+                flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE != 0 ->
                     VisitType.REDIRECT_TEMPORARY
-                } else {
-                    VisitType.LINK
-                }
+                else -> VisitType.LINK
             }
             val redirectSource = when {
                 flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE_PERMANENT != 0 ->

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -890,28 +890,6 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `does not notify configured history delegate for redirects`() = runBlockingTest {
-        val engineSession = GeckoEngineSession(
-            mock(),
-            geckoSessionProvider = geckoSessionProvider,
-            context = coroutineContext
-        )
-        val historyTrackingDelegate: HistoryTrackingDelegate = mock()
-
-        captureDelegates()
-
-        // Nothing breaks if history delegate isn't configured.
-        historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
-        engineSession.job.children.forEach { it.join() }
-
-        engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
-
-        historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", null, GeckoSession.HistoryDelegate.VISIT_REDIRECT_TEMPORARY)
-        engineSession.job.children.forEach { it.join() }
-        verify(historyTrackingDelegate, never()).onVisited(anyString(), any())
-    }
-
-    @Test
     fun `does not notify configured history delegate for top-level visits to error pages`() = runBlockingTest {
         val engineSession = GeckoEngineSession(
             mock(),
@@ -1019,7 +997,7 @@ class GeckoEngineSessionTest {
         )
 
         engineSession.job.children.forEach { it.join() }
-        verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/tempredirect"), eq(PageVisit(VisitType.LINK, RedirectSource.TEMPORARY)))
+        verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/tempredirect"), eq(PageVisit(VisitType.REDIRECT_TEMPORARY, RedirectSource.TEMPORARY)))
 
         historyDelegate.value.onVisited(
             geckoSession,
@@ -1030,7 +1008,7 @@ class GeckoEngineSessionTest {
         )
 
         engineSession.job.children.forEach { it.join() }
-        verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/permredirect"), eq(PageVisit(VisitType.LINK, RedirectSource.PERMANENT)))
+        verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/permredirect"), eq(PageVisit(VisitType.REDIRECT_PERMANENT, RedirectSource.PERMANENT)))
 
         // Visits below are targets of redirects, not redirects themselves.
         // Check that they're mapped to "link".
@@ -1043,7 +1021,7 @@ class GeckoEngineSessionTest {
         )
 
         engineSession.job.children.forEach { it.join() }
-        verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targettemp"), eq(PageVisit(VisitType.REDIRECT_TEMPORARY, RedirectSource.NOT_A_SOURCE)))
+        verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targettemp"), eq(PageVisit(VisitType.LINK)))
 
         historyDelegate.value.onVisited(
             geckoSession,
@@ -1054,7 +1032,7 @@ class GeckoEngineSessionTest {
         )
 
         engineSession.job.children.forEach { it.join() }
-        verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targetperm"), eq(PageVisit(VisitType.REDIRECT_PERMANENT, RedirectSource.NOT_A_SOURCE)))
+        verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targetperm"), eq(PageVisit(VisitType.LINK)))
     }
 
     @Test

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -901,8 +901,13 @@ class GeckoEngineSessionTest {
         captureDelegates()
 
         engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
+        whenever(historyTrackingDelegate.shouldStoreUri(any())).thenReturn(true)
 
-        historyDelegate.value.onVisited(geckoSession, "about:neterror", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL or GeckoSession.HistoryDelegate.VISIT_UNRECOVERABLE_ERROR)
+        historyDelegate.value.onVisited(
+            geckoSession, "about:neterror", null,
+            GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL
+                or GeckoSession.HistoryDelegate.VISIT_UNRECOVERABLE_ERROR
+        )
         engineSession.job.children.forEach { it.join() }
         verify(historyTrackingDelegate, never()).onVisited(anyString(), any())
     }
@@ -923,7 +928,7 @@ class GeckoEngineSessionTest {
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
         engineSession.job.children.forEach { it.join() }
-        verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE)))
+        verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.LINK)))
     }
 
     @Test
@@ -942,7 +947,7 @@ class GeckoEngineSessionTest {
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", "https://www.mozilla.com", GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
         engineSession.job.children.forEach { it.join() }
-        verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE)))
+        verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.RELOAD)))
     }
 
     @Test
@@ -964,7 +969,7 @@ class GeckoEngineSessionTest {
 
         engineSession.job.children.forEach { it.join() }
         verify(historyTrackingDelegate).shouldStoreUri("https://www.mozilla.com/allowed")
-        verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/allowed"), eq(PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE)))
+        verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/allowed"), eq(PageVisit(VisitType.LINK)))
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com/not-allowed", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
 

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -60,7 +60,6 @@ import mozilla.components.concept.engine.request.RequestInterceptor.Interception
 import mozilla.components.concept.engine.selection.SelectionActionDelegate
 import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.concept.storage.PageVisit
-import mozilla.components.concept.storage.RedirectSource
 import mozilla.components.concept.storage.VisitType
 import mozilla.components.support.ktx.android.view.getRectWithViewLocation
 import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
@@ -161,10 +160,7 @@ class SystemEngineView @JvmOverloads constructor(
             }
 
             runBlocking {
-                session?.settings?.historyTrackingDelegate?.onVisited(
-                    url,
-                    PageVisit(visitType, RedirectSource.NOT_A_SOURCE)
-                )
+                session?.settings?.historyTrackingDelegate?.onVisited(url, PageVisit(visitType))
             }
         }
 

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
@@ -45,7 +45,6 @@ import mozilla.components.concept.engine.request.RequestInterceptor
 import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.concept.fetch.Response
 import mozilla.components.concept.storage.PageVisit
-import mozilla.components.concept.storage.RedirectSource
 import mozilla.components.concept.storage.VisitType
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
@@ -302,10 +301,10 @@ class SystemEngineViewTest {
         whenever(historyDelegate.shouldStoreUri(any())).thenReturn(true)
 
         engineSession.webView.webViewClient.doUpdateVisitedHistory(webView, "https://www.mozilla.com", false)
-        verify(historyDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE)))
+        verify(historyDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.LINK)))
 
         engineSession.webView.webViewClient.doUpdateVisitedHistory(webView, "https://www.mozilla.com", true)
-        verify(historyDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE)))
+        verify(historyDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.RELOAD)))
     }
 
     @Test
@@ -322,7 +321,7 @@ class SystemEngineViewTest {
 
         // Verify that engine session asked delegate if uri should be stored.
         engineSession.webView.webViewClient.doUpdateVisitedHistory(webView, "https://www.mozilla.com", false)
-        verify(historyDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE)))
+        verify(historyDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.LINK)))
         verify(historyDelegate).shouldStoreUri("https://www.mozilla.com")
 
         // Verify that engine won't try to store a uri that delegate doesn't want.

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
@@ -53,14 +53,8 @@ open class PlacesHistoryStorage(
                     VisitObservation(
                         uri,
                         visitType = visit.visitType.into(),
-                        isRedirectSource = when (visit.redirectSource) {
-                            RedirectSource.PERMANENT, RedirectSource.TEMPORARY -> true
-                            RedirectSource.NOT_A_SOURCE -> false
-                        },
-                        isPermanentRedirectSource = when (visit.redirectSource) {
-                            RedirectSource.PERMANENT -> true
-                            RedirectSource.TEMPORARY, RedirectSource.NOT_A_SOURCE -> false
-                        }
+                        isRedirectSource = visit.redirectSource != null,
+                        isPermanentRedirectSource = visit.redirectSource == RedirectSource.PERMANENT
                     )
                 )
             }

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
@@ -19,7 +19,6 @@ import mozilla.components.concept.storage.HistoryMetadataKey
 import mozilla.components.concept.storage.HistoryMetadataObservation
 import mozilla.components.concept.storage.PageObservation
 import mozilla.components.concept.storage.PageVisit
-import mozilla.components.concept.storage.RedirectSource
 import mozilla.components.concept.storage.VisitType
 import mozilla.components.concept.sync.SyncAuthInfo
 import mozilla.components.concept.sync.SyncStatus
@@ -55,15 +54,15 @@ class PlacesHistoryStorageTest {
 
     @Test
     fun `storage allows recording and querying visits of different types`() = runBlocking {
-        history.recordVisit("http://www.firefox.com/1", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.firefox.com/2", PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.firefox.com/3", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.firefox.com/4", PageVisit(VisitType.REDIRECT_TEMPORARY, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.firefox.com/5", PageVisit(VisitType.REDIRECT_PERMANENT, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.firefox.com/6", PageVisit(VisitType.FRAMED_LINK, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.firefox.com/7", PageVisit(VisitType.EMBED, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.firefox.com/8", PageVisit(VisitType.BOOKMARK, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.firefox.com/9", PageVisit(VisitType.DOWNLOAD, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com/1", PageVisit(VisitType.LINK))
+        history.recordVisit("http://www.firefox.com/2", PageVisit(VisitType.RELOAD))
+        history.recordVisit("http://www.firefox.com/3", PageVisit(VisitType.TYPED))
+        history.recordVisit("http://www.firefox.com/4", PageVisit(VisitType.REDIRECT_TEMPORARY))
+        history.recordVisit("http://www.firefox.com/5", PageVisit(VisitType.REDIRECT_PERMANENT))
+        history.recordVisit("http://www.firefox.com/6", PageVisit(VisitType.FRAMED_LINK))
+        history.recordVisit("http://www.firefox.com/7", PageVisit(VisitType.EMBED))
+        history.recordVisit("http://www.firefox.com/8", PageVisit(VisitType.BOOKMARK))
+        history.recordVisit("http://www.firefox.com/9", PageVisit(VisitType.DOWNLOAD))
 
         val recordedVisits = history.getDetailedVisits(0)
         assertEquals(9, recordedVisits.size)
@@ -143,7 +142,7 @@ class PlacesHistoryStorageTest {
 
     @Test
     fun `storage passes through recordObservation calls`() = runBlocking {
-        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.LINK))
         history.recordObservation("http://www.mozilla.org", PageObservation(title = "Mozilla"))
 
         var recordedVisits = history.getDetailedVisits(0)
@@ -173,7 +172,7 @@ class PlacesHistoryStorageTest {
         )
 
         for (url in toAdd) {
-            history.recordVisit(url, PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+            history.recordVisit(url, PageVisit(VisitType.LINK))
         }
 
         var infos = history.getTopFrecentSites(0, frecencyThreshold = FrecencyThresholdOption.NONE)
@@ -225,15 +224,15 @@ class PlacesHistoryStorageTest {
 
     @Test
     fun `store can be used to query detailed visit information`() = runBlocking {
-        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.LINK))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.RELOAD))
         history.recordObservation(
             "http://www.mozilla.org",
             PageObservation("Mozilla", "https://test.com/og-image-url")
         )
-        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.LINK))
 
-        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.REDIRECT_TEMPORARY, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.REDIRECT_TEMPORARY))
 
         val visits = history.getDetailedVisits(0, excludeTypes = listOf(VisitType.REDIRECT_TEMPORARY))
         assertEquals(3, visits.size)
@@ -260,21 +259,21 @@ class PlacesHistoryStorageTest {
         assertEquals(0, history.getVisited().size)
 
         // Regular visits are tracked.
-        history.recordVisit("https://www.mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("https://www.mozilla.org", PageVisit(VisitType.LINK))
         assertEquals(listOf("https://www.mozilla.org/"), history.getVisited())
 
         // Multiple visits can be tracked, results ordered by "URL's first seen first".
-        history.recordVisit("https://www.firefox.com", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("https://www.firefox.com", PageVisit(VisitType.LINK))
         assertEquals(listOf("https://www.mozilla.org/", "https://www.firefox.com/"), history.getVisited())
 
         // Visits marked as reloads can be tracked.
-        history.recordVisit("https://www.firefox.com", PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("https://www.firefox.com", PageVisit(VisitType.RELOAD))
         assertEquals(listOf("https://www.mozilla.org/", "https://www.firefox.com/"), history.getVisited())
 
         // Visited urls are certainly a set.
-        history.recordVisit("https://www.firefox.com", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("https://www.mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("https://www.wikipedia.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("https://www.firefox.com", PageVisit(VisitType.LINK))
+        history.recordVisit("https://www.mozilla.org", PageVisit(VisitType.LINK))
+        history.recordVisit("https://www.wikipedia.org", PageVisit(VisitType.LINK))
         assertEquals(
             listOf("https://www.mozilla.org/", "https://www.firefox.com/", "https://www.wikipedia.org/"),
             history.getVisited()
@@ -286,7 +285,7 @@ class PlacesHistoryStorageTest {
         assertEquals(0, history.getVisited(listOf()).size)
 
         // Regular visits are tracked
-        history.recordVisit("https://www.mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("https://www.mozilla.org", PageVisit(VisitType.LINK))
         assertEquals(listOf(true), history.getVisited(listOf("https://www.mozilla.org")))
 
         // Duplicate requests are handled.
@@ -298,16 +297,16 @@ class PlacesHistoryStorageTest {
         assertEquals(listOf(false, true), history.getVisited(listOf("https://www.unknown.com", "https://www.mozilla.org")))
 
         // Multiple visits can be tracked. Reloads can be tracked.
-        history.recordVisit("https://www.firefox.com", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("https://www.mozilla.org", PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("https://www.wikipedia.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("https://www.firefox.com", PageVisit(VisitType.LINK))
+        history.recordVisit("https://www.mozilla.org", PageVisit(VisitType.RELOAD))
+        history.recordVisit("https://www.wikipedia.org", PageVisit(VisitType.LINK))
         assertEquals(listOf(true, true, false, true), history.getVisited(listOf("https://www.firefox.com", "https://www.wikipedia.org", "https://www.unknown.com", "https://www.mozilla.org")))
     }
 
     @Test
     fun `store can be used to track page meta information - title and previewImageUrl changes`() = runBlocking {
         // Title and previewImageUrl changes are recorded.
-        history.recordVisit("https://www.wikipedia.org", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("https://www.wikipedia.org", PageVisit(VisitType.TYPED))
         history.recordObservation(
             "https://www.wikipedia.org",
             PageObservation("Wikipedia", "https://test.com/og-image-url")
@@ -324,9 +323,9 @@ class PlacesHistoryStorageTest {
         assertEquals("https://test.com/og-image-url", recorded[0].previewImageUrl)
 
         // Titles for different pages are recorded.
-        history.recordVisit("https://www.firefox.com", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("https://www.firefox.com", PageVisit(VisitType.TYPED))
         history.recordObservation("https://www.firefox.com", PageObservation("Firefox"))
-        history.recordVisit("https://www.mozilla.org", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("https://www.mozilla.org", PageVisit(VisitType.TYPED))
         history.recordObservation("https://www.mozilla.org", PageObservation("Мозилла"))
         recorded = history.getDetailedVisits(0)
         assertEquals(3, recorded.size)
@@ -342,13 +341,13 @@ class PlacesHistoryStorageTest {
     fun `store can provide suggestions`() = runBlocking {
         assertEquals(0, history.getSuggestions("Mozilla", 100).size)
 
-        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.LINK))
         val search = history.getSuggestions("Mozilla", 100)
         assertEquals(0, search.size)
 
-        history.recordVisit("http://www.wikipedia.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.moscow.ru", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.wikipedia.org", PageVisit(VisitType.LINK))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.LINK))
+        history.recordVisit("http://www.moscow.ru", PageVisit(VisitType.LINK))
         history.recordObservation("http://www.mozilla.org", PageObservation("Mozilla"))
         history.recordObservation("http://www.firefox.com", PageObservation("Mozilla Firefox"))
         history.recordObservation("http://www.moscow.ru", PageObservation("Moscow City"))
@@ -392,21 +391,21 @@ class PlacesHistoryStorageTest {
     fun `store can provide autocomplete suggestions`() = runBlocking {
         assertNull(history.getAutocompleteSuggestion("moz"))
 
-        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.LINK))
         var res = history.getAutocompleteSuggestion("moz")!!
         assertEquals("mozilla.org/", res.text)
         assertEquals("http://www.mozilla.org/", res.url)
         assertEquals("placesHistory", res.source)
         assertEquals(1, res.totalItems)
 
-        history.recordVisit("http://firefox.com", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://firefox.com", PageVisit(VisitType.LINK))
         res = history.getAutocompleteSuggestion("firefox")!!
         assertEquals("firefox.com/", res.text)
         assertEquals("http://firefox.com/", res.url)
         assertEquals("placesHistory", res.source)
         assertEquals(1, res.totalItems)
 
-        history.recordVisit("https://en.wikipedia.org/wiki/Mozilla", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("https://en.wikipedia.org/wiki/Mozilla", PageVisit(VisitType.LINK))
         res = history.getAutocompleteSuggestion("en")!!
         assertEquals("en.wikipedia.org/", res.text)
         assertEquals("https://en.wikipedia.org/", res.url)
@@ -426,20 +425,20 @@ class PlacesHistoryStorageTest {
     fun `store ignores url parse exceptions during record operations`() = runBlocking {
         // These aren't valid URIs, and if we're not explicitly ignoring exceptions from the underlying
         // storage layer, these calls will throw.
-        history.recordVisit("mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("mozilla.org", PageVisit(VisitType.LINK))
         history.recordObservation("mozilla.org", PageObservation("mozilla"))
     }
 
     @Test
     fun `store can delete everything`() = runBlocking {
-        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.DOWNLOAD, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.BOOKMARK, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.EMBED, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.REDIRECT_PERMANENT, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.REDIRECT_TEMPORARY, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.TYPED))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.DOWNLOAD))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.BOOKMARK))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.RELOAD))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.EMBED))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.REDIRECT_PERMANENT))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.REDIRECT_TEMPORARY))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.LINK))
 
         history.recordObservation("http://www.firefox.com", PageObservation("Firefox"))
 
@@ -452,14 +451,14 @@ class PlacesHistoryStorageTest {
 
     @Test
     fun `store can delete by url`() = runBlocking {
-        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.DOWNLOAD, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.BOOKMARK, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.EMBED, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.REDIRECT_PERMANENT, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.REDIRECT_TEMPORARY, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.TYPED))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.DOWNLOAD))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.BOOKMARK))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.RELOAD))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.EMBED))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.REDIRECT_PERMANENT))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.REDIRECT_TEMPORARY))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.LINK))
 
         history.recordObservation("http://www.firefox.com", PageObservation("Firefox"))
 
@@ -476,9 +475,9 @@ class PlacesHistoryStorageTest {
 
     @Test
     fun `store can delete by 'since'`() = runBlocking {
-        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.DOWNLOAD, RedirectSource.NOT_A_SOURCE))
-        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.BOOKMARK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.TYPED))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.DOWNLOAD))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.BOOKMARK))
 
         history.deleteVisitsSince(0)
         val visits = history.getVisited()
@@ -488,11 +487,11 @@ class PlacesHistoryStorageTest {
     @Test
     fun `store can delete by 'range'`() {
         runBlocking {
-            history.recordVisit("http://www.mozilla.org/1", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
+            history.recordVisit("http://www.mozilla.org/1", PageVisit(VisitType.TYPED))
             Thread.sleep(10)
-            history.recordVisit("http://www.mozilla.org/2", PageVisit(VisitType.DOWNLOAD, RedirectSource.NOT_A_SOURCE))
+            history.recordVisit("http://www.mozilla.org/2", PageVisit(VisitType.DOWNLOAD))
             Thread.sleep(10)
-            history.recordVisit("http://www.mozilla.org/3", PageVisit(VisitType.BOOKMARK, RedirectSource.NOT_A_SOURCE))
+            history.recordVisit("http://www.mozilla.org/3", PageVisit(VisitType.BOOKMARK))
         }
 
         val ts = runBlocking {
@@ -517,11 +516,11 @@ class PlacesHistoryStorageTest {
     @Test
     fun `store can delete visit by 'url' and 'timestamp'`() {
         runBlocking {
-            history.recordVisit("http://www.mozilla.org/1", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
+            history.recordVisit("http://www.mozilla.org/1", PageVisit(VisitType.TYPED))
             Thread.sleep(10)
-            history.recordVisit("http://www.mozilla.org/2", PageVisit(VisitType.DOWNLOAD, RedirectSource.NOT_A_SOURCE))
+            history.recordVisit("http://www.mozilla.org/2", PageVisit(VisitType.DOWNLOAD))
             Thread.sleep(10)
-            history.recordVisit("http://www.mozilla.org/3", PageVisit(VisitType.BOOKMARK, RedirectSource.NOT_A_SOURCE))
+            history.recordVisit("http://www.mozilla.org/3", PageVisit(VisitType.BOOKMARK))
         }
 
         val ts = runBlocking {
@@ -565,7 +564,7 @@ class PlacesHistoryStorageTest {
     fun `can run prune on the store`() = runBlocking {
         // Empty.
         history.prune()
-        history.recordVisit("http://www.mozilla.org/1", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.mozilla.org/1", PageVisit(VisitType.TYPED))
         // Non-empty.
         history.prune()
     }

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryStorage.kt
@@ -136,21 +136,18 @@ interface HistoryStorage : Storage {
  * Information to record about a visit.
  *
  * @property visitType The transition type for this visit. See [VisitType].
- * @property redirectSource If this visit is redirecting to another page,
+ * @property redirectSource Optional; if this visit is redirecting to another page,
  *  what kind of redirect is it? See [RedirectSource] for the options.
  */
 data class PageVisit(
     val visitType: VisitType,
-    val redirectSource: RedirectSource
+    val redirectSource: RedirectSource? = null
 )
 
 /**
  * A redirect source describes how a page redirected to another page.
  */
 enum class RedirectSource {
-    // The page didn't redirect to another page.
-    NOT_A_SOURCE,
-
     // The page temporarily redirected to another page.
     TEMPORARY,
 

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
@@ -11,7 +11,6 @@ import mozilla.components.concept.storage.HistoryAutocompleteResult
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.concept.storage.PageObservation
 import mozilla.components.concept.storage.PageVisit
-import mozilla.components.concept.storage.RedirectSource
 import mozilla.components.concept.storage.SearchResult
 import mozilla.components.concept.storage.TopFrecentSiteInfo
 import mozilla.components.concept.storage.VisitInfo
@@ -34,17 +33,17 @@ class HistoryDelegateTest {
         val storage = mock<HistoryStorage>()
         val delegate = HistoryDelegate(lazy { storage })
 
-        delegate.onVisited("about:blank", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
-        verify(storage, never()).recordVisit("about:blank", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
+        delegate.onVisited("about:blank", PageVisit(VisitType.TYPED))
+        verify(storage, never()).recordVisit("about:blank", PageVisit(VisitType.TYPED))
 
-        delegate.onVisited("http://www.mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
-        verify(storage).recordVisit("http://www.mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        delegate.onVisited("http://www.mozilla.org", PageVisit(VisitType.LINK))
+        verify(storage).recordVisit("http://www.mozilla.org", PageVisit(VisitType.LINK))
 
-        delegate.onVisited("http://www.firefox.com", PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE))
-        verify(storage).recordVisit("http://www.firefox.com", PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE))
+        delegate.onVisited("http://www.firefox.com", PageVisit(VisitType.RELOAD))
+        verify(storage).recordVisit("http://www.firefox.com", PageVisit(VisitType.RELOAD))
 
-        delegate.onVisited("http://www.firefox.com", PageVisit(VisitType.BOOKMARK, RedirectSource.NOT_A_SOURCE))
-        verify(storage).recordVisit("http://www.firefox.com", PageVisit(VisitType.BOOKMARK, RedirectSource.NOT_A_SOURCE))
+        delegate.onVisited("http://www.firefox.com", PageVisit(VisitType.BOOKMARK))
+        verify(storage).recordVisit("http://www.firefox.com", PageVisit(VisitType.BOOKMARK))
     }
 
     @Test


### PR DESCRIPTION

We were incorrectly handling redirect flags in the onVisited history
delegate.

Specifically, code in the delegate wrapper didn't properly distinguish
between redirect source and target. If a page is a redirect source, that
means it's the page that is redirecting somewhere. If a page is a
target, that means this is another page was redirecting to.

The comments in the code correctly identified this difference, but the
code itself didn't. Perhaps due to potentially misleading names of
redirect constant flags?

Also, this patch removes a test that was attempting to verify that we
wouldn't notify delegates of redirects (meaning, we won't save them).
However, the test itself was configured incorrectly, so even though it
was passing, we were saving the redirects. And further, we actually do
want to save redirects in the most general sense. E.g. to facilitate
correct autocomplete of both src and target in the toolbar.

There's also some minor cleanup attached to this PR as well in a separate commit.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
