### PR TITLE
Closes #11188: Mergify: Replace deprecated "strict mode" merge action

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,7 @@
+queue_rules:
+  - name: default
+    conditions:
+      - status-success=complete-pr
 pull_request_rules:
   - name: Resolve conflict
     conditions:
@@ -14,9 +18,10 @@ pull_request_rules:
       review:
         type: APPROVE
         message: MickeyMoz 💪
-      merge:
+      queue:
         method: rebase
-        strict: smart
+        name: default
+        rebase_fallback: none
   - name: L10N - Auto Merge
     conditions:
       - author=mozilla-l10n-automation-bot
@@ -26,9 +31,10 @@ pull_request_rules:
       review:
         type: APPROVE
         message: LGTM 😎
-      merge:
+      queue:
         method: rebase
-        strict: smart
+        name: default
+        rebase_fallback: none
   - name: Release automation
     conditions:
       - author=github-actions[bot]
@@ -38,9 +44,10 @@ pull_request_rules:
       review:
         type: APPROVE
         message: 🚢
-      merge:
+      queue:
         method: rebase
-        strict: smart
+        name: default
+        rebase_fallback: none
       delete_head_branch:
         force: false
   - name: Needs landing - Rebase
@@ -52,9 +59,10 @@ pull_request_rules:
       - label!=work in progress
       - label!=do not land
     actions:
-      merge:
+      queue:
         method: rebase
-        strict: smart
+        name: default
+        rebase_fallback: none
   - name: Needs landing - Squash
     conditions:
       - status-success=complete-pr
@@ -64,6 +72,7 @@ pull_request_rules:
       - label!=work in progress
       - label!=do not land
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart
+        name: default
+        rebase_fallback: none


### PR DESCRIPTION
The "merge" action was deprecated and now there's a new "queue" action with a separate merge queue.