### PR TITLE
For #7477 - Execute WebNotification click based on incoming Intent

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -534,6 +534,10 @@ class GeckoEngine(
         )
     }
 
+    override fun unregisterServiceWorkerDelegate() {
+        runtime.serviceWorkerDelegate = null
+    }
+
     override fun handleWebNotificationClick(webNotification: Parcelable) {
         (webNotification as? WebNotification)?.click()
     }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.engine.gecko
 
 import android.content.Context
+import android.os.Parcelable
 import android.util.AttributeSet
 import android.util.JsonReader
 import androidx.annotation.VisibleForTesting
@@ -64,6 +65,7 @@ import org.mozilla.geckoview.GeckoRuntimeSettings
 import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoWebExecutor
 import org.mozilla.geckoview.WebExtensionController
+import org.mozilla.geckoview.WebNotification
 import java.lang.ref.WeakReference
 
 /**
@@ -530,6 +532,10 @@ class GeckoEngine(
             runtime = runtime,
             engineSettings = defaultSettings
         )
+    }
+
+    override fun handleWebNotificationClick(webNotification: Parcelable) {
+        (webNotification as? WebNotification)?.click()
     }
 
     /**

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegate.kt
@@ -30,7 +30,8 @@ internal class GeckoWebNotificationDelegate(
             direction = textDirection,
             lang = lang,
             requireInteraction = requireInteraction,
-            triggeredByWebExtension = source == null
+            triggeredByWebExtension = source == null,
+            engineNotification = this@toWebNotification
         )
     }
 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -78,6 +78,7 @@ import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_SIGN
 import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_UNEXPECTED_ADDON_TYPE
 import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_USER_CANCELED
 import org.mozilla.geckoview.WebExtensionController
+import org.mozilla.geckoview.WebNotification
 import org.mozilla.geckoview.WebPushController
 import org.robolectric.Robolectric
 import org.robolectric.Shadows.shadowOf
@@ -2108,6 +2109,20 @@ class GeckoEngineTest {
         assertEquals(delegate, result.delegate)
         assertEquals(runtime, result.runtime)
         assertEquals(settings, result.engineSettings)
+    }
+
+    @Test
+    fun `handleWebNotificationClick calls click on the WebNotification`() {
+        val runtime = GeckoRuntime.getDefault(testContext)
+        val settings = DefaultSettings()
+        val engine = GeckoEngine(context, runtime = runtime, defaultSettings = settings)
+
+        // Check that having another argument doesn't cause any issues
+        engine.handleWebNotificationClick(runtime)
+
+        val notification: WebNotification = mock()
+        engine.handleWebNotificationClick(notification)
+        verify(notification).click()
     }
 
     private fun createSocialTrackersLogEntryList(): List<ContentBlockingController.LogEntry> {

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -2112,6 +2112,19 @@ class GeckoEngineTest {
     }
 
     @Test
+    fun `unregisterServiceWorkerDelegate sets delegate to null`() {
+        val runtime = GeckoRuntime.getDefault(testContext)
+        val settings = DefaultSettings()
+        val engine = GeckoEngine(context, runtime = runtime, defaultSettings = settings)
+
+        engine.registerServiceWorkerDelegate(mock())
+        assertNotNull(runtime.serviceWorkerDelegate)
+
+        engine.unregisterServiceWorkerDelegate()
+        assertNull(runtime.serviceWorkerDelegate)
+    }
+
+    @Test
     fun `handleWebNotificationClick calls click on the WebNotification`() {
         val runtime = GeckoRuntime.getDefault(testContext)
         val settings = DefaultSettings()

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -5,6 +5,7 @@
 package mozilla.components.concept.engine
 
 import android.content.Context
+import android.os.Parcelable
 import android.util.AttributeSet
 import android.util.JsonReader
 import androidx.annotation.MainThread
@@ -220,6 +221,17 @@ interface Engine : WebExtensionRuntime, DataCleanable {
     fun registerServiceWorkerDelegate(
         serviceWorkerDelegate: ServiceWorkerDelegate
     ): Unit = throw UnsupportedOperationException("Service workers support not available in this engine")
+
+    /**
+     * Handles user interacting with a web notification.
+     *
+     * @param webNotification [Parcelable] representing a web notification.
+     * If the `Parcelable` is not a web notification this method will be no-op.
+     *
+     * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/Notification">MDN Notification docs</a>
+     */
+    fun handleWebNotificationClick(webNotification: Parcelable): Unit =
+        throw UnsupportedOperationException("Web notification clicks not yet supported in this engine")
 
     /**
      * Fetch a list of trackers logged for a given [session] .

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -223,6 +223,13 @@ interface Engine : WebExtensionRuntime, DataCleanable {
     ): Unit = throw UnsupportedOperationException("Service workers support not available in this engine")
 
     /**
+     * Un-registers the attached [ServiceWorkerDelegate] if one was added with
+     * [registerServiceWorkerDelegate].
+     */
+    fun unregisterServiceWorkerDelegate(): Unit =
+        throw UnsupportedOperationException("Service workers support not available in this engine")
+
+    /**
      * Handles user interacting with a web notification.
      *
      * @param webNotification [Parcelable] representing a web notification.

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webnotifications/WebNotification.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webnotifications/WebNotification.kt
@@ -4,6 +4,9 @@
 
 package mozilla.components.concept.engine.webnotifications
 
+import android.os.Parcelable
+import mozilla.components.concept.engine.Engine
+
 /**
  * A notification sent by the Web Notifications API.
  *
@@ -16,6 +19,8 @@ package mozilla.components.concept.engine.webnotifications
  * @property direction Preference for text direction.
  * @property lang language of the notification.
  * @property requireInteraction Preference flag that indicates the notification should remain.
+ * @property engineNotification Notification instance native to [Engine] which can be
+ * sent across processes or persisted and restored later.
  * @property timestamp Time when the notification was created.
  * @property triggeredByWebExtension True if this notification was triggered by a
  * web extension, otherwise false.
@@ -29,6 +34,7 @@ data class WebNotification(
     val direction: String?,
     val lang: String?,
     val requireInteraction: Boolean,
+    val engineNotification: Parcelable,
     val timestamp: Long = System.currentTimeMillis(),
     val triggeredByWebExtension: Boolean = false
 )

--- a/components/feature/webnotifications/build.gradle
+++ b/components/feature/webnotifications/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation project(':browser-icons')
     implementation project(':concept-engine')
     implementation project(':feature-sitepermissions')
+    implementation project(':feature-intent')
     implementation project(':support-ktx')
     implementation project(':support-utils')
 

--- a/components/feature/webnotifications/src/main/java/mozilla/components/feature/webnotifications/NativeNotificationBridge.kt
+++ b/components/feature/webnotifications/src/main/java/mozilla/components/feature/webnotifications/NativeNotificationBridge.kt
@@ -26,7 +26,7 @@ internal class NativeNotificationBridge(
     @DrawableRes private val smallIcon: Int
 ) {
     companion object {
-        private const val EXTRA_ON_CLICK = "mozac.feature.webnotifications.generic.onclick"
+        internal const val EXTRA_ON_CLICK = "mozac.feature.webnotifications.generic.onclick"
     }
 
     /**
@@ -50,7 +50,7 @@ internal class NativeNotificationBridge(
         with(notification) {
             activityClass?.let {
                 val intent = Intent(context, activityClass).apply {
-                    putExtra(EXTRA_ON_CLICK, tag)
+                    putExtra(EXTRA_ON_CLICK, notification.engineNotification)
                 }
 
                 PendingIntent.getActivity(context, requestId, intent, PendingIntentUtils.defaultFlags).apply {

--- a/components/feature/webnotifications/src/main/java/mozilla/components/feature/webnotifications/WebNotificationIntentProcessor.kt
+++ b/components/feature/webnotifications/src/main/java/mozilla/components/feature/webnotifications/WebNotificationIntentProcessor.kt
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.webnotifications
+
+import android.content.Intent
+import android.os.Parcelable
+import mozilla.components.concept.engine.Engine
+import mozilla.components.feature.intent.processing.IntentProcessor
+
+/**
+ * Intent processor that tries matching a web notification and delegating a click interaction with it.
+ */
+class WebNotificationIntentProcessor(
+    private val engine: Engine
+) : IntentProcessor {
+    /**
+     * Processes an incoming intent expected to contain information about a web notification.
+     * If such information is available this will inform the web notification about it being clicked.
+     */
+    override fun process(intent: Intent): Boolean {
+        @Suppress("MoveVariableDeclarationIntoWhen")
+        val engineNotification = intent.extras?.get(NativeNotificationBridge.EXTRA_ON_CLICK) as? Parcelable
+
+        return when (engineNotification) {
+            null -> false
+            else -> {
+                engine.handleWebNotificationClick(engineNotification)
+                true
+            }
+        }
+    }
+}

--- a/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/NativeNotificationBridgeTest.kt
+++ b/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/NativeNotificationBridgeTest.kt
@@ -39,7 +39,7 @@ private const val TEST_CHANNEL = "testChannel"
 class NativeNotificationBridgeTest {
     private val blankNotification = WebNotification(
         TEST_TITLE, TEST_TAG, TEST_TEXT, TEST_URL, null, null,
-        null, true, 0
+        null, true, mock(), 0
     )
 
     private lateinit var icons: BrowserIcons

--- a/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/WebNotificationFeatureTest.kt
+++ b/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/WebNotificationFeatureTest.kt
@@ -49,7 +49,8 @@ class WebNotificationFeatureTest {
         "https://mozilla.org/image.ico",
         "rtl",
         "en",
-        false
+        false,
+        mock()
     )
 
     @Before
@@ -143,6 +144,7 @@ class WebNotificationFeatureTest {
             "rtl",
             "en",
             false,
+            mock(),
             triggeredByWebExtension = true
         )
 

--- a/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/WebNotificationIntentProcessorTest.kt
+++ b/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/WebNotificationIntentProcessorTest.kt
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.webnotifications
+
+import android.content.Intent
+import android.os.Parcelable
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.concept.engine.Engine
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class WebNotificationIntentProcessorTest {
+    private val engine: Engine = mock()
+    private val processor = WebNotificationIntentProcessor(engine)
+
+    @Test
+    fun `GIVEN an Intent WHEN it contains a parcelable with our private key THEN processing is successful`() {
+        val notification = mock<Parcelable>()
+        val intent = Intent().putExtra(NativeNotificationBridge.EXTRA_ON_CLICK, notification)
+
+        val result = processor.process(intent)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `GIVEN an Intent WHEN it does not contain a parcelable with our private key THEN fail at processing the intent`() {
+        val intent = Intent()
+
+        val result = processor.process(intent)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `GIVEN an Intent WHEN it contains a parcelable with our private key THEN delegate the engine to handle it`() {
+        val notification = mock<Parcelable>()
+        val intent = Intent().putExtra(NativeNotificationBridge.EXTRA_ON_CLICK, notification)
+
+        processor.process(intent)
+
+        verify(engine).handleWebNotificationClick(notification)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **feature-webnotifications**
+  * 🌟 The Engine notification (WebNotification) is now persisted in the native notification, transparent to the consuming app which can delegate the native notification click to a new `WebNotificationIntentProcessor` to actually check and trigger a WebNotification click when appropriate.
+
 # 100.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v99.0.0...v100.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/147?closed=1)


### PR DESCRIPTION
Gecko's WebNotification will be persisted in the native Android notification
that is posted like before to target a specific activity in the app.
When the user clicks the notification the target activity can delegate a new
WebNotificationIntentProcessor component to actually process notification's
contentIntent and trigger `click` on the WebNotification.



https://user-images.githubusercontent.com/11428869/161588211-ba33b12a-6cd9-41b8-b1c3-7024e9b8c74e.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
