### PR TITLE
For #11632 - Search suggestion buttons in awesomebar not visible

### DIFF
--- a/components/ui/icons/src/main/res/drawable/mozac_ic_edit_suggestion.xml
+++ b/components/ui/icons/src/main/res/drawable/mozac_ic_edit_suggestion.xml
@@ -9,6 +9,6 @@
     android:viewportWidth="24.0"
     android:viewportHeight="24.0">
     <path
-        android:fillColor="@color/mozac_ui_icons_fill"
+        android:fillColor="#000000"
         android:pathData="M19.78 18.72L6.56 5.5h8.443a0.75 0.75 0 0 0 0-1.5H4.581L4 4.581v10.422a0.75 0.75 0 0 0 1.5 0V6.56l13.22 13.22a0.748 0.748 0 0 0 1.06 0 0.749 0.749 0 0 0 0-1.06z" />
 </vector>


### PR DESCRIPTION
Fixes #11632 
This is a patch that fixes the issue above.
For some reason the image editing happening in Suggestion.kt doesn't like the dynamic attribute color value that is set in `mozac_ui_icons_fill`, and on the icon itself (by color/mozac_ui_icons_fill). 
A simple fix is to change the default color of the icon to a static one.
It shouldn't be a issue that the default color is changed for the icon, since:

1. The icon is only used by awesomebar (as far as I can tell)
2. The icon is always tinted again by default through Suggestion.kt - that's where the issue comes from in the first place

This fixes the issue and the icon can be tinted.

CC: @gabrielluong 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: N/A
- [x] **Tests**: N/A
- [ ] **Changelog**: To be added if this is patch is deemed good to go
- [x] **Accessibility**: N/A

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
