### PR TITLE
For #11753 - Update compose to 1.1.1 and Kotlin to 1.6.10

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -7,7 +7,7 @@
 
 // Synchronized version numbers for dependencies used by (some) modules
 object Versions {
-    const val kotlin = "1.5.31"
+    const val kotlin = "1.6.10"
     const val coroutines = "1.5.2"
 
     const val junit = "4.12"
@@ -36,7 +36,7 @@ object Versions {
 
     const val material = "1.2.1"
 
-    const val compose_version = "1.0.5"
+    const val compose_version = "1.1.1"
 
     object AndroidX {
         const val activityCompose = "1.4.0"
@@ -55,7 +55,7 @@ object Versions {
         const val test = "1.3.0"
         const val test_ext = "1.1.2"
         const val espresso = "3.3.0"
-        const val room = "2.3.0"
+        const val room = "2.4.2"
         const val paging = "2.1.2"
         const val palette = "1.0.0"
         const val preferences = "1.1.1"

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -587,6 +587,9 @@ class GeckoEngineSession(
                                 onLaunchIntentRequest(url = url, appIntent = appIntent)
                             }
                         }
+                        else -> {
+                            // no-op
+                        }
                     }
                 }
             } else {

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
@@ -261,6 +261,9 @@ internal fun PopupWindow.displayPopup(currentData: MenuPositioningData) {
 
         is BrowserMenuPlacement.AnchoredToTop.ManualAnchoring,
         is BrowserMenuPlacement.AnchoredToBottom.ManualAnchoring -> showAtAnchorLocation(currentData)
+        else -> {
+            // no-op
+        }
     }
 }
 

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/LinkingMiddleware.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/LinkingMiddleware.kt
@@ -48,6 +48,9 @@ internal class LinkingMiddleware(
             is EngineAction.UnlinkEngineSessionAction -> {
                 unlink(context, action)
             }
+            else -> {
+                // no-op
+            }
         }
 
         next(action)
@@ -57,6 +60,9 @@ internal class LinkingMiddleware(
                 context.state.findTabOrCustomTab(action.tabId)?.let { tab ->
                     engineObserver = link(context, action.engineSession, tab, action.skipLoading)
                 }
+            }
+            else -> {
+                // no-op
             }
         }
 

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/TabsRemovedMiddleware.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/TabsRemovedMiddleware.kt
@@ -47,6 +47,9 @@ internal class TabsRemovedMiddleware(
             is CustomTabListAction.RemoveCustomTabAction -> context.state.findCustomTab(action.tabId)?.let {
                 onTabsRemoved(context, listOf(it))
             }
+            else -> {
+                // no-op
+            }
         }
 
         next(action)

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/WebExtensionMiddleware.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/WebExtensionMiddleware.kt
@@ -34,6 +34,9 @@ internal class WebExtensionMiddleware : Middleware<BrowserState, BrowserAction> 
                     activeTab?.engineState?.engineSession?.markActiveForWebExtensions(false)
                 }
             }
+            else -> {
+                // no-op
+            }
         }
 
         next(action)
@@ -42,6 +45,9 @@ internal class WebExtensionMiddleware : Middleware<BrowserState, BrowserAction> 
             is TabListAction,
             is EngineAction.LinkEngineSessionAction -> {
                 switchActiveStateIfNeeded(context)
+            }
+            else -> {
+                // no-op
             }
         }
     }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/TabsRemovedMiddlewareTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/TabsRemovedMiddlewareTest.kt
@@ -246,9 +246,8 @@ class TabsRemovedMiddlewareTest {
                 is TabListAction.RemoveTabAction,
                 is CustomTabListAction.RemoveAllCustomTabsAction,
                 is CustomTabListAction.RemoveCustomTabAction -> return
+                else -> next(action)
             }
-
-            next(action)
         }
     }
 }

--- a/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/ThumbnailsMiddleware.kt
+++ b/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/ThumbnailsMiddleware.kt
@@ -51,6 +51,9 @@ class ThumbnailsMiddleware(
             is TabListAction.RemoveTabsAction -> {
                 action.tabIds.forEach { thumbnailStorage.deleteThumbnail(it) }
             }
+            else -> {
+                // no-op
+            }
         }
 
         next(action)

--- a/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/AwesomeBar.kt
+++ b/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/AwesomeBar.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -88,14 +90,16 @@ fun AwesomeBar(
             .background(colors.background)
     ) {
         val fetcher = remember(groups) { SuggestionFetcher(groups, profiler) }
+        val suggestions by remember {
+            derivedStateOf { fetcher.state.value }
+        }
 
         LaunchedEffect(text, fetcher) {
             fetcher.fetch(text)
         }
 
         Suggestions(
-            groups,
-            fetcher,
+            suggestions,
             colors,
             orientation,
             onSuggestionClicked,

--- a/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/Suggestions.kt
+++ b/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/Suggestions.kt
@@ -20,8 +20,7 @@ import mozilla.components.concept.awesomebar.AwesomeBar
 @Composable
 @Suppress("LongParameterList")
 internal fun Suggestions(
-    groups: List<AwesomeBar.SuggestionProviderGroup>,
-    fetcher: SuggestionFetcher,
+    suggestions: Map<AwesomeBar.SuggestionProviderGroup, List<AwesomeBar.Suggestion>>,
     colors: AwesomeBarColors,
     orientation: AwesomeBarOrientation,
     onSuggestionClicked: (AwesomeBar.SuggestionProviderGroup, AwesomeBar.Suggestion) -> Unit,
@@ -36,30 +35,25 @@ internal fun Suggestions(
         state = state,
         modifier = Modifier.testTag("mozac.awesomebar.suggestions")
     ) {
-        val suggestions = fetcher.state.value
 
-        groups.forEach { group ->
-            val groupSuggestions = suggestions[group] ?: emptyList()
-
-            if (groupSuggestions.isNotEmpty()) {
-                group.title?.let { title ->
-                    item(group.id) {
-                        SuggestionGroup(title, colors)
-                    }
+        suggestions.forEach { (group, suggestions) ->
+            group.title?.let { title ->
+                item(group.id) {
+                    SuggestionGroup(title, colors)
                 }
+            }
 
-                items(
-                    items = groupSuggestions.take(group.limit),
-                    key = { suggestion -> "${group.id}:${suggestion.provider.id}:${suggestion.id}" }
-                ) { suggestion ->
-                    Suggestion(
-                        suggestion,
-                        colors,
-                        orientation,
-                        onSuggestionClicked = { onSuggestionClicked(group, suggestion) },
-                        onAutoComplete = { onAutoComplete(group, suggestion) }
-                    )
-                }
+            items(
+                items = suggestions.take(group.limit),
+                key = { suggestion -> "${group.id}:${suggestion.provider.id}:${suggestion.id}" }
+            ) { suggestion ->
+                Suggestion(
+                    suggestion,
+                    colors,
+                    orientation,
+                    onSuggestionClicked = { onSuggestionClicked(group, suggestion) },
+                    onAutoComplete = { onAutoComplete(group, suggestion) }
+                )
             }
         }
     }

--- a/components/feature/containers/src/main/java/mozilla/components/feature/containers/ContainerMiddleware.kt
+++ b/components/feature/containers/src/main/java/mozilla/components/feature/containers/ContainerMiddleware.kt
@@ -43,6 +43,9 @@ class ContainerMiddleware(
             is InitAction -> initializeContainers(context.store)
             is ContainerAction.AddContainerAction -> addContainer(action)
             is ContainerAction.RemoveContainerAction -> removeContainer(context.store, action)
+            else -> {
+                // no-op
+            }
         }
 
         next(action)

--- a/components/feature/downloads/src/androidTest/java/mozilla/components/feature/downloads/OnDeviceDownloadStorageTest.kt
+++ b/components/feature/downloads/src/androidTest/java/mozilla/components/feature/downloads/OnDeviceDownloadStorageTest.kt
@@ -38,6 +38,7 @@ class OnDeviceDownloadStorageTest {
     private lateinit var database: DownloadsDatabase
 
     @get:Rule
+    @Suppress("DEPRECATION")
     val helper: MigrationTestHelper = MigrationTestHelper(
         InstrumentationRegistry.getInstrumentation(),
         DownloadsDatabase::class.java.canonicalName,

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadMiddleware.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadMiddleware.kt
@@ -68,6 +68,9 @@ class DownloadMiddleware(
                     return
                 }
             }
+            else -> {
+                // no-op
+            }
         }
 
         next(action)
@@ -84,6 +87,9 @@ class DownloadMiddleware(
             }
             is DownloadAction.AddDownloadAction -> sendDownloadIntent(action.download)
             is DownloadAction.RestoreDownloadStateAction -> sendDownloadIntent(action.download)
+            else -> {
+                // no-op
+            }
         }
     }
 

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadCancelDialogFragmentTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadCancelDialogFragmentTest.kt
@@ -17,11 +17,11 @@ import mozilla.components.feature.downloads.ui.DownloadCancelDialogFragment
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
-import org.mockito.Mockito.verify
 import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
@@ -33,12 +33,14 @@ class DownloadCancelDialogFragmentTest {
         spy(DownloadCancelDialogFragment.newInstance(2)).apply {
             doReturn(testContext).`when`(this).requireContext()
             doReturn(mockFragmentManager()).`when`(this).parentFragmentManager
+            var wasAcceptClicked = false
+            onAcceptClicked = { _, _ -> wasAcceptClicked = true }
 
             with(onCreateDialog(null)) {
                 findViewById<Button>(R.id.accept_button).apply { performClick() }
             }
 
-            verify(this).onAcceptClicked
+            assertTrue(wasAcceptClicked)
         }
     }
 
@@ -47,12 +49,14 @@ class DownloadCancelDialogFragmentTest {
         spy(DownloadCancelDialogFragment.newInstance(2)).apply {
             doReturn(testContext).`when`(this).requireContext()
             doReturn(mockFragmentManager()).`when`(this).parentFragmentManager
+            var wasDenyCalled = false
+            onDenyClicked = { wasDenyCalled = true }
 
             with(onCreateDialog(null)) {
                 findViewById<Button>(R.id.deny_button).apply { performClick() }
             }
 
-            verify(this).onDenyClicked
+            assertTrue(wasDenyCalled)
         }
     }
 

--- a/components/feature/logins/src/androidTest/java/mozilla/components/feature/logins/LoginExceptionStorageTest.kt
+++ b/components/feature/logins/src/androidTest/java/mozilla/components/feature/logins/LoginExceptionStorageTest.kt
@@ -37,6 +37,7 @@ class LoginExceptionStorageTest {
     var instantTaskExecutorRule = InstantTaskExecutorRule()
 
     @get:Rule
+    @Suppress("DEPRECATION")
     val helper: MigrationTestHelper = MigrationTestHelper(
         InstrumentationRegistry.getInstrumentation(),
         LoginExceptionStorage::class.java.canonicalName,

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -438,6 +438,9 @@ class PromptFeature private constructor(
                     it.onDeny()
                 }
                 is Dismissible -> it.onDismiss()
+                else -> {
+                    // no-op
+                }
             }
         }
     }
@@ -502,6 +505,9 @@ class PromptFeature private constructor(
                 }
 
                 is Repost -> it.onConfirm()
+                else -> {
+                    // no-op
+                }
             }
         }
     }
@@ -517,6 +523,9 @@ class PromptFeature private constructor(
         store.consumePromptFrom(sessionId, promptRequestUID, activePrompt) {
             when (it) {
                 is TimeSelection -> it.onClear()
+                else -> {
+                    // no-op
+                }
             }
         }
     }

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptMiddleware.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptMiddleware.kt
@@ -32,6 +32,9 @@ class PromptMiddleware : Middleware<BrowserState, BrowserAction> {
                     return
                 }
             }
+            else -> {
+                // no-op
+            }
         }
 
         next(action)

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/SaveLoginDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/SaveLoginDialogFragment.kt
@@ -332,6 +332,9 @@ internal class SaveLoginDialogFragment : PromptDialogFragment() {
                             context?.getString(R.string.mozac_feature_prompt_update_confirmation)
                         )
                     }
+                    else -> {
+                        // no-op
+                    }
                 }
             }
             validateStateUpdate?.invokeOnCompletion {

--- a/components/feature/pwa/src/androidTest/java/mozilla/components/feature/pwa/db/ManifestDatabaseMigrationTest.kt
+++ b/components/feature/pwa/src/androidTest/java/mozilla/components/feature/pwa/db/ManifestDatabaseMigrationTest.kt
@@ -15,6 +15,7 @@ class ManifestDatabaseMigrationTest {
     private val TEST_DB = "migration-test"
 
     @Rule @JvmField
+    @Suppress("DEPRECATION")
     val helper: MigrationTestHelper = MigrationTestHelper(
         InstrumentationRegistry.getInstrumentation(),
         ManifestDatabase::class.java.canonicalName,

--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewMiddleware.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewMiddleware.kt
@@ -121,6 +121,9 @@ class ReaderViewMiddleware : Middleware<BrowserState, BrowserAction> {
                     context.dispatch(ContentAction.UpdateUrlAction(tab.id, url))
                 }
             }
+            else -> {
+                // no-op
+            }
         }
     }
 

--- a/components/feature/recentlyclosed/src/main/java/mozilla/components/feature/recentlyclosed/RecentlyClosedMiddleware.kt
+++ b/components/feature/recentlyclosed/src/main/java/mozilla/components/feature/recentlyclosed/RecentlyClosedMiddleware.kt
@@ -73,6 +73,9 @@ class RecentlyClosedMiddleware(
             is InitAction -> {
                 initializeRecentlyClosed(context.store)
             }
+            else -> {
+                // no-op
+            }
         }
 
         next(action)

--- a/components/feature/search/src/main/java/mozilla/components/feature/search/middleware/SearchMiddleware.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/middleware/SearchMiddleware.kt
@@ -56,6 +56,9 @@ class SearchMiddleware(
             is SearchAction.UpdateCustomSearchEngineAction -> saveCustomSearchEngine(action)
             is SearchAction.RemoveCustomSearchEngineAction -> removeCustomSearchEngine(action)
             is SearchAction.SelectSearchEngineAction -> updateSearchEngineSelection(action)
+            else -> {
+                // no-op
+            }
         }
 
         next(action)
@@ -65,6 +68,9 @@ class SearchMiddleware(
                 updateHiddenSearchEngines(context.state.search.hiddenSearchEngines)
             is SearchAction.AddAdditionalSearchEngineAction, is SearchAction.RemoveAdditionalSearchEngineAction ->
                 updateAdditionalSearchEngines(context.state.search.additionalSearchEngines)
+            else -> {
+                // no-op
+            }
         }
     }
 

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/middleware/LastAccessMiddleware.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/middleware/LastAccessMiddleware.kt
@@ -67,6 +67,9 @@ class LastAccessMiddleware : Middleware<BrowserState, BrowserAction> {
                     context.dispatchUpdateActionForId(action.sessionId)
                 }
             }
+            else -> {
+                // no-op
+            }
         }
     }
 

--- a/components/feature/sitepermissions/src/androidTest/java/mozilla/components/feature/sitepermissions/db/OnDeviceSitePermissionsStorageTest.kt
+++ b/components/feature/sitepermissions/src/androidTest/java/mozilla/components/feature/sitepermissions/db/OnDeviceSitePermissionsStorageTest.kt
@@ -34,6 +34,7 @@ class OnDeviceSitePermissionsStorageTest {
     private lateinit var database: SitePermissionsDatabase
 
     @get:Rule
+    @Suppress("DEPRECATION")
     val helper: MigrationTestHelper = MigrationTestHelper(
         InstrumentationRegistry.getInstrumentation(),
         SitePermissionsDatabase::class.java.canonicalName,

--- a/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsFeature.kt
+++ b/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsFeature.kt
@@ -899,6 +899,9 @@ class SitePermissionsFeature(
                     is ContentAudioCapture, is ContentAudioMicrophone -> {
                         systemPermissions.add(RECORD_AUDIO)
                     }
+                    else -> {
+                        // no-op
+                    }
                 }
             }
             return systemPermissions.all { context.isPermissionGranted((it)) }

--- a/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/db/TabCollectionDao.kt
+++ b/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/db/TabCollectionDao.kt
@@ -48,6 +48,7 @@ internal interface TabCollectionDao {
     )
     fun getTabCollections(): Flow<List<TabCollectionWithTabs>>
 
+    @Transaction
     @Query(
         """
         SELECT *

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/WindowFeature.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/WindowFeature.kt
@@ -52,6 +52,9 @@ class WindowFeature(
                             )
                             windowRequest.start()
                         }
+                        else -> {
+                            // no-op
+                        }
                     }
                 }
         }

--- a/components/feature/top-sites/src/androidTest/java/mozilla/components/feature/top/sites/OnDevicePinnedSitesStorageTest.kt
+++ b/components/feature/top-sites/src/androidTest/java/mozilla/components/feature/top/sites/OnDevicePinnedSitesStorageTest.kt
@@ -36,6 +36,7 @@ class OnDevicePinnedSitesStorageTest {
     var instantTaskExecutorRule = InstantTaskExecutorRule()
 
     @get:Rule
+    @Suppress("DEPRECATION")
     val helper: MigrationTestHelper = MigrationTestHelper(
         InstrumentationRegistry.getInstrumentation(),
         TopSiteDatabase::class.java.canonicalName,

--- a/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleMiddleware.kt
+++ b/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleMiddleware.kt
@@ -38,6 +38,9 @@ class LocaleMiddleware(
         when (action) {
             is LocaleAction.RestoreLocaleStateAction -> restoreLocale(context.store)
             is LocaleAction.UpdateLocaleAction -> updateLocale(action.locale)
+            else -> {
+                // no-op
+            }
         }
 
         next(action)


### PR DESCRIPTION
This also required updating room to >= 2.4.0.
This new version adds a deprecation of the `MigrationTestHelper` api used in
`LoginExceptionStorageTest` that is to be later fixed in #11765.

`activity_compose` was also updated to the latest stable version to ensure a
better match with the latest stable version for compose.

Most of the changes are around supporting exhaustive `when`s for sealed classes as a new kotlin feature - https://kotlinlang.org/docs/whatsnew1530.html#exhaustive-when-statements-for-sealed-and-boolean-subjects

Updating `kotlin-coroutines` will be a followup - https://github.com/mozilla-mobile/android-components/issues/11755

This should help fix https://github.com/mozilla-mobile/fenix/issues/23989 - stress tested the scenario that I found to reproduce that crash and it doesn't happen anymore but more tests are needed before landing the updates at once on all projects.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
