### PR TITLE
Closes #11368 - CreditCardEnc scrubbing on key loss; key management refactor

### DIFF
--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
@@ -340,7 +340,7 @@ interface CreditCardsAddressesStorageDelegate {
      * @param encryptedCardNumber An encrypted credit card number to be decrypted.
      * @return A plaintext, non-encrypted credit card number.
      */
-    fun decrypt(encryptedCardNumber: CreditCardNumber.Encrypted): CreditCardNumber.Plaintext?
+    suspend fun decrypt(encryptedCardNumber: CreditCardNumber.Encrypted): CreditCardNumber.Plaintext?
 
     /**
      * Returns all stored addresses. This is called when the engine believes an address field

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
@@ -113,6 +113,11 @@ interface CreditCardsAddressesStorage {
      * @return [CreditCardCrypto] instance.
      */
     fun getCreditCardCrypto(): CreditCardCrypto
+
+    /**
+     * Removes any encrypted data from this storage. Useful after encountering key loss.
+     */
+    suspend fun scrubEncryptedData()
 }
 
 /**

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/KeyManager.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/KeyManager.kt
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.storage
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.IllegalStateException
+
+/**
+ * Knows how to manage (generate, store, validate) keys and recover from their loss.
+ */
+abstract class KeyManager : KeyProvider {
+    // Exists to ensure that key generation/validation/recovery flow is synchronized.
+    private val keyMutex = Mutex()
+
+    /**
+     * @return Generated key.
+     */
+    abstract fun createKey(): String
+
+    /**
+     * Determines if [rawKey] is still valid for a given [canary], or if recovery is necessary.
+     * @return Optional [KeyGenerationReason.RecoveryNeeded] if recovery is necessary.
+     */
+    abstract fun isKeyRecoveryNeeded(rawKey: String, canary: String): KeyGenerationReason.RecoveryNeeded?
+
+    /**
+     * Returns a stored canary, if there's one. A canary is some known string encrypted with the managed key.
+     * @return an optional, stored canary string.
+     */
+    abstract fun getStoredCanary(): String?
+
+    /**
+     * Returns a stored key, if there's one.
+     */
+    abstract fun getStoredKey(): String?
+
+    /**
+     * Stores [key]; using the key, generate and store a canary.
+     */
+    abstract fun storeKeyAndCanary(key: String)
+
+    /**
+     * Recover from key loss that happened due to [reason].
+     * If this KeyManager wraps a storage layer, it should probably remove the now-unreadable data.
+     */
+    abstract suspend fun recoverFromKeyLoss(reason: KeyGenerationReason.RecoveryNeeded)
+
+    override suspend fun getOrGenerateKey(): ManagedKey = keyMutex.withLock(this) {
+        val managedKey = getManagedKey()
+
+        (managedKey.wasGenerated as? KeyGenerationReason.RecoveryNeeded)?.let {
+            recoverFromKeyLoss(managedKey.wasGenerated)
+        }
+        return managedKey
+    }
+
+    /**
+     * Access should be guarded by [keyMutex].
+     */
+    private fun getManagedKey(): ManagedKey {
+        val storedCanaryPhrase = getStoredCanary()
+        val storedKey = getStoredKey()
+
+        return when {
+            // We expected the key to be present, and it is.
+            storedKey != null && storedCanaryPhrase != null -> {
+                // Make sure that the key is valid.
+                when (val recoveryReason = isKeyRecoveryNeeded(storedKey, storedCanaryPhrase)) {
+                    is KeyGenerationReason -> ManagedKey(generateAndStoreKey(), recoveryReason)
+                    null -> ManagedKey(storedKey)
+                }
+            }
+
+            // The key is present, but we didn't expect it to be there.
+            storedKey != null && storedCanaryPhrase == null -> {
+                // This isn't expected to happen. We can't check this key's validity.
+                ManagedKey(generateAndStoreKey(), KeyGenerationReason.RecoveryNeeded.AbnormalState)
+            }
+
+            // We expected the key to be present, but it's gone missing on us.
+            storedKey == null && storedCanaryPhrase != null -> {
+                // At this point, we're forced to generate a new key to recover and move forward.
+                // However, that means that any data that was previously encrypted is now unreadable.
+                ManagedKey(generateAndStoreKey(), KeyGenerationReason.RecoveryNeeded.Lost)
+            }
+
+            // We didn't expect the key to be present, and it's not.
+            storedKey == null && storedCanaryPhrase == null -> {
+                // Normal case when interacting with this class for the first time.
+                ManagedKey(generateAndStoreKey(), KeyGenerationReason.New)
+            }
+
+            else -> throw IllegalStateException()
+        }
+    }
+
+    /**
+     * Access should be guarded by [keyMutex].
+     */
+    private fun generateAndStoreKey(): String {
+        return createKey().also { newKey ->
+            storeKeyAndCanary(newKey)
+        }
+    }
+}

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/KeyProvider.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/KeyProvider.kt
@@ -13,19 +13,7 @@ interface KeyProvider {
      *
      * @return [ManagedKey] that wraps the encryption key.
      */
-    fun key(): ManagedKey
-}
-
-/**
- * Knows how to recover from bad/missing encryption keys, e.g. instances of [KeyGenerationReason.RecoveryNeeded].
- */
-interface KeyRecoveryHandler {
-    /**
-     * Performs storage-specific recovery.
-     *
-     * @param reason Describes what happened to the previous key and why a recovery is needed.
-     */
-    fun recoverFromBadKey(reason: KeyGenerationReason.RecoveryNeeded)
+    suspend fun getOrGenerateKey(): ManagedKey
 }
 
 /**

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/LoginsStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/LoginsStorage.kt
@@ -237,7 +237,7 @@ interface LoginsStorage : AutoCloseable {
      * @param login [EncryptedLogin] to decrypt
      * @return [Login] with decrypted data
      */
-    fun decryptLogin(login: EncryptedLogin): Login
+    suspend fun decryptLogin(login: EncryptedLogin): Login
 }
 
 /**

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
@@ -413,7 +413,7 @@ internal class WorkManagerSyncWorker(
         val localEncryptionKeys = engineKeyProviders.mapKeys {
             it.key.nativeName
         }.mapValues {
-            it.value.key().key
+            it.value.getOrGenerateKey().key
         }
 
         // We're now ready to sync.

--- a/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorage.kt
+++ b/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorage.kt
@@ -168,6 +168,10 @@ class AutofillCreditCardsAddressesStorage(
         return crypto
     }
 
+    override suspend fun scrubEncryptedData() = withContext(coroutineContext) {
+        conn.getStorage().scrubEncryptedData()
+    }
+
     override fun registerWithSyncManager() {
         conn.getStorage().registerWithSyncManager()
     }

--- a/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCrypto.kt
+++ b/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCrypto.kt
@@ -7,12 +7,12 @@ package mozilla.components.service.sync.autofill
 import android.content.Context
 import android.content.SharedPreferences
 import mozilla.appservices.autofill.AutofillException
-import mozilla.appservices.autofill.createKey
 import mozilla.appservices.autofill.decryptString
 import mozilla.appservices.autofill.encryptString
 import mozilla.components.concept.storage.CreditCardCrypto
 import mozilla.components.concept.storage.CreditCardNumber
 import mozilla.components.concept.storage.KeyGenerationReason
+import mozilla.components.concept.storage.KeyManager
 import mozilla.components.concept.storage.ManagedKey
 import mozilla.components.lib.dataprotect.SecureAbove22Preferences
 import mozilla.components.support.base.log.logger.Logger
@@ -31,7 +31,7 @@ class AutofillCrypto(
     private val context: Context,
     private val securePrefs: SecureAbove22Preferences,
     private val storage: AutofillCreditCardsAddressesStorage
-) : CreditCardCrypto {
+) : CreditCardCrypto, KeyManager() {
     private val logger = Logger("AutofillCrypto")
     private val plaintextPrefs by lazy { context.getSharedPreferences(AUTOFILL_PREFS, Context.MODE_PRIVATE) }
 
@@ -40,7 +40,7 @@ class AutofillCrypto(
         plaintextCardNumber: CreditCardNumber.Plaintext
     ): CreditCardNumber.Encrypted? {
         return try {
-            CreditCardNumber.Encrypted(encrypt(key, plaintextCardNumber.number))
+            CreditCardNumber.Encrypted(encryptString(key.key, plaintextCardNumber.number))
         } catch (e: AutofillException.JsonException) {
             logger.warn("Failed to encrypt", e)
             null
@@ -55,7 +55,7 @@ class AutofillCrypto(
         encryptedCardNumber: CreditCardNumber.Encrypted
     ): CreditCardNumber.Plaintext? {
         return try {
-            CreditCardNumber.Plaintext(decrypt(key, encryptedCardNumber.number))
+            CreditCardNumber.Plaintext(decryptString(key.key, encryptedCardNumber.number))
         } catch (e: AutofillException.JsonException) {
             logger.warn("Failed to decrypt", e)
             null
@@ -65,94 +65,45 @@ class AutofillCrypto(
         }
     }
 
-    override suspend fun getOrGenerateKey(): ManagedKey = synchronized(this) {
-        val managedKey = getManagedKey()
+    override fun createKey() = mozilla.appservices.autofill.createKey()
 
-        // Record abnormal events if any were detected.
-        // At this point, we should emit some telemetry.
-        // See https://github.com/mozilla-mobile/android-components/issues/10122
-        when (managedKey.wasGenerated) {
-            is KeyGenerationReason.RecoveryNeeded.Lost -> {
-                logger.warn("Key was lost")
+    override fun isKeyRecoveryNeeded(rawKey: String, canary: String): KeyGenerationReason.RecoveryNeeded? {
+        return try {
+            if (CANARY_PHRASE_PLAINTEXT == decryptString(rawKey, canary)) {
+                null
+            } else {
+                KeyGenerationReason.RecoveryNeeded.Corrupt
             }
-            is KeyGenerationReason.RecoveryNeeded.Corrupt -> {
-                logger.warn("Key was corrupted")
-            }
-            is KeyGenerationReason.RecoveryNeeded.AbnormalState -> {
-                logger.warn("Abnormal state while reading the key")
-            }
-            null, KeyGenerationReason.New -> {
-                // All good! Got either a brand new key or read a valid key.
-            }
-        }
-        (managedKey.wasGenerated as? KeyGenerationReason.RecoveryNeeded)?.let {
-            storage.conn.getStorage().scrubEncryptedData()
-        }
-        return managedKey
-    }
-
-    private fun encrypt(key: ManagedKey, cleartext: String) = encryptString(key.key, cleartext)
-    private fun decrypt(key: ManagedKey, ciphertext: String) = decryptString(key.key, ciphertext)
-
-    @Suppress("ComplexMethod")
-    private fun getManagedKey(): ManagedKey = synchronized(this) {
-        val encryptedCanaryPhrase = plaintextPrefs.getString(CANARY_PHRASE_CIPHERTEXT_KEY, null)
-        val storedKey = securePrefs.getString(AUTOFILL_KEY)
-
-        return@synchronized when {
-            // We expected the key to be present, and it is.
-            storedKey != null && encryptedCanaryPhrase != null -> {
-                // Make sure that the key is valid.
-                try {
-                    if (CANARY_PHRASE_PLAINTEXT == decryptString(storedKey, encryptedCanaryPhrase)) {
-                        ManagedKey(storedKey)
-                    } else {
-                        // A bad key should trigger a CryptoException, but check this branch just in case.
-                        ManagedKey(generateAndStoreKey(), KeyGenerationReason.RecoveryNeeded.Corrupt)
-                    }
-                } catch (e: AutofillException.JsonException) {
-                    ManagedKey(generateAndStoreKey(), KeyGenerationReason.RecoveryNeeded.Corrupt)
-                } catch (e: AutofillException.CryptoException) {
-                    ManagedKey(generateAndStoreKey(), KeyGenerationReason.RecoveryNeeded.Corrupt)
-                }
-            }
-
-            // The key is present, but we didn't expect it to be there.
-            storedKey != null && encryptedCanaryPhrase == null -> {
-                // This isn't expected to happen. We can't check this key's validity.
-                ManagedKey(generateAndStoreKey(), KeyGenerationReason.RecoveryNeeded.AbnormalState)
-            }
-
-            // We expected the key to be present, but it's gone missing on us.
-            storedKey == null && encryptedCanaryPhrase != null -> {
-                // At this point, we're forced to generate a new key to recover and move forward.
-                // However, that means that any data that was previously encrypted is now unreadable.
-                ManagedKey(generateAndStoreKey(), KeyGenerationReason.RecoveryNeeded.Lost)
-            }
-
-            // We didn't expect the key to be present, and it's not.
-            storedKey == null && encryptedCanaryPhrase == null -> {
-                // Normal case when interacting with this class for the first time.
-                ManagedKey(generateAndStoreKey(), KeyGenerationReason.New)
-            }
-
-            else -> throw AutofillCryptoException.IllegalState()
+        } catch (e: AutofillException.JsonException) {
+            KeyGenerationReason.RecoveryNeeded.Corrupt
+        } catch (e: AutofillException.CryptoException) {
+            KeyGenerationReason.RecoveryNeeded.Corrupt
         }
     }
 
-    private fun generateAndStoreKey(): String {
-        return createKey().also { newKey ->
-            // To consider: should this be a non-destructive operation, just in case?
-            // e.g. if we thought we lost the key, but actually did not, that would let us recover data later on.
-            // otherwise, if we mess up and override a perfectly good key, the data is gone for good.
-            securePrefs.putString(AUTOFILL_KEY, newKey)
-            // To detect key corruption or absence, use the newly generated key to encrypt a known string.
-            // See isKeyValid below.
-            plaintextPrefs
-                .edit()
-                .putString(CANARY_PHRASE_CIPHERTEXT_KEY, encryptString(newKey, CANARY_PHRASE_PLAINTEXT))
-                .apply()
-        }
+    override fun getStoredCanary(): String? {
+        return plaintextPrefs.getString(CANARY_PHRASE_CIPHERTEXT_KEY, null)
+    }
+
+    override fun getStoredKey(): String? {
+        return securePrefs.getString(AUTOFILL_KEY)
+    }
+
+    override fun storeKeyAndCanary(key: String) {
+        // To consider: should this be a non-destructive operation, just in case?
+        // e.g. if we thought we lost the key, but actually did not, that would let us recover data later on.
+        // otherwise, if we mess up and override a perfectly good key, the data is gone for good.
+        securePrefs.putString(AUTOFILL_KEY, key)
+        // To detect key corruption or absence, use the newly generated key to encrypt a known string.
+        // See isKeyValid below.
+        plaintextPrefs
+            .edit()
+            .putString(CANARY_PHRASE_CIPHERTEXT_KEY, encryptString(key, CANARY_PHRASE_PLAINTEXT))
+            .apply()
+    }
+
+    override suspend fun recoverFromKeyLoss(reason: KeyGenerationReason.RecoveryNeeded) {
+        storage.scrubEncryptedData()
     }
 
     companion object {

--- a/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/GeckoCreditCardsAddressesStorageDelegate.kt
+++ b/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/GeckoCreditCardsAddressesStorageDelegate.kt
@@ -28,9 +28,9 @@ class GeckoCreditCardsAddressesStorageDelegate(
     private val isCreditCardAutofillEnabled: () -> Boolean = { false }
 ) : CreditCardsAddressesStorageDelegate {
 
-    override fun decrypt(encryptedCardNumber: CreditCardNumber.Encrypted): CreditCardNumber.Plaintext? {
+    override suspend fun decrypt(encryptedCardNumber: CreditCardNumber.Encrypted): CreditCardNumber.Plaintext? {
         val crypto = storage.value.getCreditCardCrypto()
-        val key = crypto.key()
+        val key = crypto.getOrGenerateKey()
         return crypto.decrypt(key, encryptedCardNumber)
     }
 

--- a/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorageTest.kt
+++ b/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorageTest.kt
@@ -57,7 +57,7 @@ class AutofillCreditCardsAddressesStorageTest {
         assertNotNull(creditCard)
 
         assertEquals(creditCardFields.billingName, creditCard.billingName)
-        assertEquals(plaintextNumber, storage.crypto.decrypt(storage.crypto.key(), creditCard.encryptedCardNumber))
+        assertEquals(plaintextNumber, storage.crypto.decrypt(storage.crypto.getOrGenerateKey(), creditCard.encryptedCardNumber))
         assertEquals(creditCardFields.cardNumberLast4, creditCard.cardNumberLast4)
         assertEquals(creditCardFields.expiryMonth, creditCard.expiryMonth)
         assertEquals(creditCardFields.expiryYear, creditCard.expiryYear)
@@ -126,7 +126,7 @@ class AutofillCreditCardsAddressesStorageTest {
         val creditCard3 = storage.addCreditCard(creditCardFields3)
 
         val creditCards = storage.getAllCreditCards()
-        val key = storage.crypto.key()
+        val key = storage.crypto.getOrGenerateKey()
 
         val savedCreditCard1 = creditCards.find { it == creditCard1 }
         assertNotNull(savedCreditCard1)
@@ -167,7 +167,7 @@ class AutofillCreditCardsAddressesStorageTest {
 
         creditCard = storage.getCreditCard(creditCard.guid)!!
 
-        val key = storage.crypto.key()
+        val key = storage.crypto.getOrGenerateKey()
 
         assertEquals(newCreditCardFields.billingName, creditCard.billingName)
         assertEquals(newCreditCardFields.cardNumber, storage.crypto.decrypt(key, creditCard.encryptedCardNumber))

--- a/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/SyncableLoginsStorage.kt
+++ b/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/SyncableLoginsStorage.kt
@@ -5,7 +5,6 @@
 package mozilla.components.service.sync.logins
 
 import android.content.Context
-import android.content.SharedPreferences
 import androidx.annotation.GuardedBy
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -14,10 +13,8 @@ import kotlinx.coroutines.withContext
 import mozilla.appservices.logins.DatabaseLoginsStorage
 import mozilla.appservices.logins.migrateLoginsWithMetrics
 import mozilla.components.concept.storage.EncryptedLogin
-import mozilla.components.concept.storage.KeyGenerationReason
 import mozilla.components.concept.storage.Login
 import mozilla.components.concept.storage.LoginEntry
-import mozilla.components.concept.storage.ManagedKey
 import mozilla.components.concept.storage.LoginsStorage
 import mozilla.components.concept.sync.SyncableStore
 import mozilla.components.lib.dataprotect.SecureAbove22Preferences
@@ -291,10 +288,10 @@ class SyncableLoginsStorage(
         if (version == 0) {
             try {
                 migrateLoginsWithMetrics(
-                        context.getDatabasePath(DB_NAME).absolutePath,
-                        crypto.getOrGenerateKey().key,
-                        context.getDatabasePath(DB_NAME_SQLCIPHER).absolutePath,
-                        sqlcipherKey,
+                    context.getDatabasePath(DB_NAME).absolutePath,
+                    crypto.getOrGenerateKey().key,
+                    context.getDatabasePath(DB_NAME_SQLCIPHER).absolutePath,
+                    sqlcipherKey,
                 )
                 // Note: DatabaseLoginsStorage.migrateLogins, defined in
                 // application-services, is responsible for reporting the migration

--- a/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/SyncableLoginsStorage.kt
+++ b/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/SyncableLoginsStorage.kt
@@ -5,18 +5,19 @@
 package mozilla.components.service.sync.logins
 
 import android.content.Context
+import android.content.SharedPreferences
 import androidx.annotation.GuardedBy
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import mozilla.appservices.logins.DatabaseLoginsStorage
 import mozilla.appservices.logins.migrateLoginsWithMetrics
-import mozilla.appservices.sync15.SyncTelemetryPing
 import mozilla.components.concept.storage.EncryptedLogin
 import mozilla.components.concept.storage.KeyGenerationReason
-import mozilla.components.concept.storage.KeyRecoveryHandler
 import mozilla.components.concept.storage.Login
 import mozilla.components.concept.storage.LoginEntry
+import mozilla.components.concept.storage.ManagedKey
 import mozilla.components.concept.storage.LoginsStorage
 import mozilla.components.concept.sync.SyncableStore
 import mozilla.components.lib.dataprotect.SecureAbove22Preferences
@@ -117,13 +118,17 @@ typealias RequestFailedException = mozilla.appservices.logins.LoginsStorageExcep
 class SyncableLoginsStorage(
     private val context: Context,
     private val securePrefs: Lazy<SecureAbove22Preferences>
-) : LoginsStorage, SyncableStore, KeyRecoveryHandler, AutoCloseable {
+) : LoginsStorage, SyncableStore, AutoCloseable {
     private val plaintextPrefs by lazy { context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE) }
     private val logger = Logger("SyncableLoginsStorage")
     private val coroutineContext by lazy { Dispatchers.IO }
     val crypto by lazy { LoginsCrypto(context, securePrefs.value, this) }
-    private val conn by lazy {
-        migrateSQLCipherDBIfNeeded()
+
+    internal val conn by lazy {
+        // Migration must run before we initialize the database.
+        runBlocking(coroutineContext) {
+            migrateSQLCipherDBIfNeeded()
+        }
         LoginStorageConnection.init(dbPath = context.getDatabasePath(DB_NAME).absolutePath)
         LoginStorageConnection
     }
@@ -188,7 +193,7 @@ class SyncableLoginsStorage(
      */
     @Throws(LoginsStorageException::class)
     override suspend fun list(): List<Login> = withContext(coroutineContext) {
-        val key = crypto.key()
+        val key = crypto.getOrGenerateKey()
         conn.getStorage().list().map { crypto.decryptLogin(it.toEncryptedLogin(), key) }
     }
 
@@ -200,7 +205,7 @@ class SyncableLoginsStorage(
      */
     @Throws(CryptoException::class, InvalidRecordException::class, LoginsStorageException::class)
     override suspend fun add(entry: LoginEntry) = withContext(coroutineContext) {
-        conn.getStorage().add(entry.toLoginEntry(), crypto.key().key).toEncryptedLogin()
+        conn.getStorage().add(entry.toLoginEntry(), crypto.getOrGenerateKey().key).toEncryptedLogin()
     }
 
     /**
@@ -217,7 +222,7 @@ class SyncableLoginsStorage(
         LoginsStorageException::class
     )
     override suspend fun update(guid: String, entry: LoginEntry) = withContext(coroutineContext) {
-        conn.getStorage().update(guid, entry.toLoginEntry(), crypto.key().key).toEncryptedLogin()
+        conn.getStorage().update(guid, entry.toLoginEntry(), crypto.getOrGenerateKey().key).toEncryptedLogin()
     }
 
     /**
@@ -228,7 +233,7 @@ class SyncableLoginsStorage(
      */
     @Throws(CryptoException::class, InvalidRecordException::class, LoginsStorageException::class)
     override suspend fun addOrUpdate(entry: LoginEntry) = withContext(coroutineContext) {
-        conn.getStorage().addOrUpdate(entry.toLoginEntry(), crypto.key().key).toEncryptedLogin()
+        conn.getStorage().addOrUpdate(entry.toLoginEntry(), crypto.getOrGenerateKey().key).toEncryptedLogin()
     }
 
     override fun registerWithSyncManager() {
@@ -246,7 +251,7 @@ class SyncableLoginsStorage(
      */
     @Throws(CryptoException::class, LoginsStorageException::class)
     override suspend fun importLoginsAsync(logins: List<Login>): JSONObject = withContext(coroutineContext) {
-        JSONObject(conn.getStorage().importMultiple(logins.map { it.toLogin() }, crypto.key().key))
+        JSONObject(conn.getStorage().importMultiple(logins.map { it.toLogin() }, crypto.getOrGenerateKey().key))
     }
 
     /**
@@ -254,7 +259,7 @@ class SyncableLoginsStorage(
      */
     @Throws(LoginsStorageException::class)
     override suspend fun getByBaseDomain(origin: String): List<Login> = withContext(coroutineContext) {
-        val key = crypto.key()
+        val key = crypto.getOrGenerateKey()
         conn.getStorage().getByBaseDomain(origin).map { crypto.decryptLogin(it.toEncryptedLogin(), key) }
     }
 
@@ -264,48 +269,32 @@ class SyncableLoginsStorage(
      */
     @Throws(LoginsStorageException::class)
     override suspend fun findLoginToUpdate(entry: LoginEntry): Login? = withContext(coroutineContext) {
-        conn.getStorage().findLoginToUpdate(entry.toLoginEntry(), crypto.key().key)?.toLogin()
+        conn.getStorage().findLoginToUpdate(entry.toLoginEntry(), crypto.getOrGenerateKey().key)?.toLogin()
     }
 
     /**
      * @throws [CryptoException] invalid encryption key
      */
-    override fun decryptLogin(login: EncryptedLogin) = crypto.decryptLogin(login)
+    override suspend fun decryptLogin(login: EncryptedLogin) = crypto.decryptLogin(login)
 
     override fun close() {
         coroutineContext.cancel()
         conn.close()
     }
 
-    override fun recoverFromBadKey(reason: KeyGenerationReason.RecoveryNeeded) {
-        when (reason) {
-            is KeyGenerationReason.RecoveryNeeded.Lost -> logger.warn("Logins key lost, new one generated")
-            is KeyGenerationReason.RecoveryNeeded.Corrupt -> logger.warn("Logins key was corrupted, new one generated")
-            is KeyGenerationReason.RecoveryNeeded.AbnormalState -> logger.warn(
-                "Logins key lost due to storage malfunction, new one generated"
-            )
-        }
-        // If the key needed to be regenerated, then we lose all
-        // usernames/passwords which were encrypted with the old key.  This
-        // means we can't really use the logins anymore and wipeLocal() is the
-        // best we can do.
-        conn.getStorage().wipeLocal()
-    }
-
-    private fun migrateSQLCipherDBIfNeeded() {
+    private suspend fun migrateSQLCipherDBIfNeeded() {
         // Migrate the SQLCipher DB if needed
-        val sqlcipherKey = securePrefs.value.getString(ENCRYPTION_KEY_SQLCIPHER)
-        if (sqlcipherKey == null) return
+        val sqlcipherKey = securePrefs.value.getString(ENCRYPTION_KEY_SQLCIPHER) ?: return
 
         val version = plaintextPrefs.getInt(SQL_CIPHER_MIGRATION, 0)
 
         if (version == 0) {
             try {
                 migrateLoginsWithMetrics(
-                    context.getDatabasePath(DB_NAME).absolutePath,
-                    crypto.key().key,
-                    context.getDatabasePath(DB_NAME_SQLCIPHER).absolutePath,
-                    sqlcipherKey,
+                        context.getDatabasePath(DB_NAME).absolutePath,
+                        crypto.getOrGenerateKey().key,
+                        context.getDatabasePath(DB_NAME_SQLCIPHER).absolutePath,
+                        sqlcipherKey,
                 )
                 // Note: DatabaseLoginsStorage.migrateLogins, defined in
                 // application-services, is responsible for reporting the migration

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,19 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **concept-storage**:
+  * ⚠️ **This is a breaking change**: `KeyProvider#key` has been renamed to `KeyProvider#getOrGenerateKey` and is now `suspend`.
+  * ⚠️ **This is a breaking change**: `KeyRecoveryHandler` has been removed.
+  * ⚠️ **This is a breaking change**: `CreditCardsAddressesStorage` gained a new method - `scrubEncryptedData`.
+  * 🌟️️ **Add an abstract `KeyManager` which implements `KeyProvider` and knows how to store, retrieve and verify managed keys.
+
+* **service-sync-logins**:
+  * `LoginsCrypto` is now using `concept-storage`@`KeyManager` as its basis.
+
+* **service-sync-autofill**:
+  * `AutofillCrypto` is now using `concept-storage`@`KeyManager` as its basis.
+  * `AutofillCrypto` is now able to recover from key loss (by scrubbing encrypted credit card data).
+
 # 96.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v95.0.0...v96.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/143?closed=1)


### PR DESCRIPTION
Two parts to this:

Closes mozilla-mobile#11368 - Handle key recovery flow for credit cards storage

- remove KeyRecoveryHandler indirection, I don't think it was adding
  any value
- AutofillCrypto and LoginsCrypto are now taking shape of a 'key
  manager' type objects - they know how to get, validate and store keys,
  as well as recover corresponding storage classes from key loss.
- AutofillCrypto now scrubs credit cards - removes encrypted CC numbers
  and resets the sync engine - in case of key loss.

Closes mozilla-mobile#11099: Introduce KeyManager structure

This adds an abstract KeyManager class to our storage component, which
establishes a pattern of managing keys as used by our storage classes
that require encryption.

AutofillCrypto and LoginsCrypto become implementors of this basis class,
allowing them to explicitly share structure and some core functionality.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
