### PR TITLE
Added features to support application-services branch builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,10 +93,20 @@ subprojects {
         }
     }
 
+
     // Allow local appservices substitution in each subproject.
+    def appServicesSrcDir = null
     if (gradle.hasProperty('localProperties.autoPublish.application-services.dir')) {
-        ext.appServicesSrcDir = gradle."localProperties.autoPublish.application-services.dir"
-        apply from: "${rootProject.projectDir}/${appServicesSrcDir}/build-scripts/substitute-local-appservices.gradle"
+        appServicesSrcDir = gradle.getProperty('localProperties.autoPublish.application-services.dir')
+    } else if (gradle.hasProperty('localProperties.branchBuild.application-services.dir')) {
+        appServicesSrcDir = gradle.getProperty('localProperties.branchBuild.application-services.dir')
+    }
+    if (appServicesSrcDir) {
+        if (appServicesSrcDir.startsWith("/")) {
+            apply from: "${appServicesSrcDir}/build-scripts/substitute-local-appservices.gradle"
+        } else {
+            apply from: "${rootProject.projectDir}/${appServicesSrcDir}/build-scripts/substitute-local-appservices.gradle"
+        }
     }
 
     if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopsrcdir')) {

--- a/components/support/base/build.gradle
+++ b/components/support/base/build.gradle
@@ -26,8 +26,13 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
+        def appServicesVersion = Versions.mozilla_appservices
+        if (gradle.hasProperty("localProperties.branchBuild.application-services.version")) {
+            appServicesVersion = gradle["localProperties.branchBuild.application-services.version"]
+        }
+
         buildConfigField("String", "LIBRARY_VERSION", "\"" + config.componentsVersion + "\"")
-        buildConfigField("String", "APPLICATION_SERVICES_VERSION", "\"" + Versions.mozilla_appservices + "\"")
+        buildConfigField("String", "APPLICATION_SERVICES_VERSION", "\"" + appServicesVersion + "\"")
         buildConfigField("String", "GLEAN_SDK_VERSION", "\"" + Versions.mozilla_glean + "\"")
         buildConfigField("String", "GIT_HASH", "\"dev build\"")
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -81,10 +81,11 @@ gradle.projectsLoaded { ->
 
     if (gradle.rootProject.hasProperty("nightlyVersion")) {
         version = gradle.rootProject.nightlyVersion
-    }
+    } else if (gradle.rootProject.hasProperty("local")) {
     // To support local auto-publication workflow, we use a version prefix we wouldn't normally encounter.
-    if (gradle.rootProject.hasProperty("local")) {
         version = "0.0.1"
+    } else if (gradle.hasProperty("localProperties.branchBuild.android-components.version")) {
+        version = gradle.getProperty("localProperties.branchBuild.android-components.version")
     }
     // Wait until root project is "loaded" before we set "config"
     // Note that since this is set on "rootProject.ext", it will be "in scope" during the evaluation of all projects'

--- a/substitute-local-ac.gradle
+++ b/substitute-local-ac.gradle
@@ -1,4 +1,18 @@
-logger.lifecycle("[local-ac] adjusting project to use locally published android-components modules")
+
+def version = null
+if (gradle.hasProperty("localProperties.autoPublish.android-components.dir")) {
+  //  We're doing local development using the autoPublish system.  This automatically rebuilds and
+  //  publishes android-components packages whenever the source changes.
+  // This version string will selected the latest build package
+  version = '0.0.1-+'
+} else if (gradle.hasProperty("localProperties.branchBuild.android-components.version")) {
+  //  We're running a branch build.  Here the version is set to the git commit id in
+  //  local.properties
+  version = gradle.getProperty("localProperties.branchBuild.android-components.version")
+} else {
+  throw new Exception("substitute-local-appservices.gradle called from unexpected context")
+}
+logger.lifecycle("[local-ac] adjusting project to use locally published android-components modules (${version})")
 
 // Inject mavenLocal repository. This is where we're expected to publish modules.
 repositories {
@@ -22,7 +36,7 @@ configurations.all { config ->
                     def group = dependency.requested.group
                     if (group == 'org.mozilla.components') {
                         def name = dependency.requested.module
-                        dependency.useTarget([group: group, name: name, version: '0.0.1-+'])
+                        dependency.useTarget([group: group, name: name, version: version])
                     }
                 }
             }


### PR DESCRIPTION
This is part of the application-services branch builds project, described in https://github.com/mozilla/application-services/issues/4615.  The basic idea is to add support for a CI building/testing Fenix using in-progress branches from application-services, android-components, and/or fenix.

I'm making PRs on a-s, a-c, and fenix for this.  They all work together to allow us to:

 - Locally building/publishing application-services and android-components using the git commit ID as the version name
 - Use gradle dependency substitution to select the packages from the last step.  This is similar to the autoPublish system, but has some subtle differences.

I think this code is decent and not too bad, but there's probably a better way.  I'm open to discussing different mechanisms for doing this.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
