### PR TITLE
Add baidu search ad telemetry

### DIFF
--- a/components/feature/search/src/main/java/mozilla/components/feature/search/telemetry/BaseSearchTelemetry.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/telemetry/BaseSearchTelemetry.kt
@@ -104,7 +104,11 @@ abstract class BaseSearchTelemetry {
             queryParam = "word",
             codeParam = "from",
             codePrefixes = listOf("1000969a"),
-            followOnParams = listOf("oq")
+            followOnParams = listOf("oq"),
+            extraAdServersRegexps = listOf(
+                "^https?://www\\.baidu\\.com/baidu\\.php?",
+                "^https?://m\\.baidu\\.com/baidu\\.php?"
+            )
         ),
         SearchProviderModel(
             name = "bing",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **feature-search**
+  * Adds the `extraAdServersRegexps` of Baidu to help sending the baidu search telemetry of ads. [#11582](https://github.com/mozilla-mobile/android-components/pull/11582)
+
 * **browser-toolbar**
   * 🚒 Bug fixed [issue #11545](https://github.com/mozilla-mobile/android-components/issues/11545) - `clearColorFilter` doesn't work on Api 21, 22, so the default white filter remains set.Use `clearColorFilter` only when the version of API is bigger than 22
 


### PR DESCRIPTION
Add the extraAdServersRegexps of Baidu to help sending the baidu search telemetry of ads. 
