### PR TITLE
Replace clearColorFilter with setColorFilter for security icon

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.graphics.Color
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
+import android.os.Build
 import android.util.TypedValue
 import android.view.View
 import android.view.accessibility.AccessibilityEvent
@@ -500,7 +501,7 @@ class DisplayToolbar internal constructor(
             Toolbar.SiteSecurity.INSECURE -> colors.securityIconInsecure
             Toolbar.SiteSecurity.SECURE -> colors.securityIconSecure
         }
-        if (color == Color.TRANSPARENT) {
+        if (color == Color.TRANSPARENT && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             views.securityIndicator.clearColorFilter()
         } else {
             views.securityIndicator.setColorFilter(color)

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.toolbar.display
 
 import android.graphics.Color
+import android.os.Build
 import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.core.view.isGone
@@ -41,6 +42,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.reset
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
+import org.robolectric.util.ReflectionHelpers
 
 @RunWith(AndroidJUnit4::class)
 class DisplayToolbarTest {
@@ -649,18 +651,42 @@ class DisplayToolbarTest {
         assertNull(displayToolbar.views.securityIndicator.colorFilter)
 
         displayToolbar.colors = displayToolbar.colors.copy(
-            securityIconSecure = Color.TRANSPARENT,
-            securityIconInsecure = Color.TRANSPARENT
-        )
-
-        assertNull(displayToolbar.views.securityIndicator.colorFilter)
-
-        displayToolbar.colors = displayToolbar.colors.copy(
             securityIconSecure = Color.BLUE,
             securityIconInsecure = Color.BLUE
         )
 
         assertNotNull(displayToolbar.views.securityIndicator.colorFilter)
+    }
+
+    @Test
+    fun `color filter is set with transparent when securityIconColor changes to transparent and api version is lower than 23`() {
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", 22)
+        val (_, displayToolbar) = createDisplayToolbar()
+
+        assertNull(displayToolbar.views.securityIndicator.colorFilter)
+
+        displayToolbar.colors = displayToolbar.colors.copy(
+            securityIconSecure = Color.TRANSPARENT,
+            securityIconInsecure = Color.TRANSPARENT
+        )
+
+        assertNotNull(displayToolbar.views.securityIndicator.colorFilter)
+    }
+
+    @Test
+    fun `color filter is cleared when securityIconColor changes to transparent and api version is bigger than 22`() {
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", 23)
+
+        val (_, displayToolbar) = createDisplayToolbar()
+
+        assertNull(displayToolbar.views.securityIndicator.colorFilter)
+
+        displayToolbar.colors = displayToolbar.colors.copy(
+            securityIconSecure = Color.TRANSPARENT,
+            securityIconInsecure = Color.TRANSPARENT
+        )
+
+        assertNull(displayToolbar.views.securityIndicator.colorFilter)
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **browser-toolbar**
+  * 🚒 Bug fixed [issue #11545](https://github.com/mozilla-mobile/android-components/issues/11545) - `clearColorFilter` doesn't work on Api 21, 22, so the default white filter remains set.Use `clearColorFilter` only when the version of API is bigger than 22
+
 * **support-ktx**
   * 🚒 Bug fixed [issue #11527](https://github.com/mozilla-mobile/android-components/issues/11527) - Fix some situations in which the immersive mode wasn't properly applied.
 


### PR DESCRIPTION
For #11545

Clear color filter doesn't work on Api 21, 22
Even if we invalidate the view after clearColorFilter the filter is not removed, so to fix the bug we need to use setColorFilter with color Color.Transparent



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
