### PR TITLE
AwesomeBar(): Pass SuggestionFetcher down instead of list of suggestions

### DIFF
--- a/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/AwesomeBar.kt
+++ b/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/AwesomeBar.kt
@@ -95,7 +95,7 @@ fun AwesomeBar(
 
         Suggestions(
             groups,
-            fetcher.state.value,
+            fetcher,
             colors,
             orientation,
             onSuggestionClicked,

--- a/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/Suggestions.kt
+++ b/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/Suggestions.kt
@@ -21,7 +21,7 @@ import mozilla.components.concept.awesomebar.AwesomeBar
 @Suppress("LongParameterList")
 internal fun Suggestions(
     groups: List<AwesomeBar.SuggestionProviderGroup>,
-    suggestions: Map<AwesomeBar.SuggestionProviderGroup, List<AwesomeBar.Suggestion>>,
+    fetcher: SuggestionFetcher,
     colors: AwesomeBarColors,
     orientation: AwesomeBarOrientation,
     onSuggestionClicked: (AwesomeBar.SuggestionProviderGroup, AwesomeBar.Suggestion) -> Unit,
@@ -36,6 +36,8 @@ internal fun Suggestions(
         state = state,
         modifier = Modifier.testTag("mozac.awesomebar.suggestions")
     ) {
+        val suggestions = fetcher.state.value
+
         groups.forEach { group ->
             val groupSuggestions = suggestions[group] ?: emptyList()
 


### PR DESCRIPTION
Previously we asked `SuggestionFetcher` for the list of suggestions in `AwesomeBar()` and then passed it down to `Suggestions()`. This happened automatically whenever `SuggestionFetcher` got new suggestions from the providers. By passing it down to `Suggestions()` and subscribing inside `LazyColumn`, only that subset needs to be recomposed whenever new suggestions are available. I couldn't really measure whether this makes a difference. But the code is nicer too if we subscribe to state only where it's actually needed.