### PR TITLE
Couple fixes for invalid login handling (#11767)

### DIFF
--- a/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/DefaultLoginValidationDelegate.kt
+++ b/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/DefaultLoginValidationDelegate.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.async
+import mozilla.components.concept.base.crash.CrashReporting
 import mozilla.components.concept.storage.Login
 import mozilla.components.concept.storage.LoginEntry
 import mozilla.components.concept.storage.LoginValidationDelegate
@@ -21,7 +22,8 @@ import mozilla.components.support.base.log.logger.Logger
  */
 class DefaultLoginValidationDelegate(
     private val storage: Lazy<LoginsStorage>,
-    private val scope: CoroutineScope = CoroutineScope(IO)
+    private val scope: CoroutineScope = CoroutineScope(IO),
+    private val crashReporting: CrashReporting? = null
 ) : LoginValidationDelegate {
     private val logger = Logger("DefaultAddonUpdater")
 
@@ -34,7 +36,8 @@ class DefaultLoginValidationDelegate(
             val foundLogin = try {
                 storage.value.findLoginToUpdate(entry)
             } catch (e: LoginsStorageException) {
-                logger.error("Failure in shouldUpdateOrCreateAsync: $e")
+                logger.warn("Failure in shouldUpdateOrCreateAsync: $e")
+                crashReporting?.submitCaughtException(e)
                 null
             }
             if (foundLogin == null) Result.CanBeCreated else Result.CanBeUpdated(foundLogin)


### PR DESCRIPTION
- Updated `SaveLoginDialogFragment` to not send logins to
  `shouldUpdateOrCreateAsync()` if we know they're invalid.

- Updated `DefaultLoginValidationDelegate` to not crash if an invalid
  login is passed to it.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
