### PR TITLE
For #11387 - Remove deprecated constructor from PromptFeature.kt

### DIFF
--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -231,39 +231,6 @@ class PromptFeature private constructor(
         onSelectCreditCard = onSelectCreditCard
     )
 
-    @Deprecated("Pass only activity or fragment instead")
-    constructor(
-        activity: Activity? = null,
-        fragment: Fragment? = null,
-        store: BrowserStore,
-        customTabId: String? = null,
-        fragmentManager: FragmentManager,
-        loginPickerView: SelectablePromptView<Login>? = null,
-        onManageLogins: () -> Unit = {},
-        creditCardPickerView: SelectablePromptView<CreditCard>? = null,
-        onManageCreditCards: () -> Unit = {},
-        onSelectCreditCard: () -> Unit = {},
-        onNeedToRequestPermissions: OnNeedToRequestPermissions
-    ) : this(
-        container = activity?.let { PromptContainer.Activity(it) }
-            ?: fragment?.let { PromptContainer.Fragment(it) }
-            ?: throw IllegalStateException(
-                "activity and fragment references " +
-                    "must not be both null, at least one must be initialized."
-            ),
-        store = store,
-        customTabId = customTabId,
-        fragmentManager = fragmentManager,
-        shareDelegate = DefaultShareDelegate(),
-        loginValidationDelegate = null,
-        onNeedToRequestPermissions = onNeedToRequestPermissions,
-        loginPickerView = loginPickerView,
-        onManageLogins = onManageLogins,
-        creditCardPickerView = creditCardPickerView,
-        onManageCreditCards = onManageCreditCards,
-        onSelectCreditCard = onSelectCreditCard
-    )
-
     private val filePicker = FilePicker(container, store, customTabId, onNeedToRequestPermissions)
 
     @VisibleForTesting(otherwise = PRIVATE)

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
@@ -729,12 +729,6 @@ class PromptFeatureTest {
         feature.handleDialogsRequest(mock<PromptRequest.File>(), mock())
     }
 
-    @Suppress("Deprecation")
-    @Test(expected = IllegalStateException::class)
-    fun `Initializing a PromptFeature without giving an activity or fragment reference will throw an exception`() {
-        PromptFeature(null, null, store, null, fragmentManager) { }
-    }
-
     @Test
     fun `onActivityResult with RESULT_OK and isMultipleFilesSelection false will consume PromptRequest`() {
         var onSingleFileSelectionWasCalled = false


### PR DESCRIPTION
Fixes #11387 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
