### PR TITLE
Issue #11654: Change fetchProvidedTopSites into TopSitesProviderConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ _Components and libraries to interact with backend services._
 
 * 🔴 [**Pocket**](components/service/pocket/README.md) - A library for communicating with the Pocket API.
 
+* 🔴 [**Contile**](components/service/contile/README.md) - A library for communicating with the Contile services API.
+
 ## Support
 
 _Supporting components with generic helper code._

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/DefaultTopSitesStorage.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/DefaultTopSitesStorage.kt
@@ -24,7 +24,7 @@ import kotlin.coroutines.CoroutineContext
  * @param historyStorage An instance of [PlacesHistoryStorage], used for retrieving top frecent
  * sites from history.
  * @param topSitesProvider An optional instance of [TopSitesProvider], used for retrieving
- * additional top sites from a provider.
+ * additional top sites from a provider. The returned top sites are added before pinned sites.
  * @param defaultTopSites A list containing a title to url pair of default top sites to be added
  * to the [PinnedSiteStorage].
  */
@@ -83,27 +83,33 @@ class DefaultTopSitesStorage(
         }
     }
 
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress("ComplexCondition", "TooGenericExceptionCaught")
     override suspend fun getTopSites(
         totalSites: Int,
-        fetchProvidedTopSites: Boolean,
-        frecencyConfig: FrecencyThresholdOption?
+        frecencyConfig: FrecencyThresholdOption?,
+        providerConfig: TopSitesProviderConfig?
     ): List<TopSite> {
         val topSites = ArrayList<TopSite>()
         val pinnedSites = pinnedSitesStorage.getPinnedSites().take(totalSites)
         var numSitesRequired = totalSites - pinnedSites.size
 
-        topSites.addAll(pinnedSites)
-
-        if (fetchProvidedTopSites && topSitesProvider != null) {
+        if (topSitesProvider != null &&
+            providerConfig != null &&
+            providerConfig.showProviderTopSites &&
+            pinnedSites.size < providerConfig.maxThreshold
+        ) {
             try {
-                val providerTopSites = topSitesProvider.getTopSites()
-                topSites.addAll(providerTopSites.take(numSitesRequired))
+                val providerTopSites = topSitesProvider
+                    .getTopSites()
+                    .take(numSitesRequired)
+                topSites.addAll(providerTopSites)
                 numSitesRequired -= providerTopSites.size
             } catch (e: Exception) {
                 logger.error("Failed to fetch top sites from provider", e)
             }
         }
+
+        topSites.addAll(pinnedSites)
 
         if (frecencyConfig != null && numSitesRequired > 0) {
             // Get 'totalSites' sites for duplicate entries with

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/TopSitesConfig.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/TopSitesConfig.kt
@@ -11,13 +11,26 @@ import mozilla.components.concept.storage.FrecencyThresholdOption
  * whether or not to include top frecent sites in the top sites feature.
  *
  * @property totalSites A total number of sites that will be displayed.
- * @property fetchProvidedTopSites Whether or not to fetch top sites from the [TopSitesProvider].
  * @property frecencyConfig If [frecencyConfig] is specified, only visited sites with a frecency
  * score above the given threshold will be returned. Otherwise, frecent top site results are
  * not included.
+ * @property providerConfig An instance of [TopSitesProviderConfig] that specifies whether or
+ * not to fetch top sites from the [TopSitesProvider].
  */
 data class TopSitesConfig(
     val totalSites: Int,
-    val fetchProvidedTopSites: Boolean,
-    val frecencyConfig: FrecencyThresholdOption?
+    val frecencyConfig: FrecencyThresholdOption?,
+    val providerConfig: TopSitesProviderConfig?
+)
+
+/**
+ * Top sites provider configuration to specify whether or not to fetch top sites from the provider.
+ *
+ * @property showProviderTopSites Whether or not to display the top sites from the provider.
+ * @property maxThreshold Only fetch the top sites from the provider if the number of top sites are
+ * below the maximum threshold.
+ */
+data class TopSitesProviderConfig(
+    val showProviderTopSites: Boolean,
+    val maxThreshold: Int = Int.MAX_VALUE
 )

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/TopSitesStorage.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/TopSitesStorage.kt
@@ -43,15 +43,16 @@ interface TopSitesStorage : Observable<TopSitesStorage.Observer> {
      * If `frecencyConfig` is specified, fill in any missing top sites with frecent top site results.
      *
      * @param totalSites A total number of sites that will be retrieve if possible.
-     * @param fetchProvidedTopSites Whether or not to fetch top sites from the [TopSitesProvider].
      * @param frecencyConfig If [frecencyConfig] is specified, only visited sites with a frecency
      * score above the given threshold will be returned. Otherwise, frecent top site results are
      * not included.
+     * @param providerConfig An instance of [TopSitesProviderConfig] that specifies whether or
+     * not to fetch top sites from the [TopSitesProvider].
      */
     suspend fun getTopSites(
         totalSites: Int,
-        fetchProvidedTopSites: Boolean,
-        frecencyConfig: FrecencyThresholdOption?
+        frecencyConfig: FrecencyThresholdOption? = null,
+        providerConfig: TopSitesProviderConfig? = null
     ): List<TopSite>
 
     /**

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/presenter/DefaultTopSitesPresenter.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/presenter/DefaultTopSitesPresenter.kt
@@ -45,9 +45,9 @@ internal class DefaultTopSitesPresenter(
 
         scope.launch {
             val topSites = storage.getTopSites(
-                innerConfig.totalSites,
-                innerConfig.fetchProvidedTopSites,
-                innerConfig.frecencyConfig
+                totalSites = innerConfig.totalSites,
+                frecencyConfig = innerConfig.frecencyConfig,
+                providerConfig = innerConfig.providerConfig
             )
 
             scope.launch(Dispatchers.Main) {

--- a/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/DefaultTopSitesStorageTest.kt
+++ b/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/DefaultTopSitesStorageTest.kt
@@ -154,7 +154,7 @@ class DefaultTopSitesStorageTest {
     }
 
     @Test
-    fun `getTopSites returns only default and pinned sites when frecencyConfig is null`() = runBlockingTest {
+    fun `GIVEN frecencyConfig and providerConfig are null WHEN getTopSites is called THEN only default and pinned sites are returned`() = runBlockingTest {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
             pinnedSitesStorage = pinnedSitesStorage,
             historyStorage = historyStorage,
@@ -183,41 +183,25 @@ class DefaultTopSitesStorageTest {
         )
         whenever(pinnedSitesStorage.getPinnedSitesCount()).thenReturn(2)
 
-        var topSites = defaultTopSitesStorage.getTopSites(
-            totalSites = 0,
-            fetchProvidedTopSites = false,
-            frecencyConfig = null
-        )
+        var topSites = defaultTopSitesStorage.getTopSites(totalSites = 0)
 
         assertTrue(topSites.isEmpty())
         assertEquals(defaultTopSitesStorage.cachedTopSites, topSites)
 
-        topSites = defaultTopSitesStorage.getTopSites(
-            totalSites = 1,
-            fetchProvidedTopSites = false,
-            frecencyConfig = null
-        )
+        topSites = defaultTopSitesStorage.getTopSites(totalSites = 1)
 
         assertEquals(1, topSites.size)
         assertEquals(defaultSite, topSites[0])
         assertEquals(defaultTopSitesStorage.cachedTopSites, topSites)
 
-        topSites = defaultTopSitesStorage.getTopSites(
-            totalSites = 2,
-            fetchProvidedTopSites = false,
-            frecencyConfig = null
-        )
+        topSites = defaultTopSitesStorage.getTopSites(totalSites = 2)
 
         assertEquals(2, topSites.size)
         assertEquals(defaultSite, topSites[0])
         assertEquals(pinnedSite, topSites[1])
         assertEquals(defaultTopSitesStorage.cachedTopSites, topSites)
 
-        topSites = defaultTopSitesStorage.getTopSites(
-            totalSites = 5,
-            fetchProvidedTopSites = false,
-            frecencyConfig = null
-        )
+        topSites = defaultTopSitesStorage.getTopSites(totalSites = 5)
 
         assertEquals(2, topSites.size)
         assertEquals(defaultSite, topSites[0])
@@ -226,7 +210,7 @@ class DefaultTopSitesStorageTest {
     }
 
     @Test
-    fun `GIVEN fetchProvidedTopSites is true WHEN getTopSites is called THEN default, pinned and provided top sites are returned`() = runBlockingTest {
+    fun `GIVEN providerConfig is specified WHEN getTopSites is called THEN default, pinned and provided top sites are returned`() = runBlockingTest {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
             pinnedSitesStorage = pinnedSitesStorage,
             historyStorage = historyStorage,
@@ -265,19 +249,16 @@ class DefaultTopSitesStorageTest {
         )
         whenever(topSitesProvider.getTopSites()).thenReturn(listOf(providedSite))
 
-        var topSites = defaultTopSitesStorage.getTopSites(
-            totalSites = 0,
-            fetchProvidedTopSites = false,
-            frecencyConfig = null
-        )
+        var topSites = defaultTopSitesStorage.getTopSites(totalSites = 0)
 
         assertTrue(topSites.isEmpty())
         assertEquals(defaultTopSitesStorage.cachedTopSites, topSites)
 
         topSites = defaultTopSitesStorage.getTopSites(
             totalSites = 1,
-            fetchProvidedTopSites = true,
-            frecencyConfig = null
+            providerConfig = TopSitesProviderConfig(
+                showProviderTopSites = true
+            )
         )
 
         assertEquals(1, topSites.size)
@@ -286,8 +267,9 @@ class DefaultTopSitesStorageTest {
 
         topSites = defaultTopSitesStorage.getTopSites(
             totalSites = 2,
-            fetchProvidedTopSites = true,
-            frecencyConfig = null
+            providerConfig = TopSitesProviderConfig(
+                showProviderTopSites = true
+            )
         )
 
         assertEquals(2, topSites.size)
@@ -297,19 +279,60 @@ class DefaultTopSitesStorageTest {
 
         topSites = defaultTopSitesStorage.getTopSites(
             totalSites = 5,
-            fetchProvidedTopSites = true,
-            frecencyConfig = null
+            providerConfig = TopSitesProviderConfig(
+                showProviderTopSites = true
+            )
         )
 
         assertEquals(3, topSites.size)
+        assertEquals(providedSite, topSites[0])
+        assertEquals(defaultSite, topSites[1])
+        assertEquals(pinnedSite, topSites[2])
+        assertEquals(defaultTopSitesStorage.cachedTopSites, topSites)
+
+        topSites = defaultTopSitesStorage.getTopSites(
+            totalSites = 5,
+            providerConfig = TopSitesProviderConfig(
+                showProviderTopSites = false
+            )
+        )
+
+        assertEquals(2, topSites.size)
         assertEquals(defaultSite, topSites[0])
         assertEquals(pinnedSite, topSites[1])
-        assertEquals(providedSite, topSites[2])
+        assertEquals(defaultTopSitesStorage.cachedTopSites, topSites)
+
+        topSites = defaultTopSitesStorage.getTopSites(
+            totalSites = 5,
+            providerConfig = TopSitesProviderConfig(
+                showProviderTopSites = true,
+                maxThreshold = 8
+            )
+        )
+
+        assertEquals(3, topSites.size)
+        assertEquals(providedSite, topSites[0])
+        assertEquals(defaultSite, topSites[1])
+        assertEquals(pinnedSite, topSites[2])
+        assertEquals(defaultTopSitesStorage.cachedTopSites, topSites)
+
+        topSites = defaultTopSitesStorage.getTopSites(
+            totalSites = 5,
+            frecencyConfig = null,
+            providerConfig = TopSitesProviderConfig(
+                showProviderTopSites = true,
+                maxThreshold = 2
+            )
+        )
+
+        assertEquals(2, topSites.size)
+        assertEquals(defaultSite, topSites[0])
+        assertEquals(pinnedSite, topSites[1])
         assertEquals(defaultTopSitesStorage.cachedTopSites, topSites)
     }
 
     @Test
-    fun `GIVEN fetchProvidedTopSites is true and frecencyConfig is specified WHEN getTopSites is called THEN default, pinned, provided and frecent top sites are returned`() = runBlockingTest {
+    fun `GIVEN frecencyConfig and providerConfig are specified WHEN getTopSites is called THEN default, pinned, provided and frecent top sites are returned`() = runBlockingTest {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
             pinnedSitesStorage = pinnedSitesStorage,
             historyStorage = historyStorage,
@@ -353,16 +376,20 @@ class DefaultTopSitesStorageTest {
 
         var topSites = defaultTopSitesStorage.getTopSites(
             totalSites = 0,
-            fetchProvidedTopSites = true,
-            frecencyConfig = FrecencyThresholdOption.NONE
+            frecencyConfig = FrecencyThresholdOption.NONE,
+            providerConfig = TopSitesProviderConfig(
+                showProviderTopSites = true
+            )
         )
 
         assertTrue(topSites.isEmpty())
 
         topSites = defaultTopSitesStorage.getTopSites(
             totalSites = 1,
-            fetchProvidedTopSites = true,
-            frecencyConfig = FrecencyThresholdOption.NONE
+            frecencyConfig = FrecencyThresholdOption.NONE,
+            providerConfig = TopSitesProviderConfig(
+                showProviderTopSites = true
+            )
         )
 
         assertEquals(1, topSites.size)
@@ -371,8 +398,10 @@ class DefaultTopSitesStorageTest {
 
         topSites = defaultTopSitesStorage.getTopSites(
             totalSites = 2,
-            fetchProvidedTopSites = true,
-            frecencyConfig = FrecencyThresholdOption.NONE
+            frecencyConfig = FrecencyThresholdOption.NONE,
+            providerConfig = TopSitesProviderConfig(
+                showProviderTopSites = true
+            )
         )
 
         assertEquals(2, topSites.size)
@@ -382,26 +411,30 @@ class DefaultTopSitesStorageTest {
 
         topSites = defaultTopSitesStorage.getTopSites(
             totalSites = 3,
-            fetchProvidedTopSites = true,
-            frecencyConfig = FrecencyThresholdOption.NONE
+            frecencyConfig = FrecencyThresholdOption.NONE,
+            providerConfig = TopSitesProviderConfig(
+                showProviderTopSites = true
+            )
         )
 
         assertEquals(3, topSites.size)
-        assertEquals(defaultSite, topSites[0])
-        assertEquals(pinnedSite, topSites[1])
-        assertEquals(providedSite, topSites[2])
+        assertEquals(providedSite, topSites[0])
+        assertEquals(defaultSite, topSites[1])
+        assertEquals(pinnedSite, topSites[2])
         assertEquals(defaultTopSitesStorage.cachedTopSites, topSites)
 
         topSites = defaultTopSitesStorage.getTopSites(
             totalSites = 5,
-            fetchProvidedTopSites = true,
-            frecencyConfig = FrecencyThresholdOption.NONE
+            frecencyConfig = FrecencyThresholdOption.NONE,
+            providerConfig = TopSitesProviderConfig(
+                showProviderTopSites = true
+            )
         )
 
         assertEquals(4, topSites.size)
-        assertEquals(defaultSite, topSites[0])
-        assertEquals(pinnedSite, topSites[1])
-        assertEquals(providedSite, topSites[2])
+        assertEquals(providedSite, topSites[0])
+        assertEquals(defaultSite, topSites[1])
+        assertEquals(pinnedSite, topSites[2])
         assertEquals(frecentSite1.toTopSite(), topSites[3])
         assertEquals(defaultTopSitesStorage.cachedTopSites, topSites)
     }
@@ -441,7 +474,6 @@ class DefaultTopSitesStorageTest {
 
         var topSites = defaultTopSitesStorage.getTopSites(
             totalSites = 0,
-            fetchProvidedTopSites = false,
             frecencyConfig = FrecencyThresholdOption.NONE
         )
 
@@ -449,7 +481,6 @@ class DefaultTopSitesStorageTest {
 
         topSites = defaultTopSitesStorage.getTopSites(
             totalSites = 1,
-            fetchProvidedTopSites = false,
             frecencyConfig = FrecencyThresholdOption.NONE
         )
 
@@ -459,7 +490,6 @@ class DefaultTopSitesStorageTest {
 
         topSites = defaultTopSitesStorage.getTopSites(
             totalSites = 2,
-            fetchProvidedTopSites = false,
             frecencyConfig = FrecencyThresholdOption.NONE
         )
 
@@ -470,7 +500,6 @@ class DefaultTopSitesStorageTest {
 
         topSites = defaultTopSitesStorage.getTopSites(
             totalSites = 5,
-            fetchProvidedTopSites = false,
             frecencyConfig = FrecencyThresholdOption.NONE
         )
 
@@ -492,7 +521,6 @@ class DefaultTopSitesStorageTest {
 
         topSites = defaultTopSitesStorage.getTopSites(
             totalSites = 5,
-            fetchProvidedTopSites = false,
             frecencyConfig = FrecencyThresholdOption.NONE
         )
 
@@ -516,7 +544,6 @@ class DefaultTopSitesStorageTest {
 
         topSites = defaultTopSitesStorage.getTopSites(
             totalSites = 5,
-            fetchProvidedTopSites = false,
             frecencyConfig = FrecencyThresholdOption.NONE
         )
 
@@ -582,7 +609,6 @@ class DefaultTopSitesStorageTest {
 
         val topSites = defaultTopSitesStorage.getTopSites(
             totalSites = 5,
-            fetchProvidedTopSites = false,
             frecencyConfig = FrecencyThresholdOption.NONE
         )
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **feature-top-sites**
+  * ⚠️ **This is a breaking change**: This changes `fetchProvidedTopSites` in `TopSitesConfig` into a data class `TopSitesProviderConfig` that specifies whether or not to display the top sites from the provider. [#11654](https://github.com/mozilla-mobile/android-components/issues/11654)
+
 # 98.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v97.0.0...v98.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/145?closed=1)


### PR DESCRIPTION
Fixes #11654

This changes `fetchProvidedTopSites` into a data class `TopSitesProviderConfig` that specifies
whether or not to display the top sites from the provider and the maximum threshold at which to
fetch the top sites from the provider.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
