### PR TITLE
Closes #11726: Fix intermittents in recently closed tabs storage tests

### DIFF
--- a/components/feature/recentlyclosed/src/test/java/mozilla/components/feature/recentlyclosed/RecentlyClosedTabsStorageTest.kt
+++ b/components/feature/recentlyclosed/src/test/java/mozilla/components/feature/recentlyclosed/RecentlyClosedTabsStorageTest.kt
@@ -89,13 +89,14 @@ class RecentlyClosedTabsStorageTest {
     @Test
     fun testAddingTabsWithMax() {
         // Test tab
+        val t1 = System.currentTimeMillis()
         val closedTab = RecoverableTab(
             engineSessionState = null,
             state = TabState(
                 id = "first-tab",
                 title = "Mozilla",
                 url = "https://mozilla.org",
-                lastAccess = System.currentTimeMillis()
+                lastAccess = t1
             )
         )
 
@@ -107,7 +108,7 @@ class RecentlyClosedTabsStorageTest {
                 id = "second-tab",
                 title = "Pocket",
                 url = "https://pocket.com",
-                lastAccess = System.currentTimeMillis()
+                lastAccess = t1 - 1000
             )
         )
 
@@ -195,14 +196,13 @@ class RecentlyClosedTabsStorageTest {
         )
 
         // Test tab
-        val t2 = t1 - 1000
         val secondClosedTab = RecoverableTab(
             engineSessionState = mock(),
             state = TabState(
                 id = "second-tab",
                 title = "Pocket",
                 url = "https://pocket.com",
-                lastAccess = t2
+                lastAccess = t1 - 1000
             )
         )
 
@@ -233,13 +233,14 @@ class RecentlyClosedTabsStorageTest {
     fun testRemovingOneTab() {
         // Test tab
         val engineState1: EngineSessionState = mock()
+        val t1 = System.currentTimeMillis()
         val closedTab = RecoverableTab(
             engineSessionState = engineState1,
             state = TabState(
                 id = "first-tab",
                 title = "Mozilla",
                 url = "https://mozilla.org",
-                lastAccess = System.currentTimeMillis()
+                lastAccess = t1
             )
         )
 
@@ -251,7 +252,7 @@ class RecentlyClosedTabsStorageTest {
                 id = "second-tab",
                 title = "Pocket",
                 url = "https://pocket.com",
-                lastAccess = System.currentTimeMillis()
+                lastAccess = t1 - 1000
             )
         )
 


### PR DESCRIPTION
Tests would create two tabs and read them back, asserting a certain order.
However, storage orders these tabs by their lastAccess time, which in tests
was set to current time. If this code is running fast enough, that time
would be the same for both tabs down to a ms, resulting in non-defined ordering
during a read.

Fix this by using relative times instead.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
