### PR TITLE
PromptFeature: Only dismiss prompts with shouldDismissOnLoad flag set

### DIFF
--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -757,7 +757,10 @@ class PromptFeature private constructor(
         if (canShowThisPrompt(promptRequest)) {
             dialog.show(fragmentManager, FRAGMENT_TAG)
             activePrompt = WeakReference(dialog)
-            activePromptsToDismiss.add(dialog)
+
+            if (promptRequest.shouldDismissOnLoad) {
+                activePromptsToDismiss.add(dialog)
+            }
         } else {
             (promptRequest as Dismissible).onDismiss()
             store.dispatch(ContentAction.ConsumePromptRequestAction(session.id, promptRequest))


### PR DESCRIPTION
Follow-up from https://github.com/mozilla-mobile/android-components/pull/11436 to fix issue in https://github.com/mozilla-mobile/fenix/pull/22951