### PR TITLE
Move shouldStoreUri to storage

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -680,6 +680,13 @@ class GeckoEngineSession(
                 return GeckoResult.fromValue(false)
             }
 
+            val delegate = settings.historyTrackingDelegate ?: return GeckoResult.fromValue(false)
+
+            // Check if the delegate wants this type of url.
+            if (!delegate.shouldStoreUri(url)) {
+                return GeckoResult.fromValue(false)
+            }
+
             val isReload = lastVisitedURL?.let { it == url } ?: false
 
             // Note the difference between `VISIT_REDIRECT_PERMANENT`,
@@ -709,13 +716,6 @@ class GeckoEngineSession(
                 flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE != 0 ->
                     RedirectSource.TEMPORARY
                 else -> null
-            }
-
-            val delegate = settings.historyTrackingDelegate ?: return GeckoResult.fromValue(false)
-
-            // Check if the delegate wants this type of url.
-            if (!delegate.shouldStoreUri(url)) {
-                return GeckoResult.fromValue(false)
             }
 
             return launchGeckoResult {
@@ -757,7 +757,7 @@ class GeckoEngineSession(
         }
     }
 
-    @Suppress("ComplexMethod")
+    @Suppress("ComplexMethod", "NestedBlockDepth")
     internal fun createContentDelegate() = object : GeckoSession.ContentDelegate {
         override fun onFirstComposite(session: GeckoSession) = Unit
 
@@ -848,12 +848,14 @@ class GeckoEngineSession(
             if (!privateMode) {
                 currentUrl?.let { url ->
                     settings.historyTrackingDelegate?.let { delegate ->
-                        // NB: There's no guarantee that the title change will be processed by the
-                        // delegate before the session is closed (and the corresponding coroutine
-                        // job is cancelled). Observers will always be notified of the title
-                        // change though.
-                        launch(coroutineContext) {
-                            delegate.onTitleChanged(url, title ?: "")
+                        if (delegate.shouldStoreUri(url)) {
+                            // NB: There's no guarantee that the title change will be processed by the
+                            // delegate before the session is closed (and the corresponding coroutine
+                            // job is cancelled). Observers will always be notified of the title
+                            // change though.
+                            launch(coroutineContext) {
+                                delegate.onTitleChanged(url, title ?: "")
+                            }
                         }
                     }
                 }
@@ -865,8 +867,10 @@ class GeckoEngineSession(
             if (!privateMode) {
                 currentUrl?.let { url ->
                     settings.historyTrackingDelegate?.let { delegate ->
-                        launch(coroutineContext) {
-                            delegate.onPreviewImageChange(url, previewImageUrl)
+                        if (delegate.shouldStoreUri(url)) {
+                            launch(coroutineContext) {
+                                delegate.onPreviewImageChange(url, previewImageUrl)
+                            }
                         }
                     }
                 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -785,6 +785,7 @@ class GeckoEngineSessionTest {
         contentDelegate.value.onTitleChange(geckoSession, "Hello World!")
 
         engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
+        whenever(historyTrackingDelegate.shouldStoreUri(eq("https://www.mozilla.com"))).thenReturn(true)
 
         contentDelegate.value.onTitleChange(geckoSession, "Hello World!")
         verify(historyTrackingDelegate, never()).onTitleChanged(anyString(), anyString())
@@ -794,6 +795,7 @@ class GeckoEngineSessionTest {
 
         contentDelegate.value.onTitleChange(geckoSession, "Hello World!")
         verify(historyTrackingDelegate).onTitleChanged(eq("https://www.mozilla.com"), eq("Hello World!"))
+        verify(historyTrackingDelegate).shouldStoreUri(eq("https://www.mozilla.com"))
     }
 
     @Test
@@ -846,6 +848,7 @@ class GeckoEngineSessionTest {
         contentDelegate.value.onPreviewImage(geckoSession, previewImageUrl)
 
         engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
+        whenever(historyTrackingDelegate.shouldStoreUri(eq("https://www.mozilla.com"))).thenReturn(true)
 
         contentDelegate.value.onPreviewImage(geckoSession, previewImageUrl)
         verify(historyTrackingDelegate, never()).onPreviewImageChange(anyString(), anyString())
@@ -855,6 +858,7 @@ class GeckoEngineSessionTest {
 
         contentDelegate.value.onPreviewImage(geckoSession, previewImageUrl)
         verify(historyTrackingDelegate).onPreviewImageChange(eq("https://www.mozilla.com"), eq(previewImageUrl))
+        verify(historyTrackingDelegate).shouldStoreUri(eq("https://www.mozilla.com"))
     }
 
     @Test

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
@@ -27,6 +27,7 @@ import mozilla.components.support.test.robolectric.testContext
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -1297,6 +1298,29 @@ class PlacesHistoryStorageTest {
             throw PlacesException("test")
         }
         assertEquals(emptyList<HistoryMetadata>(), result)
+    }
+
+    @Test
+    fun `history delegate's shouldStoreUri works as expected`() {
+        // Not an excessive list of allowed schemes.
+        assertTrue(history.canAddUri("http://www.mozilla.com"))
+        assertTrue(history.canAddUri("https://www.mozilla.com"))
+        assertTrue(history.canAddUri("ftp://files.mozilla.com/stuff/fenix.apk"))
+        assertTrue(history.canAddUri("about:reader?url=http://www.mozilla.com/interesting-article.html"))
+        assertTrue(history.canAddUri("https://john.doe@www.example.com:123/forum/questions/?tag=networking&order=newest#top"))
+        assertTrue(history.canAddUri("ldap://2001:db8::7/c=GB?objectClass?one"))
+        assertTrue(history.canAddUri("telnet://192.0.2.16:80/"))
+
+        assertFalse(history.canAddUri("withoutSchema.html"))
+        assertFalse(history.canAddUri("about:blank"))
+        assertFalse(history.canAddUri("news:comp.infosystems.www.servers.unix"))
+        assertFalse(history.canAddUri("imap://mail.example.com/~mozilla"))
+        assertFalse(history.canAddUri("chrome://config"))
+        assertFalse(history.canAddUri("data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D"))
+        assertFalse(history.canAddUri("data:text/html,<script>alert('hi');</script>"))
+        assertFalse(history.canAddUri("resource://internal-thingy-js-inspector/script.js"))
+        assertFalse(history.canAddUri("javascript:alert('hello!');"))
+        assertFalse(history.canAddUri("blob:https://api.mozilla.com/resource.png"))
     }
 
     private fun assertHistoryMetadataRecord(

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryStorage.kt
@@ -23,6 +23,11 @@ interface HistoryStorage : Storage {
     suspend fun recordObservation(uri: String, observation: PageObservation)
 
     /**
+     * @return True if provided [uri] can be added to the storage layer.
+     */
+    fun canAddUri(uri: String): Boolean
+
+    /**
      * Maps a list of page URIs to a list of booleans indicating if each URI was visited.
      * @param uris a list of page URIs about which "visited" information is being requested.
      * @return A list of booleans indicating visited status of each

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
@@ -22,7 +22,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
@@ -32,9 +31,6 @@ class HistoryDelegateTest {
     fun `history delegate passes through onVisited calls`() = runBlocking {
         val storage = mock<HistoryStorage>()
         val delegate = HistoryDelegate(lazy { storage })
-
-        delegate.onVisited("about:blank", PageVisit(VisitType.TYPED))
-        verify(storage, never()).recordVisit("about:blank", PageVisit(VisitType.TYPED))
 
         delegate.onVisited("http://www.mozilla.org", PageVisit(VisitType.LINK))
         verify(storage).recordVisit("http://www.mozilla.org", PageVisit(VisitType.LINK))
@@ -53,9 +49,6 @@ class HistoryDelegateTest {
 
         delegate.onTitleChanged("http://www.mozilla.org", "Mozilla")
         verify(storage).recordObservation("http://www.mozilla.org", PageObservation("Mozilla"))
-
-        delegate.onTitleChanged("about:blank", "Blank!")
-        verify(storage, never()).recordObservation("about:blank", PageObservation("Blank!"))
     }
 
     @Test
@@ -69,140 +62,124 @@ class HistoryDelegateTest {
             "http://www.mozilla.org",
             PageObservation(previewImageUrl = previewImageUrl)
         )
-
-        delegate.onPreviewImageChange("about:blank", previewImageUrl)
-        verify(storage, never()).recordObservation(
-            "about:blank",
-            PageObservation(previewImageUrl = previewImageUrl)
-        )
     }
 
     @Test
     fun `history delegate passes through getVisited calls`() = runBlocking {
-        class TestHistoryStorage : HistoryStorage {
-            var getVisitedListCalled = false
-            var getVisitedPlainCalled = false
-
-            override suspend fun warmUp() {
-                fail()
-            }
-
-            override suspend fun recordVisit(uri: String, visit: PageVisit) {
-                fail()
-            }
-
-            override suspend fun recordObservation(uri: String, observation: PageObservation) {
-                fail()
-            }
-
-            override suspend fun getVisited(uris: List<String>): List<Boolean> {
-                getVisitedListCalled = true
-                assertEquals(listOf("http://www.mozilla.org", "http://www.firefox.com"), uris)
-                return emptyList()
-            }
-
-            override suspend fun getVisited(): List<String> {
-                getVisitedPlainCalled = true
-                return emptyList()
-            }
-
-            override suspend fun getDetailedVisits(start: Long, end: Long, excludeTypes: List<VisitType>): List<VisitInfo> {
-                fail()
-                return emptyList()
-            }
-
-            override suspend fun getVisitsPaginated(offset: Long, count: Long, excludeTypes: List<VisitType>): List<VisitInfo> {
-                fail()
-                return emptyList()
-            }
-
-            override suspend fun getTopFrecentSites(
-                numItems: Int,
-                frecencyThreshold: FrecencyThresholdOption
-            ): List<TopFrecentSiteInfo> {
-                fail()
-                return emptyList()
-            }
-
-            override fun getSuggestions(query: String, limit: Int): List<SearchResult> {
-                fail()
-                return listOf()
-            }
-
-            override fun getAutocompleteSuggestion(query: String): HistoryAutocompleteResult? {
-                fail()
-                return null
-            }
-
-            override suspend fun deleteEverything() {
-                fail()
-            }
-
-            override suspend fun deleteVisitsSince(since: Long) {
-                fail()
-            }
-
-            override suspend fun deleteVisitsBetween(startTime: Long, endTime: Long) {
-                fail()
-            }
-
-            override suspend fun deleteVisitsFor(url: String) {
-                fail()
-            }
-
-            override suspend fun deleteVisit(url: String, timestamp: Long) {
-                fail()
-            }
-
-            override suspend fun prune() {
-                fail()
-            }
-
-            override suspend fun runMaintenance() {
-                fail()
-            }
-
-            override fun cleanup() {
-                fail()
-            }
-        }
-
         val storage = TestHistoryStorage()
         val delegate = HistoryDelegate(lazy { storage })
 
         assertFalse(storage.getVisitedPlainCalled)
         assertFalse(storage.getVisitedListCalled)
+        assertFalse(storage.canAddUriCalled)
 
         delegate.getVisited()
         assertTrue(storage.getVisitedPlainCalled)
         assertFalse(storage.getVisitedListCalled)
+        assertFalse(storage.canAddUriCalled)
 
         delegate.getVisited(listOf("http://www.mozilla.org", "http://www.firefox.com"))
         assertTrue(storage.getVisitedListCalled)
+        assertFalse(storage.canAddUriCalled)
     }
 
     @Test
-    fun `history delegate's shouldStoreUri works as expected`() {
-        val delegate = HistoryDelegate(mock())
+    fun `history delegate checks with storage canAddUriCalled`() = runBlocking {
+        val storage = TestHistoryStorage()
+        val delegate = HistoryDelegate(lazy { storage })
 
-        // Not an excessive list of allowed schemes.
-        assertTrue(delegate.shouldStoreUri("http://www.mozilla.com"))
-        assertTrue(delegate.shouldStoreUri("https://www.mozilla.com"))
-        assertTrue(delegate.shouldStoreUri("ftp://files.mozilla.com/stuff/fenix.apk"))
-        assertTrue(delegate.shouldStoreUri("about:reader?url=http://www.mozilla.com/interesting-article.html"))
-        assertTrue(delegate.shouldStoreUri("https://john.doe@www.example.com:123/forum/questions/?tag=networking&order=newest#top"))
-        assertTrue(delegate.shouldStoreUri("ldap://2001:db8::7/c=GB?objectClass?one"))
-        assertTrue(delegate.shouldStoreUri("telnet://192.0.2.16:80/"))
+        assertFalse(storage.canAddUriCalled)
+        delegate.shouldStoreUri("test")
+        assertTrue(storage.canAddUriCalled)
+    }
 
-        assertFalse(delegate.shouldStoreUri("withoutSchema.html"))
-        assertFalse(delegate.shouldStoreUri("about:blank"))
-        assertFalse(delegate.shouldStoreUri("news:comp.infosystems.www.servers.unix"))
-        assertFalse(delegate.shouldStoreUri("imap://mail.example.com/~mozilla"))
-        assertFalse(delegate.shouldStoreUri("chrome://config"))
-        assertFalse(delegate.shouldStoreUri("data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D"))
-        assertFalse(delegate.shouldStoreUri("data:text/html,<script>alert('hi');</script>"))
-        assertFalse(delegate.shouldStoreUri("resource://internal-thingy-js-inspector/script.js"))
-        assertFalse(delegate.shouldStoreUri("javascript:alert('hello!');"))
-        assertFalse(delegate.shouldStoreUri("blob:https://api.mozilla.com/resource.png"))
+    private class TestHistoryStorage : HistoryStorage {
+        var getVisitedListCalled = false
+        var getVisitedPlainCalled = false
+        var canAddUriCalled = false
+
+        override suspend fun warmUp() {
+            fail()
+        }
+
+        override suspend fun recordVisit(uri: String, visit: PageVisit) {}
+
+        override suspend fun recordObservation(uri: String, observation: PageObservation) {}
+
+        override fun canAddUri(uri: String): Boolean {
+            canAddUriCalled = true
+            return true
+        }
+
+        override suspend fun getVisited(uris: List<String>): List<Boolean> {
+            getVisitedListCalled = true
+            assertEquals(listOf("http://www.mozilla.org", "http://www.firefox.com"), uris)
+            return emptyList()
+        }
+
+        override suspend fun getVisited(): List<String> {
+            getVisitedPlainCalled = true
+            return emptyList()
+        }
+
+        override suspend fun getDetailedVisits(start: Long, end: Long, excludeTypes: List<VisitType>): List<VisitInfo> {
+            fail()
+            return emptyList()
+        }
+
+        override suspend fun getVisitsPaginated(offset: Long, count: Long, excludeTypes: List<VisitType>): List<VisitInfo> {
+            fail()
+            return emptyList()
+        }
+
+        override suspend fun getTopFrecentSites(
+            numItems: Int,
+            frecencyThreshold: FrecencyThresholdOption
+        ): List<TopFrecentSiteInfo> {
+            fail()
+            return emptyList()
+        }
+
+        override fun getSuggestions(query: String, limit: Int): List<SearchResult> {
+            fail()
+            return listOf()
+        }
+
+        override fun getAutocompleteSuggestion(query: String): HistoryAutocompleteResult? {
+            fail()
+            return null
+        }
+
+        override suspend fun deleteEverything() {
+            fail()
+        }
+
+        override suspend fun deleteVisitsSince(since: Long) {
+            fail()
+        }
+
+        override suspend fun deleteVisitsBetween(startTime: Long, endTime: Long) {
+            fail()
+        }
+
+        override suspend fun deleteVisitsFor(url: String) {
+            fail()
+        }
+
+        override suspend fun deleteVisit(url: String, timestamp: Long) {
+            fail()
+        }
+
+        override suspend fun prune() {
+            fail()
+        }
+
+        override suspend fun runMaintenance() {
+            fail()
+        }
+
+        override fun cleanup() {
+            fail()
+        }
     }
 }


### PR DESCRIPTION
In feature-session we had some logic to filter out certain URIs prior to storing them. This
patch moves this logic into the storage layer, so that it has a broader
coverage - whenever we attempt to write some URL into the storage, we'll
now go through this filter.

Before, we'd only go through this filter for writes that were routed via
the HistoryDelegate.

After this change, direct writes (such as for metadata) are also
covered.

This shouldn't change all that much - the storage implementation is
likely to have rejected these URIs. Now, instead of letting it through
exceptions at us (which we catch and report via sentry), we simply don't
even call into the storage if we don't expect these calls to succeed.

This should reduce volume of "url without base" type of 'info' events we
see in Sentry.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
