### PR TITLE
Closes #11819:Remove nativeMessaging permission from the add-on BLOCKED_PERMISSIONS list

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt
@@ -356,7 +356,7 @@ class AddonManager(
     companion object {
         // List of invalid permissions for external add-ons i.e. permissions only
         // granted to built-in extensions:
-        val BLOCKED_PERMISSIONS = listOf("geckoViewAddons", "nativeMessaging")
+        val BLOCKED_PERMISSIONS = listOf("geckoViewAddons")
 
         // Size of the icon to load for temporary extensions
         const val TEMPORARY_ADDON_ICON_SIZE = 48

--- a/components/feature/addons/src/test/java/AddonManagerTest.kt
+++ b/components/feature/addons/src/test/java/AddonManagerTest.kt
@@ -507,7 +507,7 @@ class AddonManagerTest {
     fun `installAddon fails for blocked permission`() {
         val addon = Addon(
             id = "ext1",
-            permissions = listOf("bookmarks", "geckoviewaddons", "nativemessaging")
+            permissions = listOf("bookmarks", "geckoviewaddons")
         )
 
         val engine: Engine = mock()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **feature-addons**
+  * 🚒 Bug fixed [issue #11819] https://github.com/mozilla-mobile/android-components/issues/11819) - Do not block installation of extensions with the "nativeMessaging" permission any longer, but ignore the permission instead for non-builtin add-ons.
+
 * **feature-top-sites**
   * ⚠️ **This is a breaking change**: This changes `fetchProvidedTopSites` in `TopSitesConfig` into a data class `TopSitesProviderConfig` that specifies whether or not to display the top sites from the provider. [#11654](https://github.com/mozilla-mobile/android-components/issues/11654)
 


### PR DESCRIPTION


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
