### PR TITLE
Add a method to remove navigation actions from toolbar

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -68,6 +68,7 @@ internal fun ImageView.setTintResource(@ColorRes tintColorResource: Int) {
  *  +----------------+ +----------------+
  * ```
  */
+@Suppress("TooManyFunctions")
 class BrowserToolbar @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -296,6 +297,16 @@ class BrowserToolbar @JvmOverloads constructor(
      */
     override fun addNavigationAction(action: Toolbar.Action) {
         display.addNavigationAction(action)
+    }
+
+    /**
+     * Removes a previously added navigation action (see [addNavigationAction]). If the provided
+     * action was never added, this method has no effect.
+     *
+     * @param action the action to remove.
+     */
+    override fun removeNavigationAction(action: Toolbar.Action) {
+        display.removeNavigationAction(action)
     }
 
     /**

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -641,6 +641,16 @@ class DisplayToolbar internal constructor(
     internal fun addNavigationAction(action: Toolbar.Action) {
         views.navigationActions.addAction(action)
     }
+
+    /**
+     * Removes a previously added navigation action (see [addNavigationAction]). If the provided
+     * action was never added, this method has no effect.
+     *
+     * @param action the action to remove.
+     */
+    internal fun removeNavigationAction(action: Toolbar.Action) {
+        views.navigationActions.removeAction(action)
+    }
 }
 
 /**

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -385,6 +385,22 @@ class BrowserToolbarTest {
     }
 
     @Test
+    fun `remove navigation action will be forwarded to display toolbar`() {
+        val toolbar = BrowserToolbar(testContext)
+        val display: DisplayToolbar = mock()
+
+        toolbar.display = display
+
+        val action = BrowserToolbar.Button(mock(), "Hello") {
+            // Do nothing
+        }
+
+        toolbar.removeNavigationAction(action)
+
+        verify(display).removeNavigationAction(action)
+    }
+
+    @Test
     fun `remove page action will be forwarded to display toolbar`() {
         val toolbar = BrowserToolbar(testContext)
         val display: DisplayToolbar = mock()

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -337,6 +337,23 @@ class DisplayToolbarTest {
     }
 
     @Test
+    fun `navigation action can be removed`() {
+        val contentDescription = "to-be-removed"
+
+        val (_, displayToolbar) = createDisplayToolbar()
+
+        val action = BrowserToolbar.Button(mock(), contentDescription) {}
+        // Removing action which was never added has no effect
+        displayToolbar.removeNavigationAction(action)
+
+        displayToolbar.addNavigationAction(action)
+        assertEquals(1, displayToolbar.views.navigationActions.childCount)
+
+        displayToolbar.removeNavigationAction(action)
+        assertEquals(0, displayToolbar.views.navigationActions.childCount)
+    }
+
+    @Test
     fun `page action can be removed`() {
         val contentDescription = "to-be-removed"
 

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -126,6 +126,14 @@ interface Toolbar {
     fun removePageAction(action: Action)
 
     /**
+     * Removes a previously added navigation action (see [addNavigationAction]). If the the provided
+     * actions was never added, this method has no effect.
+     *
+     * @param action the action to remove.
+     */
+    fun removeNavigationAction(action: Action)
+
+    /**
      * Declare that the actions (navigation actions, browser actions, page actions) have changed and
      * should be updated if needed.
      */

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/CustomTabSessionTitleObserverTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/CustomTabSessionTitleObserverTest.kt
@@ -87,6 +87,7 @@ class CustomTabSessionTitleObserverTest {
         override fun addPageAction(action: Toolbar.Action) = Unit
         override fun removePageAction(action: Toolbar.Action) = Unit
         override fun addNavigationAction(action: Toolbar.Action) = Unit
+        override fun removeNavigationAction(action: Toolbar.Action) = Unit
         override fun addEditAction(action: Toolbar.Action) = Unit
         override fun setOnEditListener(listener: Toolbar.OnEditListener) = Unit
         override fun displayMode() = Unit

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
@@ -88,6 +88,10 @@ class ToolbarAutocompleteFeatureTest {
             fail()
         }
 
+        override fun removeNavigationAction(action: Toolbar.Action) {
+            fail()
+        }
+
         override fun setOnEditListener(listener: Toolbar.OnEditListener) {
             fail()
         }

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
@@ -73,6 +73,10 @@ class ToolbarInteractorTest {
             fail()
         }
 
+        override fun removeNavigationAction(action: Toolbar.Action) {
+            fail()
+        }
+
         override fun setOnEditListener(listener: Toolbar.OnEditListener) {
             fail()
         }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/v95.0.0/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/v95.0.0/.config.yml)
 
+* **concept-toolbar**
+  * 🌟️️ **Add removeNavigationAction method which removes a previously added navigation action
+
 * **support-utils**
   * 🌟️️ **Add Firefox Focus packages to known browsers list
 


### PR DESCRIPTION
For #11279
Add a new method(removeNavigationAction) in Toolbar interface to be able to remove a navigation action
as we have at this moment for browser/page actions(removeBrowserAction, removePageAction)



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
