### PR TITLE
Find nimbus-fml.exe from pre-built binaries

### DIFF
--- a/components/tooling/nimbus-gradle-plugin/src/main/groovy/mozilla/components/tooling/nimbus/NimbusGradlePlugin.groovy
+++ b/components/tooling/nimbus-gradle-plugin/src/main/groovy/mozilla/components/tooling/nimbus/NimbusGradlePlugin.groovy
@@ -257,7 +257,7 @@ class NimbusPlugin implements Plugin<Project> {
         String osPart
         String os = System.getProperty("os.name").toLowerCase()
         if (os.contains("win")) {
-            osPart = "windows"
+            osPart = "pc-windows-gnu"
         } else if (os.contains("nix") || os.contains("nux") || os.contains("aix")) {
             osPart = "unknown-linux-musl"
         } else if (os.contains("mac")) {
@@ -282,7 +282,12 @@ class NimbusPlugin implements Plugin<Project> {
     }
 
     static def getFMLPath(Project project) {
-        return [getFMLRoot(project), "nimbus-fml"].join(File.separator)
+        String os = System.getProperty("os.name").toLowerCase()
+        String binaryName = "nimbus-fml"
+        if (os.contains("win")) {
+            binaryName = "nimbus-fml.exe"
+        }
+        return [getFMLRoot(project), binaryName].join(File.separator)
     }
 
     def setupVariantTasks(variant, project, extension, oneTimeTasks, isLibrary = false) {

--- a/components/tooling/nimbus-gradle-plugin/src/main/groovy/mozilla/components/tooling/nimbus/NimbusGradlePlugin.groovy
+++ b/components/tooling/nimbus-gradle-plugin/src/main/groovy/mozilla/components/tooling/nimbus/NimbusGradlePlugin.groovy
@@ -171,7 +171,7 @@ class NimbusPlugin implements Plugin<Project> {
         // a) this plugin is going to live in the AS repo (eventually)
         // See https://github.com/mozilla-mobile/android-components/issues/11422 for tying this
         // to a version that is specified in buildSrc/src/main/java/Dependencies.kt
-        return "90.0.0"
+        return "91.0.1"
     }
 
     // Try one or more hosts to download the given file.


### PR DESCRIPTION
Fixes #4812.

This requires https://github.com/mozilla/application-services/pull/4814 to land that builds the Windows version of `nimbus-fml.exe`; **and** a release of Application Services (currently `91.0.0`).

FWIW: Breaking changes advertised in `91.0.0` are only for use-cases not in use in Fenix.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
