### PR TITLE
Issue #11693: Set a null default value to frecencyConfig and providerConfig in TopSitesConfig

### DIFF
--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/TopSitesConfig.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/TopSitesConfig.kt
@@ -19,8 +19,8 @@ import mozilla.components.concept.storage.FrecencyThresholdOption
  */
 data class TopSitesConfig(
     val totalSites: Int,
-    val frecencyConfig: FrecencyThresholdOption?,
-    val providerConfig: TopSitesProviderConfig?
+    val frecencyConfig: FrecencyThresholdOption? = null,
+    val providerConfig: TopSitesProviderConfig? = null
 )
 
 /**

--- a/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/DefaultTopSitesStorageTest.kt
+++ b/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/DefaultTopSitesStorageTest.kt
@@ -318,7 +318,6 @@ class DefaultTopSitesStorageTest {
 
         topSites = defaultTopSitesStorage.getTopSites(
             totalSites = 5,
-            frecencyConfig = null,
             providerConfig = TopSitesProviderConfig(
                 showProviderTopSites = true,
                 maxThreshold = 2


### PR DESCRIPTION
Fixes #11693


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
