### PR TITLE
Revert "Updates application services to 87.2.0"

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,7 +29,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "2.4"
 
-    const val mozilla_appservices = "87.2.0"
+    const val mozilla_appservices = "87.1.0"
 
     const val mozilla_glean = "42.0.1"
 


### PR DESCRIPTION
This reverts commit 0fc3ed13b3dce1377e8b6dcf00dee18e1ffb765d.

I've merged-in https://github.com/mozilla-mobile/android-components/pull/11410 - but then realized how close we are to basically everyone being away for holidays, and that the A-S upgrade is taking in a SyncManager refactor (https://github.com/mozilla/application-services/commit/c4c7774c59ce8e6e9cd98e3c5b8be178a5abf729) which I can't entirely verify to be perfectly safe. We simply don't have time right now to ensure this won't blow up on Nightly (even for some portion of users), so let's just roll back the A-S upgrade and take it in January once folks are back. 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
