### PR TITLE
Fix release promotion error on python3

### DIFF
--- a/taskcluster/ac_taskgraph/release_promotion.py
+++ b/taskcluster/ac_taskgraph/release_promotion.py
@@ -160,4 +160,4 @@ def release_promotion_action(parameters, graph_config, input, task_group_id, tas
 
 def read_version_file():
     with open(os.path.join(os.path.dirname(__file__), '..', '..', 'version.txt')) as f:
-        return f.read().strip().decode('utf-8')
+        return f.read().strip()


### PR DESCRIPTION
Fixes: 2c755220be ("RELENG-559 - Run taskgraph generation with Python 3")