### PR TITLE
Fix for the browser-icons test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,7 @@ subprojects {
             tasks.matching {it instanceof Test}.configureEach() {
                 systemProperty "robolectric.logging", "stdout"
                 systemProperty "logging.test-mode", "true"
+                systemProperty "javax.net.ssl.trustStoreType", "JKS"
 
                 testLogging.events = []
 


### PR DESCRIPTION
The tests have been failing for me, I believe because of robolectric/robolectric#5496.

This change makes the tests pass again for me.  I think at least one other dev should test it though to make sure I didn't break them for others.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
