### PR TITLE
fix readermode estimated reading time disappear

### DIFF
--- a/components/feature/readerview/src/main/assets/extensions/readerview/readerview.js
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/readerview.js
@@ -39,7 +39,7 @@ class ReaderView {
    */
   show(doc, url, options = {fontSize: 4, fontType: "sans-serif", colorScheme: "light"}) {
     let result = new Readability(doc, {classesToPreserve: preservedClasses}).parse();
-    result.language = doc.documentElement.lang;
+    result.language = doc.documentElement.lang ? doc.documentElement.lang: "en";
     document.title = result.title;
 
     let article = Object.assign(
@@ -179,6 +179,16 @@ class ReaderView {
           readingTimeString = `${readingTimeMinsFast} - ${readingTimeString}`;
         }
         return readingTimeString;
+      } else if (parts.length == 2) {
+        var readingTime = parts[0].value;
+        var minutesLiteral = parts[1].value;
+        var readingTimeString = `${readingTime} ${minutesLiteral}`;
+        if (readingTimeMinsSlow != readingTimeMinsFast) {
+            readingTimeString = `${new Intl.NumberFormat(lang).format(readingTimeMinsFast)} - ${readingTimeString}`;
+        }
+        return readingTimeString;
+      } else {
+        return parts[0].value;
       }
     }
     catch(error) {


### PR DESCRIPTION
This PR is related to [fenix](https://github.com/mozilla-mobile/fenix) repository issue [#22634](https://github.com/mozilla-mobile/fenix/issues/22634).

This PR may fix the issue where when user enables readermode in a tab and reloads the tab the estimated reading time was disappearing or when user switches the tab and comes back the estimated reading time was disappearing.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
