### PR TITLE
Update room to support M1s with arm64 JDKs

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -54,7 +54,7 @@ object Versions {
         const val test = "1.3.0"
         const val test_ext = "1.1.2"
         const val espresso = "3.3.0"
-        const val room = "2.3.0"
+        const val room = "2.4.0-alpha03"
         const val paging = "2.1.2"
         const val palette = "1.0.0"
         const val preferences = "1.1.1"


### PR DESCRIPTION
When M1 users start using the "more correct" arm64 JDKs after application-services PR lands https://github.com/mozilla/application-services/pull/4792 android components fails to build because room doesn't have a M1-compatible fix until `2.4`. The fix was found from:

https://stackoverflow.com/questions/68922875/room-database-is-not-working-in-mac-book-pro-m1

### Note: This shouldn't land until https://github.com/mozilla/application-services/pull/4792 lands

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
