### PR TITLE
For #10638 - Remove reflective access to "mSpanSlop" and "mMinSpan"

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserGestureDetector.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserGestureDetector.kt
@@ -48,7 +48,6 @@ internal class BrowserGestureDetector(
     )
 
     @VisibleForTesting
-    @Suppress("SoonBlockedPrivateApi") // https://github.com/mozilla-mobile/android-components/issues/10638
     internal var scaleGestureDetector = ScaleGestureDetector(
         applicationContext,
         CustomScaleDetectorListener(
@@ -56,24 +55,7 @@ internal class BrowserGestureDetector(
             listener.onScale ?: {},
             listener.onScaleEnd ?: {}
         )
-    ).apply {
-        // Use reflection to modify two fields controlling the sensitivity of our scale detector.
-        // The lower the values the higher the sensitivity.
-        // Values of 0 here would mean all swipe events will be treated as pinch/spread to zoom gestures,
-        // in our context effectively meaning no scrolling, only zooming.
-        try {
-            listOf(
-                javaClass.getDeclaredField("mSpanSlop"),
-                javaClass.getDeclaredField("mMinSpan")
-            ).forEach { field ->
-                field.isAccessible = true
-                field.set(this, (field.get(this) as Int) / 2)
-            }
-        } catch (e: ReflectiveOperationException) {
-            // Seems like some OEMs made some breaking changes in the framework.
-            // no-op
-        }
-    }
+    )
 
     /**
      * Accepts MotionEvents and dispatches zoom / scroll events to the registered listener when appropriate.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **browser-toolbar**
+  * Removed reflective access to non-public SDK APIs controlling the sensitivity of the gesture detector following which sparingly and for very short time a pinch/spread to zoom gesture might be identified first as a scroll gesture and move the toolbar a little before snapping to it's original position.
+
 * **feature-session**
    * 🆕 New `ScreenOrientationFeature` to enable support for setting a requested screen orientation as part of supporting the ScreenOrientation web APIs.
 


### PR DESCRIPTION
Removed reflective access to non-public SDK APIs controlling the sensitivity of
the gesture detector following which sparingly and for very short time a
pinch/spread to zoom gesture might be identified first as a scroll gesture and
move the toolbar a little before snapping to it's original position.
Basically we're now using the framework default behavior.

Since both Fenix and Focus are targetting Android 30+ we were already getting
`NoSuchFieldException` as expected as per https://developer.android.com/guide/app-compatibility/restrictions-non-sdk-interfaces#results-of-keeping-non-sdk

https://user-images.githubusercontent.com/11428869/154687710-cb23c1cd-ab5c-42ec-bd76-0d405dcccc1a.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
