### PR TITLE
Closes #11655: expose HistoryVisitInfo.isRemote; update A-S to 91.0.1

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,7 +29,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "2.8.1"
 
-    const val mozilla_appservices = "90.0.1"
+    const val mozilla_appservices = "91.0.1"
 
     const val mozilla_glean = "43.0.2"
 

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Types.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Types.kt
@@ -107,7 +107,8 @@ internal fun mozilla.appservices.places.uniffi.HistoryVisitInfo.into(): VisitInf
         title = this.title,
         visitTime = this.timestamp,
         visitType = this.visitType.into(),
-        previewImageUrl = this.previewImageUrl
+        previewImageUrl = this.previewImageUrl,
+        isRemote = this.isRemote,
     )
 }
 

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryStorage.kt
@@ -201,7 +201,7 @@ enum class FrecencyThresholdOption {
  * @property visitTime The time the page was visited in integer milliseconds since the unix epoch.
  * @property visitType What the transition type of the visit is, expressed as [VisitType].
  * @property previewImageUrl The preview image of the page (e.g. the hero image), if available.
- * @property isRemote Distinguishes visits made on the device and those that come from syncing.
+ * @property isRemote Distinguishes visits made on the device and those that come from Sync.
  */
 data class VisitInfo(
     val url: String,

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryStorage.kt
@@ -201,13 +201,15 @@ enum class FrecencyThresholdOption {
  * @property visitTime The time the page was visited in integer milliseconds since the unix epoch.
  * @property visitType What the transition type of the visit is, expressed as [VisitType].
  * @property previewImageUrl The preview image of the page (e.g. the hero image), if available.
+ * @property isRemote Distinguishes visits made on the device and those that come from syncing.
  */
 data class VisitInfo(
     val url: String,
     val title: String?,
     val visitTime: Long,
     val visitType: VisitType,
-    val previewImageUrl: String?
+    val previewImageUrl: String?,
+    var isRemote: Boolean,
 )
 
 /**


### PR DESCRIPTION
Fixes [#11655](https://github.com/mozilla-mobile/android-components/issues/11655).

Looks like there is no need for tests, as it is just passing the value down.

It requires app-services to be updated to the latest version, I tested on current main: isRemote flag is there.