### PR TITLE
For # #11374 - Restore immersive mode

### DIFF
--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/Activity.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/Activity.kt
@@ -5,7 +5,10 @@
 package mozilla.components.support.ktx.android.view
 
 import android.app.Activity
+import android.os.Build
+import android.view.View
 import android.view.ViewTreeObserver
+import android.view.WindowInsets.Type.statusBars
 import android.view.WindowManager
 import androidx.annotation.VisibleForTesting
 import androidx.core.view.WindowInsetsCompat
@@ -14,22 +17,59 @@ import mozilla.components.support.base.log.logger.Logger
 
 /**
  * Attempts to call immersive mode using the View to hide the status bar and navigation buttons.
+ * This will automatically register and use an [View.OnApplyWindowInsetsListener] on API 30+ or an
+ * [View.OnSystemUiVisibilityChangeListener] for below APIs to restore immersive mode if interactions
+ * with various other widgets like the keyboard or dialogs broken the activity out of immersive mode without
+ * [exitImmersiveModeIfNeeded] being called.
+ *
  * @param onWindowFocusChangeListener optional callback to ensure immersive mode is stable
  * Note that the callback reference should be kept by the caller and be used for [exitImmersiveModeIfNeeded] call.
  */
 fun Activity.enterToImmersiveMode(
     onWindowFocusChangeListener: ViewTreeObserver.OnWindowFocusChangeListener? = null
 ) {
+    setAsImmersive()
+    enableImmersiveModeRestore(onWindowFocusChangeListener)
+}
+
+@VisibleForTesting
+internal fun Activity.setAsImmersive() {
     window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     window.getWindowInsetsController().apply {
         hide(WindowInsetsCompat.Type.systemBars())
         systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
     }
+}
 
-    // We need to make sure system bars do not become permanently visible after interactions with content
-    // see https://github.com/mozilla-mobile/fenix/issues/20240
+/**
+ * Anytime a new Window is focused like of a Dialog or of the keyboard the activity
+ * will exit immersive mode.
+ * This will observe such events and set again the activity to be immersive
+ * the next time it gets focused.
+ */
+@VisibleForTesting
+internal fun Activity.enableImmersiveModeRestore(
+    onWindowFocusChangeListener: ViewTreeObserver.OnWindowFocusChangeListener?
+) {
     onWindowFocusChangeListener?.let {
         window.decorView.viewTreeObserver?.addOnWindowFocusChangeListener(it)
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        window.decorView.setOnApplyWindowInsetsListener { view, insets ->
+            println(view)
+            if (insets.isVisible(statusBars())) {
+                setAsImmersive()
+            }
+            insets
+        }
+    } else {
+        @Suppress("DEPRECATION") // insets.isVisible(int) is available only starting with API 30
+        window.decorView.setOnSystemUiVisibilityChangeListener { newFlags ->
+            if (newFlags and View.SYSTEM_UI_FLAG_FULLSCREEN == 0) {
+                setAsImmersive()
+            }
+        }
     }
 }
 
@@ -38,7 +78,6 @@ fun Activity.enterToImmersiveMode(
  * @param onWindowFocusChangeListener optional callback to ensure immersive mode is stable
  * Note that the callback reference should be kept by the caller and be the same used for [enterToImmersiveMode] call.
  */
-@Suppress("DEPRECATION")
 fun Activity.exitImmersiveModeIfNeeded(
     onWindowFocusChangeListener: ViewTreeObserver.OnWindowFocusChangeListener? = null
 ) {
@@ -46,9 +85,18 @@ fun Activity.exitImmersiveModeIfNeeded(
         // We left immersive mode already.
         return
     }
+
     onWindowFocusChangeListener?.let {
         window.decorView.viewTreeObserver?.removeOnWindowFocusChangeListener(it)
     }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        window.decorView.setOnApplyWindowInsetsListener(null)
+    } else {
+        @Suppress("DEPRECATION")
+        window.decorView.setOnSystemUiVisibilityChangeListener(null)
+    }
+
     window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     window.getWindowInsetsController().apply {
         show(WindowInsetsCompat.Type.systemBars())
@@ -62,9 +110,7 @@ fun Activity.exitImmersiveModeIfNeeded(
 val Activity.onWindowFocusChangeListener: ViewTreeObserver.OnWindowFocusChangeListener
     get() = ViewTreeObserver.OnWindowFocusChangeListener { hasFocus ->
         if (hasFocus) {
-            window.getWindowInsetsController().apply {
-                hide(WindowInsetsCompat.Type.systemBars())
-            }
+            setAsImmersive()
         }
     }
 

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ActivityTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ActivityTest.kt
@@ -11,17 +11,19 @@ import android.view.Window
 import android.view.WindowManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.any
+import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
+import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 
-@Suppress("Deprecation")
+@Suppress("DEPRECATION")
 @RunWith(AndroidJUnit4::class)
 class ActivityTest {
 
@@ -43,14 +45,58 @@ class ActivityTest {
     }
 
     @Test
-    fun `check enterImmersibleMode sets the correct flags`() {
+    fun `check enterToImmersiveMode sets the correct flags`() {
 
         activity.enterToImmersiveMode()
+
+        // verify entering immersive mode
+        verify(window).addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        verify(decorView).systemUiVisibility = View.SYSTEM_UI_FLAG_FULLSCREEN
+        verify(decorView).systemUiVisibility = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+        // verify that the immersive mode restoration is set as expected
+        verify(window.decorView.viewTreeObserver, never()).addOnWindowFocusChangeListener(any())
+        verify(window.decorView).setOnSystemUiVisibilityChangeListener(any())
+    }
+
+    @Test
+    fun `check setAsImmersive sets the correct flags`() {
+        activity.setAsImmersive()
 
         verify(window).addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         verify(decorView).systemUiVisibility = View.SYSTEM_UI_FLAG_FULLSCREEN
         verify(decorView).systemUiVisibility = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
         verify(window.decorView.viewTreeObserver, never()).addOnWindowFocusChangeListener(any())
+    }
+
+    @Test
+    fun `check enableImmersiveModeRestore sets the correct insets listeners`() {
+        activity.enableImmersiveModeRestore(null)
+        verify(window.decorView.viewTreeObserver, never()).addOnWindowFocusChangeListener(any())
+        verify(window.decorView).setOnSystemUiVisibilityChangeListener(any())
+
+        val windowFocusChangeListener: ViewTreeObserver.OnWindowFocusChangeListener = mock()
+        activity.enableImmersiveModeRestore(windowFocusChangeListener)
+        verify(window.decorView.viewTreeObserver).addOnWindowFocusChangeListener(windowFocusChangeListener)
+        verify(window.decorView, times(2)).setOnSystemUiVisibilityChangeListener(any())
+    }
+
+    @Test
+    fun `check enableImmersiveModeRestore set insets listeners have the correct behavior`() {
+        val insetListenerCaptor = argumentCaptor<View.OnSystemUiVisibilityChangeListener>()
+        activity.enableImmersiveModeRestore(null)
+        verify(window.decorView).setOnSystemUiVisibilityChangeListener(insetListenerCaptor.capture())
+
+        insetListenerCaptor.value.onSystemUiVisibilityChange(View.SYSTEM_UI_FLAG_FULLSCREEN)
+        // If the activity requested to enter fullscreen no immersive mode restoration is needed.
+        verify(window, never()).addFlags(anyInt())
+        verify(decorView, never()).systemUiVisibility = anyInt()
+        verify(decorView, never()).systemUiVisibility = anyInt()
+
+        insetListenerCaptor.value.onSystemUiVisibilityChange(View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR)
+        // Cannot test if "setAsImmersive()" was called it being an extension function but we can check the effect of that call.
+        verify(window).addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        verify(decorView).systemUiVisibility = View.SYSTEM_UI_FLAG_FULLSCREEN
+        verify(decorView).systemUiVisibility = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
     }
 
     @Test
@@ -64,6 +110,7 @@ class ActivityTest {
         verify(window, never()).clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         verify(decorView, never()).systemUiVisibility = View.SYSTEM_UI_FLAG_FULLSCREEN.inv()
         verify(decorView, never()).systemUiVisibility = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION.inv()
+        verify(decorView, never()).setOnSystemUiVisibilityChangeListener(null)
 
         attributes.flags = WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
 
@@ -72,15 +119,7 @@ class ActivityTest {
         verify(window).clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         verify(decorView, times(2)).systemUiVisibility = View.SYSTEM_UI_FLAG_VISIBLE
         verify(window.decorView.viewTreeObserver, never()).removeOnWindowFocusChangeListener(any())
-    }
-
-    @Test
-    fun `check enterImmersibleMode with callback adds the correct callback`() {
-        val callback: ViewTreeObserver.OnWindowFocusChangeListener = mock()
-
-        activity.enterToImmersiveMode(callback)
-
-        verify(window.decorView.viewTreeObserver).addOnWindowFocusChangeListener(callback)
+        verify(decorView).setOnSystemUiVisibilityChangeListener(null)
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **support-ktx**
+  * 🚒 Bug fixed [issue #11374](https://github.com/mozilla-mobile/android-components/issues/11374) - Restore immersive mode after interacting with other Windows.
+
 * **feature-prompts**:
   * Removes deprecated constructor in `PromptFeature`.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ permalink: /changelog/
 
 * **support-ktx**
   * 🚒 Bug fixed [issue #11374](https://github.com/mozilla-mobile/android-components/issues/11374) - Restore immersive mode after interacting with other Windows.
+  * ⚠️ **This is a breaking change**: `OnWindowFocusChangeListener` parameter is removed from `Activity.enterToImmersiveMode()`. There was no way to guarantee that the argument knew to handle immersive mode. Now everything is handled internally.
 
 * **feature-prompts**:
   * Removes deprecated constructor in `PromptFeature`.

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -22,7 +22,6 @@ import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import mozilla.components.support.ktx.android.view.enterToImmersiveMode
 import mozilla.components.support.ktx.android.view.exitImmersiveModeIfNeeded
-import mozilla.components.support.ktx.android.view.onWindowFocusChangeListener
 import org.mozilla.samples.browser.ext.components
 import org.mozilla.samples.browser.integration.ReaderViewIntegration
 
@@ -103,8 +102,6 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
             view = binding.root
         )
 
-        val onWindowFocusChangeListener = activity?.onWindowFocusChangeListener
-
         fullScreenFeature.set(
             feature = FullScreenFeature(
                 components.store,
@@ -112,9 +109,9 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                 sessionId
             ) { inFullScreen ->
                 if (inFullScreen) {
-                    activity?.enterToImmersiveMode(onWindowFocusChangeListener)
+                    activity?.enterToImmersiveMode()
                 } else {
-                    activity?.exitImmersiveModeIfNeeded(onWindowFocusChangeListener)
+                    activity?.exitImmersiveModeIfNeeded()
                 }
             },
             owner = this,


### PR DESCRIPTION
This was an issue not reproducing on all devices.
Added a new insets listener to know when they change and set again immersive mode for the fullscreen Activity. (same as Chrome uses)
Handle focus changes internally to guarantee that these events will also restore immersive mode whereas previously clients could pass any focus listener even one not knowing to restore the immersive mode.

<table>
  <tr>
    <th>Before</th>
    <td><video src="https://user-images.githubusercontent.com/11428869/145202864-813f0949-7d50-41a6-87b9-b8ce5af1b7e9.mp4" /></td>
  </tr>
  <tr>
    <th>After</th>
    <td><video src="https://user-images.githubusercontent.com/11428869/145203129-bb6f45c6-6134-4837-b083-9f5f8b97156a.mp4" /></td>
  </tr>
</table>



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
