### PR TITLE
Issue #11496: Add Violet70A80 to ui-colors

### DIFF
--- a/components/ui/colors/src/main/java/mozilla/components/ui/colors/PhotonColors.kt
+++ b/components/ui/colors/src/main/java/mozilla/components/ui/colors/PhotonColors.kt
@@ -156,6 +156,7 @@ object PhotonColors {
     val Violet60 = Color(0xFF7542E5)
     val Violet70 = Color(0xFF592ACB)
     val Violet70A12 = Color(0x1F592ACB)
+    val Violet70A80 = Color(0xCC592ACB)
     val Violet80 = Color(0xFF45278D)
     val Violet90 = Color(0xFF321C64)
     val Violet90A20 = Color(0x33321C64)

--- a/components/ui/colors/src/main/res/values/photon_colors.xml
+++ b/components/ui/colors/src/main/res/values/photon_colors.xml
@@ -193,6 +193,7 @@
 	<color name="photonViolet60">#ff7542e5</color>
 	<color name="photonViolet70">#ff592ACB</color>
 	<color name="photonViolet70A12">#1F592ACB</color>
+	<color name="photonViolet70A80">#CC592ACB</color>
 	<color name="photonViolet80">#ff45278d</color>
 	<color name="photonViolet90">#ff321c64</color>
 	<color name="photonViolet90A20">#33321c64</color>


### PR DESCRIPTION
Fixes #11496 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
