### PR TITLE
Remove debug lock owner from the KeyManager mutex

### DIFF
--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/KeyManager.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/KeyManager.kt
@@ -48,7 +48,7 @@ abstract class KeyManager : KeyProvider {
      */
     abstract suspend fun recoverFromKeyLoss(reason: KeyGenerationReason.RecoveryNeeded)
 
-    override suspend fun getOrGenerateKey(): ManagedKey = keyMutex.withLock(this) {
+    override suspend fun getOrGenerateKey(): ManagedKey = keyMutex.withLock {
         val managedKey = getManagedKey()
 
         (managedKey.wasGenerated as? KeyGenerationReason.RecoveryNeeded)?.let {


### PR DESCRIPTION
I've misread the API, specifying this `owner` is causing lots of ISEs,
while this code shouldn't deadlock in practice.

see https://github.com/mozilla-mobile/fenix/issues/22877



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
