### PR TITLE
Close #11462: Allow to choose the restore location of a tab in the tabstray.

### DIFF
--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
@@ -11,6 +11,7 @@ import mozilla.components.browser.session.storage.SessionStorage
 import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.RestoreCompleteAction
 import mozilla.components.browser.state.action.TabListAction
+import mozilla.components.browser.state.action.TabListAction.RestoreAction.RestoreLocation
 import mozilla.components.browser.state.action.UndoAction
 import mozilla.components.browser.state.selector.findNormalOrPrivateTabByUrl
 import mozilla.components.browser.state.selector.findTab
@@ -328,9 +329,13 @@ class TabsUseCases(
         /**
          * Restores the given list of [RecoverableTab]s.
          */
-        operator fun invoke(tabs: List<RecoverableTab>, selectTabId: String? = null) {
+        operator fun invoke(
+            tabs: List<RecoverableTab>,
+            selectTabId: String? = null,
+            restoreLocation: RestoreLocation = RestoreLocation.END
+        ) {
             store.dispatch(
-                TabListAction.RestoreAction(tabs, selectTabId, TabListAction.RestoreAction.RestoreLocation.BEGINNING)
+                TabListAction.RestoreAction(tabs, selectTabId, restoreLocation)
             )
         }
 
@@ -371,8 +376,12 @@ class TabsUseCases(
          * Restores the given [RecoverableTab] and updates the selected tab if [updateSelection] is
          * `true`.
          */
-        operator fun invoke(tab: RecoverableTab, updateSelection: Boolean = true) {
-            invoke(listOf(tab))
+        operator fun invoke(
+            tab: RecoverableTab,
+            updateSelection: Boolean = true,
+            restoreLocation: RestoreLocation = RestoreLocation.END
+        ) {
+            invoke(listOf(tab), null, restoreLocation)
 
             if (updateSelection) {
                 selectTab(tab.id)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,6 +39,9 @@ permalink: /changelog/
 * **feature-session**
   * Added support in `SessionUseCases.GoBackUseCase` and `SessionUseCases.GoForwardUseCase` to support optional `userInteraction` parameter in the Gecko engine.
 
+* **feature-tabs**
+  * Added options in `TabsUseCases.RestoreUseCase` to allow to choose the restore position of a tab (default value : `RestoreLocation.END`)
+
 # 96.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v95.0.0...v96.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/143?closed=1)


### PR DESCRIPTION
Added optional parameters for `TabsUseCases.RestoreUseCase` that allow the browser to choose the restore location of a tab in the tabstray. Default value is `RestoreLocation.END`.

This closes mozilla-mobile/fenix#22372

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
-  [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
