### PR TITLE
Fixup Nimbus breaking change (Nimbus needing an android Context object)

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,7 +29,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "2.8.1"
 
-    const val mozilla_appservices = "87.2.0"
+    const val mozilla_appservices = "89.0.0"
 
     const val mozilla_glean = "43.0.2"
 

--- a/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/Nimbus.kt
+++ b/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/Nimbus.kt
@@ -98,9 +98,6 @@ class Nimbus(
  * experiment.
  */
 class NimbusDisabled(
+    override val context: Context,
     private val delegate: Observable<NimbusInterface.Observer> = ObserverRegistry()
-) : NimbusApi, Observable<NimbusInterface.Observer> by delegate {
-    companion object {
-        val instance: NimbusApi by lazy { NimbusDisabled() }
-    }
-}
+) : NimbusApi, Observable<NimbusInterface.Observer> by delegate

--- a/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/NimbusTest.kt
+++ b/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/NimbusTest.kt
@@ -27,7 +27,7 @@ class NimbusTest {
     @Test
     fun `Nimbus disabled and enabled can have observers registered on it`() {
         val enabled: NimbusApi = Nimbus(context, appInfo, null)
-        val disabled: NimbusApi = NimbusDisabled.instance
+        val disabled: NimbusApi = NimbusDisabled(context)
 
         val observer = object : NimbusInterface.Observer {}
 
@@ -37,7 +37,7 @@ class NimbusTest {
 
     @Test
     fun `NimbusDisabled is empty`() {
-        val nimbus: NimbusApi = NimbusDisabled()
+        val nimbus: NimbusApi = NimbusDisabled(context)
         nimbus.fetchExperiments()
         nimbus.applyPendingExperiments()
         assertTrue("getActiveExperiments should be empty", nimbus.getActiveExperiments().isEmpty())


### PR DESCRIPTION
Fixes breakage from https://github.com/mozilla/application-services/pull/4784.

Requires Application Services 89.0.0. https://github.com/mozilla/application-services/pull/4788

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.