### PR TITLE
For #11869 - Set PendingIntent as mutable for autofill authentication

### DIFF
--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/dataset/LoginDatasetBuilder.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/dataset/LoginDatasetBuilder.kt
@@ -87,7 +87,7 @@ internal data class LoginDatasetBuilder(
                 context,
                 configuration.activityRequestCode + requestOffset,
                 confirmIntent,
-                PendingIntentUtils.defaultFlags or PendingIntent.FLAG_CANCEL_CURRENT
+                PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_CANCEL_CURRENT
             ).intentSender
 
             dataset.setAuthentication(intentSender)

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/dataset/SearchDatasetBuilder.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/dataset/SearchDatasetBuilder.kt
@@ -17,7 +17,6 @@ import mozilla.components.feature.autofill.AutofillConfiguration
 import mozilla.components.feature.autofill.R
 import mozilla.components.feature.autofill.handler.MAX_LOGINS
 import mozilla.components.feature.autofill.structure.ParsedStructure
-import mozilla.components.support.utils.PendingIntentUtils
 
 @RequiresApi(Build.VERSION_CODES.O)
 internal data class SearchDatasetBuilder(
@@ -37,7 +36,7 @@ internal data class SearchDatasetBuilder(
             context,
             configuration.activityRequestCode + MAX_LOGINS,
             searchIntent,
-            PendingIntentUtils.defaultFlags or PendingIntent.FLAG_CANCEL_CURRENT
+            PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_CANCEL_CURRENT
         )
         val intentSender: IntentSender = searchPendingIntent.intentSender
 

--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/fill/AuthFillResponseBuilder.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/fill/AuthFillResponseBuilder.kt
@@ -65,7 +65,7 @@ internal data class AuthFillResponseBuilder(
             context,
             configuration.activityRequestCode,
             authIntent,
-            PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_MUTABLE
         )
         val intentSender: IntentSender = authPendingIntent.intentSender
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **feature-autofill**
+  * 🚒 Bug fixed [issue #11869](https://github.com/mozilla-mobile/android-components/issues/11869) - Fix regression causing autofill to not work after unlocking the app doing the autofill or after accepting that the authenticity of the autofill target could not be verified.
+
 * **feature-contextmenu**
   * 🚒 Bug fixed [issue #11829](https://github.com/mozilla-mobile/android-components/pull/11830) - To make the additional note visible in landscape mode.
 


### PR DESCRIPTION
[FillResponse.Builder#setAuthentication](https://developer.android.com/reference/android/service/autofill/FillResponse.Builder#setAuthentication(android.view.autofill.AutofillId%5B%5D,%20android.content.IntentSender,%20android.widget.RemoteViews)) explicitly requires a mutable intent.

Result:

https://user-images.githubusercontent.com/11428869/158375467-ab32d879-092e-428a-8f6e-880d7f8d3ca2.mov





### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
