### PR TITLE
app-services tabs component constructor now wants a database filename

### DIFF
--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/RemoteTabsStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/RemoteTabsStorage.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.storage.sync
 
+import android.content.Context
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancelChildren
@@ -15,16 +16,20 @@ import mozilla.components.concept.sync.Device
 import mozilla.components.concept.sync.SyncableStore
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.utils.logElapsedTime
+import java.io.File
 import mozilla.appservices.remotetabs.InternalException as RemoteTabProviderException
 import mozilla.appservices.remotetabs.TabsStore as RemoteTabsProvider
+
+private const val TABS_DB_NAME = "tabs.sqlite"
 
 /**
  * An interface which defines read/write methods for remote tabs data.
  */
 open class RemoteTabsStorage(
+    private val context: Context,
     private val crashReporter: CrashReporting? = null
 ) : Storage, SyncableStore {
-    internal val api by lazy { RemoteTabsProvider() }
+    internal val api by lazy { RemoteTabsProvider(File(context.filesDir, TABS_DB_NAME).canonicalPath) }
     private val scope by lazy { CoroutineScope(Dispatchers.IO) }
     internal val logger = Logger("RemoteTabsStorage")
 

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/RemoteTabsStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/RemoteTabsStorageTest.kt
@@ -13,6 +13,7 @@ import mozilla.appservices.remotetabs.RemoteTab
 import mozilla.components.concept.base.crash.CrashReporting
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -36,7 +37,7 @@ class RemoteTabsStorageTest {
     @Before
     fun setup() {
         crashReporter = mock()
-        remoteTabs = spy(RemoteTabsStorage(crashReporter))
+        remoteTabs = spy(RemoteTabsStorage(testContext, crashReporter))
         apiMock = mock(RemoteTabsProvider::class.java)
         `when`(remoteTabs.api).thenReturn(apiMock)
     }

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorage.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorage.kt
@@ -38,7 +38,7 @@ import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 class SyncedTabsStorage(
     private val accountManager: FxaAccountManager,
     private val store: BrowserStore,
-    private val tabsStorage: RemoteTabsStorage = RemoteTabsStorage(),
+    private val tabsStorage: RemoteTabsStorage,
     private val debounceMillis: Long = 1000L,
 ) : SyncedTabsProvider {
     private var scope: CoroutineScope? = null

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -53,7 +53,13 @@ permalink: /changelog/
   
 * **site-permission-feature**
   * 🆕 New Add to SitePermissionsFeature a property to set visibility for NotAskAgainCheckBox
-  
+
+* **browser-storage-sync**
+  * ⚠️ **This is a breaking change**: When constructing a `RemoteTabsStorage` object you must now a `Context` which is used to determine the location of the sqlite database which is used to persist the remote tabs [#11799](https://github.com/mozilla-mobile/android-components/pull/11799).
+
+* **feature-syncedtabs**
+  * ⚠️ **This is a breaking change**: When constructing a `SyncedTabsStorage`, the `tabsStorage: RemoteTabsStorage` parameter is no longer optional so must be supplied [#11799](https://github.com/mozilla-mobile/android-components/pull/11799).
+
 # 99.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v98.0.0...v99.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/146?closed=1)


### PR DESCRIPTION
This is the matching PR for https://github.com/mozilla/application-services/pull/4862. Marking as draft because there's no a-s release yet, but CC @grigoryk @jonalmeida 