### PR TITLE
Issue #11692: Set WebRequest::beConservative in GeckoViewFetchClient

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchClient.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchClient.kt
@@ -87,6 +87,8 @@ private fun Request.toWebRequest(): WebRequest = WebRequest.Builder(url)
     .addHeadersFrom(this)
     .addBodyFrom(this)
     .cacheMode(if (useCaches) CACHE_MODE_DEFAULT else CACHE_MODE_RELOAD)
+    // Turn off bleeding-edge network features to avoid breaking core browser functionality.
+    .beConservative(true)
     .build()
 
 private fun WebRequest.Builder.addHeadersFrom(request: Request): WebRequest.Builder {


### PR DESCRIPTION
beConservative is configurable now so we need to set the value in
GeckoViewFetchClient.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
