### PR TITLE
Closes #11682: Make Fenix nightly the official Firefox nightly on Browsers

### DIFF
--- a/components/support/utils/src/main/java/mozilla/components/support/utils/Browsers.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/Browsers.kt
@@ -42,12 +42,12 @@ class Browsers private constructor(
 
         FIREFOX_BETA("org.mozilla.firefox_beta"),
         FIREFOX_AURORA("org.mozilla.fennec_aurora"),
-        FIREFOX_NIGHTLY("org.mozilla.fennec"),
+        FIREFOX_FENNEC_NIGHTLY("org.mozilla.fennec"),
         FIREFOX_FDROID("org.mozilla.fennec_fdroid"),
 
         FIREFOX_LITE("org.mozilla.rocket"),
 
-        FENIX_PREVIEW("org.mozilla.fenix"),
+        FIREFOX_NIGHTLY("org.mozilla.fenix"),
         FENIX_DEBUG("org.mozilla.fenix.debug"),
 
         FIREFOX_FOCUS_DEBUG("org.mozilla.focus.debug"),
@@ -135,6 +135,7 @@ class Browsers private constructor(
                 defaultBrowser.packageName == KnownBrowser.FIREFOX.packageName ||
                     defaultBrowser.packageName == KnownBrowser.FIREFOX_BETA.packageName ||
                     defaultBrowser.packageName == KnownBrowser.FIREFOX_AURORA.packageName ||
+                    defaultBrowser.packageName == KnownBrowser.FIREFOX_FENNEC_NIGHTLY.packageName ||
                     defaultBrowser.packageName == KnownBrowser.FIREFOX_NIGHTLY.packageName ||
                     defaultBrowser.packageName == KnownBrowser.FIREFOX_FDROID.packageName
                 )

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,9 @@ permalink: /changelog/
 
 * **feature-top-sites**
   * ⚠️ **This is a breaking change**: This changes `fetchProvidedTopSites` in `TopSitesConfig` into a data class `TopSitesProviderConfig` that specifies whether or not to display the top sites from the provider. [#11654](https://github.com/mozilla-mobile/android-components/issues/11654)
+* **support-utils**
+  * 🌟️️ **Added new Browsers constant for Fennec `Browsers.FIREFOX_FENNEC_NIGHTLY`.
+  * ⚠️ **This is a breaking change**: `Browsers.FIREFOX_NIGHTLY` now points to `org.mozilla.fenix`, for fennec nightly use `Browsers.FIREFOX_FENNEC_NIGHTLY` [#11682](https://github.com/mozilla-mobile/android-components/pull/11682).
 
 # 98.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v97.0.0...v98.0.0)


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
