### PR TITLE
For #11527 - Use deprecated APIs for immersive mode since they work better

### DIFF
--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ActivityTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ActivityTest.kt
@@ -54,7 +54,6 @@ class ActivityTest {
         verify(decorView).systemUiVisibility = View.SYSTEM_UI_FLAG_FULLSCREEN
         verify(decorView).systemUiVisibility = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
         // verify that the immersive mode restoration is set as expected
-        verify(window.decorView.viewTreeObserver).addOnWindowFocusChangeListener(any())
         verify(window.decorView).setOnSystemUiVisibilityChangeListener(any())
     }
 
@@ -65,7 +64,6 @@ class ActivityTest {
         verify(window).addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         verify(decorView).systemUiVisibility = View.SYSTEM_UI_FLAG_FULLSCREEN
         verify(decorView).systemUiVisibility = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-        verify(window.decorView.viewTreeObserver, never()).addOnWindowFocusChangeListener(any())
         verify(window.decorView, never()).setOnSystemUiVisibilityChangeListener(any())
     }
 
@@ -73,7 +71,6 @@ class ActivityTest {
     fun `check enableImmersiveModeRestore sets focus and insets listeners`() {
         activity.enableImmersiveModeRestore()
 
-        verify(window.decorView.viewTreeObserver).addOnWindowFocusChangeListener(any())
         verify(window.decorView).setOnSystemUiVisibilityChangeListener(any())
     }
 
@@ -98,26 +95,6 @@ class ActivityTest {
     }
 
     @Test
-    fun `check enableImmersiveModeRestore set focus listener has the correct behavior`() {
-        val focusListenerCaptor = argumentCaptor<ViewTreeObserver.OnWindowFocusChangeListener>()
-
-        activity.enableImmersiveModeRestore()
-        verify(window.decorView.viewTreeObserver).addOnWindowFocusChangeListener(focusListenerCaptor.capture())
-
-        focusListenerCaptor.value.onWindowFocusChanged(false)
-        // If the activity is not focused restoration is needed.
-        // Cannot test if "setAsImmersive()" was called it being an extension function but we can check the effect of that call.
-        verify(window, never()).addFlags(anyInt())
-        verify(decorView, never()).systemUiVisibility = anyInt()
-        verify(decorView, never()).systemUiVisibility = anyInt()
-
-        focusListenerCaptor.value.onWindowFocusChanged(true)
-        verify(window).addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        verify(decorView).systemUiVisibility = View.SYSTEM_UI_FLAG_FULLSCREEN
-        verify(decorView).systemUiVisibility = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-    }
-
-    @Test
     fun `check exitImmersiveModeIfNeeded sets the correct flags`() {
         val attributes = mock(WindowManager.LayoutParams::class.java)
         `when`(window.attributes).thenReturn(attributes)
@@ -129,7 +106,6 @@ class ActivityTest {
         verify(decorView, never()).systemUiVisibility = View.SYSTEM_UI_FLAG_FULLSCREEN.inv()
         verify(decorView, never()).systemUiVisibility = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION.inv()
         verify(decorView, never()).setOnSystemUiVisibilityChangeListener(null)
-        verify(window.decorView.viewTreeObserver, never()).removeOnWindowFocusChangeListener(any())
 
         attributes.flags = WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
 
@@ -137,9 +113,7 @@ class ActivityTest {
 
         verify(window).clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         verify(decorView, times(2)).systemUiVisibility = View.SYSTEM_UI_FLAG_VISIBLE
-        verify(window.decorView.viewTreeObserver).removeOnWindowFocusChangeListener(any())
         verify(decorView).setOnSystemUiVisibilityChangeListener(null)
-        verify(window.decorView.viewTreeObserver).removeOnWindowFocusChangeListener(any())
     }
 
     @Test
@@ -151,12 +125,10 @@ class ActivityTest {
         activity.exitImmersiveModeIfNeeded()
 
         verify(decorView, never()).setOnSystemUiVisibilityChangeListener(null)
-        verify(window.decorView.viewTreeObserver, never()).removeOnWindowFocusChangeListener(any())
 
         attributes.flags = WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
         activity.exitImmersiveModeIfNeeded()
 
         verify(decorView).setOnSystemUiVisibilityChangeListener(null)
-        verify(window.decorView.viewTreeObserver).removeOnWindowFocusChangeListener(any())
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **support-ktx**
+  * 🚒 Bug fixed [issue #11527](https://github.com/mozilla-mobile/android-components/issues/11527) - Using now deprecated APIs to fix immersive mode not being applied all the time. https://issuetracker.google.com/u/2/issues/214012501 can be followed for what seems a framework issue.
+
 * **lib/publicsuffixlist**
   * ⚠️ **This is a breaking change**: Removed `String.urlToTrimmedHost` extension method.
 


### PR DESCRIPTION
Opened https://issuetracker.google.com/u/2/issues/214012501 for what seems a
bug with the new insets based APIs.
In the meantime we are using the old OnSystemUiVisibilityChangeListener to
know when to restore immersive mode.

Removed the onWindowFocusChangeListener extension property since by having to
offer it through a getter the current implementation would always leak the old
one.
Fenix wasn't using it when this APIs allowed Fenix to pass such a listener and
there was no issue observed so there should be no observable negative impact.


https://user-images.githubusercontent.com/11428869/149172994-476728b2-abdc-49fc-b597-2796e9dd4f5f.mov





### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
