### PR TITLE
Make findLoginToUpdate suspend

### DIFF
--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/LoginsStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/LoginsStorage.kt
@@ -172,7 +172,7 @@ interface LoginsStorage : AutoCloseable {
      * @param entry [LoginEntry] being saved
      * @return [Login] that should be updated, or null if the login should be added
      */
-    fun findLoginToUpdate(entry: LoginEntry): Login?
+    suspend fun findLoginToUpdate(entry: LoginEntry): Login?
 
     /**
      * Inserts the provided login into the database

--- a/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/SyncableLoginsStorage.kt
+++ b/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/SyncableLoginsStorage.kt
@@ -263,8 +263,8 @@ class SyncableLoginsStorage(
      * @throws [LoginsStorageException] On unexpected errors (IO failure, rust panics, etc)
      */
     @Throws(LoginsStorageException::class)
-    override fun findLoginToUpdate(entry: LoginEntry): Login? {
-        return conn.getStorage().findLoginToUpdate(entry.toLoginEntry(), crypto.key().key)?.toLogin()
+    override suspend fun findLoginToUpdate(entry: LoginEntry): Login? = withContext(coroutineContext) {
+        conn.getStorage().findLoginToUpdate(entry.toLoginEntry(), crypto.key().key)?.toLogin()
     }
 
     /**


### PR DESCRIPTION
It accesses the DB, so it should be suspend like the other methods.

The corresponding Fenix PR was just merged.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
