### PR TITLE
Demonstrate what more robust storage might look like

### DIFF
--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
@@ -15,6 +15,16 @@ import kotlinx.parcelize.Parcelize
 interface CreditCardsAddressesStorage {
 
     /**
+     * Returns true if the underlying storage has been successfully opened, false otherwise.
+     *
+     * Returning false will typically mean there was a fatal error opening the database, so
+     * all other functions in this interface are likely to throw IllegalStateException exceptions
+     * or otherwise behave in an unexpected way.
+     *
+     */
+    fun hasStorage(): Boolean
+
+    /**
      * Inserts the provided credit card into the database, and returns
      * the newly added [CreditCard].
      *


### PR DESCRIPTION
This is a POC for #11810 and https://github.com/mozilla/application-services/issues/4872. There is a companion PR for Fenix which I'll link.

The point is that while we have fixed the most common manifestation of #11810  in app-services, there *will* still be cases with the same symptoms which we can't fix via code - particularly when there really is a corrupt sqlite database or no space on the device. We should try and avoid crashing in those cases and instead offer a degraded autofill experience.

This PR is just for autofill - it (a) tries to handle the exception opening the DB and (b) simulates such an exception just to see what happens. With this, Fenix doesn't crash, even when browsing to autofill test pages. It probably does crash if you try and explicitly add a creditcard, but that would (a) be easily fixed and (b) far far better than crashing as the app starts.

The question: is a strategy like this worth pursuing? I think each component would be slightly different but of a similar shape (ie, over time, we'd need to do something similar for all our components)

In https://github.com/mozilla/application-services/issues/4872, Ben floated the idea of trying to work out how to do this in rust and perform the same kind of short-circuiting there, but I pushed back a little on that - in particular, consider, say, `CreditCard add_credit_card(UpdatableCreditCardFields cc);` - I think the only way to sanely do this at a lower level would be to have that function return `null` in these error cases, which seems like a bad outcome and still likely to crash naive clients - I think it's better to let the app itself deal with catastrophic errors than having the lower-level components try and pretend everything is OK.

WDYT? cc @kbrosnan, @grigoryk, @gabrielluong, @bendk, @lougeniaC64 