### PR TITLE
updates application services to 86.2.1

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,7 +29,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "2.4"
 
-    const val mozilla_appservices = "86.2.0"
+    const val mozilla_appservices = "86.2.1"
 
     const val mozilla_glean = "42.0.1"
 


### PR DESCRIPTION
fixes  https://github.com/mozilla/application-services/issues/4691
Updates applications services to v86.2.1, this patch release has **exactly** one change that fixes web push, for more information look at: https://github.com/mozilla/application-services/issues/4691. We want to get this in this nightly cycle before the bug hits beta. You can verify that the release only has this one change, by looking at [the diff between the releases](https://github.com/mozilla/application-services/compare/v86.2.0...v86.2.1)

The change log:
# v86.2.1 (_2021-12-02_)

[Full Changelog](https://github.com/mozilla/application-services/compare/v86.2.0...v86.2.1)

## Push
### What's fixed
  - Fixes a bug where the subscriptions would fail because the server didn't return the `uaid`, this seems to happen only when the client sends request that include the `uaid`.([#4697](https://github.com/mozilla/application-services/pull/4697))
  
cc: @jonalmeida
