### PR TITLE
add to SitePermissionsFeature a property to set visibility for NotAskAgainCheckBox

### DIFF
--- a/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsFeature.kt
+++ b/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsFeature.kt
@@ -91,6 +91,7 @@ internal const val STORAGE_ACCESS_DOCUMENTATION_URL =
  * need to be requested. Once the request is completed, [onPermissionsResult] needs to be invoked.
  * @property onShouldShowRequestPermissionRationale a callback that allows the feature to query
  * the ActivityCompat.shouldShowRequestPermissionRationale or the Fragment.shouldShowRequestPermissionRationale values.
+ * @property shouldShowDoNotAskAgainCheckBox optional Visibility for Do not ask again Checkbox
  **/
 
 @Suppress("TooManyFunctions", "LargeClass", "LongParameterList")
@@ -104,7 +105,8 @@ class SitePermissionsFeature(
     private val dialogConfig: DialogConfig? = null,
     override val onNeedToRequestPermissions: OnNeedToRequestPermissions,
     val onShouldShowRequestPermissionRationale: (permission: String) -> Boolean,
-    private val store: BrowserStore
+    private val store: BrowserStore,
+    private val shouldShowDoNotAskAgainCheckBox: Boolean = true,
 ) : LifecycleAwareFeature, PermissionsFeature {
     @VisibleForTesting
     internal val selectOrAddUseCase by lazy {
@@ -714,7 +716,7 @@ class SitePermissionsFeature(
                 permissionRequest,
                 R.string.mozac_feature_sitepermissions_camera_and_microphone,
                 R.drawable.mozac_ic_microphone,
-                showDoNotAskAgainCheckBox = true,
+                showDoNotAskAgainCheckBox = shouldShowDoNotAskAgainCheckBox,
                 shouldSelectRememberChoice = dialogConfig?.shouldPreselectDoNotAskAgain
                     ?: DialogConfig.DEFAULT_PRESELECT_DO_NOT_ASK_AGAIN
             )
@@ -736,7 +738,7 @@ class SitePermissionsFeature(
                     permissionRequest,
                     R.string.mozac_feature_sitepermissions_location_title,
                     R.drawable.mozac_ic_location,
-                    showDoNotAskAgainCheckBox = true,
+                    showDoNotAskAgainCheckBox = shouldShowDoNotAskAgainCheckBox,
                     shouldSelectRememberChoice = dialogConfig?.shouldPreselectDoNotAskAgain
                         ?: DialogConfig.DEFAULT_PRESELECT_DO_NOT_ASK_AGAIN
                 )
@@ -760,7 +762,7 @@ class SitePermissionsFeature(
                     permissionRequest,
                     R.string.mozac_feature_sitepermissions_microfone_title,
                     R.drawable.mozac_ic_microphone,
-                    showDoNotAskAgainCheckBox = true,
+                    showDoNotAskAgainCheckBox = shouldShowDoNotAskAgainCheckBox,
                     shouldSelectRememberChoice = dialogConfig?.shouldPreselectDoNotAskAgain
                         ?: DialogConfig.DEFAULT_PRESELECT_DO_NOT_ASK_AGAIN
                 )
@@ -772,7 +774,7 @@ class SitePermissionsFeature(
                     permissionRequest,
                     R.string.mozac_feature_sitepermissions_camera_title,
                     R.drawable.mozac_ic_video,
-                    showDoNotAskAgainCheckBox = true,
+                    showDoNotAskAgainCheckBox = shouldShowDoNotAskAgainCheckBox,
                     shouldSelectRememberChoice = dialogConfig?.shouldPreselectDoNotAskAgain
                         ?: DialogConfig.DEFAULT_PRESELECT_DO_NOT_ASK_AGAIN
                 )

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -50,7 +50,10 @@ permalink: /changelog/
 
 * **lib-crash-sentry**
   * 🌟️️ Add `sendCaughtExceptions` config flag to `SentryService`, allowing consumers to disable submitting caught exceptions. By default it's enabled, maintaining prior behaviour. Useful in projects with high volumes of caught exceptions and multiple release channels.
-
+  
+* **site-permission-feature**
+  * 🆕 New Add to SitePermissionsFeature a property to set visibility for NotAskAgainCheckBox
+  
 # 99.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v98.0.0...v99.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/146?closed=1)


### PR DESCRIPTION
Add to SitePermissionsFeature a property to set visibility for NotAskAgainCheckBox from SitePermissionsDialogFragment. I need that for Focus because the application doesn't remember the browsing history of the user. The checkbox and the text "Remember decision for this site" should be hidden.

<img src="https://user-images.githubusercontent.com/8118371/161043835-ea252b91-8647-45c2-837c-5ba02840cc3d.png" width="300" height="600" /> 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
