### PR TITLE
Handle places exceptions when querying highlights

### DIFF
--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
@@ -277,7 +277,9 @@ open class PlacesHistoryStorage(
         weights: HistoryHighlightWeights,
         limit: Int
     ): List<HistoryHighlight> {
-        return places.reader().getHighlights(weights.into(), limit).intoHighlights()
+        return handlePlacesExceptions("getHistoryHighlights", default = emptyList()) {
+            places.reader().getHighlights(weights.into(), limit).intoHighlights()
+        }
     }
 
     override suspend fun noteHistoryMetadataObservation(


### PR DESCRIPTION
We did this for all other reads for history/metadata. Let's do it for highlights as well now that we're about to start using it. No reason to crash over it, let's record as info instead. We may still have clients out there with invalid data.