### PR TITLE
Allow observing when account manager is ready to be queried for account state

### DIFF
--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
@@ -296,6 +296,13 @@ enum class AuthFlowError {
  */
 interface AccountObserver {
     /**
+     * Account state has been resolved and can now be queried.
+     *
+     * @param authenticatedAccount Currently resolved authenticated account, if any.
+     */
+    fun onReady(authenticatedAccount: OAuthAccount?) = Unit
+
+    /**
      * Account just got logged out.
      */
     fun onLoggedOut() = Unit

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -384,14 +384,8 @@ open class FxaAccountManager(
         else -> null
     }
 
-    /**
-     * Fetches an up-to-date [Profile] if account is in an authenticated state.
-     */
-    suspend fun fetchProfile(): Profile? {
-        return refreshProfile(true)
-    }
-
-    private suspend fun refreshProfile(ignoreCache: Boolean): Profile? {
+    @VisibleForTesting
+    internal suspend fun refreshProfile(ignoreCache: Boolean): Profile? {
         return authenticatedAccount()?.getProfile(ignoreCache = ignoreCache)?.let { newProfile ->
             profile = newProfile
             notifyObservers {

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -401,7 +401,7 @@ open class FxaAccountManager(
      * @param pairingUrl Optional pairing URL in case a pairing flow is being initiated.
      * @return An authentication url which is to be presented to the user.
      */
-    suspend fun beginAuthentication(pairingUrl: String? = null): String? {
+    suspend fun beginAuthentication(pairingUrl: String? = null): String? = withContext(coroutineContext) {
         // It's possible that at this point authentication is considered to be "in-progress".
         // For example, if user started authentication flow, but cancelled it (closing a custom tab)
         // without finishing.
@@ -428,7 +428,7 @@ open class FxaAccountManager(
         })
         processQueue(event)
         oauthObservers.unregisterObservers()
-        return deferredAuthUrl
+        deferredAuthUrl
     }
 
     /**
@@ -499,7 +499,7 @@ open class FxaAccountManager(
     /**
      * Pumps the state machine until all events are processed and their side-effects resolve.
      */
-    private suspend fun processQueue(event: Event) = withContext(coroutineContext) {
+    private suspend fun processQueue(event: Event) {
         eventQueue.add(event)
         do {
             val toProcess: Event = eventQueue.poll()!!

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -173,6 +173,7 @@ open class FxaAccountManager(
     // initialization, instead of triggering the full state machine knowing in advance we'll hit auth problems.
     // See https://github.com/mozilla-mobile/android-components/issues/5102
     @Volatile private var state: State = State.Idle(AccountState.NotAuthenticated)
+    @Volatile private var isAccountManagerReady: Boolean = false
     private val eventQueue = ConcurrentLinkedQueue<Event>()
 
     @VisibleForTesting
@@ -337,6 +338,11 @@ open class FxaAccountManager(
      */
     suspend fun start() = withContext(coroutineContext) {
         processQueue(Event.Account.Start)
+
+        if (!isAccountManagerReady) {
+            notifyObservers { onReady(authenticatedAccount()) }
+            isAccountManagerReady = true
+        }
     }
 
     /**

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -1440,7 +1440,7 @@ class FxaAccountManagerTest {
 
         `when`(mockAccount.getProfile(ignoreCache = true)).thenReturn(profile)
         assertNull(manager.accountProfile())
-        assertEquals(profile, manager.fetchProfile())
+        assertEquals(profile, manager.refreshProfile(true))
 
         verify(accountObserver, times(1)).onProfileUpdated(profile)
         verify(accountObserver, never()).onAuthenticated(any(), any())

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,12 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **concept-sync**
+  * 🌟️️ Add `onReady` method to `AccountObserver`, allowing consumers to know when they can start querying account state.
+
+* **service-firefox-accounts**
+  * ⚠️ **This is a breaking change**: `fetchProfile` was removed from `FxaAccountManager`.
+
 # 99.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v98.0.0...v99.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/146?closed=1)
@@ -44,6 +50,7 @@ permalink: /changelog/
 
 * **feature-tabs**
   * ⚠️ **This is a breaking change**: `RestoreUseCase` implementation responsible for restoring `RecoverableTab` instances now takes a `TabState` and a `EngineSessionStateStorage` instead (and will read/rehydrate an EngineSessionState prior to restoring).
+
 
 # 98.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v97.0.0...v98.0.0)


### PR DESCRIPTION
We need this for https://github.com/mozilla-mobile/fenix/issues/15882

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
