### PR TITLE
Remove 'mozilla-mobile/releng' as a CODEOWNER of /automation dir

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,7 +25,7 @@
 # Release Engineering pipeline
 /.cron.yml @mozilla-mobile/releng @mozilla-mobile/act
 /.taskcluster.yml @mozilla-mobile/releng @mozilla-mobile/act
-/automation/ @mozilla-mobile/releng @mozilla-mobile/act
+/automation/ @mozilla-mobile/act
 /taskcluster/ @mozilla-mobile/releng @mozilla-mobile/act
 
 /components/browser/awesomebar/             @mozilla-mobile/act


### PR DESCRIPTION
If there are files in here folks believe releng should still be a CODEOWNER of, please let me know and I can make the rules more specific.
