### PR TITLE
Closes #11252: fix for not hiding the keyboard after edit toolbar loses focus

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
@@ -9,7 +9,6 @@ import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.view.KeyEvent
 import android.view.View
-import android.view.inputmethod.InputMethodManager
 import android.widget.ImageView
 import androidx.annotation.ColorInt
 import androidx.annotation.VisibleForTesting
@@ -211,7 +210,7 @@ class EditToolbar internal constructor(
      */
     fun focus() {
         views.url.run {
-            showKeyboard(flags = InputMethodManager.SHOW_FORCED)
+            showKeyboard()
             requestFocus()
         }
     }


### PR DESCRIPTION

Initially, we thought that it has something to do with deprecated `toggleSoftInput` method, the change that came with android 12.
It has some text regarding changes in how focus works

```
* In particular during focus changes, the current visibility of the IME is not
     * well defined. Starting in {@link Build.VERSION_CODES#S Android S}, this only
     * has an effect if the calling app is the current IME focus.
     */
```

However, testing inside a dummy app reviled that this method still works correctly on android 12.
We came by the `showKeyboard(flags = InputMethodManager.SHOW_FORCED)` line, which was causing the hide/show-again affect. It turned out to be a fix for Fire TV projects, on which keyboard didn't work correctly unless was called by `SHOW_FORCED`.

Related issues could be check inside the #11252 issue.