### PR TITLE
for #5271: store loaded tabs when finished loading

### DIFF
--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/controller/DefaultController.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/controller/DefaultController.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.launch
 import mozilla.components.feature.syncedtabs.storage.SyncedTabsProvider
 import mozilla.components.feature.syncedtabs.view.SyncedTabsView
 import mozilla.components.feature.syncedtabs.view.SyncedTabsView.ErrorType
+import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.service.fxa.manager.ext.withConstellation
 import mozilla.components.service.fxa.sync.SyncReason
@@ -58,7 +59,7 @@ internal class DefaultController(
     override fun syncAccount() {
         scope.launch {
             accountManager.withConstellation { refreshDevices() }
-            accountManager.syncNow(SyncReason.User)
+            accountManager.syncNow(SyncReason.User, customEngineSubset = listOf(SyncEngine.Tabs))
         }
     }
 }

--- a/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/controller/DefaultControllerTest.kt
+++ b/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/controller/DefaultControllerTest.kt
@@ -13,6 +13,7 @@ import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.feature.syncedtabs.storage.SyncedTabsStorage
 import mozilla.components.feature.syncedtabs.view.SyncedTabsView
 import mozilla.components.feature.syncedtabs.view.SyncedTabsView.ErrorType
+import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.service.fxa.sync.SyncReason
 import mozilla.components.support.test.mock
@@ -146,6 +147,6 @@ class DefaultControllerTest {
         controller.syncAccount()
 
         verify(constellation).refreshDevices()
-        verify(accountManager).syncNow(SyncReason.User, false)
+        verify(accountManager).syncNow(SyncReason.User, false, listOf(SyncEngine.Tabs))
     }
 }


### PR DESCRIPTION
### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
