### PR TITLE
Fix browser-session dead link in components.md

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -10,7 +10,7 @@ permalink: /components/
 
 Every browser will need two core components:
 
-* **[browser-session](https://github.com/mozilla-mobile/android-components/tree/main/components/browser/session)** - Representing the state of the browser (_"What tabs are opened?"_, _"What URLs are they pointing to?"_)
+* **[browser-state](https://github.com/mozilla-mobile/android-components/tree/main/components/browser/state)** - Representing the state of the browser (_"What tabs are opened?"_, _"What URLs are they pointing to?"_)
 * **browser-engine** - The browser engine that transforms web pages into an interactive visual representation. The _browser-engine_ component comes in multiple flavors. We are supporting [Android's WebView](https://github.com/mozilla-mobile/android-components/tree/main/components/browser/engine-system) (limited feature set) and **GeckoView** ([Release](https://github.com/mozilla-mobile/android-components/tree/main/components/browser/engine-gecko), [Beta](https://github.com/mozilla-mobile/android-components/tree/main/components/browser/engine-gecko-beta) and [Nightly](https://github.com/mozilla-mobile/android-components/tree/main/components/browser/engine-gecko-nightly) channels) currently. The actual implementation is hidden behind [generic interfaces](https://github.com/mozilla-mobile/android-components/tree/main/components/concept) so that apps can build against multiple engines (e.g. based on product flavor) and so that other components work seemlessly with all implementations.
 
 Other high-level browser components may depend on those core components.


### PR DESCRIPTION
The browser-session component was renamed to browser-state in #1843



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
