### PR TITLE
Bump AndroidX annotation to 1.3.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -39,7 +39,7 @@ object Versions {
 
     object AndroidX {
         const val activityCompose = "1.4.0"
-        const val annotation = "1.1.0"
+        const val annotation = "1.3.0"
         const val appcompat = "1.3.0"
         const val autofill = "1.1.0"
         const val browser = "1.3.0"


### PR DESCRIPTION
Builds seem to be failing without it: https://firefox-ci-tc.services.mozilla.com/tasks/RApwuSKQRzitnO0mOdFk-A/runs/1/logs/public/logs/live.log

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
