### PR TITLE
Closes #11400: Allow overriding title/description of error pages

### DIFF
--- a/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
+++ b/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
@@ -16,17 +16,26 @@ object ErrorPages {
 
     /**
      * Provides an encoded URL for an error page. Supports displaying images
+     *
+     * @param titleOverride A function that can return an error page title for an error type. If not
+     * provided or if `null` is returned from the function then the default page title for this
+     * error type, provided by this component, will be used.
+     * @param descriptionOverride  A function that can return an error page description text for an
+     * error type. If not provided or if `null` is returned from the function then the default
+     * description text for this error type, provided by this component, will be used.
      */
     @SuppressLint("StringFormatInvalid")
     fun createUrlEncodedErrorPage(
         context: Context,
         errorType: ErrorType,
         uri: String? = null,
-        htmlResource: String = HTML_RESOURCE_FILE
+        htmlResource: String = HTML_RESOURCE_FILE,
+        titleOverride: (ErrorType) -> String? = { null },
+        descriptionOverride: (ErrorType) -> String? = { null }
     ): String {
-        val title = context.getString(errorType.titleRes)
+        val title = titleOverride(errorType) ?: context.getString(errorType.titleRes)
         val button = context.getString(errorType.refreshButtonRes)
-        val description = context.getString(errorType.messageRes, uri)
+        val description = descriptionOverride(errorType) ?: context.getString(errorType.messageRes, uri)
         val imageName = if (errorType.imageNameRes != null) context.getString(errorType.imageNameRes) + ".svg" else ""
         val continueHttpButton = context.getString(R.string.mozac_browser_errorpages_httpsonly_button)
         val badCertAdvanced = context.getString(R.string.mozac_browser_errorpages_security_bad_cert_advanced)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,9 @@ permalink: /changelog/
   * `AutofillCrypto` is now using `concept-storage`@`KeyManager` as its basis.
   * `AutofillCrypto` is now able to recover from key loss (by scrubbing encrypted credit card data).
 
+* **browser-errorpages**
+  * `ErrorPages.createUrlEncodedErrorPage()` allows overriding the title or description for specific error types now.
+
 # 96.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v95.0.0...v96.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/143?closed=1)


### PR DESCRIPTION
In Focus we want to customize the HTTPS-Only error page text with Focus-specific strings (since it will enable the feature by default). This patch adds a mechanism for overriding the title/description for an error page based on the error type.