### PR TITLE
Pause playback on ACTION_AUDIO_BECOMING_NOISY broadcast 

### DIFF
--- a/components/feature/media/src/main/java/mozilla/components/feature/media/service/MediaSessionServiceDelegate.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/service/MediaSessionServiceDelegate.kt
@@ -45,6 +45,11 @@ private class BecomingNoisyReceiver(private val controller: MediaSession.Control
             controller?.pause()
         }
     }
+    @VisibleForTesting
+    fun deviceIsBecomingNoisy(context: Context) {
+        val becomingNoisyIntent = Intent(AudioManager.ACTION_AUDIO_BECOMING_NOISY)
+        onReceive(context, becomingNoisyIntent)
+    }
 }
 
 /**
@@ -211,5 +216,10 @@ internal class MediaSessionServiceDelegate(
     internal fun shutdown() {
         mediaSession.release()
         service.stopSelf()
+    }
+
+    @VisibleForTesting
+    internal fun deviceBecomingNoisy(context: Context) {
+        noisyAudioStreamReceiver?.deviceIsBecomingNoisy(context)
     }
 }

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/service/MediaSessionServiceDelegateTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/service/MediaSessionServiceDelegateTest.kt
@@ -351,4 +351,30 @@ class MediaSessionServiceDelegateTest {
         verify(service, never()).stopSelf()
         verify(delegate).destroy()
     }
+
+    @Test
+    fun `when device is becoming noisy, playback is paused`() {
+        val controller: MediaSession.Controller = mock()
+
+        val initialState = BrowserState(
+            tabs = listOf(
+                createTab(
+                    "https://www.mozilla.org",
+                    mediaSessionState = MediaSessionState(controller, playbackState = MediaSession.PlaybackState.PLAYING)
+                )
+            )
+        )
+        val store = BrowserStore(initialState)
+        val service: AbstractMediaSessionService = mock()
+        val delegate = spy(MediaSessionServiceDelegate(testContext, service, store))
+
+        delegate.onCreate()
+
+        verify(service, never()).stopSelf()
+        verify(delegate, never()).shutdown()
+
+        delegate.deviceBecomingNoisy(testContext)
+
+        verify(controller).pause()
+    }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,9 @@ permalink: /changelog/
 * **feature-webnotifications**
   * 🌟 The Engine notification (WebNotification) is now persisted in the native notification, transparent to the consuming app which can delegate the native notification click to a new `WebNotificationIntentProcessor` to actually check and trigger a WebNotification click when appropriate.
 
+* **feature-media**
+  * Media playback is now paused when AudioManager.ACTION_AUDIO_BECOMING_NOISY is broadcast by the system.
+
 # 100.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v99.0.0...v100.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/147?closed=1)


### PR DESCRIPTION
This fixes [#2468](https://github.com/mozilla-mobile/android-components/issues/2468).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Both are green locally
- [x] **Tests**: This needs a physical action on the device: turning off bluetooth headset, unplugging an headphone jack/usb headphones, etc.
- [x] **Changelog**: I think this is a visible change so I added a line
- [x] **Accessibility**: No user-facing feature, but this brings application playing media in line with any other Android app in terms of UX.

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
