### PR TITLE
Issue #11355: Add DarkGrey30A96 and DarkGrey90A96 to photon colors

### DIFF
--- a/components/ui/colors/src/main/java/mozilla/components/ui/colors/PhotonColors.kt
+++ b/components/ui/colors/src/main/java/mozilla/components/ui/colors/PhotonColors.kt
@@ -131,6 +131,7 @@ object PhotonColors {
     val DarkGrey10 = Color(0xFF52525E)
     val DarkGrey20 = Color(0xFF4A4A55)
     val DarkGrey30 = Color(0xFF42414D)
+    val DarkGrey30A96 = Color(0xF542414D)
     val DarkGrey40 = Color(0xFF3A3944)
     val DarkGrey50 = Color(0xFF32313C)
     val DarkGrey60 = Color(0xFF2B2A33)
@@ -138,6 +139,7 @@ object PhotonColors {
     val DarkGrey80 = Color(0xFF1C1B22)
     val DarkGrey90 = Color(0xFF15141A)
     val DarkGrey90A40 = Color(0x6615141A)
+    val DarkGrey90A96 = Color(0xF515141A)
 
     // Violet
     val Violet05 = Color(0xFFE7DFFF)

--- a/components/ui/colors/src/main/res/values/photon_colors.xml
+++ b/components/ui/colors/src/main/res/values/photon_colors.xml
@@ -168,6 +168,7 @@
 	<color name="photonDarkGrey10">#ff52525e</color>
 	<color name="photonDarkGrey20">#ff4a4a55</color>
 	<color name="photonDarkGrey30">#ff42414d</color>
+	<color name="photonDarkGrey30A96">#f542414d</color>
 	<color name="photonDarkGrey40">#ff3a3944</color>
 	<color name="photonDarkGrey50">#ff32313c</color>
 	<color name="photonDarkGrey60">#ff2b2a33</color>
@@ -175,6 +176,7 @@
 	<color name="photonDarkGrey80">#ff1c1b22</color>
 	<color name="photonDarkGrey90">#ff15141a</color>
 	<color name="photonDarkGrey90A40">#6615141a</color>
+	<color name="photonDarkGrey90A96">#f515141a</color>
 
 	<!-- Violet -->
 	<color name="photonViolet05">#ffE7DFFF</color>


### PR DESCRIPTION
Fixes #11355 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
