### PR TITLE
Closes #11488: Add a long press listener to nav bar

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -268,6 +268,30 @@ class DisplayToolbar internal constructor(
     }
 
     /**
+     * Sets a listener to be invoked when the site security indicator icon is clicked and held.
+     */
+    fun setOnSiteSecurityLongClickListener(listener: (() -> Unit)?) {
+        if (listener == null) {
+            views.securityIndicator.setOnLongClickListener(null)
+            views.securityIndicator.background = null
+        } else {
+            views.securityIndicator.setOnLongClickListener {
+                listener.invoke()
+                true
+            }
+
+            val outValue = TypedValue()
+            context.theme.resolveAttribute(
+                android.R.attr.selectableItemBackgroundBorderless,
+                outValue,
+                true
+            )
+
+            views.securityIndicator.setBackgroundResource(outValue.resourceId)
+        }
+    }
+
+    /**
      * Sets a listener to be invoked when the site tracking protection indicator icon is clicked.
      */
     fun setOnTrackingProtectionClickedListener(listener: (() -> Unit)?) {

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -736,6 +736,39 @@ class DisplayToolbarTest {
     }
 
     @Test
+    fun `clicking and holding the site security indicator invokes listener`() {
+        var listenerInvoked = false
+
+        val (_, displayToolbar) = createDisplayToolbar()
+
+        assertNull(displayToolbar.views.securityIndicator.background)
+
+        displayToolbar.setOnSiteSecurityLongClickListener {
+            listenerInvoked = true
+        }
+
+        assertNotNull(displayToolbar.views.securityIndicator.background)
+
+        displayToolbar.views.securityIndicator.performLongClick()
+
+        assertTrue(listenerInvoked)
+
+        listenerInvoked = false
+
+        displayToolbar.setOnSiteSecurityLongClickListener { }
+
+        assertNotNull(displayToolbar.views.securityIndicator.background)
+
+        displayToolbar.views.securityIndicator.performLongClick()
+
+        assertFalse(listenerInvoked)
+
+        displayToolbar.setOnSiteSecurityLongClickListener(null)
+
+        assertNull(displayToolbar.views.securityIndicator.background)
+    }
+
+    @Test
     fun `Security icon has proper content description`() {
         val (_, displayToolbar) = createDisplayToolbar()
         val siteSecurityIconView = displayToolbar.views.securityIndicator


### PR DESCRIPTION
Relates to [this](https://github.com/mozilla-mobile/android-components/issues/11488) issue.

Added a long press listener to security icon in nav bar, and added a test for it.
<img width="395" alt="Screen Shot 2022-01-05 at 3 03 35 PM" src="https://user-images.githubusercontent.com/92760693/148438734-c3068c9d-7ecb-4930-a803-d8c2286deedd.png">

