### PR TITLE
Add end callback to removeAllExceptions

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorage.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorage.kt
@@ -146,7 +146,7 @@ internal class TrackingProtectionExceptionFileStorage(
         runtime.storageController.setPermission(contentPermission, VALUE_DENY)
     }
 
-    override fun removeAll(activeSessions: List<EngineSession>?) {
+    override fun removeAll(activeSessions: List<EngineSession>?, onRemove: () -> Unit) {
         val storage = runtime.storageController
         activeSessions?.forEach { engineSession ->
             engineSession.notifyObservers {
@@ -158,6 +158,7 @@ internal class TrackingProtectionExceptionFileStorage(
             trackingExceptions.forEach {
                 storage.setPermission(it, VALUE_DENY)
             }
+            onRemove.invoke()
         }
     }
 

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/content/blocking/TrackingProtectionExceptionStorage.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/content/blocking/TrackingProtectionExceptionStorage.kt
@@ -51,8 +51,9 @@ interface TrackingProtectionExceptionStorage {
      * Removes all domains from the exception list.
      * @param activeSessions A list of all active sessions (including CustomTab
      * sessions) to be notified.
+     * @param onRemove A callback to inform that the list of active sessions has been removed
      */
-    fun removeAll(activeSessions: List<EngineSession>? = null)
+    fun removeAll(activeSessions: List<EngineSession>? = null, onRemove: () -> Unit = {})
 
     /**
      * Restore all domains stored in the storage.

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/TrackingProtectionUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/TrackingProtectionUseCases.kt
@@ -97,12 +97,12 @@ class TrackingProtectionUseCases(
         /**
          * Removes all domains from the exception list.
          */
-        operator fun invoke() {
+        operator fun invoke(onRemove: () -> Unit = {}) {
             val engineSessions = (store.state.tabs + store.state.customTabs).mapNotNull { tab ->
                 tab.engineState.engineSession
             }
 
-            engine.trackingProtectionExceptionStore.removeAll(engineSessions)
+            engine.trackingProtectionExceptionStore.removeAll(engineSessions, onRemove)
         }
     }
 

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/TrackingProtectionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/TrackingProtectionUseCasesTest.kt
@@ -231,7 +231,7 @@ class TrackingProtectionUseCasesTest {
     fun `removeAll exceptions`() {
         useCases.removeAllExceptions()
 
-        verify(exceptionStore).removeAll(any())
+        verify(exceptionStore).removeAll(any(), any())
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/v95.0.0/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/v95.0.0/.config.yml)
 
+* **feature-session**
+  * 🌟️️ **Add callback as a parameter to RemoveAllExceptionsUseCase which will be called after exceptions removing
+
 * **concept-toolbar**
   * 🌟️️ **Add removeNavigationAction method which removes a previously added navigation action
 


### PR DESCRIPTION
For #11261
Add a callback to know when the process of removing all the exceptions was ended, in this manner we are avoiding race conditions

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
