### PR TITLE
Initialise securityIconInsecure with Color.TRANSPARENT

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -177,7 +177,7 @@ class DisplayToolbar internal constructor(
      */
     var colors: Colors = Colors(
         securityIconSecure = ContextCompat.getColor(context, R.color.photonWhite),
-        securityIconInsecure = ContextCompat.getColor(context, R.color.photonWhite),
+        securityIconInsecure = Color.TRANSPARENT,
         emptyIcon = ContextCompat.getColor(context, R.color.photonWhite),
         menu = ContextCompat.getColor(context, R.color.photonWhite),
         hint = views.origin.hintColor,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **browser-toolbar**
+  * 🚒 Bug fixed [issue #11537](https://github.com/mozilla-mobile/android-components/issues/11537) - Initialise "securityIconInsecure" with Color.TRANSPARENT to clear the color filters
+
 * **lib/publicsuffixlist**
   * ⚠️ **This is a breaking change**: Removed `String.urlToTrimmedHost` extension method.
 


### PR DESCRIPTION
For #11537
"securityIconInsecure" is initialised with a white filter and because in Focus is a different
logic of security, tracking icons initialisation seems to cause a bug on some devices with Android 5
To solve this corner case we should set "securityIconInsecure = Color.TRANSPARENT"
by default and all color filters are cleared



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
