### PR TITLE
Closes #11413: Clean up old auto-published artifacts in local maven

### DIFF
--- a/automation/publish_to_maven_local_if_modified.py
+++ b/automation/publish_to_maven_local_if_modified.py
@@ -103,12 +103,16 @@ except FileNotFoundError:
     pass
 
 if contents_hash == last_contents_hash:
-    print("Contents have not changed, no need to publish")
+    print("Contents have not changed, no need to publish.")
 else:
-    print("Contents have changed, publishing")
+    print("Contents have changed, need to publish.")
     if sys.platform.startswith("win"):
+        print("Publishing latest state to a local maven repository.")
         run_cmd_checked(["gradlew.bat", "publishToMavenLocal", f"-Plocal={time.time_ns()}"], shell=True)
     else:
+        print("Cleaning up old builds from a local maven repository...")
+        run_cmd_checked(["rm -rf ~/.m2/repository/org/mozilla/components/"], shell=True)
+        print("Publishing latest state to local maven repository.")
         run_cmd_checked(["./gradlew", "publishToMavenLocal", f"-Plocal={time.time_ns()}"])
     with open(LAST_CONTENTS_HASH_FILE, "w") as f:
         f.write(contents_hash)


### PR DESCRIPTION
For the auto-publication flow we only the latest published artifacts.
This patch clears up ~/.m2/repository/org/mozilla/components before
publishing, ensuring we do not accumulate old builds over time.

Need to confirm the shell syntax for Windows, but this should work on
linux/osx.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
