### PR TITLE
closes #11798: allow engines to be specified during manual syncs

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/SyncManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/SyncManager.kt
@@ -110,7 +110,11 @@ object GlobalSyncableStoreProvider {
  */
 internal interface SyncDispatcher : Closeable, Observable<SyncStatusObserver> {
     fun isSyncActive(): Boolean
-    fun syncNow(reason: SyncReason, debounce: Boolean = false)
+    fun syncNow(
+        reason: SyncReason,
+        debounce: Boolean = false,
+        customEngineSubset: List<SyncEngine> = listOf(),
+    )
     fun startPeriodicSync(unit: TimeUnit, period: Long, initialDelay: Long)
     fun stopPeriodicSync()
     fun workersStateChanged(isRunning: Boolean)
@@ -150,12 +154,17 @@ internal abstract class SyncManager(
      *
      * @param reason A [SyncReason] indicating why this sync is being requested.
      * @param debounce Whether or not this sync should debounced.
+     * @param customEngineSubset A subset of supported engines to sync. Defaults to all supported engines.
      */
-    internal fun now(reason: SyncReason, debounce: Boolean = false) = synchronized(this) {
+    internal fun now(
+        reason: SyncReason,
+        debounce: Boolean = false,
+        customEngineSubset: List<SyncEngine> = listOf(),
+    ) = synchronized(this) {
         if (syncDispatcher == null) {
             logger.info("Sync is not enabled. Ignoring 'sync now' request.")
         }
-        syncDispatcher?.syncNow(reason, debounce)
+        syncDispatcher?.syncNow(reason, debounce, customEngineSubset)
     }
 
     /**

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -127,8 +127,12 @@ class FxaAccountManagerTest {
             return inner.isSyncActive()
         }
 
-        override fun syncNow(reason: SyncReason, debounce: Boolean) {
-            inner.syncNow(reason, debounce)
+        override fun syncNow(
+            reason: SyncReason,
+            debounce: Boolean,
+            customEngineSubset: List<SyncEngine>,
+        ) {
+            inner.syncNow(reason, debounce, customEngineSubset)
         }
 
         override fun startPeriodicSync(unit: TimeUnit, period: Long, initialDelay: Long) {
@@ -1692,25 +1696,25 @@ class FxaAccountManagerTest {
         // onAuthenticated - mapping of AuthType to SyncReason
         integration.onAuthenticated(mock(), AuthType.Signin)
         verify(syncManager, times(1)).start()
-        verify(syncManager, times(1)).now(eq(SyncReason.FirstSync), anyBoolean())
+        verify(syncManager, times(1)).now(eq(SyncReason.FirstSync), anyBoolean(), eq(listOf()))
         integration.onAuthenticated(mock(), AuthType.Signup)
         verify(syncManager, times(2)).start()
-        verify(syncManager, times(2)).now(eq(SyncReason.FirstSync), anyBoolean())
+        verify(syncManager, times(2)).now(eq(SyncReason.FirstSync), anyBoolean(), eq(listOf()))
         integration.onAuthenticated(mock(), AuthType.Pairing)
         verify(syncManager, times(3)).start()
-        verify(syncManager, times(3)).now(eq(SyncReason.FirstSync), anyBoolean())
+        verify(syncManager, times(3)).now(eq(SyncReason.FirstSync), anyBoolean(), eq(listOf()))
         integration.onAuthenticated(mock(), AuthType.MigratedReuse)
         verify(syncManager, times(4)).start()
-        verify(syncManager, times(4)).now(eq(SyncReason.FirstSync), anyBoolean())
+        verify(syncManager, times(4)).now(eq(SyncReason.FirstSync), anyBoolean(), eq(listOf()))
         integration.onAuthenticated(mock(), AuthType.OtherExternal("test"))
         verify(syncManager, times(5)).start()
-        verify(syncManager, times(5)).now(eq(SyncReason.FirstSync), anyBoolean())
+        verify(syncManager, times(5)).now(eq(SyncReason.FirstSync), anyBoolean(), eq(listOf()))
         integration.onAuthenticated(mock(), AuthType.Existing)
         verify(syncManager, times(6)).start()
-        verify(syncManager, times(1)).now(eq(SyncReason.Startup), anyBoolean())
+        verify(syncManager, times(1)).now(eq(SyncReason.Startup), anyBoolean(), eq(listOf()))
         integration.onAuthenticated(mock(), AuthType.Recovered)
         verify(syncManager, times(7)).start()
-        verify(syncManager, times(2)).now(eq(SyncReason.Startup), anyBoolean())
+        verify(syncManager, times(2)).now(eq(SyncReason.Startup), anyBoolean(), eq(listOf()))
         verifyNoMoreInteractions(syncManager)
 
         // onProfileUpdated - no-op


### PR DESCRIPTION
### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
