### PR TITLE
Handle SCOPE_SYNC access tokens missing a 'key'

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Exceptions.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Exceptions.kt
@@ -56,9 +56,22 @@ sealed class AccountManagerException(message: String) : Exception(message) {
     class AuthRecoveryCircuitBreakerException(operation: String) : AccountManagerException(
         "Auth recovery circuit breaker triggered by: $operation"
     )
+
+    /**
+     * Unexpectedly encountered an access token without a key.
+     * @param operation An operation which triggered this state.
+     */
+    class MissingKeyFromSyncScopedAccessToken(operation: String) : AccountManagerException(
+        "Encountered an access token without a key: $operation"
+    )
 }
 
 /**
  * FxaException wrapper easily identifying it as the result of a failed operation of sending tabs.
  */
 class SendCommandException(fxaException: FxaException) : Exception(fxaException)
+
+/**
+ * Thrown if we saw a keyed access token without a key (e.g. obtained for SCOPE_SYNC).
+ */
+internal class AccessTokenUnexpectedlyWithoutKey : Exception()

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Types.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Types.kt
@@ -78,7 +78,7 @@ fun AccessTokenInfo.into(): mozilla.components.concept.sync.AccessTokenInfo {
  * @throws IllegalStateException if [AccessTokenInfo] didn't have key information.
  */
 fun mozilla.components.concept.sync.AccessTokenInfo.asSyncAuthInfo(tokenServerUrl: String): SyncAuthInfo {
-    val keyInfo = this.key ?: throw IllegalStateException("missing OAuthScopedKey")
+    val keyInfo = this.key ?: throw AccessTokenUnexpectedlyWithoutKey()
 
     return SyncAuthInfo(
         kid = keyInfo.kid,

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/State.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/State.kt
@@ -34,6 +34,7 @@ internal sealed class Event {
                 return "${this.javaClass.simpleName} - $operation"
             }
         }
+        object AccessTokenKeyError : Account()
 
         data class MigrateFromAccount(val account: ShareableAccount, val reuseSessionToken: Boolean) : Account() {
             override fun toString(): String {
@@ -92,6 +93,7 @@ internal fun State.next(event: Event): State? = when (this) {
         }
         AccountState.Authenticated -> when (event) {
             is Event.Account.AuthenticationError -> State.Active(ProgressState.RecoveringFromAuthProblem)
+            is Event.Account.AccessTokenKeyError -> State.Idle(AccountState.AuthenticationProblem)
             is Event.Account.Logout -> State.Active(ProgressState.LoggingOut)
             else -> null
         }

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/manager/StateKtTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/manager/StateKtTest.kt
@@ -26,6 +26,7 @@ class StateKtTest {
                 }
                 AccountState.Authenticated -> when (event) {
                     is Event.Account.AuthenticationError -> State.Active(ProgressState.RecoveringFromAuthProblem)
+                    Event.Account.AccessTokenKeyError -> State.Idle(AccountState.AuthenticationProblem)
                     Event.Account.Logout -> State.Active(ProgressState.LoggingOut)
                     else -> null
                 }
@@ -82,6 +83,7 @@ class StateKtTest {
             "BeginEmailFlow" -> Event.Account.BeginEmailFlow
             "CancelAuth" -> Event.Progress.CancelAuth
             "AuthenticationError" -> Event.Account.AuthenticationError("fxa op")
+            "AccessTokenKeyError" -> Event.Account.AccessTokenKeyError
             "MigrateFromAccount" -> Event.Account.MigrateFromAccount(mock(), true)
             "RetryMigration" -> Event.Account.RetryMigration
             "Logout" -> Event.Account.Logout


### PR DESCRIPTION
For reasons that are currently vague and not understood well, we could
be getting SCOPE_SYNC access tokens without a 'key'. Currently, that
will cause a crash. This patch adds just enough handling of this state
to avoid crashing, transition the account into one of the terminal
states ('not authenticated' if this happened during a login, 'auth
problem' if this happened afterwards), and report an 'info' via the
crash reporter with enough information to understand when exactly this
happens.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
