### PR TITLE
Closes #11208: Add tab partitions and groups to BrowserState

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -21,6 +21,7 @@ import mozilla.components.browser.state.state.ReaderState
 import mozilla.components.browser.state.state.SearchState
 import mozilla.components.browser.state.state.SecurityInfoState
 import mozilla.components.browser.state.state.SessionState
+import mozilla.components.browser.state.state.TabGroup
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.TrackingProtectionState
 import mozilla.components.browser.state.state.UndoHistoryState
@@ -230,6 +231,90 @@ sealed class TabListAction : BrowserAction() {
      * Removes all non-private [TabSessionState]s.
      */
     object RemoveAllNormalTabsAction : TabListAction()
+}
+
+/**
+ * [BrowserAction] implementations related to updating tab partitions and groups inside [BrowserState].
+ */
+sealed class TabGroupAction : BrowserAction() {
+    /**
+     * Adds a new group to [BrowserState.tabPartitions]. If the corresponding partition
+     * doesn't exist it will be created.
+     *
+     * @property partition the ID of the partition the group belongs to.
+     * @property group the [TabGroup] to add.
+     */
+    data class AddTabGroupAction(
+        val partition: String,
+        val group: TabGroup
+    ) : TabGroupAction()
+
+    /**
+     * Removes a group from [BrowserState.tabPartitions]. Empty partitions will be
+     * be removed i.e., if the last group in a partition is removed, the partition
+     * is removed as well.
+     *
+     * @property partition the ID of the partition the group belongs to.
+     * @property group the ID of the group to remove.
+     */
+    data class RemoveTabGroupAction(
+        val partition: String,
+        val group: String
+    ) : TabGroupAction()
+
+    /**
+     * Adds the provided tab to a group in [BrowserState].
+     *
+     * @property partition the ID of the partition the group belongs to. If the corresponding
+     * partition doesn't exist it will be created.
+     * @property group the ID of the group.
+     * @property tabId the ID of the tab to add to the group.
+     */
+    data class AddTabAction(
+        val partition: String,
+        val group: String,
+        val tabId: String,
+    ) : TabGroupAction()
+
+    /**
+     * Adds the provided tabs to a group in [BrowserState].
+     *
+     * @property partition the ID of the partition the group belongs to. If the corresponding
+     * partition doesn't exist it will be created.
+     * @property group the ID of the group.
+     * @property tabIds the IDs of the tabs to add to the group.
+     */
+    data class AddTabsAction(
+        val partition: String,
+        val group: String,
+        val tabIds: List<String>
+    ) : TabGroupAction()
+
+    /**
+     * Removes the provided tab from a group in [BrowserState].
+     *
+     * @property partition the ID of the partition the group belongs to.
+     * @property group the ID of the group.
+     * @property tabId the ID of the tab to remove from the group.
+     */
+    data class RemoveTabAction(
+        val partition: String,
+        val group: String,
+        val tabId: String
+    ) : TabGroupAction()
+
+    /**
+     * Removes the provided tabs from a group in [BrowserState].
+     *
+     * @property partition the ID of the partition the group belongs to.
+     * @property group the ID of the group.
+     * @property tabIds the IDs of the tabs to remove from the group.
+     */
+    data class RemoveTabsAction(
+        val partition: String,
+        val group: String,
+        val tabIds: List<String>
+    ) : TabGroupAction()
 }
 
 /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
@@ -23,6 +23,7 @@ import mozilla.components.browser.state.action.RestoreCompleteAction
 import mozilla.components.browser.state.action.SearchAction
 import mozilla.components.browser.state.action.ShareInternetResourceAction
 import mozilla.components.browser.state.action.SystemAction
+import mozilla.components.browser.state.action.TabGroupAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
 import mozilla.components.browser.state.action.UndoAction
@@ -53,6 +54,7 @@ internal object BrowserStateReducer {
             is ReaderAction -> ReaderStateReducer.reduce(state, action)
             is SystemAction -> SystemReducer.reduce(state, action)
             is TabListAction -> TabListReducer.reduce(state, action)
+            is TabGroupAction -> TabGroupReducer.reduce(state, action)
             is TrackingProtectionAction -> TrackingProtectionStateReducer.reduce(state, action)
             is WebExtensionAction -> WebExtensionReducer.reduce(state, action)
             is MediaSessionAction -> MediaSessionReducer.reduce(state, action)

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TabGroupReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TabGroupReducer.kt
@@ -1,0 +1,169 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.reducer
+
+import mozilla.components.browser.state.action.TabGroupAction
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.TabGroup
+import mozilla.components.browser.state.state.TabPartition
+import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.browser.state.state.getGroupById
+
+internal object TabGroupReducer {
+
+    /**
+     * [TabGroupAction] reducer function for modifying tab groups in [BrowserState.tabPartitions].
+     */
+    fun reduce(state: BrowserState, action: TabGroupAction): BrowserState {
+        return when (action) {
+            is TabGroupAction.AddTabGroupAction -> {
+                action.group.tabIds.forEach { state.assertTabExists(it) }
+                state.addTabGroup(action.partition, action.group)
+            }
+
+            is TabGroupAction.RemoveTabGroupAction -> {
+                state.removeTabGroup(action.partition, action.group)
+            }
+
+            is TabGroupAction.AddTabAction -> {
+                state.assertTabExists(action.tabId)
+
+                if (!state.groupExists(action.partition, action.group)) {
+                    state.addTabGroup(action.partition, TabGroup(action.group, tabIds = listOf(action.tabId)))
+                } else {
+                    state.updateTabGroup(action.partition, action.group) {
+                        it.copy(tabIds = it.tabIds + action.tabId)
+                    }
+                }
+            }
+
+            is TabGroupAction.AddTabsAction -> {
+                action.tabIds.forEach { state.assertTabExists(it) }
+
+                if (!state.groupExists(action.partition, action.group)) {
+                    state.addTabGroup(action.partition, TabGroup(action.group, tabIds = action.tabIds))
+                } else {
+                    state.updateTabGroup(action.partition, action.group) {
+                        it.copy(tabIds = it.tabIds + action.tabIds)
+                    }
+                }
+            }
+
+            is TabGroupAction.RemoveTabAction -> {
+                state.updateTabGroup(action.partition, action.group) {
+                    it.copy(tabIds = it.tabIds - action.tabId)
+                }
+            }
+
+            is TabGroupAction.RemoveTabsAction -> {
+                state.updateTabGroup(action.partition, action.group) {
+                    it.copy(tabIds = it.tabIds - action.tabIds)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Adds the provided tab group and creates the partition if needed.
+ */
+private fun BrowserState.addTabGroup(partitionId: String, group: TabGroup): BrowserState {
+    val partition = tabPartitions[partitionId]
+    val updatedPartition = if (partition != null) {
+        if (partition.getGroupById(group.id) != null) {
+            throw IllegalArgumentException("Tab group with same ID already exists")
+        }
+        partition.copy(tabGroups = partition.tabGroups + group)
+    } else {
+        TabPartition(partitionId, tabGroups = listOf(group))
+    }
+    return copy(tabPartitions = tabPartitions + (partitionId to updatedPartition))
+}
+
+/**
+ * Removes a tab group from the provided partition.
+ */
+private fun BrowserState.removeTabGroup(partitionId: String, groupId: String): BrowserState {
+    val partition = tabPartitions[partitionId]
+    val group = partition?.getGroupById(groupId)
+    return if (group != null) {
+        val updatedPartition = partition.copy(tabGroups = partition.tabGroups - group)
+        if (updatedPartition.tabGroups.isEmpty()) {
+            copy(tabPartitions = tabPartitions - partitionId)
+        } else {
+            copy(tabPartitions = tabPartitions + (partitionId to updatedPartition))
+        }
+    } else {
+        this
+    }
+}
+
+/**
+ * Checks if a tab group exists in the provided partition.
+ */
+private fun BrowserState.groupExists(partitionId: String, groupId: String): Boolean {
+    return tabPartitions[partitionId]?.getGroupById(groupId) != null
+}
+
+/**
+ * Checks that the provided tab exists and throws an
+ * [IllegalArgumentException] otherwise.
+ *
+ * @param tabId the id of the [TabSessionState] to check.
+ */
+private fun BrowserState.assertTabExists(tabId: String) {
+    require(tabs.find { it.id == tabId } != null) {
+        "Tab does not exist"
+    }
+}
+
+/**
+ * Utility function to update a [TabGroup] within a [TabPartition] in [BrowserState].
+ */
+private fun BrowserState.updateTabGroup(
+    partitionId: String,
+    groupId: String,
+    update: (TabGroup) -> TabGroup
+): BrowserState {
+    return updateTabPartition(partitionId) { partition ->
+        partition.updateTabGroup(groupId, update)
+    }
+}
+
+/**
+ * Updates the specified tab partition by invoking [update].
+ */
+private inline fun BrowserState.updateTabPartition(
+    partitionId: String,
+    crossinline update: (TabPartition) -> TabPartition
+): BrowserState {
+    val partition = tabPartitions[partitionId] ?: return this
+    return copy(tabPartitions = tabPartitions + (partitionId to update(partition)))
+}
+
+/**
+ * Updates the specified tab group within this partition by invoking [update].
+ */
+private inline fun TabPartition.updateTabGroup(
+    groupId: String,
+    crossinline update: (TabGroup) -> TabGroup
+): TabPartition {
+    return tabGroups.update(groupId, update)?.let {
+        copy(tabGroups = it)
+    } ?: this
+}
+
+/**
+ * Updates the provided tab group by invoking [update].
+ */
+private inline fun List<TabGroup>.update(
+    groupId: String,
+    crossinline update: (TabGroup) -> TabGroup
+): List<TabGroup>? {
+    val groupIndex = indexOfFirst { it.id == groupId }
+    if (groupIndex == -1) return null
+
+    return subList(0, groupIndex) + update(get(groupIndex)) + subList(groupIndex + 1, size)
+}

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/BrowserState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/BrowserState.kt
@@ -13,6 +13,8 @@ import java.util.Locale
  * Value type that represents the complete state of the browser/engine.
  *
  * @property tabs the list of open tabs, defaults to an empty list.
+ * @property tabPartitions a mapping of IDs to the corresponding [TabPartition]. A partition
+ * is used to store tab groups for a specific feature.
  * @property closedTabs the list of recently closed tabs if a [RecentlyClosedMiddleware] is added,
  * defaults to an empty list.
  * @property selectedTabId the ID of the currently selected (active) tab.
@@ -32,9 +34,10 @@ import java.util.Locale
  */
 data class BrowserState(
     val tabs: List<TabSessionState> = emptyList(),
+    val tabPartitions: Map<String, TabPartition> = emptyMap(),
+    val customTabs: List<CustomTabSessionState> = emptyList(),
     val closedTabs: List<RecoverableTab> = emptyList(),
     val selectedTabId: String? = null,
-    val customTabs: List<CustomTabSessionState> = emptyList(),
     val containers: Map<String, ContainerState> = emptyMap(),
     val extensions: Map<String, WebExtensionState> = emptyMap(),
     val activeWebExtensionTabId: String? = null,

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabPartition.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabPartition.kt
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.state
+
+import java.util.UUID
+
+/**
+ * Value type representing a tab partition. Partitions can overlap i.e., a tab
+ * can be in multiple partitions at the same time.
+ *
+ * @property id The ID of a tab partition. This should uniquely identify
+ * the feature responsible for managing those groups.
+ * @property tabGroups The groups of tabs in this partition. A partition can
+ * have one or more groups, depending on use case. Empty partitions will be
+ * removed by the system.
+ */
+data class TabPartition(
+    val id: String,
+    val tabGroups: List<TabGroup> = emptyList()
+)
+
+/**
+ * Value type representing a tab group.
+ *
+ * @property id The unique ID of this tab group.
+ * @property name The name of this tab group.
+ * @property tabIds The IDs of all tabs in this group.
+ */
+data class TabGroup(
+    val id: String = UUID.randomUUID().toString(),
+    val name: String = "",
+    val tabIds: List<String> = emptyList()
+)
+
+/**
+ * Returns the first tab group matching the provided [name], or null if no match
+ * was found. Note that we allow multiple groups with the same name in a
+ * partition but disambiguation needs to be handled on a feature level.
+ */
+fun TabPartition.getGroupByName(name: String) = this.tabGroups.firstOrNull {
+    it.name.equals(name, ignoreCase = true)
+}
+
+/**
+ * Returns the tab group matching the provided [id], or null if not match was found.
+ */
+fun TabPartition.getGroupById(id: String) = this.tabGroups.firstOrNull {
+    it.id == id
+}

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/TabGroupActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/TabGroupActionTest.kt
@@ -1,0 +1,245 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.action
+
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.TabGroup
+import mozilla.components.browser.state.state.TabPartition
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.browser.state.state.getGroupById
+import mozilla.components.browser.state.state.getGroupByName
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.support.test.ext.joinBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TabGroupActionTest {
+
+    @Test
+    fun `AddTabGroupAction - Adds provided group and creates partition if needed`() {
+        val store = BrowserStore()
+
+        val partition = "testFeaturePartition"
+        val testGroup = TabGroup("test", "testGroup")
+        store.dispatch(TabGroupAction.AddTabGroupAction(partition = partition, group = testGroup)).joinBlocking()
+
+        val expectedPartition = store.state.tabPartitions[partition]
+        assertNotNull(expectedPartition)
+        assertSame(testGroup, expectedPartition?.getGroupById(testGroup.id))
+        assertSame(testGroup, expectedPartition?.getGroupByName(testGroup.name))
+    }
+
+    @Test
+    fun `AddTabGroupAction - Adds provided group with tabs`() {
+        val store = BrowserStore(
+            BrowserState(
+                tabs = listOf(
+                    createTab(id = "tab1", url = "https://firefox.com"),
+                    createTab(id = "tab2", url = "https://mozilla.org")
+                )
+            )
+        )
+
+        val partition = "testFeaturePartition"
+        val testGroup = TabGroup("test", tabIds = listOf("tab1", "tab2"))
+        store.dispatch(TabGroupAction.AddTabGroupAction(partition = partition, group = testGroup)).joinBlocking()
+
+        val expectedPartition = store.state.tabPartitions[partition]
+        assertNotNull(expectedPartition)
+        assertSame(testGroup, expectedPartition?.getGroupById(testGroup.id))
+        assertEquals(listOf("tab1", "tab2"), expectedPartition?.getGroupById(testGroup.id)?.tabIds)
+    }
+
+    @Test
+    fun `RemoveTabGroupAction - Removes provided group`() {
+        val tabGroup1 = TabGroup("test1", tabIds = listOf("tab1", "tab2"))
+        val tabGroup2 = TabGroup("test2", tabIds = listOf("tab1", "tab2"))
+        val tabPartition = TabPartition("testFeaturePartition", tabGroups = listOf(tabGroup1, tabGroup2))
+
+        val store = BrowserStore(
+            BrowserState(
+                tabs = listOf(
+                    createTab(id = "tab1", url = "https://firefox.com"),
+                    createTab(id = "tab2", url = "https://mozilla.org")
+                ),
+                tabPartitions = mapOf("testFeaturePartition" to tabPartition)
+            )
+        )
+
+        assertNotNull(store.state.tabPartitions[tabPartition.id]?.getGroupById(tabGroup1.id))
+        assertNotNull(store.state.tabPartitions[tabPartition.id]?.getGroupById(tabGroup2.id))
+        store.dispatch(TabGroupAction.RemoveTabGroupAction(tabPartition.id, tabGroup1.id)).joinBlocking()
+        assertNull(store.state.tabPartitions[tabPartition.id]?.getGroupById(tabGroup1.id))
+        assertNotNull(store.state.tabPartitions[tabPartition.id]?.getGroupById(tabGroup2.id))
+    }
+
+    @Test
+    fun `RemoveTabGroupAction - Empty partitions are removed`() {
+        val tabGroup = TabGroup("test1", tabIds = listOf("tab1", "tab2"))
+        val tabPartition = TabPartition("testFeaturePartition", tabGroups = listOf(tabGroup))
+
+        val store = BrowserStore(
+            BrowserState(
+                tabs = listOf(
+                    createTab(id = "tab1", url = "https://firefox.com"),
+                    createTab(id = "tab2", url = "https://mozilla.org")
+                ),
+                tabPartitions = mapOf("testFeaturePartition" to tabPartition)
+            )
+        )
+
+        assertNotNull(store.state.tabPartitions[tabPartition.id]?.getGroupById(tabGroup.id))
+        store.dispatch(TabGroupAction.RemoveTabGroupAction(tabPartition.id, tabGroup.id)).joinBlocking()
+        assertNull(store.state.tabPartitions[tabPartition.id])
+    }
+
+    @Test
+    fun `AddTabAction - Adds provided tab to groups`() {
+        val tabGroup = TabGroup("test1", tabIds = emptyList())
+        val tabPartition = TabPartition("testFeaturePartition", tabGroups = listOf(tabGroup))
+        val tab = createTab(id = "tab1", url = "https://firefox.com")
+
+        val store = BrowserStore(
+            BrowserState(
+                tabs = listOf(tab),
+                tabPartitions = mapOf("testFeaturePartition" to tabPartition)
+            )
+        )
+
+        store.dispatch(TabGroupAction.AddTabAction(tabPartition.id, tabGroup.id, tab.id)).joinBlocking()
+
+        val expectedPartition = store.state.tabPartitions[tabPartition.id]
+        assertNotNull(expectedPartition)
+        val expectedGroup = expectedPartition!!.getGroupById(tabGroup.id)
+        assertNotNull(expectedGroup)
+        assertTrue(expectedGroup!!.tabIds.contains(tab.id))
+    }
+
+    @Test
+    fun `AddTabAction - Creates partition if needed`() {
+        val tabGroup = TabGroup("test1", tabIds = emptyList())
+        val tabPartition = TabPartition("testFeaturePartition")
+        val tab = createTab(id = "tab1", url = "https://firefox.com")
+
+        val store = BrowserStore(
+            BrowserState(
+                tabs = listOf(tab)
+            )
+        )
+
+        store.dispatch(TabGroupAction.AddTabAction(tabPartition.id, tabGroup.id, tab.id)).joinBlocking()
+
+        val expectedPartition = store.state.tabPartitions[tabPartition.id]
+        assertNotNull(expectedPartition)
+        val expectedGroup = expectedPartition!!.getGroupById(tabGroup.id)
+        assertNotNull(expectedGroup)
+        assertTrue(expectedGroup!!.tabIds.contains(tab.id))
+    }
+
+    @Test
+    fun `AddTabsAction - Adds provided tab to groups`() {
+        val tabGroup = TabGroup("test1", tabIds = emptyList())
+        val tabPartition = TabPartition("testFeaturePartition", tabGroups = listOf(tabGroup))
+        val tab1 = createTab(id = "tab1", url = "https://firefox.com")
+        val tab2 = createTab(id = "tab2", url = "https://mozilla.org")
+
+        val store = BrowserStore(
+            BrowserState(
+                tabs = listOf(tab1, tab2),
+                tabPartitions = mapOf("testFeaturePartition" to tabPartition)
+            )
+        )
+
+        store.dispatch(
+            TabGroupAction.AddTabsAction(tabPartition.id, tabGroup.id, listOf(tab1.id, tab2.id))
+        ).joinBlocking()
+
+        val expectedPartition = store.state.tabPartitions[tabPartition.id]
+        assertNotNull(expectedPartition)
+        val expectedGroup = expectedPartition!!.getGroupById(tabGroup.id)
+        assertNotNull(expectedGroup)
+        assertTrue(expectedGroup!!.tabIds.contains(tab1.id))
+        assertTrue(expectedGroup.tabIds.contains(tab2.id))
+    }
+
+    @Test
+    fun `AddTabsAction - Creates partition if needed`() {
+        val tabGroup = TabGroup("test1", tabIds = emptyList())
+        val tabPartition = TabPartition("testFeaturePartition")
+        val tab1 = createTab(id = "tab1", url = "https://firefox.com")
+        val tab2 = createTab(id = "tab2", url = "https://mozilla.org")
+
+        val store = BrowserStore(
+            BrowserState(
+                tabs = listOf(tab1, tab2)
+            )
+        )
+
+        store.dispatch(
+            TabGroupAction.AddTabsAction(tabPartition.id, tabGroup.id, listOf(tab1.id, tab2.id))
+        ).joinBlocking()
+
+        val expectedPartition = store.state.tabPartitions[tabPartition.id]
+        assertNotNull(expectedPartition)
+        val expectedGroup = expectedPartition!!.getGroupById(tabGroup.id)
+        assertNotNull(expectedGroup)
+        assertTrue(expectedGroup!!.tabIds.contains(tab1.id))
+        assertTrue(expectedGroup.tabIds.contains(tab2.id))
+    }
+
+    @Test
+    fun `RemoveTabAction - Removes tab from group`() {
+        val tab1 = createTab(id = "tab1", url = "https://firefox.com")
+        val tab2 = createTab(id = "tab2", url = "https://mozilla.org")
+        val tabGroup = TabGroup("test1", tabIds = listOf(tab1.id, tab2.id))
+        val tabPartition = TabPartition("testFeaturePartition", tabGroups = listOf(tabGroup))
+
+        val store = BrowserStore(
+            BrowserState(
+                tabs = listOf(tab1, tab2),
+                tabPartitions = mapOf("testFeaturePartition" to tabPartition)
+            )
+        )
+
+        store.dispatch(TabGroupAction.RemoveTabAction(tabPartition.id, tabGroup.id, tab1.id)).joinBlocking()
+
+        val expectedPartition = store.state.tabPartitions[tabPartition.id]
+        assertNotNull(expectedPartition)
+        val expectedGroup = expectedPartition!!.getGroupById(tabGroup.id)
+        assertNotNull(expectedGroup)
+        assertFalse(expectedGroup!!.tabIds.contains(tab1.id))
+        assertTrue(expectedGroup.tabIds.contains(tab2.id))
+    }
+
+    @Test
+    fun `RemoveTabsAction - Removes tabs from group`() {
+        val tab1 = createTab(id = "tab1", url = "https://firefox.com")
+        val tab2 = createTab(id = "tab2", url = "https://mozilla.org")
+        val tabGroup = TabGroup("test1", tabIds = listOf(tab1.id, tab2.id))
+        val tabPartition = TabPartition("testFeaturePartition", tabGroups = listOf(tabGroup))
+
+        val store = BrowserStore(
+            BrowserState(
+                tabs = listOf(tab1, tab2),
+                tabPartitions = mapOf("testFeaturePartition" to tabPartition)
+            )
+        )
+
+        store.dispatch(
+            TabGroupAction.RemoveTabsAction(tabPartition.id, tabGroup.id, listOf(tab1.id, tab2.id))
+        ).joinBlocking()
+
+        val expectedPartition = store.state.tabPartitions[tabPartition.id]
+        assertNotNull(expectedPartition)
+        val expectedGroup = expectedPartition!!.getGroupById(tabGroup.id)
+        assertNotNull(expectedGroup)
+        assertTrue(expectedGroup!!.tabIds.isEmpty())
+    }
+}


### PR DESCRIPTION
Implementation of our [RFC](https://github.com/mozilla-mobile/android-components/pull/11172). Besides state and actions the only complexity added here is to automatically create the groups/partitions, as needed, and discussed in the RFC to simplify usage for consuming applications. The other piece is to make sure partitions are automatically cleaned up when tabs are removed.

Tests are on the way, but putting up for (early) review.