### PR TITLE
For #11892 - Pass ParsedStructure as bytearray instead of as parcelable

### DIFF
--- a/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/structure/ParsedStructure.kt
+++ b/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/structure/ParsedStructure.kt
@@ -6,10 +6,11 @@ package mozilla.components.feature.autofill.structure
 
 import android.content.Context
 import android.os.Build
+import android.os.Parcel
 import android.os.Parcelable
+import android.os.Parcelable.Creator
 import android.view.autofill.AutofillId
 import androidx.annotation.RequiresApi
-import kotlinx.parcelize.Parcelize
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import mozilla.components.support.utils.Browsers
 
@@ -20,13 +21,43 @@ import mozilla.components.support.utils.Browsers
  * https://github.com/mozilla-lockwise/lockwise-android/blob/d3c0511f73c34e8759e1bb597f2d3dc9bcc146f0/app/src/main/java/mozilla/lockbox/autofill/ParsedStructure.kt#L52
  */
 @RequiresApi(Build.VERSION_CODES.O)
-@Parcelize
-internal data class ParsedStructure(
+data class ParsedStructure(
     val usernameId: AutofillId? = null,
     val passwordId: AutofillId? = null,
     val webDomain: String? = null,
     val packageName: String
-) : Parcelable
+) : Parcelable {
+    constructor(parcel: Parcel) : this(
+        parcel.readParcelable(AutofillId::class.java.classLoader),
+        parcel.readParcelable(AutofillId::class.java.classLoader),
+        parcel.readString(),
+        parcel.readString() ?: ""
+    )
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeParcelable(usernameId, flags)
+        parcel.writeParcelable(passwordId, flags)
+        parcel.writeString(webDomain)
+        parcel.writeString(packageName)
+    }
+
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    /**
+     * Create instances of [ParsedStructure] from a [Parcel].
+     */
+    companion object CREATOR : Creator<ParsedStructure> {
+        override fun createFromParcel(parcel: Parcel): ParsedStructure {
+            return ParsedStructure(parcel)
+        }
+
+        override fun newArray(size: Int): Array<ParsedStructure?> {
+            return arrayOfNulls(size)
+        }
+    }
+}
 
 /**
  * Try to find a domain in the [ParsedStructure] for looking up logins. This is either a "web domain"

--- a/components/feature/autofill/src/test/java/mozilla/components/feature/autofill/structure/ParsedStructureTest.kt
+++ b/components/feature/autofill/src/test/java/mozilla/components/feature/autofill/structure/ParsedStructureTest.kt
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.autofill.structure
+
+import android.os.Parcel
+import android.view.autofill.AutofillId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ParsedStructureTest {
+    @Test
+    fun `Given a ParsedStructure WHEN parcelling and unparcelling it THEN get the same object`() {
+        // AutofillId constructor is private but it can be constructed from a parcel.
+        // Use this route instead of mocking to avoid errors like below:
+        // org.robolectric.shadows.ShadowParcel$UnreliableBehaviorError: Looking for Integer at position 72, found String
+        val usernameIdAutofillIdParcel = Parcel.obtain().apply {
+            writeInt(1) // viewId
+            writeInt(3) // flags
+            writeInt(78) // virtualIntId
+            setDataPosition(0) // be a good citizen
+        }
+        val passwordIdAutofillParcel = Parcel.obtain().apply {
+            writeInt(11) // viewId
+            writeInt(31) // flags
+            writeInt(781) // virtualIntId
+            setDataPosition(0) // be a good citizen
+        }
+        val parsedStructure = ParsedStructure(
+            usernameId = AutofillId.CREATOR.createFromParcel(usernameIdAutofillIdParcel),
+            passwordId = AutofillId.CREATOR.createFromParcel(passwordIdAutofillParcel),
+            packageName = "test",
+            webDomain = "https://mozilla.org"
+        )
+
+        // Write the object in a new Parcel.
+        val parcel = Parcel.obtain()
+        parsedStructure.writeToParcel(parcel, 0)
+
+        // Reset Parcel r/w position to be read from beginning afterwards.
+        parcel.setDataPosition(0)
+
+        // Reconstruct the original object from the Parcel.
+        val result = ParsedStructure(parcel)
+
+        assertEquals(parsedStructure, result)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **feature-autofill**
+  * 🚒 Bug fixed [issue #11893](https://github.com/mozilla-mobile/android-components/issues/11893) - Fix issue with autofilling in 3rd party applications not being immediately available after unlocking the autofill service.
+
 * **feature-contextmenu**
   * 🌟 Add new `additionalValidation` parameter to context menu options builders allowing clients to know when these options to be shown and potentially block showing them.
 


### PR DESCRIPTION
This avoids the system trying to remap our ParsedStructure parcelable failing
by not using the right ClassLoader.

Implementing Parcelable on our own was needed to be able to manually create
`ParsedStructure` from the unmarshalled parcel.

Passing out ClassLoader in the intent (as the recommended approach) did not work.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
