### PR TITLE
Issue #11388 - Add Ink80A96 to photon colors

### DIFF
--- a/components/ui/colors/src/main/java/mozilla/components/ui/colors/PhotonColors.kt
+++ b/components/ui/colors/src/main/java/mozilla/components/ui/colors/PhotonColors.kt
@@ -110,6 +110,7 @@ object PhotonColors {
     val Ink60 = Color(0xFF271948)
     val Ink70 = Color(0xFF241541)
     val Ink80 = Color(0xFF20123A)
+    val Ink80A96 = Color(0xF520123A)
     val Ink90 = Color(0xFF1D1133)
 
     // Light grey should primarily be used for the Light Theme and secondary buttons.

--- a/components/ui/colors/src/main/res/values/photon_colors.xml
+++ b/components/ui/colors/src/main/res/values/photon_colors.xml
@@ -132,6 +132,7 @@
 	<color name="photonInk60">#ff271948</color>
 	<color name="photonInk70">#ff241541</color>
 	<color name="photonInk80">#ff20123a</color>
+	<color name="photonInk80A96">#f520123a</color>
 	<color name="photonInk90">#ff1d1133</color>
 
 	<!--


### PR DESCRIPTION
Fixes #11388
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
