### PR TITLE
Closes #11241: TabSessionState.lastAccess not updated when app resumes

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/LastAccessReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/LastAccessReducer.kt
@@ -17,9 +17,8 @@ internal object LastAccessReducer {
      */
     fun reduce(state: BrowserState, action: LastAccessAction): BrowserState = when (action) {
         is UpdateLastAccessAction -> {
-            state.updateTabOrCustomTabState(action.tabId) { sessionState ->
-                val tabSessionState = sessionState as TabSessionState
-                tabSessionState.copy(lastAccess = action.lastAccess)
+            state.updateTabState(action.tabId) { sessionState ->
+                sessionState.copy(lastAccess = action.lastAccess)
             }
         }
         is UpdateLastMediaAccessAction -> {

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/engine/EngineViewPresenter.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/engine/EngineViewPresenter.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import mozilla.components.browser.state.action.EngineAction
+import mozilla.components.browser.state.action.LastAccessAction
 import mozilla.components.browser.state.selector.findTabOrCustomTabOrSelectedTab
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.store.BrowserStore
@@ -82,6 +83,9 @@ internal class EngineViewPresenter(
             // method will get invoked again.
             store.dispatch(EngineAction.CreateEngineSessionAction(tab.id))
         } else {
+            // Since we render the tab again let's update its last access flag. In the future, we
+            // may need more fine-grained flags to differentiate viewing from tab selection.
+            store.dispatch(LastAccessAction.UpdateLastAccessAction(tab.id, System.currentTimeMillis()))
             engineView.render(engineSession)
         }
     }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
@@ -13,6 +13,7 @@ import mozilla.components.browser.state.action.CustomTabListAction
 import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.engine.EngineMiddleware
+import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.createCustomTab
 import mozilla.components.browser.state.state.createTab
@@ -25,7 +26,9 @@ import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.middleware.CaptureActionsMiddleware
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -367,6 +370,29 @@ class SessionFeatureTest {
         store.waitUntilIdle()
         verify(view, atLeastOnce()).release()
         middleware.assertNotDispatched(EngineAction.CreateEngineSessionAction::class)
+    }
+
+    @Test
+    fun `last access is updated when session is rendered`() {
+        val store = prepareStore()
+
+        val actualView: View = mock()
+        val view: EngineView = mock()
+        doReturn(actualView).`when`(view).asView()
+
+        val engineSession: EngineSession = mock()
+        store.dispatch(EngineAction.LinkEngineSessionAction("B", engineSession)).joinBlocking()
+
+        val feature = SessionFeature(store, mock(), view)
+        verify(view, never()).render(any())
+
+        assertEquals(0L, store.state.findTab("B")?.lastAccess)
+        feature.start()
+        testDispatcher.advanceUntilIdle()
+        store.waitUntilIdle()
+
+        assertNotEquals(0L, store.state.findTab("B")?.lastAccess)
+        verify(view).render(engineSession)
     }
 
     private fun prepareStore(


### PR DESCRIPTION
With this we update `lastAccess` whenever the tab is rendered. This may or may not happen at the same time as selecting the tab, depending on the consuming application.