### PR TITLE
Backout WorkManager 2.7.1 version bump

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -61,7 +61,7 @@ object Versions {
         const val lifecycle = "2.2.0"
         const val media = "1.2.0"
         const val navigation = "2.4.0-alpha04"
-        const val work = "2.7.1"
+        const val work = "2.4.0"
         const val arch = "2.1.0"
         const val uiautomator = "2.2.0"
         const val localbroadcastmanager = "1.0.0"

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/update/AddonUpdaterWorkerTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/update/AddonUpdaterWorkerTest.kt
@@ -149,7 +149,7 @@ class AddonUpdaterWorkerTest {
             .setInputData(AddonUpdaterWorker.createWorkerData(addonId))
             .build()
         val recoverableException = WebExtensionException(Exception(), isRecoverable = true)
-        worker.updateAttemptStorage = updateAttemptStorage
+        (worker as AddonUpdaterWorker).updateAttemptStorage = updateAttemptStorage
 
         GlobalAddonDependencyProvider.initialize(addonManager, mock())
 
@@ -175,7 +175,7 @@ class AddonUpdaterWorkerTest {
             .setInputData(AddonUpdaterWorker.createWorkerData(addonId))
             .build()
         val unrecoverableException = WebExtensionException(Exception(), isRecoverable = false)
-        worker.updateAttemptStorage = updateAttemptStorage
+        (worker as AddonUpdaterWorker).updateAttemptStorage = updateAttemptStorage
 
         GlobalAddonDependencyProvider.initialize(addonManager, mock())
 


### PR DESCRIPTION
Focus nightlies are failing because the new WM needs us to target SDK 31. We're already on this in Fenix, but not Focus.

Filed Focus bug to upgrade target SDK: https://github.com/mozilla-mobile/focus-android/issues/6223

TC logs: https://firefox-ci-tc.services.mozilla.com/tasks/KYbl24zRRrWfpK1euzZIIg/runs/0/logs/public/logs/live.log

```
[task 2022-01-13T19:05:21.567Z] * What went wrong:
[task 2022-01-13T19:05:21.567Z] Execution failed for task ':app:checkFocusDebugAarMetadata'.
[task 2022-01-13T19:05:21.567Z] > A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
[task 2022-01-13T19:05:21.567Z]    > One or more issues found when checking AAR metadata values:
[task 2022-01-13T19:05:21.567Z]      
[task 2022-01-13T19:05:21.567Z]      The minCompileSdk (31) specified in a
[task 2022-01-13T19:05:21.567Z]      dependency's AAR metadata (META-INF/com/android/build/gradle/aar-metadata.properties)
[task 2022-01-13T19:05:21.567Z]      is greater than this module's compileSdkVersion (android-30).
[task 2022-01-13T19:05:21.567Z]      Dependency: androidx.work:work-runtime-ktx:2.7.1.
[task 2022-01-13T19:05:21.567Z]      AAR metadata file: /builds/worker/.gradle/caches/transforms-3/eb71e07de55d05b42972a18d0266f3ab/transformed/work-runtime-ktx-2.7.1/META-INF/com/android/build/gradle/aar-metadata.properties.
[task 2022-01-13T19:05:21.567Z]      
[task 2022-01-13T19:05:21.568Z]      The minCompileSdk (31) specified in a
[task 2022-01-13T19:05:21.568Z]      dependency's AAR metadata (META-INF/com/android/build/gradle/aar-metadata.properties)
[task 2022-01-13T19:05:21.568Z]      is greater than this module's compileSdkVersion (android-30).
[task 2022-01-13T19:05:21.568Z]      Dependency: androidx.work:work-runtime:2.7.1.
[task 2022-01-13T19:05:21.568Z]      AAR metadata file: /builds/worker/.gradle/caches/transforms-3/cfec6707b0139b4f4ac25df8738c1d72/transformed/work-runtime-2.7.1/META-INF/com/android/build/gradle/aar-metadata.properties.
```
