### PR TITLE
Close #11444: Add optional user interaction param to goBack/goForward

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -217,8 +217,8 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.goBack]
      */
-    override fun goBack() {
-        geckoSession.goBack()
+    override fun goBack(userInteraction: Boolean) {
+        geckoSession.goBack(userInteraction)
         if (canGoBack) {
             notifyObservers { onNavigateBack() }
         }
@@ -226,8 +226,8 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.goForward]
      */
-    override fun goForward() {
-        geckoSession.goForward()
+    override fun goForward(userInteraction: Boolean) {
+        geckoSession.goForward(userInteraction)
     }
 
     /**

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -557,7 +557,7 @@ class GeckoEngineSessionTest {
 
         engineSession.goBack()
 
-        verify(geckoSession).goBack()
+        verify(geckoSession).goBack(true)
     }
 
     @Test
@@ -569,7 +569,7 @@ class GeckoEngineSessionTest {
 
         engineSession.goForward()
 
-        verify(geckoSession).goForward()
+        verify(geckoSession).goForward(true)
     }
 
     @Test
@@ -3021,14 +3021,14 @@ class GeckoEngineSessionTest {
 
         // goBack()
         engineSession.goBack()
-        verify(geckoSession).goBack()
+        verify(geckoSession).goBack(true)
         fakePageLoad(false)
 
         fakePageLoad(true)
 
         // goForward()
         engineSession.goForward()
-        verify(geckoSession).goForward()
+        verify(geckoSession).goForward(true)
         fakePageLoad(false)
 
         fakePageLoad(true)

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -110,7 +110,7 @@ class SystemEngineSession(
     /**
      * See [EngineSession.goBack]
      */
-    override fun goBack() {
+    override fun goBack(userInteraction: Boolean) {
         webView.goBack()
         if (webView.canGoBack()) {
             notifyObservers { onNavigateBack() }
@@ -120,7 +120,7 @@ class SystemEngineSession(
     /**
      * See [EngineSession.goForward]
      */
-    override fun goForward() {
+    override fun goForward(userInteraction: Boolean) {
         webView.goForward()
     }
 

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -960,14 +960,16 @@ sealed class EngineAction : BrowserAction() {
      * Navigates back in the tab with the given [tabId].
      */
     data class GoBackAction(
-        override val tabId: String
+        override val tabId: String,
+        val userInteraction: Boolean = true
     ) : EngineAction(), ActionWithTab
 
     /**
      * Navigates forward in the tab with the given [tabId].
      */
     data class GoForwardAction(
-        override val tabId: String
+        override val tabId: String,
+        val userInteraction: Boolean = true
     ) : EngineAction(), ActionWithTab
 
     /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/EngineDelegateMiddleware.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/EngineDelegateMiddleware.kt
@@ -98,7 +98,7 @@ internal class EngineDelegateMiddleware(
         action: EngineAction.GoBackAction
     ) = scope.launch {
         getEngineSessionOrDispatch(store, action)
-            ?.goBack()
+            ?.goBack(action.userInteraction)
     }
 
     private fun goForward(
@@ -106,7 +106,7 @@ internal class EngineDelegateMiddleware(
         action: EngineAction.GoForwardAction
     ) = scope.launch {
         getEngineSessionOrDispatch(store, action)
-            ?.goForward()
+            ?.goForward(action.userInteraction)
     }
 
     private fun goToHistoryIndex(

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
@@ -58,8 +58,8 @@ class EngineObserverTest {
     fun engineSessionObserver() {
         val engineSession = object : EngineSession() {
             override val settings: Settings = mock()
-            override fun goBack() {}
-            override fun goForward() {}
+            override fun goBack(userInteraction: Boolean) {}
+            override fun goForward(userInteraction: Boolean) {}
             override fun goToHistoryIndex(index: Int) {}
             override fun reload(flags: LoadUrlFlags) {}
             override fun stopLoading() {}
@@ -115,8 +115,8 @@ class EngineObserverTest {
     fun engineSessionObserverWithSecurityChanges() {
         val engineSession = object : EngineSession() {
             override val settings: Settings = mock()
-            override fun goBack() {}
-            override fun goForward() {}
+            override fun goBack(userInteraction: Boolean) {}
+            override fun goForward(userInteraction: Boolean) {}
             override fun goToHistoryIndex(index: Int) {}
             override fun stopLoading() {}
             override fun reload(flags: LoadUrlFlags) {}
@@ -166,8 +166,8 @@ class EngineObserverTest {
     fun engineSessionObserverWithTrackingProtection() {
         val engineSession = object : EngineSession() {
             override val settings: Settings = mock()
-            override fun goBack() {}
-            override fun goForward() {}
+            override fun goBack(userInteraction: Boolean) {}
+            override fun goForward(userInteraction: Boolean) {}
             override fun goToHistoryIndex(index: Int) {}
             override fun stopLoading() {}
             override fun reload(flags: LoadUrlFlags) {}

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -618,13 +618,17 @@ abstract class EngineSession(
 
     /**
      * Navigates back in the history of this session.
+     *
+     * @param userInteraction informs the engine whether the action was user invoked.
      */
-    abstract fun goBack()
+    abstract fun goBack(userInteraction: Boolean = true)
 
     /**
      * Navigates forward in the history of this session.
+     *
+     * @param userInteraction informs the engine whether the action was user invoked.
      */
-    abstract fun goForward()
+    abstract fun goForward(userInteraction: Boolean = true)
 
     /**
      * Navigates to the specified index in the [HistoryState] of this session. The current index of

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -975,9 +975,9 @@ open class DummyEngineSession : EngineSession() {
 
     override fun reload(flags: LoadUrlFlags) {}
 
-    override fun goBack() {}
+    override fun goBack(userInteraction: Boolean) {}
 
-    override fun goForward() {}
+    override fun goForward(userInteraction: Boolean) {}
 
     override fun goToHistoryIndex(index: Int) {}
 

--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
@@ -146,7 +146,7 @@ class ReaderViewFeature(
                 store.dispatch(ReaderAction.UpdateReaderableAction(it.id, false))
                 store.dispatch(ReaderAction.ClearReaderActiveUrlAction(it.id))
                 if (it.content.canGoBack) {
-                    it.engineState.engineSession?.goBack()
+                    it.engineState.engineSession?.goBack(false)
                 } else {
                     extensionController.sendContentMessage(
                         createHideReaderMessage(),

--- a/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
+++ b/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
@@ -320,7 +320,7 @@ class ReaderViewFeatureTest {
         testDispatcher.advanceUntilIdle()
 
         readerViewFeature.hideReaderView()
-        verify(engineSession).goBack()
+        verify(engineSession).goBack(false)
     }
 
     @Test

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
@@ -200,9 +200,12 @@ class SessionUseCases(
     ) {
         /**
          * Navigates back in the history of the currently selected tab
+         *
+         * @param userInteraction informs the engine whether the action was user invoked.
          */
         operator fun invoke(
-            tabId: String? = store.state.selectedTabId
+            tabId: String? = store.state.selectedTabId,
+            userInteraction: Boolean = true
         ) {
             if (tabId == null) {
                 return
@@ -210,7 +213,8 @@ class SessionUseCases(
 
             store.dispatch(
                 EngineAction.GoBackAction(
-                    tabId
+                    tabId,
+                    userInteraction
                 )
             )
         }
@@ -221,9 +225,12 @@ class SessionUseCases(
     ) {
         /**
          * Navigates forward in the history of the currently selected session
+         *
+         * @param userInteraction informs the engine whether the action was user invoked.
          */
         operator fun invoke(
-            tabId: String? = store.state.selectedTabId
+            tabId: String? = store.state.selectedTabId,
+            userInteraction: Boolean = true
         ) {
             if (tabId == null) {
                 return
@@ -231,7 +238,8 @@ class SessionUseCases(
 
             store.dispatch(
                 EngineAction.GoForwardAction(
-                    tabId
+                    tabId,
+                    userInteraction
                 )
             )
         }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -269,13 +269,15 @@ class SessionUseCasesTest {
         store.waitUntilIdle()
         middleware.assertLastAction(EngineAction.GoBackAction::class) { action ->
             assertEquals("mozilla", action.tabId)
+            assertTrue(action.userInteraction)
         }
         middleware.reset()
 
-        useCases.goBack()
+        useCases.goBack(userInteraction = false)
         store.waitUntilIdle()
         middleware.assertLastAction(EngineAction.GoBackAction::class) { action ->
             assertEquals("mozilla", action.tabId)
+            assertFalse(action.userInteraction)
         }
     }
 
@@ -289,13 +291,15 @@ class SessionUseCasesTest {
         store.waitUntilIdle()
         middleware.assertLastAction(EngineAction.GoForwardAction::class) { action ->
             assertEquals("mozilla", action.tabId)
+            assertTrue(action.userInteraction)
         }
         middleware.reset()
 
-        useCases.goForward()
+        useCases.goForward(userInteraction = false)
         store.waitUntilIdle()
         middleware.assertLastAction(EngineAction.GoForwardAction::class) { action ->
             assertEquals("mozilla", action.tabId)
+            assertFalse(action.userInteraction)
         }
     }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,8 +12,8 @@ permalink: /changelog/
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
 * **feature-prompts**:
-  * Removes deprecated constructor in `PromptFeature`. 
-  
+  * Removes deprecated constructor in `PromptFeature`.
+
 * * **browser-engine**, **concept-engine*** **feature-sitepermissions**
   * 🌟️️ **Add support for a new `storage_access` API prompt.
 
@@ -32,6 +32,12 @@ permalink: /changelog/
 
 * **browser-errorpages**
   * `ErrorPages.createUrlEncodedErrorPage()` allows overriding the title or description for specific error types now.
+
+* **browser-engine-gecko**
+  * Added `EngineSession.goBack(boolean)` and `EngineSession.goForward(boolean)` for user interaction based navigation.
+
+* **feature-session**
+  * Added support in `SessionUseCases.GoBackUseCase` and `SessionUseCases.GoForwardUseCase` to support optional `userInteraction` parameter in the Gecko engine.
 
 # 96.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v95.0.0...v96.0.0)


### PR DESCRIPTION
Needs BZ-1644595 to land first.

One thing to note here is that we change the default behaviour to assume all calls to `goBack`/`goForward` are user interactions which seems like most of our usages in our apps, so we would have to specify `false` for the cases where they are meant to be internal calls. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
