### PR TITLE
For #11755 - Update coroutines to 1.6.1. Update tests.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -8,7 +8,7 @@
 // Synchronized version numbers for dependencies used by (some) modules
 object Versions {
     const val kotlin = "1.6.10"
-    const val coroutines = "1.5.2"
+    const val coroutines = "1.6.1"
 
     const val junit = "4.12"
     const val robolectric = "4.7.3"

--- a/components/browser/domains/build.gradle
+++ b/components/browser/domains/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_coroutines
 }
 
 apply from: '../../../publish.gradle'

--- a/components/browser/domains/src/test/java/mozilla/components/browser/domains/CustomDomainsTest.kt
+++ b/components/browser/domains/src/test/java/mozilla/components/browser/domains/CustomDomainsTest.kt
@@ -6,7 +6,7 @@ package mozilla.components.browser.domains
 
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -24,11 +24,10 @@ class CustomDomainsTest {
             .apply()
     }
 
+    @ExperimentalCoroutinesApi
     @Test
     fun customListIsEmptyByDefault() {
-        val domains = runBlocking {
-            CustomDomains.load(testContext)
-        }
+        val domains = CustomDomains.load(testContext)
 
         assertEquals(0, domains.size)
     }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -12,7 +12,6 @@ import android.os.Message
 import android.view.WindowManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.engine.gecko.ext.geckoTrackingProtectionPermission
 import mozilla.components.browser.engine.gecko.ext.isExcludedForTrackingProtection
 import mozilla.components.browser.engine.gecko.permission.geckoContentPermission
@@ -44,6 +43,8 @@ import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.expectException
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import mozilla.components.support.test.whenever
 import mozilla.components.support.utils.ThreadUtils
 import mozilla.components.test.ReflectionUtils
@@ -55,6 +56,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
@@ -101,6 +103,9 @@ typealias GeckoCookieBehavior = ContentBlocking.CookieBehavior
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 class GeckoEngineSessionTest {
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
 
     private lateinit var runtime: GeckoRuntime
     private lateinit var geckoSession: GeckoSession
@@ -774,7 +779,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `notifies configured history delegate of title changes`() = runBlockingTest {
+    fun `notifies configured history delegate of title changes`() = runTestOnMain {
         val engineSession = GeckoEngineSession(
             runtime, geckoSessionProvider = geckoSessionProvider,
             context = coroutineContext
@@ -801,7 +806,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `does not notify configured history delegate of title changes for private sessions`() = runBlockingTest {
+    fun `does not notify configured history delegate of title changes for private sessions`() = runTestOnMain {
         val engineSession = GeckoEngineSession(
             mock(),
             geckoSessionProvider = geckoSessionProvider,
@@ -833,7 +838,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `notifies configured history delegate of preview image URL changes`() = runBlockingTest {
+    fun `notifies configured history delegate of preview image URL changes`() = runTestOnMain {
         val engineSession = GeckoEngineSession(
             runtime, geckoSessionProvider = geckoSessionProvider,
             context = coroutineContext
@@ -864,7 +869,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `does not notify configured history delegate of preview image URL changes for private sessions`() = runBlockingTest {
+    fun `does not notify configured history delegate of preview image URL changes for private sessions`() = runTestOnMain {
         val engineSession = GeckoEngineSession(
             mock(),
             geckoSessionProvider = geckoSessionProvider,
@@ -896,7 +901,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `does not notify configured history delegate for top-level visits to error pages`() = runBlockingTest {
+    fun `does not notify configured history delegate for top-level visits to error pages`() = runTestOnMain {
         val engineSession = GeckoEngineSession(
             mock(),
             geckoSessionProvider = geckoSessionProvider,
@@ -919,7 +924,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `notifies configured history delegate of visits`() = runBlockingTest {
+    fun `notifies configured history delegate of visits`() = runTestOnMain {
         val engineSession = GeckoEngineSession(
             mock(),
             geckoSessionProvider = geckoSessionProvider,
@@ -938,7 +943,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `notifies configured history delegate of reloads`() = runBlockingTest {
+    fun `notifies configured history delegate of reloads`() = runTestOnMain {
         val engineSession = GeckoEngineSession(
             mock(),
             geckoSessionProvider = geckoSessionProvider,
@@ -957,7 +962,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `checks with the delegate before trying to record a visit`() = runBlockingTest {
+    fun `checks with the delegate before trying to record a visit`() = runTestOnMain {
         val engineSession = GeckoEngineSession(
             mock(),
             geckoSessionProvider = geckoSessionProvider,
@@ -985,7 +990,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `correctly processes redirect visit flags`() = runBlockingTest {
+    fun `correctly processes redirect visit flags`() = runTestOnMain {
         val engineSession = GeckoEngineSession(
             mock(),
             geckoSessionProvider = geckoSessionProvider,
@@ -1047,7 +1052,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `does not notify configured history delegate of visits for private sessions`() = runBlockingTest {
+    fun `does not notify configured history delegate of visits for private sessions`() = runTestOnMain {
         val engineSession = GeckoEngineSession(
             mock(),
             geckoSessionProvider = geckoSessionProvider,
@@ -1066,7 +1071,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `requests visited URLs from configured history delegate`() = runBlockingTest {
+    fun `requests visited URLs from configured history delegate`() = runTestOnMain {
         val engineSession = GeckoEngineSession(
             mock(),
             geckoSessionProvider = geckoSessionProvider,
@@ -1088,7 +1093,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `does not request visited URLs from configured history delegate in private sessions`() = runBlockingTest {
+    fun `does not request visited URLs from configured history delegate in private sessions`() = runTestOnMain {
         val engineSession = GeckoEngineSession(
             mock(),
             geckoSessionProvider = geckoSessionProvider,
@@ -1107,7 +1112,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `notifies configured history delegate of state changes`() = runBlockingTest {
+    fun `notifies configured history delegate of state changes`() = runTestOnMain {
         val engineSession = GeckoEngineSession(
             mock(),
             geckoSessionProvider = geckoSessionProvider,

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoResultTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoResultTest.kt
@@ -6,7 +6,7 @@ package mozilla.components.browser.engine.gecko
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
@@ -25,18 +25,18 @@ import org.robolectric.annotation.LooperMode
 class GeckoResultTest {
 
     @Test
-    fun awaitWithResult() = runBlockingTest {
+    fun awaitWithResult() = runTest {
         val result = GeckoResult.fromValue(42).await()
         assertEquals(42, result)
     }
 
     @Test(expected = IllegalStateException::class)
-    fun awaitWithException() = runBlockingTest {
+    fun awaitWithException() = runTest {
         GeckoResult.fromException<Unit>(IllegalStateException()).await()
     }
 
     @Test
-    fun fromResult() = runBlockingTest {
+    fun fromResult() = runTest {
         val result = launchGeckoResult { 42 }
 
         result.then<Int> {
@@ -46,7 +46,7 @@ class GeckoResultTest {
     }
 
     @Test
-    fun fromException() = runBlockingTest {
+    fun fromException() = runTest {
         val result = launchGeckoResult { throw IllegalStateException() }
 
         result.then<Unit>(
@@ -62,7 +62,7 @@ class GeckoResultTest {
     }
 
     @Test
-    fun asCancellableOperation() = runBlockingTest {
+    fun asCancellableOperation() = runTest {
         val geckoResult: GeckoResult<Int> = mock()
         val op = geckoResult.asCancellableOperation()
 

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoSitePermissionsStorageTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoSitePermissionsStorageTest.kt
@@ -6,7 +6,7 @@ package mozilla.components.browser.engine.gecko.permission
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.engine.permission.SitePermissions
 import mozilla.components.concept.engine.permission.SitePermissions.AutoplayStatus
 import mozilla.components.concept.engine.permission.SitePermissions.Status.ALLOWED
@@ -66,7 +66,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `GIVEN a location permission WHEN saving THEN the permission is saved in the gecko storage and set to the default value on the disk storage`() = runBlockingTest {
+    fun `GIVEN a location permission WHEN saving THEN the permission is saved in the gecko storage and set to the default value on the disk storage`() = runTest {
         val sitePermissions = createNewSitePermission().copy(location = ALLOWED)
         val geckoPermissions = geckoContentPermission("mozilla.org", PERMISSION_GEOLOCATION)
         val geckoRequest = GeckoPermissionRequest.Content("mozilla.org", PERMISSION_GEOLOCATION, geckoPermissions, mock())
@@ -83,7 +83,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `GIVEN a notification permission WHEN saving THEN the permission is saved in the gecko storage and set to the default value on the disk storage`() = runBlockingTest {
+    fun `GIVEN a notification permission WHEN saving THEN the permission is saved in the gecko storage and set to the default value on the disk storage`() = runTest {
         val sitePermissions = createNewSitePermission().copy(notification = BLOCKED)
         val geckoPermissions = geckoContentPermission("mozilla.org", PERMISSION_DESKTOP_NOTIFICATION)
         val geckoRequest = GeckoPermissionRequest.Content("mozilla.org", PERMISSION_DESKTOP_NOTIFICATION, geckoPermissions, mock())
@@ -100,7 +100,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `GIVEN a localStorage permission WHEN saving THEN the permission is saved in the gecko storage and set to the default value on the disk storage`() = runBlockingTest {
+    fun `GIVEN a localStorage permission WHEN saving THEN the permission is saved in the gecko storage and set to the default value on the disk storage`() = runTest {
         val sitePermissions = createNewSitePermission().copy(localStorage = BLOCKED)
         val geckoPermissions = geckoContentPermission("mozilla.org", PERMISSION_PERSISTENT_STORAGE)
         val geckoRequest = GeckoPermissionRequest.Content("mozilla.org", PERMISSION_PERSISTENT_STORAGE, geckoPermissions, mock())
@@ -117,7 +117,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `GIVEN a crossOriginStorageAccess permission WHEN saving THEN the permission is saved in the gecko storage and set to the default value on the disk storage`() = runBlockingTest {
+    fun `GIVEN a crossOriginStorageAccess permission WHEN saving THEN the permission is saved in the gecko storage and set to the default value on the disk storage`() = runTest {
         val sitePermissions = createNewSitePermission().copy(crossOriginStorageAccess = BLOCKED)
         val geckoPermissions = geckoContentPermission("mozilla.org", PERMISSION_STORAGE_ACCESS)
         val geckoRequest = GeckoPermissionRequest.Content("mozilla.org", PERMISSION_STORAGE_ACCESS, geckoPermissions, mock())
@@ -134,7 +134,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `GIVEN a mediaKeySystemAccess permission WHEN saving THEN the permission is saved in the gecko storage and set to the default value on the disk storage`() = runBlockingTest {
+    fun `GIVEN a mediaKeySystemAccess permission WHEN saving THEN the permission is saved in the gecko storage and set to the default value on the disk storage`() = runTest {
         val sitePermissions = createNewSitePermission().copy(mediaKeySystemAccess = ALLOWED)
         val geckoPermissions = geckoContentPermission("mozilla.org", PERMISSION_MEDIA_KEY_SYSTEM_ACCESS)
         val geckoRequest = GeckoPermissionRequest.Content("mozilla.org", PERMISSION_MEDIA_KEY_SYSTEM_ACCESS, geckoPermissions, mock())
@@ -151,7 +151,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `GIVEN a autoplayInaudible permission WHEN saving THEN the permission is saved in the gecko storage and set to the default value on the disk storage`() = runBlockingTest {
+    fun `GIVEN a autoplayInaudible permission WHEN saving THEN the permission is saved in the gecko storage and set to the default value on the disk storage`() = runTest {
         val sitePermissions = createNewSitePermission().copy(autoplayInaudible = AutoplayStatus.ALLOWED)
         val geckoPermissions = geckoContentPermission("mozilla.org", PERMISSION_AUTOPLAY_INAUDIBLE)
         val geckoRequest = GeckoPermissionRequest.Content("mozilla.org", PERMISSION_AUTOPLAY_INAUDIBLE, geckoPermissions, mock())
@@ -168,7 +168,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `GIVEN a autoplayAudible permission WHEN saving THEN the permission is saved in the gecko storage and set to the default value on the disk storage`() = runBlockingTest {
+    fun `GIVEN a autoplayAudible permission WHEN saving THEN the permission is saved in the gecko storage and set to the default value on the disk storage`() = runTest {
         val sitePermissions = createNewSitePermission().copy(autoplayAudible = AutoplayStatus.ALLOWED)
         val geckoPermissions = geckoContentPermission("mozilla.org", PERMISSION_AUTOPLAY_AUDIBLE)
         val geckoRequest = GeckoPermissionRequest.Content("mozilla.org", PERMISSION_AUTOPLAY_AUDIBLE, geckoPermissions, mock())
@@ -185,7 +185,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `WHEN saving a site permission THEN the permission is saved in the gecko storage and in disk storage`() = runBlockingTest {
+    fun `WHEN saving a site permission THEN the permission is saved in the gecko storage and in disk storage`() = runTest {
         val sitePermissions = createNewSitePermission().copy(autoplayAudible = AutoplayStatus.ALLOWED)
         val geckoPermissions = geckoContentPermission("mozilla.org", PERMISSION_AUTOPLAY_AUDIBLE)
         val geckoRequest = GeckoPermissionRequest.Content("mozilla.org", PERMISSION_AUTOPLAY_AUDIBLE, geckoPermissions, mock())
@@ -199,7 +199,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `GIVEN a temporary permission WHEN saving THEN the permission is saved in memory`() = runBlockingTest {
+    fun `GIVEN a temporary permission WHEN saving THEN the permission is saved in memory`() = runTest {
         val geckoPermissions = geckoContentPermission("mozilla.org", PERMISSION_AUTOPLAY_AUDIBLE)
         val geckoRequest = GeckoPermissionRequest.Content("mozilla.org", PERMISSION_AUTOPLAY_AUDIBLE, geckoPermissions, mock())
 
@@ -209,7 +209,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `GIVEN media type temporary permission WHEN saving THEN the permission is NOT saved in memory`() = runBlockingTest {
+    fun `GIVEN media type temporary permission WHEN saving THEN the permission is NOT saved in memory`() = runTest {
         val geckoRequest = GeckoPermissionRequest.Media("mozilla.org", emptyList(), emptyList(), mock())
 
         assertTrue(geckoStorage.geckoTemporaryPermissions.isEmpty())
@@ -220,7 +220,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `GIVEN multiple saved temporary permissions WHEN clearing all temporary permission THEN all permissions are cleared`() = runBlockingTest {
+    fun `GIVEN multiple saved temporary permissions WHEN clearing all temporary permission THEN all permissions are cleared`() = runTest {
         val geckoAutoPlayPermissions = geckoContentPermission("mozilla.org", PERMISSION_AUTOPLAY_AUDIBLE)
         val geckoPersistentStoragePermissions = geckoContentPermission("mozilla.org", PERMISSION_PERSISTENT_STORAGE)
         val geckoStorageAccessPermissions = geckoContentPermission("mozilla.org", PERMISSION_STORAGE_ACCESS)
@@ -250,7 +250,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `GIVEN a localStorage permission WHEN updating THEN the permission is updated in the gecko storage and set to the default value on the disk storage`() = runBlockingTest {
+    fun `GIVEN a localStorage permission WHEN updating THEN the permission is updated in the gecko storage and set to the default value on the disk storage`() = runTest {
         val sitePermissions = createNewSitePermission().copy(location = ALLOWED)
         val geckoPermissions = geckoContentPermission("mozilla.org", PERMISSION_GEOLOCATION)
         val geckoRequest = GeckoPermissionRequest.Content("mozilla.org", PERMISSION_AUTOPLAY_AUDIBLE, geckoPermissions, mock())
@@ -264,7 +264,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `WHEN updating a permission THEN the permission is updated in the gecko storage and on the disk storage`() = runBlockingTest {
+    fun `WHEN updating a permission THEN the permission is updated in the gecko storage and on the disk storage`() = runTest {
         val sitePermissions = createNewSitePermission().copy(location = ALLOWED)
 
         doReturn(sitePermissions).`when`(geckoStorage).updateGeckoPermissionIfNeeded(sitePermissions)
@@ -276,7 +276,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `WHEN updating THEN the permission is updated in the gecko storage and set to the default value on the disk storage`() = runBlockingTest {
+    fun `WHEN updating THEN the permission is updated in the gecko storage and set to the default value on the disk storage`() = runTest {
         val sitePermissions = SitePermissions(
             origin = "mozilla.dev",
             localStorage = ALLOWED,
@@ -323,7 +323,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `WHEN querying the store by origin THEN the gecko and the on disk storage are queried and results are combined`() = runBlockingTest {
+    fun `WHEN querying the store by origin THEN the gecko and the on disk storage are queried and results are combined`() = runTest {
         val sitePermissions = SitePermissions(
             origin = "mozilla.dev",
             localStorage = ALLOWED,
@@ -365,7 +365,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `GIVEN a gecko and on disk permissions WHEN merging values THEN both should be combined into one`() = runBlockingTest {
+    fun `GIVEN a gecko and on disk permissions WHEN merging values THEN both should be combined into one`() = runTest {
         val onDiskPermissions = SitePermissions(
             origin = "mozilla.dev",
             localStorage = ALLOWED,
@@ -404,7 +404,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `GIVEN permissions that are not present on the gecko storage WHEN merging THEN favor the values on disk permissions`() = runBlockingTest {
+    fun `GIVEN permissions that are not present on the gecko storage WHEN merging THEN favor the values on disk permissions`() = runTest {
         val onDiskPermissions = SitePermissions(
             origin = "mozilla.dev",
             localStorage = ALLOWED,
@@ -471,7 +471,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `WHEN removing a site permissions THEN permissions should be removed from the on disk and gecko storage`() = runBlockingTest {
+    fun `WHEN removing a site permissions THEN permissions should be removed from the on disk and gecko storage`() = runTest {
         val onDiskPermissions = createNewSitePermission()
 
         doReturn(Unit).`when`(geckoStorage).removeGeckoContentPermissionBy(onDiskPermissions.origin)
@@ -483,7 +483,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `WHEN removing gecko permissions THEN permissions should be set to the default values in the gecko storage`() = runBlockingTest {
+    fun `WHEN removing gecko permissions THEN permissions should be set to the default values in the gecko storage`() = runTest {
         val geckoPermissions = listOf(
             geckoContentPermission(type = PERMISSION_GEOLOCATION),
             geckoContentPermission(type = PERMISSION_DESKTOP_NOTIFICATION),
@@ -511,7 +511,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `WHEN removing a temporary permissions THEN the permissions should be remove from memory`() = runBlockingTest {
+    fun `WHEN removing a temporary permissions THEN the permissions should be remove from memory`() = runTest {
         val geckoPermissions = listOf(
             geckoContentPermission(type = PERMISSION_GEOLOCATION),
             geckoContentPermission(type = PERMISSION_GEOLOCATION),
@@ -539,7 +539,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `WHEN removing all THEN all permissions should be removed from the on disk and gecko storage`() = runBlockingTest {
+    fun `WHEN removing all THEN all permissions should be removed from the on disk and gecko storage`() = runTest {
 
         doReturn(Unit).`when`(geckoStorage).removeGeckoAllContentPermissions()
 
@@ -550,7 +550,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `WHEN removing all gecko permissions THEN remove all permissions on gecko and clear the site permissions info`() = runBlockingTest {
+    fun `WHEN removing all gecko permissions THEN remove all permissions on gecko and clear the site permissions info`() = runTest {
         val geckoPermissions = listOf(
             geckoContentPermission(type = PERMISSION_GEOLOCATION),
             geckoContentPermission(type = PERMISSION_DESKTOP_NOTIFICATION),
@@ -574,7 +574,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `WHEN querying all permission THEN the gecko and the on disk storage are queried and results are combined`() = runBlockingTest {
+    fun `WHEN querying all permission THEN the gecko and the on disk storage are queried and results are combined`() = runTest {
         val onDiskPermissions = SitePermissions(
             origin = "mozilla.dev",
             localStorage = ALLOWED,
@@ -616,7 +616,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `WHEN filtering temporary permissions THEN all temporary permissions should be removed`() = runBlockingTest {
+    fun `WHEN filtering temporary permissions THEN all temporary permissions should be removed`() = runTest {
         val temporary = listOf(geckoContentPermission(type = PERMISSION_GEOLOCATION))
 
         val geckoPermissions = listOf(
@@ -637,7 +637,7 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `WHEN compering two gecko ContentPermissions THEN they are the same when host and permissions are the same`() = runBlockingTest {
+    fun `WHEN compering two gecko ContentPermissions THEN they are the same when host and permissions are the same`() = runTest {
         val location1 = geckoContentPermission(uri = "mozilla.dev", type = PERMISSION_GEOLOCATION)
         val location2 = geckoContentPermission(uri = "mozilla.dev", type = PERMISSION_GEOLOCATION)
         val notification = geckoContentPermission(uri = "mozilla.dev", type = PERMISSION_DESKTOP_NOTIFICATION)
@@ -647,28 +647,28 @@ class GeckoSitePermissionsStorageTest {
     }
 
     @Test
-    fun `WHEN converting from gecko status to sitePermissions status THEN they get converted to the equivalent one`() = runBlockingTest {
+    fun `WHEN converting from gecko status to sitePermissions status THEN they get converted to the equivalent one`() = runTest {
         assertEquals(NO_DECISION, VALUE_PROMPT.toStatus())
         assertEquals(BLOCKED, VALUE_DENY.toStatus())
         assertEquals(ALLOWED, VALUE_ALLOW.toStatus())
     }
 
     @Test
-    fun `WHEN converting from gecko status to autoplay sitePermissions status THEN they get converted to the equivalent one`() = runBlockingTest {
+    fun `WHEN converting from gecko status to autoplay sitePermissions status THEN they get converted to the equivalent one`() = runTest {
         assertEquals(AutoplayStatus.BLOCKED, VALUE_PROMPT.toAutoPlayStatus())
         assertEquals(AutoplayStatus.BLOCKED, VALUE_DENY.toAutoPlayStatus())
         assertEquals(AutoplayStatus.ALLOWED, VALUE_ALLOW.toAutoPlayStatus())
     }
 
     @Test
-    fun `WHEN converting a sitePermissions status to gecko status THEN they get converted to the equivalent one`() = runBlockingTest {
+    fun `WHEN converting a sitePermissions status to gecko status THEN they get converted to the equivalent one`() = runTest {
         assertEquals(VALUE_PROMPT, NO_DECISION.toGeckoStatus())
         assertEquals(VALUE_DENY, BLOCKED.toGeckoStatus())
         assertEquals(VALUE_ALLOW, ALLOWED.toGeckoStatus())
     }
 
     @Test
-    fun `WHEN converting from autoplay sitePermissions to gecko status THEN they get converted to the equivalent one`() = runBlockingTest {
+    fun `WHEN converting from autoplay sitePermissions to gecko status THEN they get converted to the equivalent one`() = runTest {
         assertEquals(VALUE_DENY, AutoplayStatus.BLOCKED.toGeckoStatus())
         assertEquals(VALUE_ALLOW, AutoplayStatus.ALLOWED.toGeckoStatus())
     }

--- a/components/browser/engine-system/build.gradle
+++ b/components/browser/engine-system/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_coroutines
 
     androidTestImplementation Dependencies.androidx_test_core
     androidTestImplementation Dependencies.androidx_test_runner

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -15,7 +15,8 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.webkit.WebViewDatabase
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.engine.system.matcher.UrlMatcher
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.DefaultSettings
@@ -236,8 +237,9 @@ class SystemEngineSessionTest {
         verify(webView).restoreState(bundle)
     }
 
+    @ExperimentalCoroutinesApi
     @Test
-    fun enableTrackingProtection() {
+    fun enableTrackingProtection() = runTest {
         SystemEngineView.URL_MATCHER = UrlMatcher(arrayOf(""))
 
         val engineSession = spy(SystemEngineSession(testContext))
@@ -257,7 +259,7 @@ class SystemEngineSessionTest {
         })
 
         assertNull(engineSession.trackingProtectionPolicy)
-        runBlocking { engineSession.updateTrackingProtection() }
+        engineSession.updateTrackingProtection()
         assertEquals(
             EngineSession.TrackingProtectionPolicy.strict(),
             engineSession.trackingProtectionPolicy

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
@@ -30,7 +30,8 @@ import android.webkit.WebViewClient
 import android.webkit.WebViewDatabase
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.engine.system.matcher.UrlMatcher
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.EngineSession
@@ -77,6 +78,7 @@ import org.robolectric.Robolectric
 import org.robolectric.annotation.Config
 import java.io.StringReader
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class SystemEngineViewTest {
 
@@ -285,7 +287,7 @@ class SystemEngineViewTest {
     }
 
     @Test
-    fun `WebView client notifies configured history delegate of url visits`() = runBlocking {
+    fun `WebView client notifies configured history delegate of url visits`() = runTest {
         val engineSession = SystemEngineSession(testContext)
 
         val engineView = SystemEngineView(testContext)
@@ -308,7 +310,7 @@ class SystemEngineViewTest {
     }
 
     @Test
-    fun `WebView client checks with the delegate if the URI visit should be recorded`() = runBlocking {
+    fun `WebView client checks with the delegate if the URI visit should be recorded`() = runTest {
         val engineSession = SystemEngineSession(testContext)
         val engineView = SystemEngineView(testContext)
         val webView: WebView = mock()
@@ -332,7 +334,7 @@ class SystemEngineViewTest {
     }
 
     @Test
-    fun `WebView client requests history from configured history delegate`() {
+    fun `WebView client requests history from configured history delegate`() = runTest {
         val engineSession = SystemEngineSession(testContext)
 
         val engineView = SystemEngineView(testContext)
@@ -371,14 +373,12 @@ class SystemEngineViewTest {
         engineSession.settings.historyTrackingDelegate = historyDelegate
 
         val historyValueCallback: ValueCallback<Array<String>> = mock()
-        runBlocking {
-            engineSession.webView.webChromeClient!!.getVisitedHistory(historyValueCallback)
-        }
+        engineSession.webView.webChromeClient!!.getVisitedHistory(historyValueCallback)
         verify(historyValueCallback).onReceiveValue(arrayOf("https://www.mozilla.com"))
     }
 
     @Test
-    fun `WebView client notifies configured history delegate of title changes`() = runBlocking {
+    fun `WebView client notifies configured history delegate of title changes`() = runTest {
         val engineSession = SystemEngineSession(testContext)
 
         val engineView = SystemEngineView(testContext)

--- a/components/browser/icons/build.gradle
+++ b/components/browser/icons/build.gradle
@@ -77,6 +77,7 @@ dependencies {
     androidTestImplementation Dependencies.androidx_test_core
     androidTestImplementation Dependencies.androidx_test_runner
     androidTestImplementation Dependencies.androidx_test_rules
+    androidTestImplementation Dependencies.testing_coroutines
 }
 
 apply from: '../../../publish.gradle'

--- a/components/browser/icons/src/androidTest/java/mozilla/components/browser/icons/OnDeviceBrowserIconsTest.kt
+++ b/components/browser/icons/src/androidTest/java/mozilla/components/browser/icons/OnDeviceBrowserIconsTest.kt
@@ -6,7 +6,8 @@ package mozilla.components.browser.icons
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.icons.generator.IconGenerator
 import mozilla.components.concept.engine.manifest.Size
 import mozilla.components.concept.fetch.Client
@@ -20,8 +21,9 @@ class OnDeviceBrowserIconsTest {
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun dataUriLoad() = runBlocking {
+    fun dataUriLoad() = runTest {
         val request = IconRequest(
             url = "https://www.mozilla.org",
             size = IconRequest.Size.DEFAULT,

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/extension/IconMessageHandlerTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/extension/IconMessageHandlerTest.kt
@@ -7,9 +7,10 @@ package mozilla.components.browser.icons.extension
 import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.icons.Icon
 import mozilla.components.browser.icons.IconRequest
@@ -34,10 +35,11 @@ import org.mockito.Mockito.verify
 @RunWith(AndroidJUnit4::class)
 class IconMessageHandlerTest {
 
+    @ExperimentalCoroutinesApi
     @OptIn(DelicateCoroutinesApi::class)
     @Test
     fun `Complex message (TheVerge) is transformed into IconRequest and loaded`() {
-        runBlocking {
+        runTest {
             val bitmap: Bitmap = mock()
             val icon = Icon(bitmap, source = Icon.Source.DOWNLOAD)
             val deferredIcon = GlobalScope.async { icon }

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/generator/DefaultIconGeneratorTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/generator/DefaultIconGeneratorTest.kt
@@ -6,7 +6,6 @@ package mozilla.components.browser.icons.generator
 
 import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.icons.Icon
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.support.ktx.android.util.dpToPx
@@ -43,7 +42,7 @@ class DefaultIconGeneratorTest {
     }
 
     @Test
-    fun generate() = runBlocking {
+    fun generate() {
         val generator = DefaultIconGenerator()
 
         val icon = generator.generate(

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/loader/NonBlockingHttpIconLoaderTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/loader/NonBlockingHttpIconLoaderTest.kt
@@ -6,7 +6,6 @@ package mozilla.components.browser.icons.loader
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.icons.Icon
 import mozilla.components.browser.icons.IconRequest
@@ -20,6 +19,7 @@ import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertEquals
@@ -27,6 +27,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
@@ -41,7 +42,9 @@ import java.io.InputStream
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 class NonBlockingHttpIconLoaderTest {
-    val scope = TestCoroutineScope()
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val scope = coroutinesTestRule.scope
 
     @Test
     fun `Loader will return IconLoader#Result#NoResult for a load request and respond with the result through a callback`() = runBlockingTest {

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/loader/NonBlockingHttpIconLoaderTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/loader/NonBlockingHttpIconLoaderTest.kt
@@ -6,7 +6,6 @@ package mozilla.components.browser.icons.loader
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.icons.Icon
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.concept.fetch.Client
@@ -20,6 +19,7 @@ import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertEquals
@@ -47,7 +47,7 @@ class NonBlockingHttpIconLoaderTest {
     private val scope = coroutinesTestRule.scope
 
     @Test
-    fun `Loader will return IconLoader#Result#NoResult for a load request and respond with the result through a callback`() = runBlockingTest {
+    fun `Loader will return IconLoader#Result#NoResult for a load request and respond with the result through a callback`() = runTestOnMain {
         val clients = listOf(
             HttpURLConnectionClient(),
             OkHttpClient()
@@ -100,7 +100,7 @@ class NonBlockingHttpIconLoaderTest {
     }
 
     @Test
-    fun `Loader will not perform any requests for data uris`() = runBlockingTest {
+    fun `Loader will not perform any requests for data uris`() = runTestOnMain {
         val client: Client = mock()
         var callbackIconRequest: IconRequest? = null
         var callbackResource: IconRequest.Resource? = null
@@ -128,7 +128,7 @@ class NonBlockingHttpIconLoaderTest {
     }
 
     @Test
-    fun `Request has timeouts applied`() = runBlockingTest {
+    fun `Request has timeouts applied`() = runTestOnMain {
         val client: Client = mock()
         val loader = NonBlockingHttpIconLoader(client, scope) { _, _, _ -> }
         doReturn(
@@ -157,7 +157,7 @@ class NonBlockingHttpIconLoaderTest {
     }
 
     @Test
-    fun `NoResult is returned for non-successful requests`() = runBlockingTest {
+    fun `NoResult is returned for non-successful requests`() = runTestOnMain {
         val client: Client = mock()
         var callbackIconRequest: IconRequest? = null
         var callbackResource: IconRequest.Resource? = null
@@ -192,7 +192,7 @@ class NonBlockingHttpIconLoaderTest {
     }
 
     @Test
-    fun `Loader will not try to load URL again that just recently failed`() = runBlockingTest {
+    fun `Loader will not try to load URL again that just recently failed`() = runTestOnMain {
         val client: Client = mock()
         val loader = NonBlockingHttpIconLoader(client, scope) { _, _, _ -> }
         doReturn(
@@ -221,7 +221,7 @@ class NonBlockingHttpIconLoaderTest {
     }
 
     @Test
-    fun `Loader will return NoResult for IOExceptions happening during fetch`() = runBlockingTest {
+    fun `Loader will return NoResult for IOExceptions happening during fetch`() = runTestOnMain {
         val client: Client = mock()
         doThrow(IOException("Mock")).`when`(client).fetch(any())
         var callbackIconRequest: IconRequest? = null
@@ -247,7 +247,7 @@ class NonBlockingHttpIconLoaderTest {
     }
 
     @Test
-    fun `Loader will return NoResult for IOExceptions happening during toIconLoaderResult`() = runBlockingTest {
+    fun `Loader will return NoResult for IOExceptions happening during toIconLoaderResult`() = runTestOnMain {
         val client: Client = mock()
         var callbackIconRequest: IconRequest? = null
         var callbackResource: IconRequest.Resource? = null
@@ -285,7 +285,7 @@ class NonBlockingHttpIconLoaderTest {
     }
 
     @Test
-    fun `Loader will sanitize URL`() = runBlockingTest {
+    fun `Loader will sanitize URL`() = runTestOnMain {
         val client: Client = mock()
         val captor = argumentCaptor<Request>()
         val loader = NonBlockingHttpIconLoader(client, scope) { _, _, _ -> }

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuTest.kt
@@ -46,7 +46,6 @@ class WebExtensionBrowserMenuTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val testDispatcher = coroutinesTestRule.testDispatcher
 
     @Before
     fun setup() {
@@ -83,8 +82,6 @@ class WebExtensionBrowserMenuTest {
 
         val adapter = BrowserMenuAdapter(testContext, items)
         val menu = WebExtensionBrowserMenu(adapter, store)
-
-        testDispatcher.advanceUntilIdle()
 
         val anchor = Button(testContext)
         val popup = menu.show(anchor)
@@ -434,7 +431,6 @@ class WebExtensionBrowserMenuTest {
         val menu: WebExtensionBrowserMenu = mock()
 
         menuItem.bind(menu, view)
-        testDispatcher.advanceUntilIdle()
 
         CollectionProcessor.withFactCollection { facts ->
             container.performClick()

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItemTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItemTest.kt
@@ -14,7 +14,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.menu.R
 import mozilla.components.browser.menu.WebExtensionBrowserMenu
 import mozilla.components.concept.engine.webextension.Action
@@ -286,7 +286,7 @@ class WebExtensionBrowserMenuItemTest {
     }
 
     @Test
-    fun `GIVEN setIcon was called, WHEN bind is called, icon setup uses the tint set`() = runBlocking {
+    fun `GIVEN setIcon was called, WHEN bind is called, icon setup uses the tint set`() = runTest {
         val webExtMenuItem = spy(WebExtensionBrowserMenuItem(mock(), mock()))
         val testIconTintColorResource = R.color.accent_material_dark
         val menu: WebExtensionBrowserMenu = mock()

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItemTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItemTest.kt
@@ -40,7 +40,7 @@ class WebExtensionBrowserMenuItemTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val testDispatcher = coroutinesTestRule.testDispatcher
+    private val dispatcher = coroutinesTestRule.testDispatcher
 
     @Test
     fun `web extension menu item is visible by default`() {
@@ -85,7 +85,7 @@ class WebExtensionBrowserMenuItemTest {
 
         val action = WebExtensionBrowserMenuItem(browserAction, {})
         action.bind(mock(), view)
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertFalse(view.isEnabled)
     }
@@ -118,7 +118,7 @@ class WebExtensionBrowserMenuItemTest {
 
         val action = WebExtensionBrowserMenuItem(browserAction, {})
         action.bind(mock(), view)
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         val iconCaptor = argumentCaptor<BitmapDrawable>()
         verify(imageView).setImageDrawable(iconCaptor.capture())
@@ -158,7 +158,7 @@ class WebExtensionBrowserMenuItemTest {
 
         val action = WebExtensionBrowserMenuItem(browserAction, {})
         action.bind(mock(), view)
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(badgeView).setBadgeText(badgeText)
         assertEquals(View.INVISIBLE, badgeView.visibility)
@@ -189,7 +189,7 @@ class WebExtensionBrowserMenuItemTest {
 
         val action = WebExtensionBrowserMenuItem(browserAction, {})
         action.bind(mock(), view)
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(imageView).setImageDrawable(notNull())
     }
@@ -225,7 +225,7 @@ class WebExtensionBrowserMenuItemTest {
         val menu: WebExtensionBrowserMenu = mock()
 
         item.bind(menu, view)
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         container.performClick()
 
@@ -262,7 +262,7 @@ class WebExtensionBrowserMenuItemTest {
         val menu: WebExtensionBrowserMenu = mock()
 
         item.bind(menu, view)
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(labelView).text = "title"
         verify(badgeView).text = "badgeText"

--- a/components/browser/menu2/src/test/java/mozilla/components/browser/menu2/adapter/icons/DrawableMenuIconViewHoldersTest.kt
+++ b/components/browser/menu2/src/test/java/mozilla/components/browser/menu2/adapter/icons/DrawableMenuIconViewHoldersTest.kt
@@ -12,7 +12,6 @@ import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.menu2.R
 import mozilla.components.concept.menu.Side
 import mozilla.components.concept.menu.candidate.AsyncDrawableMenuIcon
@@ -23,6 +22,7 @@ import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -84,7 +84,7 @@ class DrawableMenuIconViewHoldersTest {
     }
 
     @Test
-    fun `async view holder sets icon on view`() = runBlockingTest {
+    fun `async view holder sets icon on view`() = runTestOnMain {
         val holder = AsyncDrawableMenuIconViewHolder(parent, layoutInflater, Side.END)
 
         val drawable = mock<Drawable>()
@@ -94,7 +94,7 @@ class DrawableMenuIconViewHoldersTest {
     }
 
     @Test
-    fun `async view holder uses loading icon and fallback icon`() = runBlockingTest {
+    fun `async view holder uses loading icon and fallback icon`() = runTestOnMain {
         val logger = mock<Logger>()
         val holder = AsyncDrawableMenuIconViewHolder(parent, layoutInflater, Side.END, logger)
 

--- a/components/browser/menu2/src/test/java/mozilla/components/browser/menu2/adapter/icons/DrawableMenuIconViewHoldersTest.kt
+++ b/components/browser/menu2/src/test/java/mozilla/components/browser/menu2/adapter/icons/DrawableMenuIconViewHoldersTest.kt
@@ -40,7 +40,6 @@ class DrawableMenuIconViewHoldersTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val testDispatcher = coroutinesTestRule.testDispatcher
 
     private lateinit var parent: ConstraintLayout
     private lateinit var layoutInflater: LayoutInflater
@@ -85,7 +84,7 @@ class DrawableMenuIconViewHoldersTest {
     }
 
     @Test
-    fun `async view holder sets icon on view`() = testDispatcher.runBlockingTest {
+    fun `async view holder sets icon on view`() = runBlockingTest {
         val holder = AsyncDrawableMenuIconViewHolder(parent, layoutInflater, Side.END)
 
         val drawable = mock<Drawable>()
@@ -95,7 +94,7 @@ class DrawableMenuIconViewHoldersTest {
     }
 
     @Test
-    fun `async view holder uses loading icon and fallback icon`() = testDispatcher.runBlockingTest {
+    fun `async view holder uses loading icon and fallback icon`() = runBlockingTest {
         val logger = mock<Logger>()
         val holder = AsyncDrawableMenuIconViewHolder(parent, layoutInflater, Side.END, logger)
 

--- a/components/browser/session-storage/src/test/java/mozilla/components/browser/session/storage/AutoSaveTest.kt
+++ b/components/browser/session-storage/src/test/java/mozilla/components/browser/session/storage/AutoSaveTest.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.BrowserState
@@ -22,6 +21,7 @@ import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
@@ -47,7 +47,7 @@ class AutoSaveTest {
 
     @Test
     fun `AutoSave - when going to background`() {
-        runBlocking {
+        runTestOnMain {
             // Keep the "owner" in scope to avoid it getting garbage collected and therefore lifecycle events
             // not getting propagated (See #1428).
             val owner = mock(LifecycleOwner::class.java)
@@ -82,7 +82,7 @@ class AutoSaveTest {
 
     @Test
     fun `AutoSave - when tab gets added`() {
-        runBlocking {
+        runTestOnMain {
             val state = BrowserState()
             val store = BrowserStore(state)
 
@@ -115,7 +115,7 @@ class AutoSaveTest {
 
     @Test
     fun `AutoSave - when tab gets removed`() {
-        runBlocking {
+        runTestOnMain {
             val sessionStorage: SessionStorage = mock()
 
             val store = BrowserStore(
@@ -151,7 +151,7 @@ class AutoSaveTest {
 
     @Test
     fun `AutoSave - when all tabs get removed`() {
-        runBlocking {
+        runTestOnMain {
             val store = BrowserStore(
                 BrowserState(
                     tabs = listOf(
@@ -187,7 +187,7 @@ class AutoSaveTest {
 
     @Test
     fun `AutoSave - when no tabs are left`() {
-        runBlocking {
+        runTestOnMain {
             val store = BrowserStore(
                 BrowserState(
                     tabs = listOf(createTab("https://www.firefox.com", id = "firefox")),
@@ -219,7 +219,7 @@ class AutoSaveTest {
 
     @Test
     fun `AutoSave - when tab gets selected`() {
-        runBlocking {
+        runTestOnMain {
             val store = BrowserStore(
                 BrowserState(
                     tabs = listOf(
@@ -255,7 +255,7 @@ class AutoSaveTest {
 
     @Test
     fun `AutoSave - when tab loading state changes`() {
-        runBlocking {
+        runTestOnMain {
             val sessionStorage: SessionStorage = mock()
 
             val store = BrowserStore(

--- a/components/browser/session-storage/src/test/java/mozilla/components/browser/session/storage/AutoSaveTest.kt
+++ b/components/browser/session-storage/src/test/java/mozilla/components/browser/session/storage/AutoSaveTest.kt
@@ -8,10 +8,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.BrowserState
@@ -23,9 +21,11 @@ import mozilla.components.support.test.eq
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
@@ -40,6 +40,11 @@ import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 class AutoSaveTest {
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val dispatcher = coroutinesTestRule.testDispatcher
+    private val scope = coroutinesTestRule.scope
+
     @Test
     fun `AutoSave - when going to background`() {
         runBlocking {
@@ -83,16 +88,13 @@ class AutoSaveTest {
 
             val sessionStorage: SessionStorage = mock()
 
-            val dispatcher = TestCoroutineDispatcher()
-            val scope = CoroutineScope(dispatcher)
-
             val autoSave = AutoSave(
                 store = store,
                 sessionStorage = sessionStorage,
                 minimumIntervalMs = 0
             ).whenSessionsChange(scope)
 
-            dispatcher.advanceUntilIdle()
+            dispatcher.scheduler.advanceUntilIdle()
 
             assertNull(autoSave.saveJob)
             verify(sessionStorage, never()).save(any())
@@ -103,7 +105,7 @@ class AutoSaveTest {
                 )
             ).joinBlocking()
 
-            dispatcher.advanceUntilIdle()
+            dispatcher.scheduler.advanceUntilIdle()
 
             autoSave.saveJob?.join()
 
@@ -126,23 +128,20 @@ class AutoSaveTest {
                 )
             )
 
-            val dispatcher = TestCoroutineDispatcher()
-            val scope = CoroutineScope(dispatcher)
-
             val autoSave = AutoSave(
                 store = store,
                 sessionStorage = sessionStorage,
                 minimumIntervalMs = 0
             ).whenSessionsChange(scope)
 
-            dispatcher.advanceUntilIdle()
+            dispatcher.scheduler.advanceUntilIdle()
 
             assertNull(autoSave.saveJob)
             verify(sessionStorage, never()).save(any())
 
             store.dispatch(TabListAction.RemoveTabAction("mozilla")).joinBlocking()
 
-            dispatcher.advanceUntilIdle()
+            dispatcher.scheduler.advanceUntilIdle()
 
             autoSave.saveJob?.join()
 
@@ -165,23 +164,20 @@ class AutoSaveTest {
 
             val sessionStorage: SessionStorage = mock()
 
-            val dispatcher = TestCoroutineDispatcher()
-            val scope = CoroutineScope(dispatcher)
-
             val autoSave = AutoSave(
                 store = store,
                 sessionStorage = sessionStorage,
                 minimumIntervalMs = 0
             ).whenSessionsChange(scope)
 
-            dispatcher.advanceUntilIdle()
+            dispatcher.scheduler.advanceUntilIdle()
 
             assertNull(autoSave.saveJob)
             verify(sessionStorage, never()).save(any())
 
             store.dispatch(TabListAction.RemoveAllNormalTabsAction).joinBlocking()
 
-            dispatcher.advanceUntilIdle()
+            dispatcher.scheduler.advanceUntilIdle()
 
             autoSave.saveJob?.join()
 
@@ -201,22 +197,19 @@ class AutoSaveTest {
 
             val sessionStorage: SessionStorage = mock()
 
-            val dispatcher = TestCoroutineDispatcher()
-            val scope = CoroutineScope(dispatcher)
-
             val autoSave = AutoSave(
                 store = store,
                 sessionStorage = sessionStorage,
                 minimumIntervalMs = 0
             ).whenSessionsChange(scope)
 
-            dispatcher.advanceUntilIdle()
+            dispatcher.scheduler.advanceUntilIdle()
 
             assertNull(autoSave.saveJob)
             verify(sessionStorage, never()).save(any())
 
             store.dispatch(TabListAction.RemoveTabAction("firefox")).joinBlocking()
-            dispatcher.advanceUntilIdle()
+            dispatcher.scheduler.advanceUntilIdle()
 
             autoSave.saveJob?.join()
 
@@ -239,23 +232,20 @@ class AutoSaveTest {
 
             val sessionStorage: SessionStorage = mock()
 
-            val dispatcher = TestCoroutineDispatcher()
-            val scope = CoroutineScope(dispatcher)
-
             val autoSave = AutoSave(
                 store = store,
                 sessionStorage = sessionStorage,
                 minimumIntervalMs = 0
             ).whenSessionsChange(scope)
 
-            dispatcher.advanceUntilIdle()
+            dispatcher.scheduler.advanceUntilIdle()
 
             assertNull(autoSave.saveJob)
             verify(sessionStorage, never()).save(any())
 
             store.dispatch(TabListAction.SelectTabAction("mozilla")).joinBlocking()
 
-            dispatcher.advanceUntilIdle()
+            dispatcher.scheduler.advanceUntilIdle()
 
             autoSave.saveJob?.join()
 
@@ -277,9 +267,6 @@ class AutoSaveTest {
                 )
             )
 
-            val dispatcher = TestCoroutineDispatcher()
-            val scope = CoroutineScope(dispatcher)
-
             val autoSave = AutoSave(
                 store = store,
                 sessionStorage = sessionStorage,
@@ -293,7 +280,7 @@ class AutoSaveTest {
                 )
             ).joinBlocking()
 
-            dispatcher.advanceUntilIdle()
+            dispatcher.scheduler.advanceUntilIdle()
 
             assertNull(autoSave.saveJob)
             verify(sessionStorage, never()).save(any())
@@ -305,7 +292,7 @@ class AutoSaveTest {
                 )
             ).joinBlocking()
 
-            dispatcher.advanceUntilIdle()
+            dispatcher.scheduler.advanceUntilIdle()
 
             autoSave.saveJob?.join()
 

--- a/components/browser/session-storage/src/test/java/mozilla/components/browser/session/storage/FileEngineSessionStateStorageTest.kt
+++ b/components/browser/session-storage/src/test/java/mozilla/components/browser/session/storage/FileEngineSessionStateStorageTest.kt
@@ -5,7 +5,7 @@
 package mozilla.components.browser.session.storage
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.support.test.fakes.engine.FakeEngine
 import mozilla.components.support.test.fakes.engine.FakeEngineSessionState
 import mozilla.components.support.test.robolectric.testContext
@@ -18,11 +18,11 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class FileEngineSessionStateStorageTest {
     @Test
-    fun `able to read and write engine session states`() = runBlocking {
+    fun `able to read and write engine session states`() = runTest {
         val storage = FileEngineSessionStateStorage(testContext, FakeEngine())
 
         // reading non-existing tab
-        assertNull(runBlocking { storage.read("test-tab") })
+        assertNull(storage.read("test-tab"))
 
         storage.write("test-tab", FakeEngineSessionState("some-engine-state"))
         val state = storage.read("test-tab")
@@ -33,7 +33,7 @@ class FileEngineSessionStateStorageTest {
     }
 
     @Test
-    fun `able to delete specific engine session states`() = runBlocking {
+    fun `able to delete specific engine session states`() = runTest {
         val storage = FileEngineSessionStateStorage(testContext, FakeEngine())
         storage.write("test-tab-1", FakeEngineSessionState("some-engine-state-1"))
         storage.write("test-tab-2", FakeEngineSessionState("some-engine-state-2"))
@@ -63,7 +63,7 @@ class FileEngineSessionStateStorageTest {
     }
 
     @Test
-    fun `able to delete all engine states`() = runBlocking {
+    fun `able to delete all engine states`() = runTest {
         val storage = FileEngineSessionStateStorage(testContext, FakeEngine())
 
         // already empty storage

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineMiddlewareTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineMiddlewareTest.kt
@@ -4,12 +4,6 @@
 
 package mozilla.components.browser.state.engine
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.engine.middleware.TrimMemoryMiddleware
 import mozilla.components.browser.state.state.BrowserState
@@ -19,32 +13,18 @@ import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
-import org.junit.After
+import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.verify
 
 class EngineMiddlewareTest {
-    private lateinit var dispatcher: TestCoroutineDispatcher
-    private lateinit var scope: CoroutineScope
-
-    @Before
-    fun setUp() {
-        dispatcher = TestCoroutineDispatcher()
-        scope = CoroutineScope(dispatcher)
-
-        Dispatchers.setMain(dispatcher)
-    }
-
-    @After
-    fun tearDown() {
-        dispatcher.cleanupTestCoroutines()
-        scope.cancel()
-
-        Dispatchers.resetMain()
-    }
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val dispatcher = coroutinesTestRule.testDispatcher
+    private val scope = coroutinesTestRule.scope
 
     @Test
     fun `Dispatching CreateEngineSessionAction multiple times should only create one engine session`() {
@@ -69,7 +49,7 @@ class EngineMiddlewareTest {
             EngineAction.CreateEngineSessionAction("mozilla")
         )
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine, Mockito.times(1)).createSession(false, null)

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
@@ -9,7 +9,7 @@ import android.graphics.Bitmap
 import android.view.WindowManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.CrashAction
@@ -821,7 +821,7 @@ class EngineObserverTest {
     }
 
     @Test
-    fun engineSessionObserverWithContentPermissionRequests() {
+    fun engineSessionObserverWithContentPermissionRequests() = runTest {
         val permissionRequest: PermissionRequest = mock()
         val store: BrowserStore = mock()
         val observer = EngineObserver("tab-id", store)
@@ -831,14 +831,12 @@ class EngineObserverTest {
         )
         doReturn(Job()).`when`(store).dispatch(action)
 
-        runBlockingTest {
-            observer.onContentPermissionRequest(permissionRequest)
-            verify(store).dispatch(action)
-        }
+        observer.onContentPermissionRequest(permissionRequest)
+        verify(store).dispatch(action)
     }
 
     @Test
-    fun engineSessionObserverWithAppPermissionRequests() {
+    fun engineSessionObserverWithAppPermissionRequests() = runTest {
         val permissionRequest: PermissionRequest = mock()
         val store: BrowserStore = mock()
         val observer = EngineObserver("tab-id", store)
@@ -847,10 +845,8 @@ class EngineObserverTest {
             permissionRequest
         )
 
-        runBlockingTest {
-            observer.onAppPermissionRequest(permissionRequest)
-            verify(store).dispatch(action)
-        }
+        observer.onAppPermissionRequest(permissionRequest)
+        verify(store).dispatch(action)
     }
 
     @Test

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/CrashMiddlewareTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/CrashMiddlewareTest.kt
@@ -4,8 +4,6 @@
 
 package mozilla.components.browser.state.engine.middleware
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.test.TestCoroutineDispatcher
 import mozilla.components.browser.state.action.CrashAction
 import mozilla.components.browser.state.engine.EngineMiddleware
 import mozilla.components.browser.state.state.BrowserState
@@ -16,12 +14,19 @@ import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.doReturn
 
 class CrashMiddlewareTest {
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val dispatcher = coroutinesTestRule.testDispatcher
+    private val scope = coroutinesTestRule.scope
+
     @Test
     fun `Crash and restore scenario`() {
         val engineSession1: EngineSession = mock()
@@ -29,8 +34,6 @@ class CrashMiddlewareTest {
         val engineSession3: EngineSession = mock()
 
         val engine: Engine = mock()
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val store = BrowserStore(
             middleware = EngineMiddleware.create(
@@ -75,7 +78,7 @@ class CrashMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertFalse(store.state.tabs[0].engineState.crashed)
         assertFalse(store.state.tabs[1].engineState.crashed)
@@ -88,7 +91,7 @@ class CrashMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         // Restoring unknown session
         store.dispatch(
@@ -97,7 +100,7 @@ class CrashMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertFalse(store.state.tabs[0].engineState.crashed)
         assertFalse(store.state.tabs[1].engineState.crashed)
@@ -109,9 +112,6 @@ class CrashMiddlewareTest {
         val engineSession: EngineSession = mock()
         val engine: Engine = mock()
         doReturn(engineSession).`when`(engine).createSession()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val store = BrowserStore(
             middleware = EngineMiddleware.create(
@@ -131,7 +131,7 @@ class CrashMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertTrue(store.state.tabs[0].engineState.crashed)
 
@@ -141,7 +141,7 @@ class CrashMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertFalse(store.state.tabs[0].engineState.crashed)
     }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/CreateEngineSessionMiddlewareTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/CreateEngineSessionMiddlewareTest.kt
@@ -5,9 +5,7 @@
 package mozilla.components.browser.state.engine.middleware
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.selector.findCustomTab
@@ -23,10 +21,11 @@ import mozilla.components.support.test.any
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.whenever
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyBoolean
@@ -38,14 +37,10 @@ import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
 class CreateEngineSessionMiddlewareTest {
-
-    private val dispatcher = TestCoroutineDispatcher()
-    private val scope = CoroutineScope(dispatcher)
-
-    @After
-    fun tearDown() {
-        dispatcher.cleanupTestCoroutines()
-    }
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val dispatcher = coroutinesTestRule.testDispatcher
+    private val scope = coroutinesTestRule.scope
 
     @Test
     fun `creates engine session if needed`() = runBlocking {
@@ -63,13 +58,13 @@ class CreateEngineSessionMiddlewareTest {
 
         store.dispatch(EngineAction.CreateEngineSessionAction(tab.id)).joinBlocking()
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         verify(engine, times(1)).createSession(false)
         assertEquals(engineSession, store.state.findTab(tab.id)?.engineState?.engineSession)
 
         store.dispatch(EngineAction.CreateEngineSessionAction(tab.id)).joinBlocking()
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         verify(engine, times(1)).createSession(false)
         assertEquals(engineSession, store.state.findTab(tab.id)?.engineState?.engineSession)
     }
@@ -92,7 +87,7 @@ class CreateEngineSessionMiddlewareTest {
         store.dispatch(EngineAction.UpdateEngineSessionStateAction(tab.id, engineSessionState)).joinBlocking()
         store.dispatch(EngineAction.CreateEngineSessionAction(tab.id)).joinBlocking()
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(engineSession).restoreState(engineSessionState)
         Unit
@@ -111,7 +106,7 @@ class CreateEngineSessionMiddlewareTest {
 
         store.dispatch(EngineAction.CreateEngineSessionAction("invalid")).joinBlocking()
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(engine, never()).createSession(anyBoolean(), any())
         Unit
@@ -135,7 +130,7 @@ class CreateEngineSessionMiddlewareTest {
         ).joinBlocking()
 
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(engine, never()).createSession(anyBoolean(), any())
         Unit
@@ -159,7 +154,7 @@ class CreateEngineSessionMiddlewareTest {
         store.dispatch(EngineAction.CreateEngineSessionAction(tab.id, followupAction = followupAction)).joinBlocking()
 
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(engine, times(1)).createSession(false)
         assertEquals(engineSession, store.state.findTab(tab.id)?.engineState?.engineSession)
@@ -187,7 +182,7 @@ class CreateEngineSessionMiddlewareTest {
         store.dispatch(EngineAction.CreateEngineSessionAction(tab.id, followupAction = followupAction))
 
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(engine, times(1)).createSession(false)
         assertEquals(engineSession, store.state.findTab(tab.id)?.engineState?.engineSession)
@@ -212,7 +207,7 @@ class CreateEngineSessionMiddlewareTest {
         store.dispatch(EngineAction.CreateEngineSessionAction(customTab.id, followupAction = followupAction)).joinBlocking()
 
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(engine, times(1)).createSession(false)
         assertEquals(engineSession, store.state.findCustomTab(customTab.id)?.engineState?.engineSession)

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/CreateEngineSessionMiddlewareTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/CreateEngineSessionMiddlewareTest.kt
@@ -5,7 +5,6 @@
 package mozilla.components.browser.state.engine.middleware
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.selector.findCustomTab
@@ -22,6 +21,7 @@ import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -43,7 +43,7 @@ class CreateEngineSessionMiddlewareTest {
     private val scope = coroutinesTestRule.scope
 
     @Test
-    fun `creates engine session if needed`() = runBlocking {
+    fun `creates engine session if needed`() = runTestOnMain {
         val engine: Engine = mock()
         val engineSession: EngineSession = mock()
         whenever(engine.createSession(anyBoolean(), any())).thenReturn(engineSession)
@@ -70,7 +70,7 @@ class CreateEngineSessionMiddlewareTest {
     }
 
     @Test
-    fun `restores engine session state if available`() = runBlocking {
+    fun `restores engine session state if available`() = runTestOnMain {
         val engine: Engine = mock()
         val engineSession: EngineSession = mock()
         whenever(engine.createSession(anyBoolean(), any())).thenReturn(engineSession)
@@ -94,7 +94,7 @@ class CreateEngineSessionMiddlewareTest {
     }
 
     @Test
-    fun `creates no engine session if tab does not exist`() = runBlocking {
+    fun `creates no engine session if tab does not exist`() = runTestOnMain {
         val engine: Engine = mock()
         `when`(engine.createSession(anyBoolean(), anyString())).thenReturn(mock())
 
@@ -113,7 +113,7 @@ class CreateEngineSessionMiddlewareTest {
     }
 
     @Test
-    fun `creates no engine session if session does not exist`() = runBlocking {
+    fun `creates no engine session if session does not exist`() = runTestOnMain {
         val engine: Engine = mock()
         `when`(engine.createSession(anyBoolean(), anyString())).thenReturn(mock())
 
@@ -137,7 +137,7 @@ class CreateEngineSessionMiddlewareTest {
     }
 
     @Test
-    fun `dispatches follow-up action after engine session is created`() = runBlocking {
+    fun `dispatches follow-up action after engine session is created`() = runTestOnMain {
         val engine: Engine = mock()
         val engineSession: EngineSession = mock()
         whenever(engine.createSession(anyBoolean(), any())).thenReturn(engineSession)
@@ -162,7 +162,7 @@ class CreateEngineSessionMiddlewareTest {
     }
 
     @Test
-    fun `dispatches follow-up action once engine session is created by pending action`() = runBlocking {
+    fun `dispatches follow-up action once engine session is created by pending action`() = runTestOnMain {
         val engine: Engine = mock()
         val engineSession: EngineSession = mock()
         whenever(engine.createSession(anyBoolean(), any())).thenReturn(engineSession)

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/EngineDelegateMiddlewareTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/EngineDelegateMiddlewareTest.kt
@@ -4,8 +4,6 @@
 
 package mozilla.components.browser.state.engine.middleware
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.test.TestCoroutineDispatcher
 import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.engine.EngineMiddleware
 import mozilla.components.browser.state.state.BrowserState
@@ -18,8 +16,10 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.doReturn
@@ -28,14 +28,16 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 
 class EngineDelegateMiddlewareTest {
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val dispatcher = coroutinesTestRule.testDispatcher
+    private val scope = coroutinesTestRule.scope
+
     @Test
     fun `LoadUrlAction for tab without engine session`() {
         val engineSession: EngineSession = mock()
         val engine: Engine = mock()
         doReturn(engineSession).`when`(engine).createSession()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val tab = createTab("https://www.mozilla.org", id = "test-tab")
         val store = BrowserStore(
@@ -55,7 +57,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine).createSession(private = false, contextId = null)
@@ -68,9 +70,6 @@ class EngineDelegateMiddlewareTest {
         val engineSession: EngineSession = mock()
         val engine: Engine = mock()
         doReturn(engineSession).`when`(engine).createSession(private = true)
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val tab = createTab("https://www.mozilla.org", id = "test-tab", private = true)
         val store = BrowserStore(
@@ -90,7 +89,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine).createSession(private = true, contextId = null)
@@ -103,9 +102,6 @@ class EngineDelegateMiddlewareTest {
         val engineSession: EngineSession = mock()
         val engine: Engine = mock()
         doReturn(engineSession).`when`(engine).createSession(contextId = "test-container")
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val tab = createTab("https://www.mozilla.org", id = "test-tab", contextId = "test-container")
         val store = BrowserStore(
@@ -125,7 +121,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine).createSession(private = false, contextId = "test-container")
@@ -137,9 +133,6 @@ class EngineDelegateMiddlewareTest {
     fun `LoadUrlAction for tab with engine session`() {
         val engineSession: EngineSession = mock()
         val engine: Engine = mock()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val store = BrowserStore(
             middleware = EngineMiddleware.create(
@@ -162,7 +155,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine, never()).createSession(ArgumentMatchers.anyBoolean(), ArgumentMatchers.anyString())
@@ -174,9 +167,6 @@ class EngineDelegateMiddlewareTest {
     fun `LoadUrlAction for private tab with engine session`() {
         val engineSession: EngineSession = mock()
         val engine: Engine = mock()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val store = BrowserStore(
             middleware = EngineMiddleware.create(
@@ -199,7 +189,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine, never()).createSession(ArgumentMatchers.anyBoolean(), ArgumentMatchers.anyString())
@@ -211,9 +201,6 @@ class EngineDelegateMiddlewareTest {
     fun `LoadUrlAction for container tab with engine session`() {
         val engineSession: EngineSession = mock()
         val engine: Engine = mock()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val store = BrowserStore(
             middleware = EngineMiddleware.create(
@@ -236,7 +223,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine, never()).createSession(ArgumentMatchers.anyBoolean(), ArgumentMatchers.anyString())
@@ -251,9 +238,6 @@ class EngineDelegateMiddlewareTest {
         doReturn(engineSession).`when`(engine).createSession()
 
         val parentEngineSession: EngineSession = mock()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val parent = createTab("https://getpocket.com", id = "parent-tab").copy(
             engineState = EngineState(parentEngineSession)
@@ -277,7 +261,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine).createSession(private = false, contextId = null)
@@ -291,9 +275,6 @@ class EngineDelegateMiddlewareTest {
         val engineSession: EngineSession = mock()
         val engine: Engine = mock()
         doReturn(engineSession).`when`(engine).createSession()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val parent = createTab("https://getpocket.com", id = "parent-tab")
         val tab = createTab("https://www.mozilla.org", id = "test-tab", parent = parent)
@@ -315,7 +296,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine, times(1)).createSession(private = false, contextId = null)
@@ -326,9 +307,6 @@ class EngineDelegateMiddlewareTest {
     @Test
     fun `LoadUrlAction with flags and additional headers`() {
         val engineSession: EngineSession = mock()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val store = BrowserStore(
             middleware = EngineMiddleware.create(
@@ -356,7 +334,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engineSession, times(1)).loadUrl(
@@ -375,9 +353,6 @@ class EngineDelegateMiddlewareTest {
         val engineSession: EngineSession = mock()
         val engine: Engine = mock()
         doReturn(engineSession).`when`(engine).createSession()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val tab = createTab("https://www.mozilla.org", id = "test-tab")
 
@@ -398,7 +373,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine).createSession(private = false, contextId = null)
@@ -410,9 +385,6 @@ class EngineDelegateMiddlewareTest {
     @Test
     fun `LoadUrlAction for not existing tab`() {
         val engine: Engine = mock()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val store = BrowserStore(
             middleware = EngineMiddleware.create(
@@ -433,7 +405,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine, never()).createSession(ArgumentMatchers.anyBoolean(), ArgumentMatchers.anyString())
@@ -445,9 +417,6 @@ class EngineDelegateMiddlewareTest {
         val engineSession: EngineSession = mock()
         val engine: Engine = mock()
         doReturn(engineSession).`when`(engine).createSession()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val tab = createTab("https://www.mozilla.org", id = "test-tab")
         val store = BrowserStore(
@@ -469,7 +438,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine).createSession(private = false, contextId = null)
@@ -486,9 +455,6 @@ class EngineDelegateMiddlewareTest {
         val engineSession: EngineSession = mock()
         val engine: Engine = mock()
         doReturn(engineSession).`when`(engine).createSession()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val tab = createTab("https://www.mozilla.org", id = "test-tab")
         val store = BrowserStore(
@@ -508,7 +474,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine).createSession(private = false, contextId = null)
@@ -523,9 +489,6 @@ class EngineDelegateMiddlewareTest {
         val engineSession: EngineSession = mock()
         val engine: Engine = mock()
         doReturn(engineSession).`when`(engine).createSession()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val tab = createTab("https://www.mozilla.org", id = "test-tab")
         val store = BrowserStore(
@@ -544,7 +507,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine).createSession(private = false, contextId = null)
@@ -557,9 +520,6 @@ class EngineDelegateMiddlewareTest {
         val engineSession: EngineSession = mock()
         val engine: Engine = mock()
         doReturn(engineSession).`when`(engine).createSession()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val tab = createTab("https://www.mozilla.org", id = "test-tab")
         val store = BrowserStore(
@@ -578,7 +538,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine).createSession(private = false, contextId = null)
@@ -591,9 +551,6 @@ class EngineDelegateMiddlewareTest {
         val engineSession: EngineSession = mock()
         val engine: Engine = mock()
         doReturn(engineSession).`when`(engine).createSession()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val tab = createTab("https://www.mozilla.org", id = "test-tab")
         val store = BrowserStore(
@@ -613,7 +570,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine).createSession(private = false, contextId = null)
@@ -626,9 +583,6 @@ class EngineDelegateMiddlewareTest {
         val engineSession: EngineSession = mock()
         val engine: Engine = mock()
         doReturn(engineSession).`when`(engine).createSession()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val tab = createTab("https://www.mozilla.org", id = "test-tab")
         val store = BrowserStore(
@@ -648,7 +602,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine).createSession(private = false, contextId = null)
@@ -661,9 +615,6 @@ class EngineDelegateMiddlewareTest {
         val engineSession: EngineSession = mock()
         val engine: Engine = mock()
         doReturn(engineSession).`when`(engine).createSession()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val tab = createTab("https://www.mozilla.org", id = "test-tab")
         val store = BrowserStore(
@@ -683,7 +634,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine).createSession(private = false, contextId = null)
@@ -696,9 +647,6 @@ class EngineDelegateMiddlewareTest {
         val engineSession: EngineSession = mock()
         val engine: Engine = mock()
         doReturn(engineSession).`when`(engine).createSession()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val tab = createTab("https://www.mozilla.org", id = "test-tab")
         val store = BrowserStore(
@@ -717,7 +665,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine).createSession(private = false, contextId = null)
@@ -730,9 +678,6 @@ class EngineDelegateMiddlewareTest {
         val engineSession: EngineSession = mock()
         val engine: Engine = mock()
         doReturn(engineSession).`when`(engine).createSession()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val tab = createTab("https://www.mozilla.org", id = "test-tab")
         val store = BrowserStore(
@@ -752,7 +697,7 @@ class EngineDelegateMiddlewareTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(engine).createSession(private = false, contextId = null)
@@ -764,9 +709,6 @@ class EngineDelegateMiddlewareTest {
     fun `PurgeHistoryAction - calls purgeHistory on engine session instances`() {
         val engineSession1: EngineSession = mock()
         val engineSession2: EngineSession = mock()
-
-        val dispatcher = TestCoroutineDispatcher()
-        val scope = CoroutineScope(dispatcher)
 
         val store = BrowserStore(
             middleware = EngineMiddleware.create(
@@ -795,7 +737,7 @@ class EngineDelegateMiddlewareTest {
 
         store.dispatch(EngineAction.PurgeHistoryAction).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(engineSession1).purgeHistory()
         verify(engineSession2).purgeHistory()

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/LinkingMiddlewareTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/LinkingMiddlewareTest.kt
@@ -5,13 +5,7 @@
 package mozilla.components.browser.state.engine.middleware
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.selector.findTab
@@ -23,11 +17,11 @@ import mozilla.components.support.test.any
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
-import org.junit.After
+import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.anyString
@@ -36,24 +30,10 @@ import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
 class LinkingMiddlewareTest {
-    private lateinit var dispatcher: TestCoroutineDispatcher
-    private lateinit var scope: CoroutineScope
-
-    @Before
-    fun setUp() {
-        dispatcher = TestCoroutineDispatcher()
-        scope = CoroutineScope(dispatcher)
-
-        Dispatchers.setMain(dispatcher)
-    }
-
-    @After
-    fun tearDown() {
-        dispatcher.cleanupTestCoroutines()
-        scope.cancel()
-
-        Dispatchers.resetMain()
-    }
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val dispatcher = coroutinesTestRule.testDispatcher
+    private val scope = coroutinesTestRule.scope
 
     @Test
     fun `loads URL after linking`() {
@@ -68,7 +48,7 @@ class LinkingMiddlewareTest {
         val engineSession: EngineSession = mock()
         store.dispatch(EngineAction.LinkEngineSessionAction(tab.id, engineSession)).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(engineSession).loadUrl(tab.content.url)
     }
@@ -92,7 +72,7 @@ class LinkingMiddlewareTest {
         val childEngineSession: EngineSession = mock()
         store.dispatch(EngineAction.LinkEngineSessionAction(child.id, childEngineSession)).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(childEngineSession).loadUrl(child.content.url, parentEngineSession)
     }
@@ -116,7 +96,7 @@ class LinkingMiddlewareTest {
         val childEngineSession: EngineSession = mock()
         store.dispatch(EngineAction.LinkEngineSessionAction(child.id, childEngineSession)).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(childEngineSession).loadUrl(child.content.url)
     }
@@ -134,7 +114,7 @@ class LinkingMiddlewareTest {
         val engineSession: EngineSession = mock()
         store.dispatch(EngineAction.LinkEngineSessionAction(tab.id, engineSession, skipLoading = true)).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(engineSession, never()).loadUrl(tab.content.url)
     }
@@ -151,7 +131,7 @@ class LinkingMiddlewareTest {
         val engineSession: EngineSession = mock()
         store.dispatch(EngineAction.LinkEngineSessionAction("invalid", engineSession)).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(engineSession, never()).loadUrl(anyString(), any(), any(), any())
     }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/LinkingMiddlewareTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/LinkingMiddlewareTest.kt
@@ -5,7 +5,6 @@
 package mozilla.components.browser.state.engine.middleware
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.selector.findTab
@@ -18,6 +17,7 @@ import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -137,7 +137,7 @@ class LinkingMiddlewareTest {
     }
 
     @Test
-    fun `registers engine observer after linking`() = runBlocking {
+    fun `registers engine observer after linking`() = runTestOnMain {
         val tab1 = createTab("https://www.mozilla.org", id = "1")
         val tab2 = createTab("https://www.mozilla.org", id = "2")
 
@@ -167,7 +167,7 @@ class LinkingMiddlewareTest {
     }
 
     @Test
-    fun `unregisters engine observer before unlinking`() = runBlocking {
+    fun `unregisters engine observer before unlinking`() = runTestOnMain {
         val tab1 = createTab("https://www.mozilla.org", id = "1")
         val tab2 = createTab("https://www.mozilla.org", id = "2")
 
@@ -192,7 +192,7 @@ class LinkingMiddlewareTest {
     }
 
     @Test
-    fun `registers engine observer when tab is added with engine session`() = runBlocking {
+    fun `registers engine observer when tab is added with engine session`() = runTestOnMain {
         val engineSession: EngineSession = mock()
         val tab1 = createTab("https://www.mozilla.org", id = "1")
         val tab2 = createTab("https://www.mozilla.org", id = "2", engineSession = engineSession)

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/SuspendMiddlewareTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/SuspendMiddlewareTest.kt
@@ -5,7 +5,6 @@
 package mozilla.components.browser.state.engine.middleware
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.state.BrowserState
@@ -17,6 +16,7 @@ import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Rule
@@ -35,7 +35,7 @@ class SuspendMiddlewareTest {
     private val scope = coroutinesTestRule.scope
 
     @Test
-    fun `suspends engine session`() = runBlocking {
+    fun `suspends engine session`() = runTestOnMain {
         val middleware = SuspendMiddleware(scope)
 
         val tab = createTab("https://www.mozilla.org", id = "1")

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/TabsRemovedMiddlewareTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/TabsRemovedMiddlewareTest.kt
@@ -5,9 +5,7 @@
 package mozilla.components.browser.state.engine.middleware
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.CustomTabListAction
 import mozilla.components.browser.state.action.EngineAction
@@ -25,9 +23,10 @@ import mozilla.components.lib.state.MiddlewareContext
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
-import org.junit.After
+import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
@@ -35,14 +34,10 @@ import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
 class TabsRemovedMiddlewareTest {
-
-    private val dispatcher = TestCoroutineDispatcher()
-    private val scope = CoroutineScope(dispatcher)
-
-    @After
-    fun tearDown() {
-        dispatcher.cleanupTestCoroutines()
-    }
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val dispatcher = coroutinesTestRule.testDispatcher
+    private val scope = coroutinesTestRule.scope
 
     @Test
     fun `closes and unlinks engine session when tab is removed`() = runBlocking {
@@ -57,7 +52,7 @@ class TabsRemovedMiddlewareTest {
         val engineSession = linkEngineSession(store, tab.id)
         store.dispatch(TabListAction.RemoveTabAction(tab.id)).joinBlocking()
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertNull(store.state.findTab(tab.id)?.engineState?.engineSession)
         verify(engineSession).close()
@@ -82,7 +77,7 @@ class TabsRemovedMiddlewareTest {
 
         store.dispatch(TabListAction.RemoveTabsAction(listOf(tab1.id, tab2.id))).joinBlocking()
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertNull(store.state.findTab(tab1.id)?.engineState?.engineSession)
         assertNull(store.state.findTab(tab2.id)?.engineState?.engineSession)
@@ -110,7 +105,7 @@ class TabsRemovedMiddlewareTest {
 
         store.dispatch(TabListAction.RemoveAllNormalTabsAction).joinBlocking()
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertNull(store.state.findTab(tab1.id)?.engineState?.engineSession)
         assertNull(store.state.findTab(tab2.id)?.engineState?.engineSession)
@@ -138,7 +133,7 @@ class TabsRemovedMiddlewareTest {
 
         store.dispatch(TabListAction.RemoveAllPrivateTabsAction).joinBlocking()
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertNull(store.state.findTab(tab1.id)?.engineState?.engineSession)
         assertNull(store.state.findTab(tab2.id)?.engineState?.engineSession)
@@ -166,7 +161,7 @@ class TabsRemovedMiddlewareTest {
 
         store.dispatch(TabListAction.RemoveAllTabsAction()).joinBlocking()
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertNull(store.state.findTab(tab1.id)?.engineState?.engineSession)
         assertNull(store.state.findTab(tab2.id)?.engineState?.engineSession)
@@ -189,7 +184,7 @@ class TabsRemovedMiddlewareTest {
         val engineSession = linkEngineSession(store, tab.id)
         store.dispatch(CustomTabListAction.RemoveCustomTabAction(tab.id)).joinBlocking()
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertNull(store.state.findTab(tab.id)?.engineState?.engineSession)
         verify(engineSession).close()
@@ -213,7 +208,7 @@ class TabsRemovedMiddlewareTest {
 
         store.dispatch(CustomTabListAction.RemoveAllCustomTabsAction).joinBlocking()
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertNull(store.state.findCustomTab(tab1.id)?.engineState?.engineSession)
         assertNull(store.state.findCustomTab(tab2.id)?.engineState?.engineSession)

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/TabsRemovedMiddlewareTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/TabsRemovedMiddlewareTest.kt
@@ -5,7 +5,6 @@
 package mozilla.components.browser.state.engine.middleware
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.CustomTabListAction
 import mozilla.components.browser.state.action.EngineAction
@@ -24,6 +23,7 @@ import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Rule
@@ -40,7 +40,7 @@ class TabsRemovedMiddlewareTest {
     private val scope = coroutinesTestRule.scope
 
     @Test
-    fun `closes and unlinks engine session when tab is removed`() = runBlocking {
+    fun `closes and unlinks engine session when tab is removed`() = runTestOnMain {
         val middleware = TabsRemovedMiddleware(scope)
 
         val tab = createTab("https://www.mozilla.org", id = "1")
@@ -59,7 +59,7 @@ class TabsRemovedMiddlewareTest {
     }
 
     @Test
-    fun `closes and unlinks engine session when list of tabs are removed`() = runBlocking {
+    fun `closes and unlinks engine session when list of tabs are removed`() = runTestOnMain {
         val middleware = TabsRemovedMiddleware(scope)
 
         val tab1 = createTab("https://www.mozilla.org", id = "1", private = false)
@@ -88,7 +88,7 @@ class TabsRemovedMiddlewareTest {
     }
 
     @Test
-    fun `closes and unlinks engine session when all normal tabs are removed`() = runBlocking {
+    fun `closes and unlinks engine session when all normal tabs are removed`() = runTestOnMain {
         val middleware = TabsRemovedMiddleware(scope)
 
         val tab1 = createTab("https://www.mozilla.org", id = "1", private = false)
@@ -116,7 +116,7 @@ class TabsRemovedMiddlewareTest {
     }
 
     @Test
-    fun `closes and unlinks engine session when all private tabs are removed`() = runBlocking {
+    fun `closes and unlinks engine session when all private tabs are removed`() = runTestOnMain {
         val middleware = TabsRemovedMiddleware(scope)
 
         val tab1 = createTab("https://www.mozilla.org", id = "1", private = true)
@@ -144,7 +144,7 @@ class TabsRemovedMiddlewareTest {
     }
 
     @Test
-    fun `closes and unlinks engine session when all tabs are removed`() = runBlocking {
+    fun `closes and unlinks engine session when all tabs are removed`() = runTestOnMain {
         val middleware = TabsRemovedMiddleware(scope)
 
         val tab1 = createTab("https://www.mozilla.org", id = "1", private = true)
@@ -172,7 +172,7 @@ class TabsRemovedMiddlewareTest {
     }
 
     @Test
-    fun `closes and unlinks engine session when custom tab is removed`() = runBlocking {
+    fun `closes and unlinks engine session when custom tab is removed`() = runTestOnMain {
         val middleware = TabsRemovedMiddleware(scope)
 
         val tab = createCustomTab("https://www.mozilla.org", id = "1")
@@ -191,7 +191,7 @@ class TabsRemovedMiddlewareTest {
     }
 
     @Test
-    fun `closes and unlinks engine session when all custom tabs are removed`() = runBlocking {
+    fun `closes and unlinks engine session when all custom tabs are removed`() = runTestOnMain {
         val middleware = TabsRemovedMiddleware(scope)
 
         val tab1 = createCustomTab("https://www.mozilla.org", id = "1")

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/TrimMemoryMiddlewareTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/TrimMemoryMiddlewareTest.kt
@@ -5,8 +5,6 @@
 package mozilla.components.browser.state.engine.middleware
 
 import android.content.ComponentCallbacks2
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.test.TestCoroutineDispatcher
 import mozilla.components.browser.state.action.SystemAction
 import mozilla.components.browser.state.selector.findCustomTab
 import mozilla.components.browser.state.selector.findTab
@@ -20,14 +18,21 @@ import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 
 class TrimMemoryMiddlewareTest {
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val dispatcher = coroutinesTestRule.testDispatcher
+    private val scope = coroutinesTestRule.scope
+
     private lateinit var engineSessionReddit: EngineSession
     private lateinit var engineSessionTheVerge: EngineSession
     private lateinit var engineSessionTwitch: EngineSession
@@ -37,8 +42,6 @@ class TrimMemoryMiddlewareTest {
     private lateinit var engineSessionFacebook: EngineSession
 
     private lateinit var store: BrowserStore
-    private val dispatcher = TestCoroutineDispatcher()
-    private val scope = CoroutineScope(dispatcher)
 
     private lateinit var engineSessionStateReddit: EngineSessionState
     private lateinit var engineSessionStateTheVerge: EngineSessionState
@@ -132,7 +135,7 @@ class TrimMemoryMiddlewareTest {
         ).joinBlocking()
 
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         store.state.findTab("theverge")!!.engineState.apply {
             assertNotNull(engineSession)
@@ -196,7 +199,7 @@ class TrimMemoryMiddlewareTest {
         ).joinBlocking()
 
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         store.state.findTab("theverge")!!.engineState.apply {
             assertNull(engineSession)

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/store/BrowserStoreTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/store/BrowserStoreTest.kt
@@ -4,7 +4,7 @@
 
 package mozilla.components.browser.state.store
 
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.InitAction
 import mozilla.components.browser.state.action.RestoreCompleteAction
@@ -50,7 +50,7 @@ class BrowserStoreTest {
     }
 
     @Test
-    fun `Adding a tab`() = runBlocking {
+    fun `Adding a tab`() = runTest {
         val store = BrowserStore()
 
         assertEquals(0, store.state.tabs.size)

--- a/components/browser/storage-sync/build.gradle
+++ b/components/browser/storage-sync/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_coroutines
 
     testImplementation Dependencies.mozilla_places
     testImplementation Dependencies.mozilla_remote_tabs

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorageTest.kt
@@ -5,13 +5,15 @@
 package mozilla.components.browser.storage.sync
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.appservices.places.uniffi.PlacesException
 import mozilla.components.concept.storage.BookmarkInfo
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -19,28 +21,33 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.concurrent.TimeUnit
 
+@ExperimentalCoroutinesApi // for runTestOnMain
 @RunWith(AndroidJUnit4::class)
 class PlacesBookmarksStorageTest {
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
     private lateinit var bookmarks: PlacesBookmarksStorage
 
     @Before
-    fun setup() = runBlocking {
+    fun setup() = runTestOnMain {
         bookmarks = PlacesBookmarksStorage(testContext)
         // There's a database on disk which needs to be cleaned up between tests.
         bookmarks.writer.deleteEverything()
     }
 
     @After
-    fun cleanup() = runBlocking {
+    fun cleanup() = runTestOnMain {
         bookmarks.cleanup()
     }
 
     @Test
-    fun `get bookmarks tree by root, recursive or not`() = runBlocking {
+    fun `get bookmarks tree by root, recursive or not`() = runTestOnMain {
         val tree = bookmarks.getTree(BookmarkRoot.Root.id)!!
         assertEquals(BookmarkRoot.Root.id, tree.guid)
         assertNotNull(tree.children)
@@ -80,7 +87,7 @@ class PlacesBookmarksStorageTest {
     }
 
     @Test
-    fun `bookmarks APIs smoke testing - basic operations`() = runBlocking {
+    fun `bookmarks APIs smoke testing - basic operations`() = runTestOnMain {
         val url = "http://www.mozilla.org"
 
         assertEquals(emptyList<BookmarkNode>(), bookmarks.getBookmarksWithUrl(url))
@@ -204,7 +211,7 @@ class PlacesBookmarksStorageTest {
     }
 
     @Test
-    fun `bookmarks import v34 populated`() = runBlocking {
+    fun `bookmarks import v34 populated`() = runTestOnMain {
         val path = getTestPath("databases/history-v34.db").absolutePath
 
         // Need to import history first before we import bookmarks.
@@ -244,7 +251,7 @@ class PlacesBookmarksStorageTest {
     }
 
     @Test
-    fun `bookmarks import v38 populated`() = runBlocking {
+    fun `bookmarks import v38 populated`() = runTestOnMain {
         val path = getTestPath("databases/populated-v38.db").absolutePath
 
         // Need to import history first before we import bookmarks.
@@ -308,7 +315,7 @@ class PlacesBookmarksStorageTest {
     }
 
     @Test
-    fun `bookmarks import v39 populated`() = runBlocking {
+    fun `bookmarks import v39 populated`() = runTestOnMain {
         val path = getTestPath("databases/populated-v39.db").absolutePath
 
         // Need to import history first before we import bookmarks.
@@ -369,7 +376,7 @@ class PlacesBookmarksStorageTest {
     }
 
     @Test
-    fun `bookmarks pinned sites read v39`() = runBlocking {
+    fun `bookmarks pinned sites read v39`() = runTestOnMain {
         val path = getTestPath("databases/pinnedSites-v39.db").absolutePath
 
         with(bookmarks.readPinnedSitesFromFennec(path)) {
@@ -392,7 +399,7 @@ class PlacesBookmarksStorageTest {
     }
 
     @Test
-    fun `bookmarks pinned sites read empty v39`() = runBlocking {
+    fun `bookmarks pinned sites read empty v39`() = runTestOnMain {
         val path = getTestPath("databases/populated-v39.db").absolutePath
 
         assertEquals(0, bookmarks.readPinnedSitesFromFennec(path).size)

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/RemoteTabsStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/RemoteTabsStorageTest.kt
@@ -6,7 +6,7 @@ package mozilla.components.browser.storage.sync
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.appservices.remotetabs.ClientRemoteTabs
 import mozilla.appservices.remotetabs.DeviceType
 import mozilla.appservices.remotetabs.RemoteTab
@@ -47,7 +47,7 @@ class RemoteTabsStorageTest {
     }
 
     @Test
-    fun `store() translates tabs to rust format`() = runBlocking {
+    fun `store() translates tabs to rust format`() = runTest {
         remoteTabs.store(
             listOf(
                 Tab(
@@ -85,7 +85,7 @@ class RemoteTabsStorageTest {
     }
 
     @Test
-    fun `getAll() translates tabs to our format`() = runBlocking {
+    fun `getAll() translates tabs to our format`() = runTest {
         `when`(apiMock.getAll()).thenReturn(
             listOf(
                 ClientRemoteTabs(
@@ -136,7 +136,7 @@ class RemoteTabsStorageTest {
     }
 
     @Test
-    fun `exceptions from getAll are propagated to the crash reporter`() = runBlocking {
+    fun `exceptions from getAll are propagated to the crash reporter`() = runTest {
         val throwable = RemoteTabProviderException("test")
         `when`(apiMock.getAll()).thenAnswer { throw throwable }
 

--- a/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/BrowserThumbnailsTest.kt
+++ b/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/BrowserThumbnailsTest.kt
@@ -6,10 +6,6 @@ package mozilla.components.browser.thumbnails
 
 import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.createTab
@@ -19,8 +15,9 @@ import mozilla.components.support.test.any
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
-import org.junit.After
+import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
@@ -33,7 +30,8 @@ import org.mockito.Mockito.verifyNoMoreInteractions
 @RunWith(AndroidJUnit4::class)
 class BrowserThumbnailsTest {
 
-    private val testDispatcher = TestCoroutineDispatcher()
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
 
     private lateinit var store: BrowserStore
     private lateinit var engineView: EngineView
@@ -42,7 +40,6 @@ class BrowserThumbnailsTest {
 
     @Before
     fun setup() {
-        Dispatchers.setMain(testDispatcher)
         store = spy(
             BrowserStore(
                 BrowserState(
@@ -55,12 +52,6 @@ class BrowserThumbnailsTest {
         )
         engineView = mock()
         thumbnails = BrowserThumbnails(testContext, engineView, store)
-    }
-
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
     }
 
     @Test

--- a/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/storage/ThumbnailStorageTest.kt
+++ b/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/storage/ThumbnailStorageTest.kt
@@ -7,17 +7,18 @@ package mozilla.components.browser.thumbnails.storage
 import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import mozilla.components.concept.base.images.ImageLoadRequest
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
@@ -26,7 +27,9 @@ import org.mockito.Mockito.spy
 @RunWith(AndroidJUnit4::class)
 class ThumbnailStorageTest {
 
-    private val testDispatcher = UnconfinedTestDispatcher()
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val testDispatcher = coroutinesTestRule.testDispatcher
 
     @Before
     @After
@@ -35,7 +38,7 @@ class ThumbnailStorageTest {
     }
 
     @Test
-    fun `clearThumbnails`() = runBlocking {
+    fun `clearThumbnails`() = runTestOnMain {
         val bitmap: Bitmap = mock()
         val thumbnailStorage = spy(ThumbnailStorage(testContext, testDispatcher))
 
@@ -54,7 +57,7 @@ class ThumbnailStorageTest {
     }
 
     @Test
-    fun `deleteThumbnail`() = runBlocking {
+    fun `deleteThumbnail`() = runTestOnMain {
         val request = "test-tab1"
         val bitmap: Bitmap = mock()
         val thumbnailStorage = spy(ThumbnailStorage(testContext, testDispatcher))
@@ -69,7 +72,7 @@ class ThumbnailStorageTest {
     }
 
     @Test
-    fun `saveThumbnail`() = runBlocking {
+    fun `saveThumbnail`() = runTestOnMain {
         val request = ImageLoadRequest("test-tab1", 100)
         val bitmap: Bitmap = mock()
         val thumbnailStorage = spy(ThumbnailStorage(testContext))
@@ -83,7 +86,7 @@ class ThumbnailStorageTest {
     }
 
     @Test
-    fun `loadThumbnail`() = runBlocking {
+    fun `loadThumbnail`() = runTestOnMain {
         val request = ImageLoadRequest("test-tab1", 100)
         val bitmap: Bitmap = mock()
         val thumbnailStorage = spy(ThumbnailStorage(testContext, testDispatcher))

--- a/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/storage/ThumbnailStorageTest.kt
+++ b/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/storage/ThumbnailStorageTest.kt
@@ -8,7 +8,7 @@ import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import mozilla.components.concept.base.images.ImageLoadRequest
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
@@ -26,7 +26,7 @@ import org.mockito.Mockito.spy
 @RunWith(AndroidJUnit4::class)
 class ThumbnailStorageTest {
 
-    private val testDispatcher = TestCoroutineDispatcher()
+    private val testDispatcher = UnconfinedTestDispatcher()
 
     @Before
     @After

--- a/components/browser/toolbar/build.gradle
+++ b/components/browser/toolbar/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_coroutines
 }
 
 apply from: '../../../publish.gradle'

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/AsyncFilterListenerTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/AsyncFilterListenerTest.kt
@@ -4,11 +4,12 @@
 
 package mozilla.components.browser.toolbar
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.isActive
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.toolbar.AutocompleteDelegate
 import mozilla.components.concept.toolbar.AutocompleteResult
 import mozilla.components.support.test.mock
@@ -24,9 +25,10 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import java.util.concurrent.Executor
 
+@ExperimentalCoroutinesApi // for runTest
 class AsyncFilterListenerTest {
     @Test
-    fun `filter listener cancels prior filter executions`() = runBlocking {
+    fun `filter listener cancels prior filter executions`() = runTest {
         val urlView: AutocompleteView = mock()
         val filter: suspend (String, AutocompleteDelegate) -> Unit = mock()
 
@@ -46,7 +48,7 @@ class AsyncFilterListenerTest {
     }
 
     @Test
-    fun `filter delegate checks for cancellations before it runs, passes results to autocomplete view`() = runBlocking {
+    fun `filter delegate checks for cancellations before it runs, passes results to autocomplete view`() = runTest {
         var filter: suspend (String, AutocompleteDelegate) -> Unit = { query, delegate ->
             assertEquals("test", query)
             delegate.applyAutocompleteResult(
@@ -132,7 +134,7 @@ class AsyncFilterListenerTest {
     }
 
     @Test
-    fun `delegate discards stale results`() = runBlocking {
+    fun `delegate discards stale results`() = runTest {
         val filter: suspend (String, AutocompleteDelegate) -> Unit = { query, delegate ->
             assertEquals("test", query)
             delegate.applyAutocompleteResult(
@@ -169,7 +171,7 @@ class AsyncFilterListenerTest {
     }
 
     @Test
-    fun `delegate discards stale lack of results`() = runBlocking {
+    fun `delegate discards stale lack of results`() = runTest {
         val filter: suspend (String, AutocompleteDelegate) -> Unit = { query, delegate ->
             assertEquals("test", query)
             delegate.noAutocompleteResult("test")
@@ -198,7 +200,7 @@ class AsyncFilterListenerTest {
     }
 
     @Test
-    fun `delegate passes through non-stale lack of results`() = runBlocking {
+    fun `delegate passes through non-stale lack of results`() = runTest {
         val filter: suspend (String, AutocompleteDelegate) -> Unit = { query, delegate ->
             assertEquals("test", query)
             delegate.noAutocompleteResult("test")
@@ -230,7 +232,7 @@ class AsyncFilterListenerTest {
     }
 
     @Test
-    fun `delegate discards results if parent scope was cancelled`() = runBlocking {
+    fun `delegate discards results if parent scope was cancelled`() = runTest {
         var preservedDelegate: AutocompleteDelegate? = null
 
         val filter: suspend (String, AutocompleteDelegate) -> Unit = { query, delegate ->
@@ -291,7 +293,7 @@ class AsyncFilterListenerTest {
     }
 
     @Test
-    fun `delegate discards lack of results if parent scope was cancelled`() = runBlocking {
+    fun `delegate discards lack of results if parent scope was cancelled`() = runTest {
         var preservedDelegate: AutocompleteDelegate? = null
 
         val filter: suspend (String, AutocompleteDelegate) -> Unit = { query, delegate ->

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/edit/EditToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/edit/EditToolbarTest.kt
@@ -7,7 +7,8 @@ package mozilla.components.browser.toolbar.edit
 import android.view.KeyEvent
 import android.view.View
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.browser.toolbar.R
 import mozilla.components.concept.toolbar.AutocompleteDelegate
@@ -27,6 +28,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.concurrent.CountDownLatch
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class EditToolbarTest {
     private fun createEditToolbar(): Pair<BrowserToolbar, EditToolbar> {
@@ -39,7 +41,7 @@ class EditToolbarTest {
     }
 
     @Test
-    fun `entered text is forwarded to async autocomplete filter`() {
+    fun `entered text is forwarded to async autocomplete filter`() = runTest {
         val toolbar = BrowserToolbar(testContext)
 
         toolbar.edit.views.url.onAttachedToWindow()
@@ -55,9 +57,7 @@ class EditToolbarTest {
 
         // Autocomplete filter will be invoked on a worker thread.
         // Serialize here for the sake of tests.
-        runBlocking {
-            latch.await()
-        }
+        latch.await()
 
         assertEquals("Hello", invokedWithParams!![0])
         assertTrue(invokedWithParams!![1] is AutocompleteDelegate)

--- a/components/concept/fetch/build.gradle
+++ b/components/concept/fetch/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_mockwebserver
+    testImplementation Dependencies.testing_coroutines
 
     testImplementation project(':support-test')
 }

--- a/components/concept/fetch/src/test/java/mozilla/components/concept/fetch/ClientTest.kt
+++ b/components/concept/fetch/src/test/java/mozilla/components/concept/fetch/ClientTest.kt
@@ -4,14 +4,16 @@
 
 package mozilla.components.concept.fetch
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class ClientTest {
+    @ExperimentalCoroutinesApi
     @Test
-    fun `Async request with coroutines`() = runBlocking {
+    fun `Async request with coroutines`() = runTest {
         val client = TestClient(responseBody = Response.Body("Hello World".byteInputStream()))
         val request = Request("https://www.mozilla.org")
 

--- a/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/AutoPushObserverTest.kt
+++ b/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/AutoPushObserverTest.kt
@@ -4,11 +4,8 @@
 
 package mozilla.components.feature.accounts.push
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.setMain
 import mozilla.components.concept.sync.ConstellationState
 import mozilla.components.concept.sync.Device
 import mozilla.components.concept.sync.DeviceConstellation
@@ -19,6 +16,8 @@ import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.nullable
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.never
@@ -27,6 +26,9 @@ import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.stubbing.OngoingStubbing
 
 class AutoPushObserverTest {
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
     private val manager: FxaAccountManager = mock()
     private val account: OAuthAccount = mock()
     private val constellation: DeviceConstellation = mock()
@@ -35,7 +37,6 @@ class AutoPushObserverTest {
     @ExperimentalCoroutinesApi
     @Test
     fun `messages are forwarded to account manager`() = runBlocking {
-        Dispatchers.setMain(TestCoroutineDispatcher())
         val observer = AutoPushObserver(manager, mock(), "test")
 
         `when`(manager.authenticatedAccount()).thenReturn(account)
@@ -71,7 +72,6 @@ class AutoPushObserverTest {
     @ExperimentalCoroutinesApi
     @Test
     fun `subscription changes are forwarded to account manager`() = runBlocking {
-        Dispatchers.setMain(TestCoroutineDispatcher())
         val observer = AutoPushObserver(manager, pushFeature, "test")
 
         whenSubscribe()

--- a/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/AutoPushObserverTest.kt
+++ b/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/AutoPushObserverTest.kt
@@ -5,7 +5,6 @@
 package mozilla.components.feature.accounts.push
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.sync.ConstellationState
 import mozilla.components.concept.sync.Device
 import mozilla.components.concept.sync.DeviceConstellation
@@ -17,6 +16,7 @@ import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.nullable
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.`when`
@@ -25,6 +25,7 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.stubbing.OngoingStubbing
 
+@ExperimentalCoroutinesApi // for runTestOnMain
 class AutoPushObserverTest {
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
@@ -36,7 +37,7 @@ class AutoPushObserverTest {
 
     @ExperimentalCoroutinesApi
     @Test
-    fun `messages are forwarded to account manager`() = runBlocking {
+    fun `messages are forwarded to account manager`() = runTestOnMain {
         val observer = AutoPushObserver(manager, mock(), "test")
 
         `when`(manager.authenticatedAccount()).thenReturn(account)
@@ -49,7 +50,7 @@ class AutoPushObserverTest {
     }
 
     @Test
-    fun `account manager is not invoked if no account is available`() = runBlocking {
+    fun `account manager is not invoked if no account is available`() = runTestOnMain {
         val observer = AutoPushObserver(manager, mock(), "test")
 
         observer.onMessageReceived("test", "foobar".toByteArray())
@@ -60,7 +61,7 @@ class AutoPushObserverTest {
     }
 
     @Test
-    fun `messages are not forwarded to account manager if they are for a different scope`() = runBlocking {
+    fun `messages are not forwarded to account manager if they are for a different scope`() = runTestOnMain {
         val observer = AutoPushObserver(manager, mock(), "fake")
 
         observer.onMessageReceived("test", "foobar".toByteArray())
@@ -71,7 +72,7 @@ class AutoPushObserverTest {
 
     @ExperimentalCoroutinesApi
     @Test
-    fun `subscription changes are forwarded to account manager`() = runBlocking {
+    fun `subscription changes are forwarded to account manager`() = runTestOnMain {
         val observer = AutoPushObserver(manager, pushFeature, "test")
 
         whenSubscribe()
@@ -91,7 +92,7 @@ class AutoPushObserverTest {
     }
 
     @Test
-    fun `do nothing if there is no account manager`() = runBlocking {
+    fun `do nothing if there is no account manager`() = runTestOnMain {
         val observer = AutoPushObserver(manager, pushFeature, "test")
 
         whenSubscribe()
@@ -103,7 +104,7 @@ class AutoPushObserverTest {
     }
 
     @Test
-    fun `subscription changes are not forwarded to account manager if they are for a different scope`() = runBlocking {
+    fun `subscription changes are not forwarded to account manager if they are for a different scope`() = runTestOnMain {
         val observer = AutoPushObserver(manager, mock(), "fake")
 
         `when`(manager.authenticatedAccount()).thenReturn(account)

--- a/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/ConstellationObserverTest.kt
+++ b/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/ConstellationObserverTest.kt
@@ -8,7 +8,7 @@ package mozilla.components.feature.accounts.push
 
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.concept.base.crash.CrashReporting
 import mozilla.components.concept.sync.ConstellationState
 import mozilla.components.concept.sync.Device
@@ -22,6 +22,7 @@ import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.nullable
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -32,6 +33,7 @@ import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mockito.stubbing.OngoingStubbing
 
+@ExperimentalCoroutinesApi // for runTestOnMain
 @RunWith(AndroidJUnit4::class)
 class ConstellationObserverTest {
 
@@ -56,7 +58,7 @@ class ConstellationObserverTest {
     val coroutinesTestRule = MainCoroutineRule()
 
     @Test
-    fun `first subscribe works`() = runBlocking {
+    fun `first subscribe works`() = runTestOnMain {
         val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
 
         verifyNoInteractions(push)
@@ -74,7 +76,7 @@ class ConstellationObserverTest {
     }
 
     @Test
-    fun `re-subscribe doesn't update constellation on same endpoint`() = runBlocking {
+    fun `re-subscribe doesn't update constellation on same endpoint`() = runTestOnMain {
         val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
 
         verifyNoInteractions(push)
@@ -93,7 +95,7 @@ class ConstellationObserverTest {
     }
 
     @Test
-    fun `re-subscribe update constellations on same endpoint if expired`() = runBlocking {
+    fun `re-subscribe update constellations on same endpoint if expired`() = runTestOnMain {
         val observer = ConstellationObserver(context, push, "testScope", account, verifier, crashReporter)
 
         verifyNoInteractions(push)

--- a/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/SendTabFeatureKtTest.kt
+++ b/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/SendTabFeatureKtTest.kt
@@ -5,7 +5,7 @@
 package mozilla.components.feature.accounts.push
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.sync.DeviceConstellation
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.service.fxa.manager.FxaAccountManager
@@ -21,7 +21,7 @@ import org.mockito.Mockito.verify
 @ExperimentalCoroutinesApi
 class SendTabFeatureKtTest {
     @Test
-    fun `feature register all observers`() = runBlockingTest {
+    fun `feature register all observers`() = runTest {
         val accountManager: FxaAccountManager = mock()
 
         SendTabFeature(

--- a/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/SendTabUseCasesTest.kt
+++ b/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/SendTabUseCasesTest.kt
@@ -5,8 +5,6 @@
 package mozilla.components.feature.accounts.push
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.concept.sync.ConstellationState
 import mozilla.components.concept.sync.Device
 import mozilla.components.concept.sync.DeviceCapability
@@ -18,8 +16,11 @@ import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.never
@@ -29,6 +30,9 @@ import java.util.UUID
 
 @ExperimentalCoroutinesApi
 class SendTabUseCasesTest {
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
 
     private val manager: FxaAccountManager = mock()
     private val account: OAuthAccount = mock()
@@ -43,7 +47,7 @@ class SendTabUseCasesTest {
     }
 
     @Test
-    fun `SendTabUseCase - tab is sent to capable device`() = runBlockingTest {
+    fun `SendTabUseCase - tab is sent to capable device`() = runTestOnMain {
         val useCases = SendTabUseCases(manager, coroutineContext)
         val device: Device = generateDevice()
 
@@ -57,7 +61,7 @@ class SendTabUseCasesTest {
     }
 
     @Test
-    fun `SendTabUseCase - tabs are sent to capable device`() = runBlockingTest {
+    fun `SendTabUseCase - tabs are sent to capable device`() = runTestOnMain {
         val useCases = SendTabUseCases(manager, coroutineContext)
         val device: Device = generateDevice()
         val tab = TabData("Title", "http://example.com")
@@ -72,7 +76,7 @@ class SendTabUseCasesTest {
     }
 
     @Test
-    fun `SendTabUseCase - tabs are NOT sent to incapable devices`() = runBlockingTest {
+    fun `SendTabUseCase - tabs are NOT sent to incapable devices`() = runTestOnMain {
         val useCases = SendTabUseCases(manager, coroutineContext)
         val device: Device = mock()
         val tab = TabData("Title", "http://example.com")
@@ -92,7 +96,7 @@ class SendTabUseCasesTest {
     }
 
     @Test
-    fun `SendTabUseCase - ONLY tabs with valid schema are sent to capable device`() = runBlockingTest {
+    fun `SendTabUseCase - ONLY tabs with valid schema are sent to capable device`() = runTestOnMain {
         val useCases = SendTabUseCases(manager, coroutineContext)
         val device: Device = generateDevice()
         val tab = TabData("Title", "http://example.com")
@@ -109,7 +113,7 @@ class SendTabUseCasesTest {
     }
 
     @Test
-    fun `SendTabUseCase - device id does not match when sending single tab`() = runBlockingTest {
+    fun `SendTabUseCase - device id does not match when sending single tab`() = runTestOnMain {
         val useCases = SendTabUseCases(manager, coroutineContext)
         val device: Device = generateDevice("123")
         val tab = TabData("Title", "http://example.com")
@@ -132,7 +136,7 @@ class SendTabUseCasesTest {
     }
 
     @Test
-    fun `SendTabUseCase - device id does not match when sending tabs`() = runBlockingTest {
+    fun `SendTabUseCase - device id does not match when sending tabs`() = runTestOnMain {
         val useCases = SendTabUseCases(manager, coroutineContext)
         val device: Device = generateDevice("123")
         val tab = TabData("Title", "http://example.com")
@@ -155,7 +159,7 @@ class SendTabUseCasesTest {
     }
 
     @Test
-    fun `SendTabToAllUseCase - tab is sent to capable devices`() = runBlockingTest {
+    fun `SendTabToAllUseCase - tab is sent to capable devices`() = runTestOnMain {
         val useCases = SendTabUseCases(manager, coroutineContext)
         val device: Device = generateDevice()
         val device2: Device = generateDevice()
@@ -172,7 +176,7 @@ class SendTabUseCasesTest {
     }
 
     @Test
-    fun `SendTabToAllUseCase - tabs is sent to capable devices`() = runBlockingTest {
+    fun `SendTabToAllUseCase - tabs is sent to capable devices`() = runTestOnMain {
         val useCases = SendTabUseCases(manager, coroutineContext)
         val device: Device = generateDevice()
         val device2: Device = generateDevice()
@@ -190,53 +194,49 @@ class SendTabUseCasesTest {
     }
 
     @Test
-    fun `SendTabToAllUseCase - tab is NOT sent to incapable devices`() {
+    fun `SendTabToAllUseCase - tab is NOT sent to incapable devices`() = runTestOnMain {
         val useCases = SendTabUseCases(manager)
         val tab = TabData("Mozilla", "https://mozilla.org")
         val device: Device = mock()
         val device2: Device = mock()
 
-        runBlocking {
-            useCases.sendToAllAsync(tab)
+        useCases.sendToAllAsync(tab)
 
-            verify(constellation, never()).sendCommandToDevice(any(), any())
+        verify(constellation, never()).sendCommandToDevice(any(), any())
 
-            `when`(device.id).thenReturn("123")
-            `when`(device2.id).thenReturn("456")
-            `when`(state.otherDevices).thenReturn(listOf(device, device2))
+        `when`(device.id).thenReturn("123")
+        `when`(device2.id).thenReturn("456")
+        `when`(state.otherDevices).thenReturn(listOf(device, device2))
 
-            useCases.sendToAllAsync(tab)
+        useCases.sendToAllAsync(tab)
 
-            verify(constellation, never()).sendCommandToDevice(any(), any())
-        }
+        verify(constellation, never()).sendCommandToDevice(any(), any())
     }
 
     @Test
-    fun `SendTabToAllUseCase - tabs are NOT sent to capable devices`() {
+    fun `SendTabToAllUseCase - tabs are NOT sent to capable devices`() = runTestOnMain {
         val useCases = SendTabUseCases(manager)
         val tab = TabData("Mozilla", "https://mozilla.org")
         val tab2 = TabData("Firefox", "https://firefox.com")
         val device: Device = mock()
         val device2: Device = mock()
 
-        runBlocking {
-            useCases.sendToAllAsync(tab)
+        useCases.sendToAllAsync(tab)
 
-            verify(constellation, never()).sendCommandToDevice(any(), any())
+        verify(constellation, never()).sendCommandToDevice(any(), any())
 
-            `when`(device.id).thenReturn("123")
-            `when`(device2.id).thenReturn("456")
-            `when`(state.otherDevices).thenReturn(listOf(device, device2))
+        `when`(device.id).thenReturn("123")
+        `when`(device2.id).thenReturn("456")
+        `when`(state.otherDevices).thenReturn(listOf(device, device2))
 
-            useCases.sendToAllAsync(listOf(tab, tab2))
+        useCases.sendToAllAsync(listOf(tab, tab2))
 
-            verify(constellation, never()).sendCommandToDevice(eq("123"), any())
-            verify(constellation, never()).sendCommandToDevice(eq("456"), any())
-        }
+        verify(constellation, never()).sendCommandToDevice(eq("123"), any())
+        verify(constellation, never()).sendCommandToDevice(eq("456"), any())
     }
 
     @Test
-    fun `SendTabToAllUseCase - ONLY tabs with valid schema are sent to capable devices`() = runBlockingTest {
+    fun `SendTabToAllUseCase - ONLY tabs with valid schema are sent to capable devices`() = runTestOnMain {
         val useCases = SendTabUseCases(manager, coroutineContext)
         val device: Device = generateDevice()
         val device2: Device = generateDevice()
@@ -258,7 +258,7 @@ class SendTabUseCasesTest {
     }
 
     @Test
-    fun `SendTabUseCase - result is false if any send tab action fails`() = runBlockingTest {
+    fun `SendTabUseCase - result is false if any send tab action fails`() = runTestOnMain {
         val useCases = SendTabUseCases(manager, coroutineContext)
         val device: Device = mock()
         val tab = TabData("Title", "http://example.com")
@@ -280,43 +280,39 @@ class SendTabUseCasesTest {
     }
 
     @Test
-    fun `filter devices returns capable devices`() {
+    fun `filter devices returns capable devices`() = runTestOnMain {
         var executed = false
-        runBlocking {
-            `when`(state.otherDevices).thenReturn(listOf(generateDevice(), generateDevice()))
-            filterSendTabDevices(manager) { _, _ ->
-                executed = true
-            }
-
-            Assert.assertTrue(executed)
+        `when`(state.otherDevices).thenReturn(listOf(generateDevice(), generateDevice()))
+        filterSendTabDevices(manager) { _, _ ->
+            executed = true
         }
+
+        Assert.assertTrue(executed)
     }
 
     @Test
-    fun `filter devices does NOT provide for incapable devices`() {
+    fun `filter devices does NOT provide for incapable devices`() = runTestOnMain {
         val device: Device = mock()
         val device2: Device = mock()
 
-        runBlocking {
-            `when`(device.id).thenReturn("123")
-            `when`(device2.id).thenReturn("456")
-            `when`(state.otherDevices).thenReturn(listOf(device, device2))
+        `when`(device.id).thenReturn("123")
+        `when`(device2.id).thenReturn("456")
+        `when`(state.otherDevices).thenReturn(listOf(device, device2))
 
-            filterSendTabDevices(manager) { _, filteredDevices ->
-                Assert.assertTrue(filteredDevices.isEmpty())
-            }
+        filterSendTabDevices(manager) { _, filteredDevices ->
+            Assert.assertTrue(filteredDevices.isEmpty())
+        }
 
-            val accountManager: FxaAccountManager = mock()
-            val account: OAuthAccount = mock()
-            val constellation: DeviceConstellation = mock()
-            val state: ConstellationState = mock()
-            `when`(accountManager.authenticatedAccount()).thenReturn(account)
-            `when`(account.deviceConstellation()).thenReturn(constellation)
-            `when`(constellation.state()).thenReturn(state)
+        val accountManager: FxaAccountManager = mock()
+        val account: OAuthAccount = mock()
+        val constellation: DeviceConstellation = mock()
+        val state: ConstellationState = mock()
+        `when`(accountManager.authenticatedAccount()).thenReturn(account)
+        `when`(account.deviceConstellation()).thenReturn(constellation)
+        `when`(constellation.state()).thenReturn(state)
 
-            filterSendTabDevices(mock()) { _, _ ->
-                Assert.fail()
-            }
+        filterSendTabDevices(mock()) { _, _ ->
+            Assert.fail()
         }
     }
 

--- a/components/feature/accounts/build.gradle
+++ b/components/feature/accounts/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_coroutines
 
     testImplementation project(':support-test')
 }

--- a/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FirefoxAccountsAuthFeatureTest.kt
+++ b/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FirefoxAccountsAuthFeatureTest.kt
@@ -8,7 +8,7 @@ import android.content.Context
 import android.os.Looper.getMainLooper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.engine.request.RequestInterceptor
 import mozilla.components.concept.sync.AccountEventsObserver
 import mozilla.components.concept.sync.AuthFlowUrl
@@ -76,7 +76,7 @@ class FirefoxAccountsAuthFeatureTest {
 
     @Config(sdk = [22])
     @Test
-    fun `begin authentication`() = runBlocking {
+    fun `begin authentication`() = runTest {
         val manager = prepareAccountManagerForSuccessfulAuthentication(
             this.coroutineContext
         )
@@ -95,7 +95,7 @@ class FirefoxAccountsAuthFeatureTest {
 
     @Config(sdk = [22])
     @Test
-    fun `begin pairing authentication`() = runBlocking {
+    fun `begin pairing authentication`() = runTest {
         val manager = prepareAccountManagerForSuccessfulAuthentication(
             this.coroutineContext
         )
@@ -114,7 +114,7 @@ class FirefoxAccountsAuthFeatureTest {
 
     @Config(sdk = [22])
     @Test
-    fun `begin authentication with errors`() = runBlocking {
+    fun `begin authentication with errors`() = runTest {
         val manager = prepareAccountManagerForFailedAuthentication(
             this.coroutineContext
         )
@@ -135,7 +135,7 @@ class FirefoxAccountsAuthFeatureTest {
 
     @Config(sdk = [22])
     @Test
-    fun `begin pairing authentication with errors`() = runBlocking {
+    fun `begin pairing authentication with errors`() = runTest {
         val manager = prepareAccountManagerForFailedAuthentication(
             this.coroutineContext
         )
@@ -155,7 +155,7 @@ class FirefoxAccountsAuthFeatureTest {
     }
 
     @Test
-    fun `auth interceptor`() = runBlocking {
+    fun `auth interceptor`() = runTest {
         val manager = mock<FxaAccountManager>()
         val redirectUrl = "https://accounts.firefox.com/oauth/success/123"
         val feature = FirefoxAccountsAuthFeature(

--- a/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FxaWebChannelFeatureTest.kt
+++ b/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FxaWebChannelFeatureTest.kt
@@ -6,7 +6,7 @@ package mozilla.components.feature.accounts
 
 import android.os.Looper.getMainLooper
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
@@ -579,7 +579,7 @@ class FxaWebChannelFeatureTest {
 
     // Receiving an oauth-login message account manager accepts the request
     @Test
-    fun `COMMAND_OAUTH_LOGIN web-channel must be processed through when the accountManager accepts the request`() = runBlocking {
+    fun `COMMAND_OAUTH_LOGIN web-channel must be processed through when the accountManager accepts the request`() = runTest {
         val accountManager: FxaAccountManager = mock() // syncConfig is null by default (is not configured)
         val engineSession: EngineSession = mock()
         val ext: WebExtension = mock()
@@ -612,7 +612,7 @@ class FxaWebChannelFeatureTest {
 
     // Receiving an oauth-login message account manager refuses the request
     @Test
-    fun `COMMAND_OAUTH_LOGIN web-channel must be processed when the accountManager refuses the request`() = runBlocking {
+    fun `COMMAND_OAUTH_LOGIN web-channel must be processed when the accountManager refuses the request`() = runTest {
         val accountManager: FxaAccountManager = mock() // syncConfig is null by default (is not configured)
         val engineSession: EngineSession = mock()
         val ext: WebExtension = mock()

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/amo/AddonCollectionProviderTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/amo/AddonCollectionProviderTest.kt
@@ -6,7 +6,7 @@ package mozilla.components.feature.addons.amo
 
 import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Request
 import mozilla.components.concept.fetch.Response
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit
 class AddonCollectionProviderTest {
 
     @Test
-    fun `getAvailableAddons - with a successful status response must contain add-ons`() = runBlocking {
+    fun `getAvailableAddons - with a successful status response must contain add-ons`() = runTest {
         val mockedClient = prepareClient(loadResourceAsString("/collection.json"))
         val provider = AddonCollectionProvider(testContext, client = mockedClient)
         val addons = provider.getAvailableAddons()
@@ -96,7 +96,7 @@ class AddonCollectionProviderTest {
     }
 
     @Test
-    fun `getAvailableAddons - with a successful status response must handle empty values`() = runBlocking {
+    fun `getAvailableAddons - with a successful status response must handle empty values`() = runTest {
         val client = prepareClient()
         val provider = AddonCollectionProvider(testContext, client = client)
 
@@ -135,7 +135,7 @@ class AddonCollectionProviderTest {
     }
 
     @Test
-    fun `getAvailableAddons - with a language`() = runBlocking {
+    fun `getAvailableAddons - with a language`() = runTest {
         val client = prepareClient(loadResourceAsString("/localized_collection.json"))
         val provider = AddonCollectionProvider(testContext, client = client)
 
@@ -208,7 +208,7 @@ class AddonCollectionProviderTest {
     }
 
     @Test
-    fun `getAvailableAddons - read timeout can be configured`() = runBlocking {
+    fun `getAvailableAddons - read timeout can be configured`() = runTest {
         val mockedClient = prepareClient()
 
         val provider = spy(AddonCollectionProvider(testContext, client = mockedClient))
@@ -224,7 +224,7 @@ class AddonCollectionProviderTest {
     }
 
     @Test(expected = IOException::class)
-    fun `getAvailableAddons - with unexpected status will throw exception`() = runBlocking {
+    fun `getAvailableAddons - with unexpected status will throw exception`() = runTest {
         val mockedClient = prepareClient(status = 500)
         val provider = AddonCollectionProvider(testContext, client = mockedClient)
         provider.getAvailableAddons()
@@ -232,7 +232,7 @@ class AddonCollectionProviderTest {
     }
 
     @Test
-    fun `getAvailableAddons - returns cached result if allowed and not expired`() = runBlocking {
+    fun `getAvailableAddons - returns cached result if allowed and not expired`() = runTest {
         val mockedClient = prepareClient(loadResourceAsString("/collection.json"))
 
         val provider = spy(AddonCollectionProvider(testContext, client = mockedClient))
@@ -250,7 +250,7 @@ class AddonCollectionProviderTest {
     }
 
     @Test
-    fun `getAvailableAddons - returns cached result if allowed and fetch failed`() = runBlocking {
+    fun `getAvailableAddons - returns cached result if allowed and fetch failed`() = runTest {
         val mockedClient: Client = mock()
         val exception = IOException("test")
         val cachedAddons: List<Addon> = emptyList()
@@ -296,7 +296,7 @@ class AddonCollectionProviderTest {
     }
 
     @Test
-    fun `getAvailableAddons - writes response to cache if configured`() = runBlocking {
+    fun `getAvailableAddons - writes response to cache if configured`() = runTest {
         val jsonResponse = loadResourceAsString("/collection.json")
         val mockedClient = prepareClient(jsonResponse)
 
@@ -311,7 +311,7 @@ class AddonCollectionProviderTest {
     }
 
     @Test
-    fun `getAvailableAddons - deletes unused cache files`() = runBlocking {
+    fun `getAvailableAddons - deletes unused cache files`() = runTest {
         val jsonResponse = loadResourceAsString("/collection.json")
         val mockedClient = prepareClient(jsonResponse)
 
@@ -414,7 +414,7 @@ class AddonCollectionProviderTest {
     }
 
     @Test
-    fun `getAddonIconBitmap - with a successful status will return a bitmap`() = runBlocking {
+    fun `getAddonIconBitmap - with a successful status will return a bitmap`() = runTest {
         val mockedClient = mock<Client>()
         val mockedResponse = mock<Response>()
         val stream: InputStream = javaClass.getResourceAsStream("/png/mozac.png")!!.buffered()
@@ -441,7 +441,7 @@ class AddonCollectionProviderTest {
     }
 
     @Test
-    fun `getAddonIconBitmap - with an unsuccessful status will return null`() = runBlocking {
+    fun `getAddonIconBitmap - with an unsuccessful status will return null`() = runTest {
         val mockedClient = prepareClient(status = 500)
         val provider = AddonCollectionProvider(testContext, client = mockedClient)
         val addon = Addon(
@@ -460,7 +460,7 @@ class AddonCollectionProviderTest {
     }
 
     @Test
-    fun `collection name can be configured`() = runBlocking {
+    fun `collection name can be configured`() = runTest {
         val mockedClient = prepareClient()
 
         val collectionName = "collection123"
@@ -483,7 +483,7 @@ class AddonCollectionProviderTest {
     }
 
     @Test
-    fun `collection sort option can be specified`() = runBlocking {
+    fun `collection sort option can be specified`() = runTest {
         val mockedClient = prepareClient()
 
         val collectionName = "collection123"
@@ -593,7 +593,7 @@ class AddonCollectionProviderTest {
     }
 
     @Test
-    fun `collection user can be configured`() = runBlocking {
+    fun `collection user can be configured`() = runTest {
         val mockedClient = prepareClient()
         val collectionUser = "user123"
         val collectionName = "collection123"
@@ -622,7 +622,7 @@ class AddonCollectionProviderTest {
     }
 
     @Test
-    fun `default collection is used if not configured`() = runBlocking {
+    fun `default collection is used if not configured`() = runTest {
         val mockedClient = prepareClient()
 
         val provider = AddonCollectionProvider(
@@ -645,7 +645,7 @@ class AddonCollectionProviderTest {
     }
 
     @Test
-    fun `cache file name is sanitized`() = runBlocking {
+    fun `cache file name is sanitized`() = runTest {
         val mockedClient = prepareClient()
         val collectionUser = "../../user"
         val collectionName = "../collection"

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/menu/WebExtensionActionMenuCandidateTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/menu/WebExtensionActionMenuCandidateTest.kt
@@ -7,7 +7,7 @@ package mozilla.components.feature.addons.menu
 import android.graphics.Color
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.menu.candidate.AsyncDrawableMenuIcon
 import mozilla.components.concept.menu.candidate.TextMenuIcon
@@ -97,7 +97,7 @@ class WebExtensionActionMenuCandidateTest {
     }
 
     @Test
-    fun `create menu candidate with icon`() = runBlockingTest {
+    fun `create menu candidate with icon`() = runTest {
         var calledWith: Int = -1
         val candidate = baseAction
             .copy(

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/migration/DefaultSupportedAddonCheckerTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/migration/DefaultSupportedAddonCheckerTest.kt
@@ -16,7 +16,6 @@ import androidx.work.testing.WorkManagerTestInitHelper
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import mozilla.components.feature.addons.migration.DefaultSupportedAddonsChecker.Companion.CHECKER_UNIQUE_PERIODIC_WORK_NAME
 import mozilla.components.feature.addons.migration.DefaultSupportedAddonsChecker.Companion.WORK_TAG_PERIODIC
@@ -36,7 +35,6 @@ import java.util.concurrent.TimeUnit
 @RunWith(AndroidJUnit4::class)
 class DefaultSupportedAddonCheckerTest {
 
-    @ExperimentalCoroutinesApi
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
 

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/migration/SupportedAddonsWorkerTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/migration/SupportedAddonsWorkerTest.kt
@@ -10,7 +10,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.ListenableWorker
 import androidx.work.await
 import androidx.work.testing.TestListenableWorkerBuilder
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.engine.webextension.EnableSource
 import mozilla.components.feature.addons.Addon
@@ -40,12 +39,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
 import java.io.IOException
-import java.lang.Exception
 
 @RunWith(AndroidJUnit4::class)
 class SupportedAddonsWorkerTest {
 
-    @ExperimentalCoroutinesApi
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
 

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonInstallationDialogFragmentTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonInstallationDialogFragmentTest.kt
@@ -15,7 +15,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.R
 import mozilla.components.feature.addons.amo.AddonCollectionProvider
@@ -141,39 +141,35 @@ class AddonInstallationDialogFragmentTest {
     }
 
     @Test
-    fun `fetching the add-on icon successfully`() {
+    fun `fetching the add-on icon successfully`() = runTest {
         val addon = mock<Addon>()
         val bitmap = mock<Bitmap>()
         val mockedImageView = spy(ImageView(testContext))
         val mockedCollectionProvider = mock<AddonCollectionProvider>()
         val fragment = createAddonInstallationDialogFragment(addon, mockedCollectionProvider)
 
-        runBlocking {
-            whenever(mockedCollectionProvider.getAddonIconBitmap(addon)).thenReturn(bitmap)
-            assertNull(fragment.arguments?.getParcelable<Bitmap>(KEY_ICON))
-            fragment.fetchIcon(addon, mockedImageView, scope).join()
-            assertNotNull(fragment.arguments?.getParcelable<Bitmap>(KEY_ICON))
-            verify(mockedImageView).setImageDrawable(Mockito.any())
-        }
+        whenever(mockedCollectionProvider.getAddonIconBitmap(addon)).thenReturn(bitmap)
+        assertNull(fragment.arguments?.getParcelable<Bitmap>(KEY_ICON))
+        fragment.fetchIcon(addon, mockedImageView, scope).join()
+        assertNotNull(fragment.arguments?.getParcelable<Bitmap>(KEY_ICON))
+        verify(mockedImageView).setImageDrawable(Mockito.any())
     }
 
     @Test
-    fun `handle errors while fetching the add-on icon`() {
+    fun `handle errors while fetching the add-on icon`() = runTest {
         val addon = mock<Addon>()
         val mockedImageView = spy(ImageView(testContext))
         val mockedCollectionProvider = mock<AddonCollectionProvider>()
         val fragment = createAddonInstallationDialogFragment(addon, mockedCollectionProvider)
 
-        runBlocking {
-            whenever(mockedCollectionProvider.getAddonIconBitmap(addon)).then {
-                throw IOException("Request failed")
-            }
-            try {
-                fragment.fetchIcon(addon, mockedImageView, scope).join()
-                verify(mockedImageView).setColorFilter(Mockito.anyInt())
-            } catch (e: IOException) {
-                fail("The exception must be handle in the adapter")
-            }
+        whenever(mockedCollectionProvider.getAddonIconBitmap(addon)).then {
+            throw IOException("Request failed")
+        }
+        try {
+            fragment.fetchIcon(addon, mockedImageView, scope).join()
+            verify(mockedImageView).setColorFilter(Mockito.anyInt())
+        } catch (e: IOException) {
+            fail("The exception must be handle in the adapter")
         }
     }
 

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonInstallationDialogFragmentTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonInstallationDialogFragmentTest.kt
@@ -16,7 +16,6 @@ import androidx.fragment.app.FragmentTransaction
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineScope
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.R
 import mozilla.components.feature.addons.amo.AddonCollectionProvider
@@ -46,7 +45,7 @@ class AddonInstallationDialogFragmentTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val scope = TestCoroutineScope(coroutinesTestRule.testDispatcher)
+    private val scope = coroutinesTestRule.scope
 
     @Test
     fun `build dialog`() {

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterTest.kt
@@ -16,7 +16,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineScope
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.R
 import mozilla.components.feature.addons.amo.AddonCollectionProvider
@@ -50,7 +49,7 @@ class AddonsManagerAdapterTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val scope = TestCoroutineScope(coroutinesTestRule.testDispatcher)
+    private val scope = coroutinesTestRule.scope
 
     @Test
     fun `createListWithSections`() {

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/UnsupportedAddonsAdapterTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/UnsupportedAddonsAdapterTest.kt
@@ -31,7 +31,6 @@ class UnsupportedAddonsAdapterTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val testDispatcher = coroutinesTestRule.testDispatcher
 
     @Test
     fun `removing successfully notifies the adapter item changed`() {
@@ -50,19 +49,16 @@ class UnsupportedAddonsAdapterTest {
         )
 
         adapter.removeUninstalledAddon(addonOne)
-        testDispatcher.advanceUntilIdle()
         verify(unsupportedAddonsAdapterDelegate, times(1)).onUninstallSuccess()
         verify(adapter, times(1)).notifyDataSetChanged()
         assertEquals(1, adapter.itemCount)
 
         adapter.removeUninstalledAddon(addonTwo)
-        testDispatcher.advanceUntilIdle()
         verify(unsupportedAddonsAdapterDelegate, times(2)).onUninstallSuccess()
         verify(adapter, times(2)).notifyDataSetChanged()
         assertEquals(0, adapter.itemCount)
 
         adapter.removeUninstalledAddon(addonTwo)
-        testDispatcher.advanceUntilIdle()
         verify(unsupportedAddonsAdapterDelegate, times(2)).onUninstallSuccess()
         verify(adapter, times(2)).notifyDataSetChanged()
     }
@@ -116,7 +112,6 @@ class UnsupportedAddonsAdapterTest {
         assertFalse(removeButtonOne.isEnabled)
         assertFalse(removeButtonTwo.isEnabled)
 
-        testDispatcher.advanceUntilIdle()
         verify(addonManager).uninstallAddon(any(), onSuccessCaptor.capture(), any())
         onSuccessCaptor.value.invoke()
         assertFalse(adapter.pendingUninstall)

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/update/AddonUpdaterWorkerTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/update/AddonUpdaterWorkerTest.kt
@@ -10,7 +10,6 @@ import androidx.work.await
 import androidx.work.testing.TestListenableWorkerBuilder
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Engine
@@ -38,7 +37,6 @@ import org.mockito.Mockito.verify
 @RunWith(AndroidJUnit4::class)
 class AddonUpdaterWorkerTest {
 
-    @ExperimentalCoroutinesApi
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
 

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/update/AddonUpdaterWorkerTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/update/AddonUpdaterWorkerTest.kt
@@ -10,7 +10,6 @@ import androidx.work.await
 import androidx.work.testing.TestListenableWorkerBuilder
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
-import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.webextension.WebExtension
@@ -21,6 +20,7 @@ import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import mozilla.components.support.test.whenever
 import mozilla.components.support.webextensions.WebExtensionSupport
 import org.junit.After
@@ -65,7 +65,7 @@ class AddonUpdaterWorkerTest {
     }
 
     @Test
-    fun `doWork - will return Result_success when SuccessfullyUpdated`() {
+    fun `doWork - will return Result_success when SuccessfullyUpdated`() = runTestOnMain {
         val updateAttemptStorage = mock<DefaultAddonUpdater.UpdateAttemptStorage>()
         val addonId = "addonId"
         val onFinishCaptor = argumentCaptor<((AddonUpdater.Status) -> Unit)>()
@@ -83,18 +83,16 @@ class AddonUpdaterWorkerTest {
             onFinishCaptor.value.invoke(AddonUpdater.Status.SuccessfullyUpdated)
         }
 
-        runBlocking {
-            doReturn(this).`when`(worker).attemptScope
+        doReturn(this).`when`(worker).attemptScope
 
-            val result = worker.startWork().await()
+        val result = worker.startWork().await()
 
-            assertEquals(ListenableWorker.Result.success(), result)
-            verify(worker).saveUpdateAttempt(addonId, AddonUpdater.Status.SuccessfullyUpdated)
-        }
+        assertEquals(ListenableWorker.Result.success(), result)
+        verify(worker).saveUpdateAttempt(addonId, AddonUpdater.Status.SuccessfullyUpdated)
     }
 
     @Test
-    fun `doWork - will return Result_success when NoUpdateAvailable`() {
+    fun `doWork - will return Result_success when NoUpdateAvailable`() = runTestOnMain {
         val addonId = "addonId"
         val onFinishCaptor = argumentCaptor<((AddonUpdater.Status) -> Unit)>()
         val addonManager = mock<AddonManager>()
@@ -108,15 +106,13 @@ class AddonUpdaterWorkerTest {
             onFinishCaptor.value.invoke(AddonUpdater.Status.NoUpdateAvailable)
         }
 
-        runBlocking {
-            val result = worker.startWork().await()
+        val result = worker.startWork().await()
 
-            assertEquals(ListenableWorker.Result.success(), result)
-        }
+        assertEquals(ListenableWorker.Result.success(), result)
     }
 
     @Test
-    fun `doWork - will return Result_failure when NotInstalled`() {
+    fun `doWork - will return Result_failure when NotInstalled`() = runTestOnMain {
         val addonId = "addonId"
         val onFinishCaptor = argumentCaptor<((AddonUpdater.Status) -> Unit)>()
         val addonManager = mock<AddonManager>()
@@ -130,15 +126,13 @@ class AddonUpdaterWorkerTest {
             onFinishCaptor.value.invoke(AddonUpdater.Status.NotInstalled)
         }
 
-        runBlocking {
-            val result = worker.startWork().await()
+        val result = worker.startWork().await()
 
-            assertEquals(ListenableWorker.Result.failure(), result)
-        }
+        assertEquals(ListenableWorker.Result.failure(), result)
     }
 
     @Test
-    fun `doWork - will return Result_retry when an Error happens and is recoverable`() {
+    fun `doWork - will return Result_retry when an Error happens and is recoverable`() = runTestOnMain {
         val updateAttemptStorage = mock<DefaultAddonUpdater.UpdateAttemptStorage>()
         val addonId = "addonId"
         val onFinishCaptor = argumentCaptor<((AddonUpdater.Status) -> Unit)>()
@@ -155,16 +149,14 @@ class AddonUpdaterWorkerTest {
             onFinishCaptor.value.invoke(AddonUpdater.Status.Error("error", recoverableException))
         }
 
-        runBlocking {
-            val result = worker.startWork().await()
+        val result = worker.startWork().await()
 
-            assertEquals(ListenableWorker.Result.retry(), result)
-            updateAttemptStorage.saveOrUpdate(any())
-        }
+        assertEquals(ListenableWorker.Result.retry(), result)
+        updateAttemptStorage.saveOrUpdate(any())
     }
 
     @Test
-    fun `doWork - will return Result_success when an Error happens and is unrecoverable`() {
+    fun `doWork - will return Result_success when an Error happens and is unrecoverable`() = runTestOnMain {
         val updateAttemptStorage = mock<DefaultAddonUpdater.UpdateAttemptStorage>()
         val addonId = "addonId"
         val onFinishCaptor = argumentCaptor<((AddonUpdater.Status) -> Unit)>()
@@ -181,16 +173,14 @@ class AddonUpdaterWorkerTest {
             onFinishCaptor.value.invoke(AddonUpdater.Status.Error("error", unrecoverableException))
         }
 
-        runBlocking {
-            val result = worker.startWork().await()
+        val result = worker.startWork().await()
 
-            assertEquals(ListenableWorker.Result.success(), result)
-            updateAttemptStorage.saveOrUpdate(any())
-        }
+        assertEquals(ListenableWorker.Result.success(), result)
+        updateAttemptStorage.saveOrUpdate(any())
     }
 
     @Test
-    fun `doWork - will try pass any exceptions to the crashReporter`() {
+    fun `doWork - will try pass any exceptions to the crashReporter`() = runTestOnMain {
         val addonId = "addonId"
         val onFinishCaptor = argumentCaptor<((AddonUpdater.Status) -> Unit)>()
         val addonManager = mock<AddonManager>()
@@ -209,12 +199,10 @@ class AddonUpdaterWorkerTest {
             onFinishCaptor.value.invoke(AddonUpdater.Status.Error("error", Exception()))
         }
 
-        runBlocking {
-            val result = worker.startWork().await()
+        val result = worker.startWork().await()
 
-            assertEquals(ListenableWorker.Result.success(), result)
-            assertTrue(crashWasReported)
-        }
+        assertEquals(ListenableWorker.Result.success(), result)
+        assertTrue(crashWasReported)
     }
 
     @Test

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/update/DefaultAddonUpdaterTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/update/DefaultAddonUpdaterTest.kt
@@ -19,7 +19,6 @@ import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.engine.webextension.DisabledFlags
 import mozilla.components.concept.engine.webextension.Metadata
@@ -46,7 +45,6 @@ import java.util.concurrent.TimeUnit
 @RunWith(AndroidJUnit4::class)
 class DefaultAddonUpdaterTest {
 
-    @ExperimentalCoroutinesApi
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
 

--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksFeatureTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksFeatureTest.kt
@@ -45,7 +45,6 @@ class AppLinksFeatureTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val testDispatcher = coroutinesTestRule.testDispatcher
 
     private lateinit var store: BrowserStore
     private lateinit var mockContext: Context
@@ -120,7 +119,6 @@ class AppLinksFeatureTest {
         val tabWithPendingAppIntent = store.state.findTab(tab.id)!!
         assertNotNull(tabWithPendingAppIntent.content.appIntent)
 
-        testDispatcher.advanceUntilIdle()
         verify(feature).handleAppIntent(tabWithPendingAppIntent, intentUrl, intent)
 
         store.waitUntilIdle()
@@ -139,7 +137,7 @@ class AppLinksFeatureTest {
         val intent: Intent = mock()
         val appIntent = AppIntentState(intentUrl, intent)
         store.dispatch(ContentAction.UpdateAppIntentAction(tab.id, appIntent)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+
         verify(feature, never()).handleAppIntent(any(), any(), any())
     }
 

--- a/components/feature/autofill/src/test/java/mozilla/components/feature/autofill/handler/FillRequestHandlerTest.kt
+++ b/components/feature/autofill/src/test/java/mozilla/components/feature/autofill/handler/FillRequestHandlerTest.kt
@@ -4,7 +4,8 @@
 
 package mozilla.components.feature.autofill.handler
 
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.storage.Login
 import mozilla.components.concept.storage.LoginsStorage
 import mozilla.components.feature.autofill.AutofillConfiguration
@@ -34,6 +35,7 @@ import org.mockito.Mockito.doReturn
 import org.robolectric.RobolectricTestRunner
 import java.util.UUID
 
+@ExperimentalCoroutinesApi // for createTestCase
 @RunWith(RobolectricTestRunner::class)
 internal class FillRequestHandlerTest {
     @Test
@@ -182,13 +184,14 @@ internal class FillRequestHandlerTest {
     }
 }
 
+@ExperimentalCoroutinesApi
 private fun <B : FillResponseBuilder> FillRequestHandlerTest.createTestCase(
     filename: String,
     packageName: String,
     logins: Map<String, Login>,
     assertThat: (B?) -> Unit,
     canVerifyRelationship: Boolean = true
-) = runBlocking {
+) = runTest {
     val structure = createMockStructure(filename, packageName)
 
     val storage: LoginsStorage = mock()

--- a/components/feature/autofill/src/test/java/mozilla/components/feature/autofill/test/MockStructure.kt
+++ b/components/feature/autofill/src/test/java/mozilla/components/feature/autofill/test/MockStructure.kt
@@ -5,11 +5,13 @@
 package mozilla.components.feature.autofill.test
 
 import android.view.autofill.AutofillId
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.feature.autofill.handler.FillRequestHandlerTest
 import mozilla.components.feature.autofill.structure.AutofillNodeNavigator
 import mozilla.components.feature.autofill.structure.RawStructure
 import java.io.File
 
+@ExperimentalCoroutinesApi
 internal fun FillRequestHandlerTest.createMockStructure(filename: String, packageName: String): RawStructure {
     val classLoader = javaClass.classLoader ?: throw RuntimeException("No class loader")
     val resource = classLoader.getResource(filename) ?: throw RuntimeException("Resource not found")

--- a/components/feature/awesomebar/build.gradle
+++ b/components/feature/awesomebar/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_mockwebserver
+    testImplementation Dependencies.testing_coroutines
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt
@@ -5,7 +5,8 @@
 package mozilla.components.feature.awesomebar.provider
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.storage.BookmarkInfo
 import mozilla.components.concept.storage.BookmarkNode
@@ -25,6 +26,7 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import java.util.UUID
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class BookmarksStorageSuggestionProviderTest {
 
@@ -36,7 +38,7 @@ class BookmarksStorageSuggestionProviderTest {
     )
 
     @Test
-    fun `Provider returns empty list when text is empty`() = runBlocking {
+    fun `Provider returns empty list when text is empty`() = runTest {
         val provider = BookmarksStorageSuggestionProvider(mock(), mock())
 
         val suggestions = provider.onInputChanged("")
@@ -44,7 +46,7 @@ class BookmarksStorageSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider returns suggestions from configured bookmarks storage`() = runBlocking {
+    fun `Provider returns suggestions from configured bookmarks storage`() = runTest {
         val provider = BookmarksStorageSuggestionProvider(bookmarks, mock())
 
         val id = bookmarks.addItem("Mobile", newItem.url!!, newItem.title!!, null)
@@ -61,7 +63,7 @@ class BookmarksStorageSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider does not return duplicate suggestions`() = runBlocking {
+    fun `Provider does not return duplicate suggestions`() = runTest {
         val provider = BookmarksStorageSuggestionProvider(bookmarks, mock())
 
         for (i in 1..20) {
@@ -73,7 +75,7 @@ class BookmarksStorageSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider limits number of returned unique suggestions`() = runBlocking {
+    fun `Provider limits number of returned unique suggestions`() = runTest {
         val provider = BookmarksStorageSuggestionProvider(bookmarks, mock())
 
         for (i in 1..100) {
@@ -90,7 +92,7 @@ class BookmarksStorageSuggestionProviderTest {
     }
 
     @Test
-    fun `provider calls speculative connect for URL of first suggestion`() = runBlocking {
+    fun `provider calls speculative connect for URL of first suggestion`() = runTest {
         val engine: Engine = mock()
         val provider = BookmarksStorageSuggestionProvider(bookmarks, mock(), engine = engine)
 
@@ -107,7 +109,7 @@ class BookmarksStorageSuggestionProviderTest {
     }
 
     @Test
-    fun `WHEN provider is set to not show edit suggestions THEN edit suggestion is set to null`() = runBlocking {
+    fun `WHEN provider is set to not show edit suggestions THEN edit suggestion is set to null`() = runTest {
         val engine: Engine = mock()
         val provider = BookmarksStorageSuggestionProvider(bookmarks, mock(), engine = engine, showEditSuggestion = false)
 

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/CombinedHistorySuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/CombinedHistorySuggestionProviderTest.kt
@@ -5,7 +5,8 @@
 package mozilla.components.feature.awesomebar.provider
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.storage.DocumentType
 import mozilla.components.concept.storage.HistoryMetadata
 import mozilla.components.concept.storage.HistoryMetadataKey
@@ -22,6 +23,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.doReturn
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class CombinedHistorySuggestionProviderTest {
 
@@ -36,7 +38,7 @@ class CombinedHistorySuggestionProviderTest {
     )
 
     @Test
-    fun `GIVEN history items exists WHEN onInputChanged is called with empty text THEN return empty suggestions list`() = runBlocking {
+    fun `GIVEN history items exists WHEN onInputChanged is called with empty text THEN return empty suggestions list`() = runTest {
         val metadata: HistoryMetadataStorage = mock()
         doReturn(listOf(historyEntry)).`when`(metadata).queryHistoryMetadata(eq("moz"), anyInt())
         val history: HistoryStorage = mock()
@@ -48,7 +50,7 @@ class CombinedHistorySuggestionProviderTest {
     }
 
     @Test
-    fun `GIVEN more suggestions asked than metadata items exist WHEN user changes input THEN return a combined list of suggestions`() = runBlocking {
+    fun `GIVEN more suggestions asked than metadata items exist WHEN user changes input THEN return a combined list of suggestions`() = runTest {
         val storage: HistoryMetadataStorage = mock()
         doReturn(listOf(historyEntry)).`when`(storage).queryHistoryMetadata(eq("moz"), anyInt())
         val history: HistoryStorage = mock()
@@ -63,7 +65,7 @@ class CombinedHistorySuggestionProviderTest {
     }
 
     @Test
-    fun `GIVEN fewer suggestions asked than metadata items exist WHEN user changes input THEN return suggestions only based on metadata items`() = runBlocking {
+    fun `GIVEN fewer suggestions asked than metadata items exist WHEN user changes input THEN return suggestions only based on metadata items`() = runTest {
         val storage: HistoryMetadataStorage = mock()
         doReturn(listOf(historyEntry)).`when`(storage).queryHistoryMetadata(eq("moz"), anyInt())
         val history: HistoryStorage = mock()
@@ -77,7 +79,7 @@ class CombinedHistorySuggestionProviderTest {
     }
 
     @Test
-    fun `GIVEN only storage history items exist WHEN user changes input THEN return suggestions only based on storage items`() = runBlocking {
+    fun `GIVEN only storage history items exist WHEN user changes input THEN return suggestions only based on storage items`() = runTest {
         val metadata: HistoryMetadataStorage = mock()
         doReturn(emptyList<HistoryMetadata>()).`when`(metadata).queryHistoryMetadata(eq("moz"), anyInt())
         val history: HistoryStorage = mock()
@@ -91,7 +93,7 @@ class CombinedHistorySuggestionProviderTest {
     }
 
     @Test
-    fun `GIVEN duplicated metadata and storage entries WHEN user changes input THEN return distinct suggestions`() = runBlocking {
+    fun `GIVEN duplicated metadata and storage entries WHEN user changes input THEN return distinct suggestions`() = runTest {
         val storage: HistoryMetadataStorage = mock()
         doReturn(listOf(historyEntry)).`when`(storage).queryHistoryMetadata(eq("moz"), anyInt())
         val history: HistoryStorage = mock()
@@ -105,7 +107,7 @@ class CombinedHistorySuggestionProviderTest {
     }
 
     @Test
-    fun `GIVEN a combined list of suggestions WHEN history results exist THEN urls are deduped and scores are adjusted`() = runBlocking {
+    fun `GIVEN a combined list of suggestions WHEN history results exist THEN urls are deduped and scores are adjusted`() = runTest {
         val metadataEntry1 = HistoryMetadata(
             key = HistoryMetadataKey("https://www.mozilla.com", null, null),
             title = "mozilla",
@@ -161,7 +163,7 @@ class CombinedHistorySuggestionProviderTest {
     }
 
     @Test
-    fun `WHEN provider is set to not show edit suggestions THEN edit suggestion is set to null`() = runBlocking {
+    fun `WHEN provider is set to not show edit suggestions THEN edit suggestion is set to null`() = runTest {
         val metadata: HistoryMetadataStorage = mock()
         doReturn(emptyList<HistoryMetadata>()).`when`(metadata).queryHistoryMetadata(eq("moz"), anyInt())
         val history: HistoryStorage = mock()

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryMetadataSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryMetadataSuggestionProviderTest.kt
@@ -4,7 +4,8 @@
 
 package mozilla.components.feature.awesomebar.provider
 
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.storage.DocumentType
 import mozilla.components.concept.storage.HistoryMetadata
@@ -30,6 +31,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 
+@ExperimentalCoroutinesApi // for runTest
 class HistoryMetadataSuggestionProviderTest {
     private val historyEntry = HistoryMetadata(
         key = HistoryMetadataKey("http://www.mozilla.com", null, null),
@@ -47,7 +49,7 @@ class HistoryMetadataSuggestionProviderTest {
     }
 
     @Test
-    fun `provider returns empty list when text is empty`() = runBlocking {
+    fun `provider returns empty list when text is empty`() = runTest {
         val provider = HistoryMetadataSuggestionProvider(mock(), mock())
 
         val suggestions = provider.onInputChanged("")
@@ -55,7 +57,7 @@ class HistoryMetadataSuggestionProviderTest {
     }
 
     @Test
-    fun `provider returns suggestions from configured history storage`() = runBlocking {
+    fun `provider returns suggestions from configured history storage`() = runTest {
         val storage: HistoryMetadataStorage = mock()
 
         whenever(storage.queryHistoryMetadata("moz", DEFAULT_METADATA_SUGGESTION_LIMIT)).thenReturn(listOf(historyEntry))
@@ -68,7 +70,7 @@ class HistoryMetadataSuggestionProviderTest {
     }
 
     @Test
-    fun `provider limits number of returned suggestions to 5 by default`() = runBlocking {
+    fun `provider limits number of returned suggestions to 5 by default`() = runTest {
         val storage: HistoryMetadataStorage = mock()
         doReturn(emptyList<HistoryMetadata>()).`when`(storage).queryHistoryMetadata(anyString(), anyInt())
         val provider = HistoryMetadataSuggestionProvider(storage, mock())
@@ -80,7 +82,7 @@ class HistoryMetadataSuggestionProviderTest {
     }
 
     @Test
-    fun `provider allows lowering the number of returned suggestions beneath the default`() = runBlocking {
+    fun `provider allows lowering the number of returned suggestions beneath the default`() = runTest {
         val storage: HistoryMetadataStorage = mock()
         doReturn(emptyList<HistoryMetadata>()).`when`(storage).queryHistoryMetadata(anyString(), anyInt())
         val provider = HistoryMetadataSuggestionProvider(
@@ -94,7 +96,7 @@ class HistoryMetadataSuggestionProviderTest {
     }
 
     @Test
-    fun `provider allows increasing the number of returned suggestions above the default`() = runBlocking {
+    fun `provider allows increasing the number of returned suggestions above the default`() = runTest {
         val storage: HistoryMetadataStorage = mock()
         doReturn(emptyList<HistoryMetadata>()).`when`(storage).queryHistoryMetadata(anyString(), anyInt())
         val provider = HistoryMetadataSuggestionProvider(
@@ -108,7 +110,7 @@ class HistoryMetadataSuggestionProviderTest {
     }
 
     @Test
-    fun `provider only as suggestions pages on which users actually spent some time`() = runBlocking {
+    fun `provider only as suggestions pages on which users actually spent some time`() = runTest {
         val storage: HistoryMetadataStorage = mock()
         val historyEntries = mutableListOf<HistoryMetadata>().apply {
             add(historyEntry)
@@ -122,7 +124,7 @@ class HistoryMetadataSuggestionProviderTest {
     }
 
     @Test
-    fun `provider calls speculative connect for URL of highest scored suggestion`() = runBlocking {
+    fun `provider calls speculative connect for URL of highest scored suggestion`() = runTest {
         val storage: HistoryMetadataStorage = mock()
         val engine: Engine = mock()
         val provider = HistoryMetadataSuggestionProvider(storage, mock(), engine = engine)
@@ -139,7 +141,7 @@ class HistoryMetadataSuggestionProviderTest {
     }
 
     @Test
-    fun `fact is emitted when suggestion is clicked`() = runBlocking {
+    fun `fact is emitted when suggestion is clicked`() = runTest {
         val storage: HistoryMetadataStorage = mock()
         val engine: Engine = mock()
         val provider = HistoryMetadataSuggestionProvider(storage, mock(), engine = engine)
@@ -173,7 +175,7 @@ class HistoryMetadataSuggestionProviderTest {
     }
 
     @Test
-    fun `WHEN provider is set to not show edit suggestions THEN edit suggestion is set to null`() = runBlocking {
+    fun `WHEN provider is set to not show edit suggestions THEN edit suggestion is set to null`() = runTest {
         val storage: HistoryMetadataStorage = mock()
 
         whenever(storage.queryHistoryMetadata("moz", DEFAULT_METADATA_SUGGESTION_LIMIT)).thenReturn(listOf(historyEntry))

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProviderTest.kt
@@ -5,7 +5,8 @@
 package mozilla.components.feature.awesomebar.provider
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.concept.storage.SearchResult
@@ -30,6 +31,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class HistoryStorageSuggestionProviderTest {
 
@@ -39,7 +41,7 @@ class HistoryStorageSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider returns empty list when text is empty`() = runBlocking {
+    fun `Provider returns empty list when text is empty`() = runTest {
         val provider = HistoryStorageSuggestionProvider(mock(), mock())
 
         val suggestions = provider.onInputChanged("")
@@ -47,7 +49,7 @@ class HistoryStorageSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider returns suggestions from configured history storage`() = runBlocking {
+    fun `Provider returns suggestions from configured history storage`() = runTest {
         val history: HistoryStorage = mock()
         Mockito.doReturn(listOf(SearchResult("id", "http://www.mozilla.com/", 10))).`when`(history).getSuggestions(eq("moz"), Mockito.anyInt())
         val provider = HistoryStorageSuggestionProvider(history, mock())
@@ -58,7 +60,7 @@ class HistoryStorageSuggestionProviderTest {
     }
 
     @Test
-    fun `WHEN provider is set to not show edit suggestions THEN edit suggestion is set to null`() = runBlocking {
+    fun `WHEN provider is set to not show edit suggestions THEN edit suggestion is set to null`() = runTest {
         val history: HistoryStorage = mock()
         Mockito.doReturn(listOf(SearchResult("id", "http://www.mozilla.com/", 10))).`when`(history).getSuggestions(eq("moz"), Mockito.anyInt())
         val provider = HistoryStorageSuggestionProvider(history, mock(), showEditSuggestion = false)
@@ -70,7 +72,7 @@ class HistoryStorageSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider limits number of returned suggestions to a max of 20 by default`() = runBlocking {
+    fun `Provider limits number of returned suggestions to a max of 20 by default`() = runTest {
         val history: HistoryStorage = mock()
         Mockito.doReturn(
             (1..100).map {
@@ -84,7 +86,7 @@ class HistoryStorageSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider allows lowering the number of returned suggestions beneath the default`() = runBlocking {
+    fun `Provider allows lowering the number of returned suggestions beneath the default`() = runTest {
         val history: HistoryStorage = mock()
         Mockito.doReturn(
             (1..50).map {
@@ -101,7 +103,7 @@ class HistoryStorageSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider allows increasing the number of returned suggestions above the default`() = runBlocking {
+    fun `Provider allows increasing the number of returned suggestions above the default`() = runTest {
         val history: HistoryStorage = mock()
         Mockito.doReturn(
             (1..50).map {
@@ -118,7 +120,7 @@ class HistoryStorageSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider dedupes suggestions`() = runBlocking {
+    fun `Provider dedupes suggestions`() = runTest {
         val storage: HistoryStorage = mock()
 
         val provider = HistoryStorageSuggestionProvider(storage, mock())
@@ -157,7 +159,7 @@ class HistoryStorageSuggestionProviderTest {
     }
 
     @Test
-    fun `provider calls speculative connect for URL of highest scored suggestion`() = runBlocking {
+    fun `provider calls speculative connect for URL of highest scored suggestion`() = runTest {
         val history: HistoryStorage = mock()
         val engine: Engine = mock()
         val provider = HistoryStorageSuggestionProvider(history, mock(), engine = engine)
@@ -175,7 +177,7 @@ class HistoryStorageSuggestionProviderTest {
     }
 
     @Test
-    fun `fact is emitted when suggestion is clicked`() = runBlocking {
+    fun `fact is emitted when suggestion is clicked`() = runTest {
         val history: HistoryStorage = mock()
         val engine: Engine = mock()
         val provider = HistoryStorageSuggestionProvider(history, mock(), engine = engine)

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchActionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchActionProviderTest.kt
@@ -4,36 +4,38 @@
 
 package mozilla.components.feature.awesomebar.provider
 
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+@ExperimentalCoroutinesApi // for runTest
 class SearchActionProviderTest {
     @Test
-    fun `provider returns no suggestion for empty text`() {
+    fun `provider returns no suggestion for empty text`() = runTest {
         val provider = SearchActionProvider(mock(), mock())
-        val suggestions = runBlocking { provider.onInputChanged("") }
+        val suggestions = provider.onInputChanged("")
 
         assertEquals(0, suggestions.size)
     }
 
     @Test
-    fun `provider returns no suggestion for blank text`() {
+    fun `provider returns no suggestion for blank text`() = runTest {
         val provider = SearchActionProvider(mock(), mock())
-        val suggestions = runBlocking { provider.onInputChanged("     ") }
+        val suggestions = provider.onInputChanged("     ")
 
         assertEquals(0, suggestions.size)
     }
 
     @Test
-    fun `provider returns suggestion matching input`() {
+    fun `provider returns suggestion matching input`() = runTest {
         val provider = SearchActionProvider(
             store = mock(),
             searchEngine = mock(),
             searchUseCase = mock()
         )
-        val suggestions = runBlocking { provider.onInputChanged("firefox") }
+        val suggestions = provider.onInputChanged("firefox")
 
         assertEquals(1, suggestions.size)
 

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchEngineSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchEngineSuggestionProviderTest.kt
@@ -6,7 +6,8 @@ package mozilla.components.feature.awesomebar.provider
 
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.feature.search.ext.createSearchEngine
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
@@ -16,6 +17,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class SearchEngineSuggestionProviderTest {
     private lateinit var defaultProvider: SearchEngineSuggestionProvider
@@ -43,21 +45,21 @@ class SearchEngineSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider returns empty list when text is empty`() = runBlocking {
+    fun `Provider returns empty list when text is empty`() = runTest {
         val suggestions = defaultProvider.onInputChanged("")
 
         assertTrue(suggestions.isEmpty())
     }
 
     @Test
-    fun `Provider returns empty list when text is blank`() = runBlocking {
+    fun `Provider returns empty list when text is blank`() = runTest {
         val suggestions = defaultProvider.onInputChanged("  ")
 
         assertTrue(suggestions.isEmpty())
     }
 
     @Test
-    fun `Provider returns empty list when text is shorter than charactersThreshold`() = runBlocking {
+    fun `Provider returns empty list when text is shorter than charactersThreshold`() = runTest {
         val provider = SearchEngineSuggestionProvider(
             testContext, engineList, mock(), 1, "description", mock(), charactersThreshold = 3
         )
@@ -68,7 +70,7 @@ class SearchEngineSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider returns empty list when list does not contain engines with typed text`() = runBlocking {
+    fun `Provider returns empty list when list does not contain engines with typed text`() = runTest {
 
         val suggestions = defaultProvider.onInputChanged("x")
 
@@ -76,7 +78,7 @@ class SearchEngineSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider returns a match when list contains the typed engine`() = runBlocking {
+    fun `Provider returns a match when list contains the typed engine`() = runTest {
 
         val suggestions = defaultProvider.onInputChanged("am")
 
@@ -84,7 +86,7 @@ class SearchEngineSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider returns empty list when the engine list is empty`() = runBlocking {
+    fun `Provider returns empty list when the engine list is empty`() = runTest {
         val providerEmpty = SearchEngineSuggestionProvider(
             testContext, emptyList(), mock(), 1, "description", mock()
         )
@@ -95,7 +97,7 @@ class SearchEngineSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider limits number of returned suggestions to maxSuggestions`() = runBlocking {
+    fun `Provider limits number of returned suggestions to maxSuggestions`() = runTest {
         // this should match to both engines in list
         val suggestions = defaultProvider.onInputChanged("n")
 

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProviderTest.kt
@@ -6,7 +6,8 @@ package mozilla.components.feature.awesomebar.provider
 
 import androidx.core.graphics.drawable.toBitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Request
@@ -39,11 +40,12 @@ import java.io.IOException
 private const val GOOGLE_MOCK_RESPONSE = "[\"firefox\",[\"firefox\",\"firefox for mac\",\"firefox quantum\",\"firefox update\",\"firefox esr\",\"firefox focus\",\"firefox addons\",\"firefox extensions\",\"firefox nightly\",\"firefox clear cache\"]]"
 private const val GOOGLE_MOCK_RESPONSE_WITH_DUPLICATES = "[\"firefox\",[\"firefox\",\"firefox\",\"firefox for mac\",\"firefox quantum\",\"firefox update\",\"firefox esr\",\"firefox esr\",\"firefox focus\",\"firefox addons\",\"firefox extensions\",\"firefox nightly\",\"firefox clear cache\"]]"
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class SearchSuggestionProviderTest {
     @Test
     fun `Provider returns suggestion with chips based on search engine suggestion`() {
-        runBlocking {
+        runTest {
             val server = MockWebServer()
             server.enqueue(MockResponse().setBody(GOOGLE_MOCK_RESPONSE))
             server.start()
@@ -101,7 +103,7 @@ class SearchSuggestionProviderTest {
 
     @Test
     fun `Provider returns multiple suggestions in MULTIPLE mode`() {
-        runBlocking {
+        runTest {
             val server = MockWebServer()
             server.enqueue(MockResponse().setBody(GOOGLE_MOCK_RESPONSE))
             server.start()
@@ -163,7 +165,7 @@ class SearchSuggestionProviderTest {
 
     @Test
     fun `Provider returns multiple suggestions with limit`() {
-        runBlocking {
+        runTest {
             val server = MockWebServer()
             server.enqueue(MockResponse().setBody(GOOGLE_MOCK_RESPONSE))
             server.start()
@@ -205,7 +207,7 @@ class SearchSuggestionProviderTest {
 
     @Test
     fun `Provider returns chips with limit`() {
-        runBlocking {
+        runTest {
             val server = MockWebServer()
             server.enqueue(MockResponse().setBody(GOOGLE_MOCK_RESPONSE))
             server.start()
@@ -242,7 +244,7 @@ class SearchSuggestionProviderTest {
 
     @Test
     fun `Provider should use engine icon by default`() {
-        runBlocking {
+        runTest {
             val server = MockWebServer()
             server.enqueue(MockResponse().setBody(GOOGLE_MOCK_RESPONSE))
             server.start()
@@ -269,7 +271,7 @@ class SearchSuggestionProviderTest {
 
     @Test
     fun `Provider should use icon parameter when available`() {
-        runBlocking {
+        runTest {
             val server = MockWebServer()
             server.enqueue(MockResponse().setBody(GOOGLE_MOCK_RESPONSE))
             server.start()
@@ -301,7 +303,7 @@ class SearchSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider returns empty list if text is empty`() = runBlocking {
+    fun `Provider returns empty list if text is empty`() = runTest {
         val provider = SearchSuggestionProvider(mock(), mock(), mock())
 
         val suggestions = provider.onInputChanged("")
@@ -310,7 +312,7 @@ class SearchSuggestionProviderTest {
 
     @Test
     fun `Provider should return default suggestion for search engine that cannot provide suggestion`() =
-        runBlocking {
+        runTest {
             val searchEngine = createSearchEngine(
                 name = "Test",
                 url = "https://localhost/?q={searchTerms}",
@@ -329,7 +331,7 @@ class SearchSuggestionProviderTest {
 
     @Test
     fun `Provider doesn't fail if fetch returns HTTP error`() {
-        runBlocking {
+        runTest {
             val server = MockWebServer()
             server.enqueue(MockResponse().setResponseCode(404).setBody("error"))
             server.start()
@@ -361,7 +363,7 @@ class SearchSuggestionProviderTest {
 
     @Test
     fun `Provider doesn't fail if fetch throws exception`() {
-        runBlocking {
+        runTest {
             val searchEngine = createSearchEngine(
                 name = "Test",
                 url = "https://localhost/?q={searchTerms}",
@@ -394,7 +396,7 @@ class SearchSuggestionProviderTest {
 
     @Test
     fun `Provider returns distinct multiple suggestions`() {
-        runBlocking {
+        runTest {
             val server = MockWebServer()
             server.enqueue(MockResponse().setBody(GOOGLE_MOCK_RESPONSE_WITH_DUPLICATES))
             server.start()
@@ -437,7 +439,7 @@ class SearchSuggestionProviderTest {
 
     @Test
     fun `Provider returns multiple suggestions with limit and no description`() {
-        runBlocking {
+        runTest {
             val server = MockWebServer()
             server.enqueue(MockResponse().setBody(GOOGLE_MOCK_RESPONSE))
             server.start()
@@ -481,7 +483,7 @@ class SearchSuggestionProviderTest {
 
     @Test
     fun `Provider calls speculativeConnect for URL of highest scored suggestion in MULTIPLE mode`() {
-        runBlocking {
+        runTest {
             val server = MockWebServer()
             server.enqueue(MockResponse().setBody(GOOGLE_MOCK_RESPONSE))
             server.start()
@@ -518,7 +520,7 @@ class SearchSuggestionProviderTest {
 
     @Test
     fun `Provider calls speculativeConnect for URL of highest scored chip in SINGLE mode`() {
-        runBlocking {
+        runTest {
             val server = MockWebServer()
             server.enqueue(MockResponse().setBody(GOOGLE_MOCK_RESPONSE))
             server.start()
@@ -555,7 +557,7 @@ class SearchSuggestionProviderTest {
 
     @Test
     fun `Provider filters exact match from multiple suggestions`() {
-        runBlocking {
+        runTest {
             val server = MockWebServer()
             server.enqueue(MockResponse().setBody(GOOGLE_MOCK_RESPONSE_WITH_DUPLICATES))
             server.start()
@@ -597,7 +599,7 @@ class SearchSuggestionProviderTest {
 
     @Test
     fun `Provider filters chips with exact match`() {
-        runBlocking {
+        runTest {
             val server = MockWebServer()
             server.enqueue(MockResponse().setBody(GOOGLE_MOCK_RESPONSE))
             server.start()

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProviderTest.kt
@@ -5,7 +5,8 @@
 package mozilla.components.feature.awesomebar.provider
 
 import android.content.res.Resources
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.createTab
@@ -20,9 +21,10 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 
+@ExperimentalCoroutinesApi // for runTest
 class SessionSuggestionProviderTest {
     @Test
-    fun `Provider returns empty list when text is empty`() = runBlocking {
+    fun `Provider returns empty list when text is empty`() = runTest {
         val resources: Resources = mock()
         `when`(resources.getString(anyInt())).thenReturn("Switch to tab")
 
@@ -33,7 +35,7 @@ class SessionSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider returns Sessions with matching URLs`() = runBlocking {
+    fun `Provider returns Sessions with matching URLs`() = runTest {
         val store = BrowserStore()
 
         val tab1 = createTab("https://www.mozilla.org")
@@ -77,7 +79,7 @@ class SessionSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider returns Sessions with matching titles`() = runBlocking {
+    fun `Provider returns Sessions with matching titles`() = runTest {
         val tab1 = createTab("https://allizom.org", title = "Internet for people, not profit — Mozilla")
         val tab2 = createTab("https://getpocket.com", title = "Pocket: My List")
         val tab3 = createTab("https://firefox.com", title = "Download Firefox — Free Web Browser")
@@ -113,7 +115,7 @@ class SessionSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider only returns non-private Sessions`() = runBlocking {
+    fun `Provider only returns non-private Sessions`() = runTest {
         val tab = createTab("https://www.mozilla.org")
         val privateTab1 = createTab("https://mozilla.org/firefox", private = true)
         val privateTab2 = createTab("https://mozilla.org/projects", private = true)
@@ -136,7 +138,7 @@ class SessionSuggestionProviderTest {
     }
 
     @Test
-    fun `Clicking suggestion invokes SelectTabUseCase`() = runBlocking {
+    fun `Clicking suggestion invokes SelectTabUseCase`() = runTest {
         val resources: Resources = mock()
         `when`(resources.getString(anyInt())).thenReturn("Switch to tab")
 
@@ -164,7 +166,7 @@ class SessionSuggestionProviderTest {
     }
 
     @Test
-    fun `When excludeSelectedSession is true provider should not include the selected session`() = runBlocking {
+    fun `When excludeSelectedSession is true provider should not include the selected session`() = runTest {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(
@@ -189,7 +191,7 @@ class SessionSuggestionProviderTest {
     }
 
     @Test
-    fun `When excludeSelectedSession is false provider should include the selected session`() = runBlocking {
+    fun `When excludeSelectedSession is false provider should include the selected session`() = runTest {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(
@@ -214,7 +216,7 @@ class SessionSuggestionProviderTest {
     }
 
     @Test
-    fun `Uses title for chip title when available, but falls back to URL`() = runBlocking {
+    fun `Uses title for chip title when available, but falls back to URL`() = runTest {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(

--- a/components/feature/containers/src/androidTest/java/mozilla/components/feature/containers/ContainerStorageTest.kt
+++ b/components/feature/containers/src/androidTest/java/mozilla/components/feature/containers/ContainerStorageTest.kt
@@ -11,7 +11,7 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.state.Container
 import mozilla.components.browser.state.state.ContainerState.Color
 import mozilla.components.browser.state.state.ContainerState.Icon
@@ -52,7 +52,7 @@ class ContainerStorageTest {
     }
 
     @Test
-    fun testAddingContainer() = runBlockingTest {
+    fun testAddingContainer() = runTest {
         storage.addContainer("1", "Personal", Color.RED, Icon.FINGERPRINT)
         storage.addContainer("2", "Shopping", Color.BLUE, Icon.CART)
 
@@ -71,7 +71,7 @@ class ContainerStorageTest {
     }
 
     @Test
-    fun testRemovingContainers() = runBlockingTest {
+    fun testRemovingContainers() = runTest {
         storage.addContainer("1", "Personal", Color.RED, Icon.FINGERPRINT)
         storage.addContainer("2", "Shopping", Color.BLUE, Icon.CART)
 
@@ -92,7 +92,7 @@ class ContainerStorageTest {
     }
 
     @Test
-    fun testGettingContainers() = runBlockingTest {
+    fun testGettingContainers() = runTest {
         storage.addContainer("1", "Personal", Color.RED, Icon.FINGERPRINT)
         storage.addContainer("2", "Shopping", Color.BLUE, Icon.CART)
 

--- a/components/feature/containers/src/androidTest/java/mozilla/components/feature/containers/db/ContainerDaoTest.kt
+++ b/components/feature/containers/src/androidTest/java/mozilla/components/feature/containers/db/ContainerDaoTest.kt
@@ -10,7 +10,7 @@ import androidx.paging.PagedList
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.state.ContainerState.Color
 import mozilla.components.browser.state.state.ContainerState.Icon
 import org.junit.After
@@ -48,7 +48,7 @@ class ContainerDaoTest {
     }
 
     @Test
-    fun testAddingContainer() = runBlockingTest {
+    fun testAddingContainer() = runTest {
         val container =
             ContainerEntity(
                 contextId = UUID.randomUUID().toString(),
@@ -70,7 +70,7 @@ class ContainerDaoTest {
     }
 
     @Test
-    fun testRemovingContainer() = runBlockingTest {
+    fun testRemovingContainer() = runTest {
         val container1 =
             ContainerEntity(
                 contextId = UUID.randomUUID().toString(),

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/AbstractCustomTabsServiceTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/AbstractCustomTabsServiceTest.kt
@@ -12,22 +12,17 @@ import android.support.customtabs.ICustomTabsCallback
 import android.support.customtabs.ICustomTabsService
 import androidx.browser.customtabs.CustomTabsService
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
 import mozilla.components.service.digitalassetlinks.RelationChecker
 import mozilla.components.support.test.mock
-import org.junit.After
+import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
@@ -36,21 +31,8 @@ import org.mockito.Mockito.verify
 @RunWith(AndroidJUnit4::class)
 class AbstractCustomTabsServiceTest {
 
-    @ExperimentalCoroutinesApi
-    private val testDispatcher = TestCoroutineDispatcher()
-
-    @ExperimentalCoroutinesApi
-    @Before
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @ExperimentalCoroutinesApi
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
-    }
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
 
     @Test
     fun customTabService() {

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
@@ -14,7 +14,7 @@ import android.widget.ImageButton
 import androidx.core.view.forEach
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.menu.BrowserMenuBuilder
@@ -857,7 +857,7 @@ class CustomTabsToolbarFeatureTest {
 
     @Test
     fun `show title only if not empty`() {
-        val dispatcher = TestCoroutineDispatcher()
+        val dispatcher = UnconfinedTestDispatcher()
         Dispatchers.setMain(dispatcher)
 
         val tab = createCustomTab(
@@ -898,8 +898,6 @@ class CustomTabsToolbarFeatureTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
-
         assertEquals("Internet for people, not profit - Mozilla", toolbar.title)
 
         Dispatchers.resetMain()
@@ -907,7 +905,7 @@ class CustomTabsToolbarFeatureTest {
 
     @Test
     fun `Will use URL as title if title was shown once and is now empty`() {
-        val dispatcher = TestCoroutineDispatcher()
+        val dispatcher = UnconfinedTestDispatcher()
         Dispatchers.setMain(dispatcher)
 
         val tab = createCustomTab(
@@ -947,15 +945,11 @@ class CustomTabsToolbarFeatureTest {
             ContentAction.UpdateUrlAction("mozilla", "https://www.mozilla.org/en-US/firefox/")
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
-
         assertEquals("", toolbar.title)
 
         store.dispatch(
             ContentAction.UpdateTitleAction("mozilla", "Firefox - Protect your life online with privacy-first products")
         ).joinBlocking()
-
-        dispatcher.advanceUntilIdle()
 
         assertEquals("Firefox - Protect your life online with privacy-first products", toolbar.title)
 
@@ -963,15 +957,11 @@ class CustomTabsToolbarFeatureTest {
             ContentAction.UpdateUrlAction("mozilla", "https://github.com/mozilla-mobile/android-components")
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
-
         assertEquals("https://github.com/mozilla-mobile/android-components", toolbar.title)
 
         store.dispatch(
             ContentAction.UpdateTitleAction("mozilla", "Le GitHub")
         ).joinBlocking()
-
-        dispatcher.advanceUntilIdle()
 
         assertEquals("Le GitHub", toolbar.title)
 
@@ -979,15 +969,11 @@ class CustomTabsToolbarFeatureTest {
             ContentAction.UpdateUrlAction("mozilla", "https://github.com/mozilla-mobile/fenix")
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
-
         assertEquals("https://github.com/mozilla-mobile/fenix", toolbar.title)
 
         store.dispatch(
             ContentAction.UpdateTitleAction("mozilla", "")
         ).joinBlocking()
-
-        dispatcher.advanceUntilIdle()
 
         assertEquals("https://github.com/mozilla-mobile/fenix", toolbar.title)
 
@@ -995,15 +981,11 @@ class CustomTabsToolbarFeatureTest {
             ContentAction.UpdateTitleAction("mozilla", "A collection of Android libraries to build browsers or browser-like applications.")
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
-
         assertEquals("A collection of Android libraries to build browsers or browser-like applications.", toolbar.title)
 
         store.dispatch(
             ContentAction.UpdateTitleAction("mozilla", "")
         ).joinBlocking()
-
-        dispatcher.advanceUntilIdle()
 
         assertEquals("https://github.com/mozilla-mobile/fenix", toolbar.title)
     }

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/OriginVerifierFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/OriginVerifierFeatureTest.kt
@@ -10,7 +10,7 @@ import androidx.browser.customtabs.CustomTabsSessionToken
 import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.feature.customtabs.store.CustomTabState
 import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
 import mozilla.components.feature.customtabs.store.OriginRelationPair
@@ -37,14 +37,14 @@ import org.mockito.Mockito.verify
 class OriginVerifierFeatureTest {
 
     @Test
-    fun `verify fails if no creatorPackageName is saved`() = runBlockingTest {
+    fun `verify fails if no creatorPackageName is saved`() = runTest {
         val feature = OriginVerifierFeature(mock(), mock(), mock())
 
         assertFalse(feature.verify(CustomTabState(), mock(), RELATION_HANDLE_ALL_URLS, mock()))
     }
 
     @Test
-    fun `verify returns existing relationship`() = runBlockingTest {
+    fun `verify returns existing relationship`() = runTest {
         val feature = OriginVerifierFeature(mock(), mock(), mock())
         val origin = "https://example.com".toUri()
         val state = CustomTabState(
@@ -61,7 +61,7 @@ class OriginVerifierFeatureTest {
     }
 
     @Test
-    fun `verify checks new relationships`() = runBlockingTest {
+    fun `verify checks new relationships`() = runTest {
         val store: CustomTabsServiceStore = mock()
         val verifier: OriginVerifier = mock()
         val feature = spy(OriginVerifierFeature(mock(), mock()) { store.dispatch(it) })

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/verify/OriginVerifierTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/verify/OriginVerifierTest.kt
@@ -10,7 +10,7 @@ import androidx.browser.customtabs.CustomTabsService.RELATION_USE_AS_ORIGIN
 import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.fetch.Response
 import mozilla.components.service.digitalassetlinks.AssetDescriptor
 import mozilla.components.service.digitalassetlinks.Relation
@@ -49,14 +49,14 @@ class OriginVerifierTest {
     }
 
     @Test
-    fun `only HTTPS allowed`() = runBlocking {
+    fun `only HTTPS allowed`() = runTest {
         val verifier = buildVerifier(RELATION_HANDLE_ALL_URLS)
         assertFalse(verifier.verifyOrigin("LOL".toUri()))
         assertFalse(verifier.verifyOrigin("http://www.android.com".toUri()))
     }
 
     @Test
-    fun verifyOrigin() = runBlocking {
+    fun verifyOrigin() = runTest {
         val verifier = buildVerifier(RELATION_USE_AS_ORIGIN)
         doReturn(true).`when`(checker).checkRelationship(
             AssetDescriptor.Web("https://www.example.com"),

--- a/components/feature/downloads/src/androidTest/java/mozilla/components/feature/downloads/OnDeviceDownloadStorageTest.kt
+++ b/components/feature/downloads/src/androidTest/java/mozilla/components/feature/downloads/OnDeviceDownloadStorageTest.kt
@@ -13,8 +13,7 @@ import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.feature.downloads.db.DownloadsDatabase
 import mozilla.components.feature.downloads.db.Migrations
@@ -165,7 +164,7 @@ class OnDeviceDownloadStorageTest {
     }
 
     @Test
-    fun testAddingDownload() = runBlockingTest {
+    fun testAddingDownload() = runTest {
         val download1 = createMockDownload("1", "url1")
         val download2 = createMockDownload("2", "url2")
         val download3 = createMockDownload("3", "url3")
@@ -184,7 +183,7 @@ class OnDeviceDownloadStorageTest {
     }
 
     @Test
-    fun testAddingDataURLDownload() = runBlockingTest {
+    fun testAddingDataURLDownload() = runTest {
         val download1 = createMockDownload("1", "data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==")
         val download2 = createMockDownload("2", "url2")
 
@@ -200,7 +199,7 @@ class OnDeviceDownloadStorageTest {
     }
 
     @Test
-    fun testUpdatingDataURLDownload() = runBlockingTest {
+    fun testUpdatingDataURLDownload() = runTest {
         val download1 = createMockDownload("1", "url1")
         val download2 = createMockDownload("2", "url2")
 
@@ -227,7 +226,7 @@ class OnDeviceDownloadStorageTest {
     }
 
     @Test
-    fun testRemovingDownload() = runBlockingTest {
+    fun testRemovingDownload() = runTest {
         val download1 = createMockDownload("1", "url1")
         val download2 = createMockDownload("2", "url2")
 
@@ -246,7 +245,7 @@ class OnDeviceDownloadStorageTest {
     }
 
     @Test
-    fun testGettingDownloads() = runBlockingTest {
+    fun testGettingDownloads() = runTest {
         val download1 = createMockDownload("1", "url1")
         val download2 = createMockDownload("2", "url2")
 
@@ -262,7 +261,7 @@ class OnDeviceDownloadStorageTest {
     }
 
     @Test
-    fun testRemovingDownloads() = runBlocking {
+    fun testRemovingDownloads() = runTest {
         for (index in 1..2) {
             storage.add(createMockDownload(index.toString(), "url1"))
         }

--- a/components/feature/downloads/src/androidTest/java/mozilla/components/feature/downloads/db/DownloadDaoTest.kt
+++ b/components/feature/downloads/src/androidTest/java/mozilla/components/feature/downloads/db/DownloadDaoTest.kt
@@ -9,7 +9,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.paging.PagedList
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.feature.downloads.DownloadStorage
 import org.junit.After
@@ -46,7 +46,7 @@ class DownloadDaoTest {
     }
 
     @Test
-    fun testInsertingAndReadingDownloads() = runBlocking {
+    fun testInsertingAndReadingDownloads() = runTest {
         val download = insertMockDownload("1", "https://www.mozilla.org/file1.txt")
         val pagedList = getDownloadsPagedList()
 
@@ -55,7 +55,7 @@ class DownloadDaoTest {
     }
 
     @Test
-    fun testRemoveAllDownloads() = runBlocking {
+    fun testRemoveAllDownloads() = runTest {
         for (index in 1..4) {
             insertMockDownload(index.toString(), "https://www.mozilla.org/file1.txt")
         }
@@ -71,7 +71,7 @@ class DownloadDaoTest {
     }
 
     @Test
-    fun testRemovingDownloads() = runBlocking {
+    fun testRemovingDownloads() = runTest {
         for (index in 1..2) {
             insertMockDownload(index.toString(), "https://www.mozilla.org/file1.txt")
         }
@@ -90,7 +90,7 @@ class DownloadDaoTest {
     }
 
     @Test
-    fun testUpdateDownload() = runBlocking {
+    fun testUpdateDownload() = runTest {
         insertMockDownload("1", "https://www.mozilla.org/file1.txt")
 
         var pagedList = getDownloadsPagedList()

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadMiddlewareTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadMiddlewareTest.kt
@@ -8,7 +8,6 @@ import android.app.DownloadManager.EXTRA_DOWNLOAD_ID
 import android.content.Context
 import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.DownloadAction
 import mozilla.components.browser.state.action.TabListAction
@@ -27,6 +26,7 @@ import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -47,7 +47,7 @@ class DownloadMiddlewareTest {
     private val dispatcher = coroutinesTestRule.testDispatcher
 
     @Test
-    fun `service is started when download is queued`() = runBlockingTest {
+    fun `service is started when download is queued`() = runTestOnMain {
         val applicationContext: Context = mock()
         val downloadMiddleware = spy(
             DownloadMiddleware(
@@ -83,7 +83,7 @@ class DownloadMiddlewareTest {
     }
 
     @Test
-    fun `saveDownload do not store private downloads`() = runBlockingTest {
+    fun `saveDownload do not store private downloads`() = runTestOnMain {
         val applicationContext: Context = mock()
         val downloadMiddleware = spy(
             DownloadMiddleware(
@@ -106,7 +106,7 @@ class DownloadMiddlewareTest {
     }
 
     @Test
-    fun `restarted downloads MUST not be passed to the downloadStorage`() = runBlockingTest {
+    fun `restarted downloads MUST not be passed to the downloadStorage`() = runTestOnMain {
         val applicationContext: Context = mock()
         val downloadStorage: DownloadStorage = mock()
         val downloadMiddleware = DownloadMiddleware(
@@ -132,7 +132,7 @@ class DownloadMiddlewareTest {
     }
 
     @Test
-    fun `previously added downloads MUST be ignored`() = runBlockingTest {
+    fun `previously added downloads MUST be ignored`() = runTestOnMain {
         val applicationContext: Context = mock()
         val downloadStorage: DownloadStorage = mock()
         val download = DownloadState("https://mozilla.org/download")
@@ -155,7 +155,7 @@ class DownloadMiddlewareTest {
     }
 
     @Test
-    fun `RemoveDownloadAction MUST remove from the storage`() = runBlockingTest {
+    fun `RemoveDownloadAction MUST remove from the storage`() = runTestOnMain {
         val applicationContext: Context = mock()
         val downloadStorage: DownloadStorage = mock()
         val downloadMiddleware = DownloadMiddleware(
@@ -178,7 +178,7 @@ class DownloadMiddlewareTest {
     }
 
     @Test
-    fun `RemoveAllDownloadsAction MUST remove all downloads from the storage`() = runBlockingTest {
+    fun `RemoveAllDownloadsAction MUST remove all downloads from the storage`() = runTestOnMain {
         val applicationContext: Context = mock()
         val downloadStorage: DownloadStorage = mock()
         val downloadMiddleware = DownloadMiddleware(
@@ -201,7 +201,7 @@ class DownloadMiddlewareTest {
     }
 
     @Test
-    fun `UpdateDownloadAction MUST update the storage when changes are needed`() = runBlockingTest {
+    fun `UpdateDownloadAction MUST update the storage when changes are needed`() = runTestOnMain {
         val applicationContext: Context = mock()
         val downloadStorage: DownloadStorage = mock()
         val downloadMiddleware = DownloadMiddleware(
@@ -242,7 +242,7 @@ class DownloadMiddlewareTest {
     }
 
     @Test
-    fun `RestoreDownloadsState MUST populate the store with items in the storage`() = runBlockingTest {
+    fun `RestoreDownloadsState MUST populate the store with items in the storage`() = runTestOnMain {
         val applicationContext: Context = mock()
         val downloadStorage: DownloadStorage = mock()
         val downloadMiddleware = DownloadMiddleware(
@@ -270,7 +270,7 @@ class DownloadMiddlewareTest {
     }
 
     @Test
-    fun `private downloads MUST NOT be restored`() = runBlockingTest {
+    fun `private downloads MUST NOT be restored`() = runTestOnMain {
         val applicationContext: Context = mock()
         val downloadStorage: DownloadStorage = mock()
         val downloadMiddleware = DownloadMiddleware(
@@ -298,7 +298,7 @@ class DownloadMiddlewareTest {
     }
 
     @Test
-    fun `sendDownloadIntent MUST call startForegroundService WHEN downloads are NOT COMPLETED, CANCELLED and FAILED`() = runBlockingTest {
+    fun `sendDownloadIntent MUST call startForegroundService WHEN downloads are NOT COMPLETED, CANCELLED and FAILED`() = runTestOnMain {
         val applicationContext: Context = mock()
         val downloadMiddleware = spy(
             DownloadMiddleware(
@@ -326,7 +326,7 @@ class DownloadMiddlewareTest {
     }
 
     @Test
-    fun `WHEN RemoveAllTabsAction and RemoveAllPrivateTabsAction are received THEN removePrivateNotifications must be called`() = runBlockingTest {
+    fun `WHEN RemoveAllTabsAction and RemoveAllPrivateTabsAction are received THEN removePrivateNotifications must be called`() = runTestOnMain {
         val applicationContext: Context = mock()
         val downloadMiddleware = spy(
             DownloadMiddleware(
@@ -355,7 +355,7 @@ class DownloadMiddlewareTest {
     }
 
     @Test
-    fun `WHEN RemoveTabsAction is received AND there is no private tabs THEN removePrivateNotifications MUST be called`() = runBlockingTest {
+    fun `WHEN RemoveTabsAction is received AND there is no private tabs THEN removePrivateNotifications MUST be called`() = runTestOnMain {
         val applicationContext: Context = mock()
         val downloadMiddleware = spy(
             DownloadMiddleware(
@@ -386,7 +386,7 @@ class DownloadMiddlewareTest {
     }
 
     @Test
-    fun `WHEN RemoveTabsAction is received AND there is a private tab THEN removePrivateNotifications MUST NOT be called`() = runBlockingTest {
+    fun `WHEN RemoveTabsAction is received AND there is a private tab THEN removePrivateNotifications MUST NOT be called`() = runTestOnMain {
         val applicationContext: Context = mock()
         val downloadMiddleware = spy(
             DownloadMiddleware(
@@ -417,7 +417,7 @@ class DownloadMiddlewareTest {
     }
 
     @Test
-    fun `WHEN RemoveTabAction is received AND there is no private tabs THEN removePrivateNotifications MUST be called`() = runBlockingTest {
+    fun `WHEN RemoveTabAction is received AND there is no private tabs THEN removePrivateNotifications MUST be called`() = runTestOnMain {
         val applicationContext: Context = mock()
         val downloadMiddleware = spy(
             DownloadMiddleware(
@@ -447,7 +447,7 @@ class DownloadMiddlewareTest {
     }
 
     @Test
-    fun `WHEN RemoveTabAction is received AND there is a private tab THEN removePrivateNotifications MUST NOT be called`() = runBlockingTest {
+    fun `WHEN RemoveTabAction is received AND there is a private tab THEN removePrivateNotifications MUST NOT be called`() = runTestOnMain {
         val applicationContext: Context = mock()
         val downloadMiddleware = spy(
             DownloadMiddleware(
@@ -477,7 +477,7 @@ class DownloadMiddlewareTest {
     }
 
     @Test
-    fun `WHEN removeStatusBarNotification is called THEN an ACTION_REMOVE_PRIVATE_DOWNLOAD intent must be created`() = runBlockingTest {
+    fun `WHEN removeStatusBarNotification is called THEN an ACTION_REMOVE_PRIVATE_DOWNLOAD intent must be created`() = runTestOnMain {
         val applicationContext: Context = mock()
         val downloadMiddleware = spy(
             DownloadMiddleware(
@@ -497,7 +497,7 @@ class DownloadMiddlewareTest {
     }
 
     @Test
-    fun `WHEN removePrivateNotifications is called THEN removeStatusBarNotification will be called only for private download`() = runBlockingTest {
+    fun `WHEN removePrivateNotifications is called THEN removeStatusBarNotification will be called only for private download`() = runTestOnMain {
         val applicationContext: Context = mock()
         val downloadMiddleware = spy(
             DownloadMiddleware(
@@ -522,7 +522,7 @@ class DownloadMiddlewareTest {
     }
 
     @Test
-    fun `WHEN removePrivateNotifications is called THEN removeStatusBarNotification will be called for all private downloads`() = runBlockingTest {
+    fun `WHEN removePrivateNotifications is called THEN removeStatusBarNotification will be called for all private downloads`() = runTestOnMain {
         val applicationContext: Context = mock()
         val downloadMiddleware = spy(
             DownloadMiddleware(
@@ -548,7 +548,7 @@ class DownloadMiddlewareTest {
     }
 
     @Test
-    fun `WHEN an action for canceling a download response is received THEN a download response must be canceled`() = runBlockingTest {
+    fun `WHEN an action for canceling a download response is received THEN a download response must be canceled`() = runTestOnMain {
         val response = mock<Response>()
         val download = DownloadState(id = "downloadID", url = "example.com/5MB.zip", response = response)
         val applicationContext: Context = mock()

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
@@ -16,10 +16,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.selector.findTab
@@ -39,14 +36,15 @@ import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.grantPermission
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.whenever
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyInt
@@ -63,14 +61,14 @@ import org.robolectric.shadows.ShadowToast
 @RunWith(AndroidJUnit4::class)
 class DownloadsFeatureTest {
 
-    private val testDispatcher = TestCoroutineDispatcher()
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val dispatcher = coroutinesTestRule.testDispatcher
 
     private lateinit var store: BrowserStore
 
     @Before
-    @ExperimentalCoroutinesApi
     fun setUp() {
-        Dispatchers.setMain(testDispatcher)
 
         store = BrowserStore(
             BrowserState(
@@ -78,13 +76,6 @@ class DownloadsFeatureTest {
                 selectedTabId = "test-tab"
             )
         )
-    }
-
-    @After
-    @ExperimentalCoroutinesApi
-    fun tearDown() {
-        Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
     }
 
     @Test
@@ -110,7 +101,7 @@ class DownloadsFeatureTest {
         store.dispatch(ContentAction.UpdateDownloadAction("test-tab", download))
             .joinBlocking()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertTrue(requestedPermissions)
         verify(fragmentManager, never()).beginTransaction()
@@ -137,7 +128,7 @@ class DownloadsFeatureTest {
         store.dispatch(ContentAction.UpdateDownloadAction("test-tab", download))
             .joinBlocking()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(fragmentManager).beginTransaction()
     }
@@ -188,7 +179,7 @@ class DownloadsFeatureTest {
         store.dispatch(ContentAction.UpdateDownloadAction("test-tab", download))
             .joinBlocking()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(downloadManager).download(eq(download), anyString())
     }
@@ -227,7 +218,7 @@ class DownloadsFeatureTest {
         store.dispatch(ContentAction.UpdateDownloadAction("test-tab", download))
             .joinBlocking()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(fragmentManager, never()).beginTransaction()
@@ -471,7 +462,7 @@ class DownloadsFeatureTest {
         store.dispatch(ContentAction.UpdateDownloadAction("test-tab", download))
             .joinBlocking()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(downloadManager).download(eq(download), anyString())
         verify(feature).showDownloadNotSupportedError()

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/share/ShareDownloadFeatureTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/share/ShareDownloadFeatureTest.kt
@@ -9,7 +9,7 @@ import android.webkit.MimeTypeMap
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
 import mozilla.components.browser.state.action.ShareInternetResourceAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.ContentState
@@ -60,7 +60,7 @@ class ShareDownloadFeatureTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val testDispatcher = coroutinesTestRule.testDispatcher
+    private val dispatcher = coroutinesTestRule.testDispatcher
 
     @Before
     fun setup() {
@@ -106,7 +106,7 @@ class ShareDownloadFeatureTest {
         shareFeature.start()
 
         store.dispatch(action).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(shareFeature).startSharing(download)
         verify(store).dispatch(ShareInternetResourceAction.ConsumeShareAction("123"))
@@ -136,7 +136,7 @@ class ShareDownloadFeatureTest {
         val shareState = ShareInternetResourceState(url = "testUrl", contentType = "contentType")
         val downloadedFile = File("filePath")
         doReturn(downloadedFile).`when`(shareFeature).download(any())
-        shareFeature.scope = TestCoroutineScope()
+        shareFeature.scope = TestScope(coroutineContext)
 
         shareFeature.startSharing(shareState)
 
@@ -153,7 +153,7 @@ class ShareDownloadFeatureTest {
         val shareState = ShareInternetResourceState(url = tooLongUrl, contentType = "contentType")
         val downloadedFile = File("filePath")
         doReturn(downloadedFile).`when`(shareFeature).download(any())
-        shareFeature.scope = TestCoroutineScope()
+        shareFeature.scope = TestScope()
 
         shareFeature.startSharing(shareState)
 
@@ -168,7 +168,7 @@ class ShareDownloadFeatureTest {
         val shareState = ShareInternetResourceState(url = "data:image/png;base64,longstring", contentType = "contentType")
         val downloadedFile = File("filePath")
         doReturn(downloadedFile).`when`(shareFeature).download(any())
-        shareFeature.scope = TestCoroutineScope()
+        shareFeature.scope = TestScope()
 
         shareFeature.startSharing(shareState)
 

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/share/ShareDownloadFeatureTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/share/ShareDownloadFeatureTest.kt
@@ -8,8 +8,6 @@ import android.content.Context
 import android.webkit.MimeTypeMap
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestScope
 import mozilla.components.browser.state.action.ShareInternetResourceAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.ContentState
@@ -27,6 +25,7 @@ import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -61,6 +60,7 @@ class ShareDownloadFeatureTest {
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
     private val dispatcher = coroutinesTestRule.testDispatcher
+    private val scope = coroutinesTestRule.scope
 
     @Before
     fun setup() {
@@ -75,7 +75,7 @@ class ShareDownloadFeatureTest {
     }
 
     @Test
-    fun `cleanupCache should automatically be called when this class is initialized`() = runBlocking {
+    fun `cleanupCache should automatically be called when this class is initialized`() = runTestOnMain {
         val cacheDir = File(context.cacheDir, cacheDirName).also { dir ->
             dir.mkdirs()
             File(dir, "leftoverFile").also { file ->
@@ -113,7 +113,7 @@ class ShareDownloadFeatureTest {
     }
 
     @Test
-    fun `cleanupCache should delete all files from the cache directory`() = runBlocking {
+    fun `cleanupCache should delete all files from the cache directory`() = runTestOnMain {
         val shareFeature = spy(ShareDownloadFeature(context, mock(), mock(), null, Dispatchers.Main))
         val testDir = File(context.cacheDir, cacheDirName).also { dir ->
             dir.mkdirs()
@@ -131,12 +131,12 @@ class ShareDownloadFeatureTest {
     }
 
     @Test
-    fun `startSharing() will download and then share the selected download`() = runBlocking {
+    fun `startSharing() will download and then share the selected download`() = runTestOnMain {
         val shareFeature = spy(ShareDownloadFeature(context, mock(), mock(), null))
         val shareState = ShareInternetResourceState(url = "testUrl", contentType = "contentType")
         val downloadedFile = File("filePath")
         doReturn(downloadedFile).`when`(shareFeature).download(any())
-        shareFeature.scope = TestScope(coroutineContext)
+        shareFeature.scope = scope
 
         shareFeature.startSharing(shareState)
 
@@ -146,14 +146,14 @@ class ShareDownloadFeatureTest {
     }
 
     @Test
-    fun `startSharing() will not use a too long HTTP url as message`() = runBlocking {
+    fun `startSharing() will not use a too long HTTP url as message`() = runTestOnMain {
         val shareFeature = spy(ShareDownloadFeature(context, mock(), mock(), null))
         val maxSizeUrl = "a".repeat(CHARACTERS_IN_SHARE_TEXT_LIMIT)
         val tooLongUrl = maxSizeUrl + 'x'
         val shareState = ShareInternetResourceState(url = tooLongUrl, contentType = "contentType")
         val downloadedFile = File("filePath")
         doReturn(downloadedFile).`when`(shareFeature).download(any())
-        shareFeature.scope = TestScope()
+        shareFeature.scope = scope
 
         shareFeature.startSharing(shareState)
 
@@ -163,12 +163,12 @@ class ShareDownloadFeatureTest {
     }
 
     @Test
-    fun `startSharing() will use an empty String as message for data URLs`() = runBlocking {
+    fun `startSharing() will use an empty String as message for data URLs`() = runTestOnMain {
         val shareFeature = spy(ShareDownloadFeature(context, mock(), mock(), null))
         val shareState = ShareInternetResourceState(url = "data:image/png;base64,longstring", contentType = "contentType")
         val downloadedFile = File("filePath")
         doReturn(downloadedFile).`when`(shareFeature).download(any())
-        shareFeature.scope = TestScope()
+        shareFeature.scope = scope
 
         shareFeature.startSharing(shareState)
 

--- a/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/internal/FindInPagePresenterTest.kt
+++ b/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/internal/FindInPagePresenterTest.kt
@@ -4,11 +4,7 @@
 
 package mozilla.components.feature.findinpage.internal
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.state.BrowserState
@@ -20,10 +16,11 @@ import mozilla.components.feature.findinpage.view.FindInPageView
 import mozilla.components.support.test.any
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
-import org.junit.After
+import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
@@ -33,13 +30,15 @@ import org.mockito.Mockito.verify
 
 class FindInPagePresenterTest {
 
-    private val testDispatcher = TestCoroutineDispatcher()
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val dispatcher = coroutinesTestRule.testDispatcher
+
     private lateinit var store: BrowserStore
 
     @Before
     @ExperimentalCoroutinesApi
     fun setUp() {
-        Dispatchers.setMain(testDispatcher)
         store = BrowserStore(
             BrowserState(
                 tabs = listOf(
@@ -50,13 +49,6 @@ class FindInPagePresenterTest {
         )
     }
 
-    @After
-    @ExperimentalCoroutinesApi
-    fun tearDown() {
-        Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
-    }
-
     @Test
     fun `view is updated to display latest find result`() {
         val view: FindInPageView = mock()
@@ -65,17 +57,17 @@ class FindInPagePresenterTest {
 
         val result = FindResultState(0, 2, false)
         store.dispatch(ContentAction.AddFindResultAction("test-tab", result)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         verify(view, never()).displayResult(result)
 
         presenter.bind(store.state.selectedTab!!)
         store.dispatch(ContentAction.AddFindResultAction("test-tab", result)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         verify(view).displayResult(result)
 
         val result2 = FindResultState(1, 2, true)
         store.dispatch(ContentAction.AddFindResultAction("test-tab", result2)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         verify(view).displayResult(result2)
     }
 
@@ -87,12 +79,12 @@ class FindInPagePresenterTest {
 
         presenter.bind(store.state.selectedTab!!)
         store.dispatch(ContentAction.AddFindResultAction("test-tab", mock())).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         verify(view, times(1)).displayResult(any())
 
         presenter.stop()
         store.dispatch(ContentAction.AddFindResultAction("test-tab", mock())).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         verify(view, times(1)).displayResult(any())
     }
 

--- a/components/feature/intent/src/test/java/mozilla/components/feature/intent/processing/TabIntentProcessorTest.kt
+++ b/components/feature/intent/src/test/java/mozilla/components/feature/intent/processing/TabIntentProcessorTest.kt
@@ -9,7 +9,6 @@ import android.content.Intent
 import android.nfc.NfcAdapter.ACTION_NDEF_DISCOVERED
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.engine.EngineMiddleware
@@ -51,7 +50,7 @@ class TabIntentProcessorTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val scope = TestCoroutineScope(coroutinesTestRule.testDispatcher)
+    private val scope = coroutinesTestRule.scope
 
     private lateinit var middleware: CaptureActionsMiddleware<BrowserState, BrowserAction>
 

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/MediaSessionFeatureTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/MediaSessionFeatureTest.kt
@@ -29,7 +29,6 @@ class MediaSessionFeatureTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val dispatcher = coroutinesTestRule.testDispatcher
 
     @Test
     fun `feature triggers foreground service when there's is media session state`() {
@@ -103,7 +102,6 @@ class MediaSessionFeatureTest {
 
         store.dispatch(MediaSessionAction.ActivatedMediaSessionAction(store.state.tabs[0].id, mock()))
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
         verify(mockApplicationContext, never()).startForegroundService(any())
 
         store.dispatch(
@@ -113,7 +111,6 @@ class MediaSessionFeatureTest {
             )
         )
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
     }
 
     @Test
@@ -143,7 +140,6 @@ class MediaSessionFeatureTest {
 
         store.dispatch(MediaSessionAction.ActivatedMediaSessionAction(store.state.tabs[0].id, mock()))
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
         verify(mockApplicationContext, never()).startForegroundService(any())
 
         store.dispatch(
@@ -153,7 +149,6 @@ class MediaSessionFeatureTest {
             )
         )
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
         verify(mockApplicationContext, times(1)).startForegroundService(any())
 
         store.dispatch(
@@ -163,17 +158,14 @@ class MediaSessionFeatureTest {
             )
         )
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
         verify(mockApplicationContext, times(1)).startForegroundService(any())
 
         store.dispatch(MediaSessionAction.DeactivatedMediaSessionAction(store.state.tabs[0].id))
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
         verify(mockApplicationContext, times(1)).startForegroundService(any())
 
         store.dispatch(MediaSessionAction.ActivatedMediaSessionAction(store.state.tabs[0].id, mock()))
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
         verify(mockApplicationContext, times(1)).startForegroundService(any())
 
         store.dispatch(
@@ -183,7 +175,6 @@ class MediaSessionFeatureTest {
             )
         )
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
         verify(mockApplicationContext, times(1)).startForegroundService(any())
 
         store.dispatch(
@@ -193,7 +184,6 @@ class MediaSessionFeatureTest {
             )
         )
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
         verify(mockApplicationContext, times(2)).startForegroundService(any())
 
         store.dispatch(
@@ -203,7 +193,6 @@ class MediaSessionFeatureTest {
             )
         )
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
         verify(mockApplicationContext, times(2)).startForegroundService(any())
     }
 }

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/ext/SessionStateKtTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/ext/SessionStateKtTest.kt
@@ -2,7 +2,7 @@ package mozilla.components.feature.media.ext
 
 import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.state.ContentState
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.support.test.mock
@@ -19,39 +19,33 @@ class SessionStateKtTest {
     private val getArtworkNull: (suspend () -> Bitmap?) = { null }
 
     @Test
-    fun `getNonPrivateIcon returns null when in private mode`() {
+    fun `getNonPrivateIcon returns null when in private mode`() = runTest {
         val sessionState: SessionState = mock()
         val contentState: ContentState = mock()
 
         whenever(sessionState.content).thenReturn(contentState)
         whenever(contentState.private).thenReturn(true)
 
-        var result: Bitmap?
-        runBlocking {
-            result = sessionState.getNonPrivateIcon(getArtwork)
-        }
+        val result = sessionState.getNonPrivateIcon(getArtwork)
 
         assertEquals(result, null)
     }
 
     @Test
-    fun `getNonPrivateIcon returns bitmap when not in private mode`() {
+    fun `getNonPrivateIcon returns bitmap when not in private mode`() = runTest {
         val sessionState: SessionState = mock()
         val contentState: ContentState = mock()
 
         whenever(sessionState.content).thenReturn(contentState)
         whenever(contentState.private).thenReturn(false)
 
-        var result: Bitmap?
-        runBlocking {
-            result = sessionState.getNonPrivateIcon(getArtwork)
-        }
+        val result = sessionState.getNonPrivateIcon(getArtwork)
 
         assertEquals(result, bitmap)
     }
 
     @Test
-    fun `getNonPrivateIcon returns content icon when not in private mode`() {
+    fun `getNonPrivateIcon returns content icon when not in private mode`() = runTest {
         val sessionState: SessionState = mock()
         val contentState: ContentState = mock()
         val icon: Bitmap = mock()
@@ -60,16 +54,13 @@ class SessionStateKtTest {
         whenever(contentState.private).thenReturn(false)
         whenever(contentState.icon).thenReturn(icon)
 
-        var result: Bitmap?
-        runBlocking {
-            result = sessionState.getNonPrivateIcon(null)
-        }
+        val result = sessionState.getNonPrivateIcon(null)
 
         assertEquals(result, icon)
     }
 
     @Test
-    fun `getNonPrivateIcon returns content icon when getArtwork return null`() {
+    fun `getNonPrivateIcon returns content icon when getArtwork return null`() = runTest {
         val sessionState: SessionState = mock()
         val contentState: ContentState = mock()
         val icon: Bitmap = mock()
@@ -78,10 +69,7 @@ class SessionStateKtTest {
         whenever(contentState.private).thenReturn(false)
         whenever(contentState.icon).thenReturn(icon)
 
-        var result: Bitmap?
-        runBlocking {
-            result = sessionState.getNonPrivateIcon(getArtworkNull)
-        }
+        val result = sessionState.getNonPrivateIcon(getArtworkNull)
 
         assertEquals(result, icon)
     }

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/fullscreen/MediaSessionFullscreenFeatureTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/fullscreen/MediaSessionFullscreenFeatureTest.kt
@@ -26,7 +26,6 @@ class MediaSessionFullscreenFeatureTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val dispatcher = coroutinesTestRule.testDispatcher
 
     @Test
     fun `screen orientation is updated correctly`() {
@@ -63,7 +62,6 @@ class MediaSessionFullscreenFeatureTest {
         )
 
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
 
         verify(mockActivity).setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT)
     }

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/notification/MediaNotificationTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/notification/MediaNotificationTest.kt
@@ -10,7 +10,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import androidx.core.app.NotificationCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.MediaSessionState
 import mozilla.components.browser.state.state.createTab
@@ -52,7 +52,7 @@ class MediaNotificationTest {
     }
 
     @Test
-    fun `media session notification for playing state`() {
+    fun `media session notification for playing state`() = runTest {
         val state = BrowserState(
             tabs = listOf(
                 createTab(
@@ -62,9 +62,7 @@ class MediaNotificationTest {
             )
         )
 
-        val notification = runBlocking {
-            MediaNotification(context, AbstractMediaSessionService::class.java).create(state.tabs[0], mock())
-        }
+        val notification = MediaNotification(context, AbstractMediaSessionService::class.java).create(state.tabs[0], mock())
 
         assertEquals("https://www.mozilla.org", notification.text)
         assertEquals("Mozilla", notification.title)
@@ -72,7 +70,7 @@ class MediaNotificationTest {
     }
 
     @Test
-    fun `media session notification for paused state`() {
+    fun `media session notification for paused state`() = runTest {
         val state = BrowserState(
             tabs = listOf(
                 createTab(
@@ -82,9 +80,7 @@ class MediaNotificationTest {
             )
         )
 
-        val notification = runBlocking {
-            MediaNotification(context, AbstractMediaSessionService::class.java).create(state.tabs[0], mock())
-        }
+        val notification = MediaNotification(context, AbstractMediaSessionService::class.java).create(state.tabs[0], mock())
 
         assertEquals("https://www.mozilla.org", notification.text)
         assertEquals("Mozilla", notification.title)
@@ -92,7 +88,7 @@ class MediaNotificationTest {
     }
 
     @Test
-    fun `media session notification for stopped state`() {
+    fun `media session notification for stopped state`() = runTest {
         val state = BrowserState(
             tabs = listOf(
                 createTab(
@@ -102,16 +98,14 @@ class MediaNotificationTest {
             )
         )
 
-        val notification = runBlocking {
-            MediaNotification(context, AbstractMediaSessionService::class.java).create(state.tabs[0], mock())
-        }
+        val notification = MediaNotification(context, AbstractMediaSessionService::class.java).create(state.tabs[0], mock())
 
         assertEquals("", notification.text)
         assertEquals("", notification.title)
     }
 
     @Test
-    fun `media session notification for playing state in private mode`() {
+    fun `media session notification for playing state in private mode`() = runTest {
         val state = BrowserState(
             tabs = listOf(
                 createTab(
@@ -121,9 +115,7 @@ class MediaNotificationTest {
             )
         )
 
-        val notification = runBlocking {
-            MediaNotification(context, AbstractMediaSessionService::class.java).create(state.tabs[0], mock())
-        }
+        val notification = MediaNotification(context, AbstractMediaSessionService::class.java).create(state.tabs[0], mock())
 
         assertEquals("", notification.text)
         assertEquals("A site is playing media", notification.title)
@@ -131,7 +123,7 @@ class MediaNotificationTest {
     }
 
     @Test
-    fun `media session notification for paused state in private mode`() {
+    fun `media session notification for paused state in private mode`() = runTest {
         val state = BrowserState(
             tabs = listOf(
                 createTab(
@@ -141,9 +133,7 @@ class MediaNotificationTest {
             )
         )
 
-        val notification = runBlocking {
-            MediaNotification(context, AbstractMediaSessionService::class.java).create(state.tabs[0], mock())
-        }
+        val notification = MediaNotification(context, AbstractMediaSessionService::class.java).create(state.tabs[0], mock())
 
         assertEquals("", notification.text)
         assertEquals("A site is playing media", notification.title)
@@ -151,7 +141,7 @@ class MediaNotificationTest {
     }
 
     @Test
-    fun `media session notification with metadata in non private mode`() {
+    fun `media session notification with metadata in non private mode`() = runTest {
         val mediaSessionState: MediaSessionState = mock()
         val metadata: MediaSession.Metadata = mock()
         whenever(mediaSessionState.metadata).thenReturn(metadata)
@@ -167,9 +157,7 @@ class MediaNotificationTest {
             )
         )
 
-        val notification = runBlocking {
-            MediaNotification(context, AbstractMediaSessionService::class.java).create(state.tabs[0], mock())
-        }
+        val notification = MediaNotification(context, AbstractMediaSessionService::class.java).create(state.tabs[0], mock())
 
         assertEquals("https://www.mozilla.org", notification.text)
         assertEquals("test title", notification.title)
@@ -177,7 +165,7 @@ class MediaNotificationTest {
     }
 
     @Test
-    fun `media session notification with metadata in private mode`() {
+    fun `media session notification with metadata in private mode`() = runTest {
         val mediaSessionState: MediaSessionState = mock()
         val metadata: MediaSession.Metadata = mock()
         whenever(mediaSessionState.metadata).thenReturn(metadata)
@@ -193,9 +181,7 @@ class MediaNotificationTest {
             )
         )
 
-        val notification = runBlocking {
-            MediaNotification(context, AbstractMediaSessionService::class.java).create(state.tabs[0], mock())
-        }
+        val notification = MediaNotification(context, AbstractMediaSessionService::class.java).create(state.tabs[0], mock())
 
         assertEquals("", notification.text)
         assertEquals("A site is playing media", notification.title)

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/service/MediaSessionServiceDelegateTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/service/MediaSessionServiceDelegateTest.kt
@@ -34,7 +34,6 @@ class MediaSessionServiceDelegateTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val dispatcher = coroutinesTestRule.testDispatcher
 
     @Test
     fun `media session state starts service in foreground`() {
@@ -113,7 +112,6 @@ class MediaSessionServiceDelegateTest {
         store.dispatch(MediaSessionAction.DeactivatedMediaSessionAction(store.state.customTabs[0].id))
 
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
 
         verify(service).stopSelf()
         verify(delegate).shutdown()

--- a/components/feature/privatemode/build.gradle
+++ b/components/feature/privatemode/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation Dependencies.kotlin_stdlib
 
     testImplementation project(':support-test')
+    testImplementation project(':support-test-libstate')
 
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.androidx_test_junit

--- a/components/feature/privatemode/src/test/java/mozilla/components/feature/privatemode/notification/PrivateNotificationFeatureTest.kt
+++ b/components/feature/privatemode/src/test/java/mozilla/components/feature/privatemode/notification/PrivateNotificationFeatureTest.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.action.CustomTabListAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.createCustomTab
@@ -15,6 +17,7 @@ import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -49,13 +52,14 @@ class PrivateNotificationFeatureTest {
     }
 
     @Test
-    fun `service should be started if pre-existing private session is present`() = runBlocking {
+    fun `service should be started if pre-existing private session is present`() = runTest(StandardTestDispatcher()) {
         val privateSession = createTab("https://firefox.com", private = true)
         val intent = argumentCaptor<Intent>()
 
         store.dispatch(TabListAction.AddTabAction(privateSession)).join()
 
         feature.start()
+        runCurrent()
         verify(context, times(1)).startService(intent.capture())
 
         val expected = Intent(testContext, AbstractPrivateNotificationService::class.java)
@@ -64,7 +68,7 @@ class PrivateNotificationFeatureTest {
     }
 
     @Test
-    fun `service should be started when private session is added`() = runBlocking {
+    fun `service should be started when private session is added`() = runTestOnMain {
         val privateSession = createTab("https://firefox.com", private = true)
 
         feature.start()
@@ -76,7 +80,7 @@ class PrivateNotificationFeatureTest {
     }
 
     @Test
-    fun `service should not be started multiple times`() = runBlocking {
+    fun `service should not be started multiple times`() = runTestOnMain {
         val privateSession1 = createTab("https://firefox.com", private = true)
         val privateSession2 = createTab("https://mozilla.org", private = true)
 
@@ -90,7 +94,7 @@ class PrivateNotificationFeatureTest {
     }
 
     @Test
-    fun `notification service should not be started when normal sessions are added`() = runBlocking {
+    fun `notification service should not be started when normal sessions are added`() = runTestOnMain {
         val normalSession = createTab("https://firefox.com")
         val customSession = createCustomTab("https://firefox.com")
 
@@ -106,7 +110,7 @@ class PrivateNotificationFeatureTest {
     }
 
     @Test
-    fun `notification service should not be started when custom sessions are added`() = runBlocking {
+    fun `notification service should not be started when custom sessions are added`() = runTestOnMain {
         val privateCustomSession = createCustomTab("https://firefox.com").let {
             it.copy(content = it.content.copy(private = true))
         }

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
@@ -17,11 +17,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.BrowserState
@@ -61,13 +57,14 @@ import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.whenever
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
@@ -84,7 +81,8 @@ import java.util.Date
 @RunWith(AndroidJUnit4::class)
 class PromptFeatureTest {
 
-    private val testDispatcher = TestCoroutineDispatcher()
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
 
     private lateinit var store: BrowserStore
     private lateinit var fragmentManager: FragmentManager
@@ -99,7 +97,6 @@ class PromptFeatureTest {
     @Before
     @ExperimentalCoroutinesApi
     fun setUp() {
-        Dispatchers.setMain(testDispatcher)
         store = BrowserStore(
             BrowserState(
                 tabs = listOf(
@@ -116,13 +113,6 @@ class PromptFeatureTest {
         fragmentManager = mockFragmentManager()
     }
 
-    @After
-    @ExperimentalCoroutinesApi
-    fun tearDown() {
-        Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
-    }
-
     @Test
     fun `PromptFeature acts on the selected session by default`() {
         val feature = spy(
@@ -136,7 +126,6 @@ class PromptFeatureTest {
 
         val promptRequest = SingleChoice(arrayOf(), {}, {})
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         verify(feature).onPromptRequested(store.state.tabs.first())
     }
 
@@ -155,7 +144,6 @@ class PromptFeatureTest {
         val promptRequest = SingleChoice(arrayOf(), {}, {})
         store.dispatch(ContentAction.UpdatePromptRequestAction("custom-tab", promptRequest))
             .joinBlocking()
-        testDispatcher.advanceUntilIdle()
         verify(feature).onPromptRequested(store.state.customTabs.first())
     }
 
@@ -172,7 +160,6 @@ class PromptFeatureTest {
 
         val promptRequest = SingleChoice(arrayOf(), {}, {})
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         feature.start()
         verify(feature).onPromptRequested(store.state.tabs.first())
     }
@@ -1449,7 +1436,6 @@ class PromptFeatureTest {
         val promptRequest = PromptRequest.Share(ShareData("Title", "Text", null), {}, {}, {})
         store.dispatch(ContentAction.UpdatePromptRequestAction("custom-tab", promptRequest))
             .joinBlocking()
-        testDispatcher.advanceUntilIdle()
 
         verify(feature).onPromptRequested(store.state.customTabs.first())
         verify(delegate).showShareSheet(
@@ -1477,7 +1463,6 @@ class PromptFeatureTest {
 
         store.dispatch(ContentAction.UpdatePromptRequestAction("custom-tab", selectCreditCardRequest))
             .joinBlocking()
-        testDispatcher.advanceUntilIdle()
 
         verify(feature).onPromptRequested(store.state.customTabs.first())
         verify(creditCardPicker).handleSelectCreditCardRequest(selectCreditCardRequest)
@@ -1500,7 +1485,6 @@ class PromptFeatureTest {
 
         store.dispatch(ContentAction.UpdatePromptRequestAction("custom-tab", selectCreditCardRequest))
             .joinBlocking()
-        testDispatcher.advanceUntilIdle()
 
         verify(feature).onPromptRequested(store.state.customTabs.first())
         verify(creditCardPicker, never()).handleSelectCreditCardRequest(selectCreditCardRequest)
@@ -1523,7 +1507,6 @@ class PromptFeatureTest {
 
         store.dispatch(ContentAction.UpdatePromptRequestAction("custom-tab", selectCreditCardRequest))
             .joinBlocking()
-        testDispatcher.advanceUntilIdle()
 
         verify(feature).onPromptRequested(store.state.customTabs.first())
         verify(creditCardPicker, never()).handleSelectCreditCardRequest(selectCreditCardRequest)

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptMiddlewareTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptMiddlewareTest.kt
@@ -28,7 +28,6 @@ class PromptMiddlewareTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val testDispatcher = coroutinesTestRule.testDispatcher
 
     private lateinit var store: BrowserStore
 
@@ -56,14 +55,12 @@ class PromptMiddlewareTest {
         val onDeny = spy { }
         val popupPrompt1 = PromptRequest.Popup("https://firefox.com", onAllow = { }, onDeny = onDeny)
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, popupPrompt1)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         assertEquals(1, tab()!!.content.promptRequests.size)
         assertEquals(popupPrompt1, tab()!!.content.promptRequests[0])
         verify(onDeny, never()).invoke()
 
         val popupPrompt2 = PromptRequest.Popup("https://firefox.com", onAllow = { }, onDeny = onDeny)
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, popupPrompt2)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         assertEquals(1, tab()!!.content.promptRequests.size)
         assertEquals(popupPrompt1, tab()!!.content.promptRequests[0])
         verify(onDeny).invoke()
@@ -74,14 +71,12 @@ class PromptMiddlewareTest {
         val onDeny = spy { }
         val popupPrompt = PromptRequest.Popup("https://firefox.com", onAllow = { }, onDeny = onDeny)
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, popupPrompt)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         assertEquals(1, tab()!!.content.promptRequests.size)
         assertEquals(popupPrompt, tab()!!.content.promptRequests[0])
         verify(onDeny, never()).invoke()
 
         val alert = PromptRequest.Alert("title", "message", false, { }, { })
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, alert)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         assertEquals(2, tab()!!.content.promptRequests.size)
         assertEquals(popupPrompt, tab()!!.content.promptRequests[0])
         assertEquals(alert, tab()!!.content.promptRequests[1])
@@ -91,14 +86,12 @@ class PromptMiddlewareTest {
     fun `Process popup after other prompt request`() {
         val alert = PromptRequest.Alert("title", "message", false, { }, { })
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, alert)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         assertEquals(1, tab()!!.content.promptRequests.size)
         assertEquals(alert, tab()!!.content.promptRequests[0])
 
         val onDeny = spy { }
         val popupPrompt = PromptRequest.Popup("https://firefox.com", onAllow = { }, onDeny = onDeny)
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, popupPrompt)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         assertEquals(2, tab()!!.content.promptRequests.size)
         assertEquals(alert, tab()!!.content.promptRequests[0])
         assertEquals(popupPrompt, tab()!!.content.promptRequests[1])
@@ -109,13 +102,11 @@ class PromptMiddlewareTest {
     fun `Process other prompt requests`() {
         val alert = PromptRequest.Alert("title", "message", false, { }, { })
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, alert)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         assertEquals(1, tab()!!.content.promptRequests.size)
         assertEquals(alert, tab()!!.content.promptRequests[0])
 
         val beforeUnloadPrompt = PromptRequest.BeforeUnload("title", onLeave = { }, onStay = { })
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, beforeUnloadPrompt)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         assertEquals(2, tab()!!.content.promptRequests.size)
         assertEquals(alert, tab()!!.content.promptRequests[0])
         assertEquals(beforeUnloadPrompt, tab()!!.content.promptRequests[1])

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/creditcard/CreditCardSelectBarTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/creditcard/CreditCardSelectBarTest.kt
@@ -9,7 +9,7 @@ import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.storage.CreditCardEntry
 import mozilla.components.feature.prompts.R
 import mozilla.components.feature.prompts.concept.SelectablePromptView
@@ -81,7 +81,7 @@ class CreditCardSelectBarTest {
     }
 
     @Test
-    fun `GIVEN a listener WHEN a credit card is selected THEN onOptionSelect is called`() = runBlocking {
+    fun `GIVEN a listener WHEN a credit card is selected THEN onOptionSelect is called`() = runTest {
         val listener: SelectablePromptView.Listener<CreditCardEntry> = mock()
         creditCardSelectBar.listener = listener
 

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/RustPushConnectionTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/RustPushConnectionTest.kt
@@ -5,7 +5,8 @@
 package mozilla.components.feature.push
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.appservices.push.DispatchInfo
 import mozilla.appservices.push.KeyInfo
 import mozilla.appservices.push.PushManager
@@ -30,48 +31,43 @@ import org.mockito.Mockito.anyString
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class RustPushConnectionTest {
 
     @Ignore("Requires push-forUnitTests; seems unnecessary to introduce it for this one test.")
     @Test
-    fun `new token initializes API`() {
+    fun `new token initializes API`() = runTest {
         val connection = createConnection()
 
         assertNull(connection.api)
 
-        runBlocking {
-            connection.updateToken("token")
-        }
+        connection.updateToken("token")
 
         assertNotNull(connection.api)
     }
 
     @Test
-    fun `new token calls update if API is already initialized`() {
+    fun `new token calls update if API is already initialized`() = runTest {
         val connection = createConnection()
         val api: PushManager = mock()
         connection.api = api
 
-        runBlocking {
-            connection.updateToken("123")
-        }
+        connection.updateToken("123")
 
         verify(api, never()).subscribe(any(), any(), any())
         verify(api).update(anyString())
     }
 
     @Test(expected = IllegalStateException::class)
-    fun `subscribe throws if API is not initialized first`() {
+    fun `subscribe throws if API is not initialized first`() = runTest {
         val connection = createConnection()
 
-        runBlocking {
-            connection.subscribe("123")
-        }
+        connection.subscribe("123")
     }
 
     @Test
-    fun `subscribe calls Rust API`() {
+    fun `subscribe calls Rust API`() = runTest {
         val connection = createConnection()
         val api: PushManager = mock()
         val response = SubscriptionResponse(
@@ -89,64 +85,54 @@ class RustPushConnectionTest {
 
         `when`(api.subscribe(anyString(), anyString(), nullable())).thenReturn(response)
 
-        runBlocking {
-            val sub = connection.subscribe("123")
+        val sub = connection.subscribe("123")
 
-            assertEquals("123", sub.scope)
-            assertEquals("auth", sub.authKey)
-            assertEquals("p256dh", sub.publicKey)
-            assertEquals("https://foo", sub.endpoint)
-        }
+        assertEquals("123", sub.scope)
+        assertEquals("auth", sub.authKey)
+        assertEquals("p256dh", sub.publicKey)
+        assertEquals("https://foo", sub.endpoint)
 
         verify(api).subscribe(anyString(), anyString(), nullable())
     }
 
     @Test(expected = IllegalStateException::class)
-    fun `unsubscribe throws if API is not initialized first`() {
+    fun `unsubscribe throws if API is not initialized first`() = runTest {
         val connection = createConnection()
 
-        runBlocking {
-            connection.unsubscribe("123")
-        }
+        connection.unsubscribe("123")
     }
 
     @Test
-    fun `unsubscribe calls Rust API`() {
+    fun `unsubscribe calls Rust API`() = runTest {
         val connection = createConnection()
         val api: PushManager = mock()
         connection.api = api
 
-        runBlocking {
-            connection.unsubscribe("123")
-        }
+        connection.unsubscribe("123")
 
         verify(api).unsubscribe(anyString())
     }
 
     @Test(expected = IllegalStateException::class)
-    fun `unsubscribeAll throws if API is not initialized first`() {
+    fun `unsubscribeAll throws if API is not initialized first`() = runTest {
         val connection = createConnection()
 
-        runBlocking {
-            connection.unsubscribeAll()
-        }
+        connection.unsubscribeAll()
     }
 
     @Test
-    fun `unsubscribeAll calls Rust API`() {
+    fun `unsubscribeAll calls Rust API`() = runTest {
         val connection = createConnection()
         val api: PushManager = mock()
         connection.api = api
 
-        runBlocking {
-            connection.unsubscribeAll()
-        }
+        connection.unsubscribeAll()
 
         verify(api).unsubscribeAll()
     }
 
     @Test
-    fun `containsSubscription returns true if a subscription exists`() {
+    fun `containsSubscription returns true if a subscription exists`() = runTest {
         val connection = createConnection()
         val api: PushManager = mock()
         connection.api = api
@@ -155,122 +141,99 @@ class RustPushConnectionTest {
             .thenReturn(mock())
             .thenReturn(null)
 
-        runBlocking {
-            assertTrue(connection.containsSubscription("validSubscription"))
-
-            assertFalse(connection.containsSubscription("invalidSubscription"))
-        }
+        assertTrue(connection.containsSubscription("validSubscription"))
+        assertFalse(connection.containsSubscription("invalidSubscription"))
     }
 
     @Test(expected = IllegalStateException::class)
-    fun `verifyConnection throws if API is not initialized first`() {
+    fun `verifyConnection throws if API is not initialized first`() = runTest {
         val connection = createConnection()
 
-        runBlocking {
-            connection.verifyConnection()
-        }
+        connection.verifyConnection()
     }
 
     @Test
-    fun `verifyConnection calls Rust API`() {
+    fun `verifyConnection calls Rust API`() = runTest {
         val connection = createConnection()
         val api: PushManager = mock()
         connection.api = api
 
-        runBlocking {
-            connection.verifyConnection()
-        }
+        connection.verifyConnection()
 
         verify(api).verifyConnection()
     }
 
     @Test(expected = IllegalStateException::class)
-    fun `decrypt throws if API is not initialized first`() {
+    fun `decrypt throws if API is not initialized first`() = runTest {
         val connection = createConnection()
 
-        runBlocking {
-            connection.decryptMessage("123", "plain text")
-        }
+        connection.decryptMessage("123", "plain text")
     }
 
     @Test
-    fun `decrypt calls Rust API`() {
+    fun `decrypt calls Rust API`() = runTest {
         val connection = createConnection()
         val api: PushManager = mock()
         val dispatchInfo: DispatchInfo = mock()
         connection.api = api
 
-        runBlocking {
-            connection.decryptMessage("123", "body")
-        }
+        connection.decryptMessage("123", "body")
 
         verify(api, never()).decrypt(anyString(), anyString(), eq(""), eq(""), eq(""))
 
         `when`(api.dispatchInfoForChid(anyString())).thenReturn(dispatchInfo)
         `when`(dispatchInfo.scope).thenReturn("test")
 
-        runBlocking {
-            connection.decryptMessage("123", "body")
-        }
+        connection.decryptMessage("123", "body")
 
         verify(api).decrypt(anyString(), anyString(), eq(""), eq(""), eq(""))
 
-        runBlocking {
-            connection.decryptMessage("123", "body", "enc", "salt", "key")
-        }
+        connection.decryptMessage("123", "body", "enc", "salt", "key")
 
         verify(api).decrypt(anyString(), anyString(), eq("enc"), eq("salt"), eq("key"))
     }
 
     @Test
-    fun `empty body decrypts nothing`() {
+    fun `empty body decrypts nothing`() = runTest {
         val connection = createConnection()
         val api: PushManager = mock()
         val dispatchInfo: DispatchInfo = mock()
         connection.api = api
 
-        runBlocking {
-            connection.decryptMessage("123", null)
-        }
+        connection.decryptMessage("123", null)
 
         verify(api, never()).decrypt(anyString(), anyString(), eq(""), eq(""), eq(""))
 
         `when`(api.dispatchInfoForChid(anyString())).thenReturn(dispatchInfo)
         `when`(dispatchInfo.scope).thenReturn("test")
 
-        runBlocking {
-            val (scope, message) = connection.decryptMessage("123", null)!!
-            assertEquals("test", scope)
-            assertNull(message)
-        }
+        val (scope, message) = connection.decryptMessage("123", null)!!
+        assertEquals("test", scope)
+        assertNull(message)
 
         verify(api, never()).decrypt(anyString(), nullable(), eq(""), eq(""), eq(""))
     }
 
     @Test(expected = IllegalStateException::class)
-    fun `close throws if API is not initialized first`() {
+    fun `close throws if API is not initialized first`() = runTest {
         val connection = createConnection()
 
-        runBlocking {
-            connection.close()
-        }
+        connection.close()
     }
 
     @Test
-    fun `close calls Rust API`() {
+    fun `close calls Rust API`() = runTest {
         val connection = createConnection()
         val api: PushManager = mock()
         connection.api = api
 
-        runBlocking {
-            connection.close()
-        }
+        connection.close()
 
         verify(api).close()
     }
 
     @Test
-    fun `initialized is true when api is not null`() {
+    fun `initialized is true when api is not null`() = runTest {
         val connection = createConnection()
 
         assertFalse(connection.isInitialized())

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/ext/CoroutineScopeKtTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/ext/CoroutineScopeKtTest.kt
@@ -8,7 +8,7 @@ package mozilla.components.feature.push.ext
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.appservices.push.InternalException
 import mozilla.appservices.push.PushException.AlreadyRegisteredException
 import mozilla.appservices.push.PushException.CommunicationException
@@ -28,7 +28,7 @@ import org.junit.Test
 class CoroutineScopeKtTest {
 
     @Test(expected = InternalException::class)
-    fun `launchAndTry throws on unrecoverable Rust exceptions`() = runBlockingTest {
+    fun `launchAndTry throws on unrecoverable Rust exceptions`() = runTest {
         CoroutineScope(coroutineContext).launchAndTry(
             errorBlock = { throw InternalException("unit test") },
             block = { throw MissingRegistrationTokenException("") }
@@ -36,7 +36,7 @@ class CoroutineScopeKtTest {
     }
 
     @Test(expected = ArithmeticException::class)
-    fun `launchAndTry throws original exception`() = runBlockingTest {
+    fun `launchAndTry throws original exception`() = runTest {
         CoroutineScope(coroutineContext).launchAndTry(
             errorBlock = { throw InternalException("unit test") },
             block = { throw ArithmeticException() }
@@ -44,7 +44,7 @@ class CoroutineScopeKtTest {
     }
 
     @Test
-    fun `launchAndTry should NOT throw on recoverable Rust exceptions`() = runBlockingTest {
+    fun `launchAndTry should NOT throw on recoverable Rust exceptions`() = runTest {
         CoroutineScope(coroutineContext).launchAndTry(
             { throw CryptoException("should not fail test") },
             { assert(true) }

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ManifestStorageTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ManifestStorageTest.kt
@@ -6,7 +6,7 @@ package mozilla.components.feature.pwa
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.feature.pwa.db.ManifestDao
 import mozilla.components.feature.pwa.db.ManifestEntity
@@ -50,14 +50,14 @@ class ManifestStorageTest {
     )
 
     @Test
-    fun `load returns null if entry does not exist`() = runBlocking {
+    fun `load returns null if entry does not exist`() = runTest {
         val storage = spy(ManifestStorage(testContext))
         mockDatabase(storage)
         assertNull(storage.loadManifest("https://example.com"))
     }
 
     @Test
-    fun `load returns valid manifest`() = runBlocking {
+    fun `load returns valid manifest`() = runTest {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
 
@@ -69,7 +69,7 @@ class ManifestStorageTest {
     }
 
     @Test
-    fun `save saves the manifest as JSON`() = runBlocking {
+    fun `save saves the manifest as JSON`() = runTest {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
 
@@ -79,7 +79,7 @@ class ManifestStorageTest {
     }
 
     @Test
-    fun `update replaces the manifest as JSON`() = runBlocking {
+    fun `update replaces the manifest as JSON`() = runTest {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
         val existing = ManifestEntity(firefoxManifest, currentTime = 0)
@@ -92,7 +92,7 @@ class ManifestStorageTest {
     }
 
     @Test
-    fun `update does not replace non-existed manifest`() = runBlocking {
+    fun `update does not replace non-existed manifest`() = runTest {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
 
@@ -104,7 +104,7 @@ class ManifestStorageTest {
     }
 
     @Test
-    fun `remove deletes saved manifests`() = runBlocking {
+    fun `remove deletes saved manifests`() = runTest {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
 
@@ -114,7 +114,7 @@ class ManifestStorageTest {
     }
 
     @Test
-    fun `loading manifests by scope returns list of manifests`() = runBlocking {
+    fun `loading manifests by scope returns list of manifests`() = runTest {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
         val manifest1 = WebAppManifest(name = "Mozilla1", startUrl = "https://mozilla.org", scope = "https://mozilla.org/pwa/1/")
@@ -131,7 +131,7 @@ class ManifestStorageTest {
     }
 
     @Test
-    fun `loading manifests with share targets returns list of manifests`() = runBlocking {
+    fun `loading manifests with share targets returns list of manifests`() = runTest {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
         val manifest1 = WebAppManifest(
@@ -158,7 +158,7 @@ class ManifestStorageTest {
     }
 
     @Test
-    fun `updateManifestUsedAt updates usedAt to current timestamp`() = runBlocking {
+    fun `updateManifestUsedAt updates usedAt to current timestamp`() = runTest {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
         val manifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org")
@@ -178,7 +178,7 @@ class ManifestStorageTest {
     }
 
     @Test
-    fun `has recent manifest returns false if no manifest is found`() = runBlocking {
+    fun `has recent manifest returns false if no manifest is found`() = runTest {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
         val timeout = ManifestStorage.ACTIVE_THRESHOLD_MS
@@ -192,7 +192,7 @@ class ManifestStorageTest {
     }
 
     @Test
-    fun `has recent manifest returns true if one or more manifests have been found`() = runBlocking {
+    fun `has recent manifest returns true if one or more manifests have been found`() = runTest {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
         val timeout = ManifestStorage.ACTIVE_THRESHOLD_MS
@@ -211,7 +211,7 @@ class ManifestStorageTest {
     }
 
     @Test
-    fun `recently used manifest count`() = runBlocking {
+    fun `recently used manifest count`() = runTest {
         val testThreshold = 1000 * 60 * 24L
         val storage = spy(ManifestStorage(testContext, activeThresholdMs = testThreshold))
         val dao = mockDatabase(storage)
@@ -241,7 +241,7 @@ class ManifestStorageTest {
     }
 
     @Test
-    fun `warmUpScopes populates cache of already installed web app scopes`() = runBlocking {
+    fun `warmUpScopes populates cache of already installed web app scopes`() = runTest {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
 
@@ -264,7 +264,7 @@ class ManifestStorageTest {
     }
 
     @Test
-    fun `getInstalledScope returns cached scope for an url`() = runBlocking {
+    fun `getInstalledScope returns cached scope for an url`() = runTest {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
 
@@ -282,7 +282,7 @@ class ManifestStorageTest {
     }
 
     @Test
-    fun `getStartUrlForInstalledScope returns cached start url for a currently installed scope`() = runBlocking {
+    fun `getStartUrlForInstalledScope returns cached start url for a currently installed scope`() = runTest {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
 

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppShortcutManagerTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppShortcutManagerTest.kt
@@ -14,7 +14,7 @@ import androidx.core.graphics.drawable.IconCompat
 import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.state.state.SecurityInfoState
 import mozilla.components.browser.state.state.SessionState
@@ -78,7 +78,7 @@ class WebAppShortcutManagerTest {
     fun teardown() = setSdkInt(0)
 
     @Test
-    fun `requestPinShortcut no-op if pinning unsupported`() = runBlockingTest {
+    fun `requestPinShortcut no-op if pinning unsupported`() = runTest {
         val manifest = baseManifest.copy(
             display = WebAppManifest.DisplayMode.STANDALONE,
             icons = listOf(
@@ -103,7 +103,7 @@ class WebAppShortcutManagerTest {
     }
 
     @Test
-    fun `requestPinShortcut won't make a PWA icon if the session is not installable`() = runBlockingTest {
+    fun `requestPinShortcut won't make a PWA icon if the session is not installable`() = runTest {
         setSdkInt(Build.VERSION_CODES.O)
         val manifest = baseManifest.copy(
             display = WebAppManifest.DisplayMode.STANDALONE,
@@ -120,7 +120,7 @@ class WebAppShortcutManagerTest {
     }
 
     @Test
-    fun `requestPinShortcut pins PWA shortcut`() = runBlockingTest {
+    fun `requestPinShortcut pins PWA shortcut`() = runTest {
         setSdkInt(Build.VERSION_CODES.O)
 
         val manifest = baseManifest.copy(
@@ -145,7 +145,7 @@ class WebAppShortcutManagerTest {
     }
 
     @Test
-    fun `requestPinShortcut pins basic shortcut`() = runBlockingTest {
+    fun `requestPinShortcut pins basic shortcut`() = runTest {
         setSdkInt(Build.VERSION_CODES.O)
 
         val session = buildInstallableSession()
@@ -160,7 +160,7 @@ class WebAppShortcutManagerTest {
     }
 
     @Test
-    fun `buildBasicShortcut uses manifest short name as label by default`() = runBlockingTest {
+    fun `buildBasicShortcut uses manifest short name as label by default`() = runTest {
         setSdkInt(Build.VERSION_CODES.O)
 
         val session = createTab("https://www.mozilla.org", title = "Internet for people, not profit — Mozilla").let {
@@ -181,7 +181,7 @@ class WebAppShortcutManagerTest {
     }
 
     @Test
-    fun `buildBasicShortcut uses manifest name as label by default`() = runBlockingTest {
+    fun `buildBasicShortcut uses manifest name as label by default`() = runTest {
         setSdkInt(Build.VERSION_CODES.O)
 
         val session = createTab("https://www.mozilla.org", title = "Internet for people, not profit — Mozilla").let {
@@ -201,7 +201,7 @@ class WebAppShortcutManagerTest {
     }
 
     @Test
-    fun `buildBasicShortcut uses session title as label if there is no manifest`() = runBlockingTest {
+    fun `buildBasicShortcut uses session title as label if there is no manifest`() = runTest {
         setSdkInt(Build.VERSION_CODES.O)
 
         val expectedTitle = "Internet for people, not profit — Mozilla"
@@ -214,7 +214,7 @@ class WebAppShortcutManagerTest {
     }
 
     @Test
-    fun `buildBasicShortcut can create a shortcut with a custom name`() = runBlockingTest {
+    fun `buildBasicShortcut can create a shortcut with a custom name`() = runTest {
         setSdkInt(Build.VERSION_CODES.O)
 
         val title = "Internet for people, not profit — Mozilla"
@@ -228,7 +228,7 @@ class WebAppShortcutManagerTest {
     }
 
     @Test
-    fun `updateShortcuts no-op`() = runBlockingTest {
+    fun `updateShortcuts no-op`() = runTest {
         val manifests = listOf(baseManifest)
         doReturn(null).`when`(manager).buildWebAppShortcut(context, manifests[0])
 
@@ -242,7 +242,7 @@ class WebAppShortcutManagerTest {
     }
 
     @Test
-    fun `updateShortcuts updates list of existing shortcuts`() = runBlockingTest {
+    fun `updateShortcuts updates list of existing shortcuts`() = runTest {
         setSdkInt(Build.VERSION_CODES.N_MR1)
         val manifests = listOf(baseManifest)
         val shortcutCompat: ShortcutInfoCompat = mock()
@@ -255,7 +255,7 @@ class WebAppShortcutManagerTest {
     }
 
     @Test
-    fun `buildWebAppShortcut builds shortcut and saves manifest`() = runBlockingTest {
+    fun `buildWebAppShortcut builds shortcut and saves manifest`() = runTest {
         doReturn(mock<IconCompat>()).`when`(manager).buildIconFromManifest(baseManifest)
 
         val shortcut = manager.buildWebAppShortcut(context, baseManifest)!!
@@ -271,7 +271,7 @@ class WebAppShortcutManagerTest {
     }
 
     @Test
-    fun `buildWebAppShortcut builds shortcut with short name`() = runBlockingTest {
+    fun `buildWebAppShortcut builds shortcut with short name`() = runTest {
         val manifest = WebAppManifest(name = "Demo Demo", shortName = "DD", startUrl = "https://example.com")
         doReturn(mock<IconCompat>()).`when`(manager).buildIconFromManifest(manifest)
 
@@ -303,7 +303,7 @@ class WebAppShortcutManagerTest {
     }
 
     @Test
-    fun `checking unknown url returns uninstalled state`() = runBlockingTest {
+    fun `checking unknown url returns uninstalled state`() = runTest {
         setSdkInt(Build.VERSION_CODES.N_MR1)
 
         val url = "https://mozilla.org"
@@ -318,7 +318,7 @@ class WebAppShortcutManagerTest {
     }
 
     @Test
-    fun `checking a known url returns installed state`() = runBlockingTest {
+    fun `checking a known url returns installed state`() = runTest {
         setSdkInt(Build.VERSION_CODES.N_MR1)
 
         val url = "https://mozilla.org/pwa/"

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppUseCasesTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppUseCasesTest.kt
@@ -6,7 +6,7 @@ package mozilla.components.feature.pwa
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.SecurityInfoState
 import mozilla.components.browser.state.state.TabSessionState
@@ -109,7 +109,7 @@ class WebAppUseCasesTest {
     }
 
     @Test
-    fun `getInstallState returns Installed if manifest exists`() = runBlockingTest {
+    fun `getInstallState returns Installed if manifest exists`() = runTest {
         val httpClient: Client = mock()
         val storage: ManifestStorage = mock()
         val shortcutManager = WebAppShortcutManager(testContext, httpClient, storage)

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/feature/ManifestUpdateFeatureTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/feature/ManifestUpdateFeatureTest.kt
@@ -5,8 +5,6 @@
 package mozilla.components.feature.pwa.feature
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.createCustomTab
@@ -20,6 +18,7 @@ import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -59,7 +58,7 @@ class ManifestUpdateFeatureTest {
     }
 
     @Test
-    fun `start and stop handle null session`() = runBlockingTest {
+    fun `start and stop handle null session`() = runTestOnMain {
         val feature = ManifestUpdateFeature(
             testContext,
             store,
@@ -80,7 +79,7 @@ class ManifestUpdateFeatureTest {
     }
 
     @Test
-    fun `Last usage is updated when feature is started`() {
+    fun `Last usage is updated when feature is started`() = runTestOnMain {
         val feature = ManifestUpdateFeature(
             testContext,
             store,
@@ -102,13 +101,11 @@ class ManifestUpdateFeatureTest {
 
         feature.updateUsageJob!!.joinBlocking()
 
-        runBlocking {
-            verify(storage).updateManifestUsedAt(baseManifest)
-        }
+        verify(storage).updateManifestUsedAt(baseManifest)
     }
 
     @Test
-    fun `updateStoredManifest is called when the manifest changes`() {
+    fun `updateStoredManifest is called when the manifest changes`() = runTestOnMain {
         val feature = ManifestUpdateFeature(
             testContext,
             store,
@@ -140,13 +137,11 @@ class ManifestUpdateFeatureTest {
 
         feature.updateJob!!.joinBlocking()
 
-        runBlocking {
-            verify(storage).updateManifest(newManifest)
-        }
+        verify(storage).updateManifest(newManifest)
     }
 
     @Test
-    fun `updateStoredManifest is not called when the manifest is the same`() {
+    fun `updateStoredManifest is not called when the manifest is the same`() = runTestOnMain {
         val feature = ManifestUpdateFeature(
             testContext,
             store,
@@ -168,13 +163,11 @@ class ManifestUpdateFeatureTest {
 
         feature.updateJob?.joinBlocking()
 
-        runBlocking {
-            verify(storage, never()).updateManifest(any())
-        }
+        verify(storage, never()).updateManifest(any())
     }
 
     @Test
-    fun `updateStoredManifest is not called when the manifest is removed`() {
+    fun `updateStoredManifest is not called when the manifest is removed`() = runTestOnMain {
         val feature = ManifestUpdateFeature(
             testContext,
             store,
@@ -203,13 +196,11 @@ class ManifestUpdateFeatureTest {
 
         feature.updateJob?.joinBlocking()
 
-        runBlocking {
-            verify(storage, never()).updateManifest(any())
-        }
+        verify(storage, never()).updateManifest(any())
     }
 
     @Test
-    fun `updateStoredManifest is not called when the manifest has a different start URL`() {
+    fun `updateStoredManifest is not called when the manifest has a different start URL`() = runTestOnMain {
         val feature = ManifestUpdateFeature(
             testContext,
             store,
@@ -239,13 +230,11 @@ class ManifestUpdateFeatureTest {
 
         feature.updateJob?.joinBlocking()
 
-        runBlocking {
-            verify(storage, never()).updateManifest(any())
-        }
+        verify(storage, never()).updateManifest(any())
     }
 
     @Test
-    fun `updateStoredManifest updates storage and shortcut`() = runBlockingTest {
+    fun `updateStoredManifest updates storage and shortcut`() = runTestOnMain {
         val feature = ManifestUpdateFeature(testContext, store, shortcutManager, storage, sessionId, baseManifest)
 
         val manifest = baseManifest.copy(shortName = "Moz")
@@ -256,7 +245,7 @@ class ManifestUpdateFeatureTest {
     }
 
     @Test
-    fun `start updates last web app usage`() = runBlockingTest {
+    fun `start updates last web app usage`() = runTestOnMain {
         val feature = ManifestUpdateFeature(testContext, store, shortcutManager, storage, sessionId, baseManifest)
 
         feature.start()

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/feature/ManifestUpdateFeatureTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/feature/ManifestUpdateFeatureTest.kt
@@ -5,12 +5,8 @@
 package mozilla.components.feature.pwa.feature
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runBlockingTest
-import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.createCustomTab
@@ -23,8 +19,9 @@ import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
-import org.junit.After
+import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
@@ -33,10 +30,12 @@ import org.mockito.Mockito.verify
 @RunWith(AndroidJUnit4::class)
 class ManifestUpdateFeatureTest {
 
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
     private lateinit var shortcutManager: WebAppShortcutManager
     private lateinit var storage: ManifestStorage
     private lateinit var store: BrowserStore
-    private lateinit var dispatcher: TestCoroutineDispatcher
 
     private val sessionId = "external-app-session-id"
     private val baseManifest = WebAppManifest(
@@ -50,9 +49,6 @@ class ManifestUpdateFeatureTest {
         storage = mock()
         shortcutManager = mock()
 
-        dispatcher = TestCoroutineDispatcher()
-        Dispatchers.setMain(dispatcher)
-
         store = BrowserStore(
             BrowserState(
                 customTabs = listOf(
@@ -60,13 +56,6 @@ class ManifestUpdateFeatureTest {
                 )
             )
         )
-    }
-
-    @After
-    fun tearDown() {
-        dispatcher.cleanupTestCoroutines()
-
-        Dispatchers.resetMain()
     }
 
     @Test
@@ -83,7 +72,6 @@ class ManifestUpdateFeatureTest {
         feature.start()
 
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
 
         feature.stop()
 
@@ -150,7 +138,6 @@ class ManifestUpdateFeatureTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
         feature.updateJob!!.joinBlocking()
 
         runBlocking {
@@ -179,7 +166,6 @@ class ManifestUpdateFeatureTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
         feature.updateJob?.joinBlocking()
 
         runBlocking {
@@ -215,7 +201,6 @@ class ManifestUpdateFeatureTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
         feature.updateJob?.joinBlocking()
 
         runBlocking {
@@ -252,7 +237,6 @@ class ManifestUpdateFeatureTest {
             )
         ).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
         feature.updateJob?.joinBlocking()
 
         runBlocking {

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessorTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessorTest.kt
@@ -9,7 +9,7 @@ import android.content.Intent.ACTION_VIEW
 import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.state.CustomTabConfig
 import mozilla.components.browser.state.state.ExternalAppType
 import mozilla.components.browser.state.state.SessionState
@@ -50,7 +50,7 @@ class WebAppIntentProcessorTest {
     }
 
     @Test
-    fun `process returns false if no manifest is in storage`() = runBlockingTest {
+    fun `process returns false if no manifest is in storage`() = runTest {
         val storage: ManifestStorage = mock()
         val processor = WebAppIntentProcessor(mock(), mock(), mock(), storage)
 
@@ -60,7 +60,7 @@ class WebAppIntentProcessorTest {
     }
 
     @Test
-    fun `process adds session ID and manifest to intent`() = runBlockingTest {
+    fun `process adds session ID and manifest to intent`() = runTest {
         val store = BrowserStore()
         val storage: ManifestStorage = mock()
 
@@ -97,7 +97,7 @@ class WebAppIntentProcessorTest {
     }
 
     @Test
-    fun `process adds custom tab config`() = runBlockingTest {
+    fun `process adds custom tab config`() = runTest {
         val intent = Intent(ACTION_VIEW_PWA, "https://mozilla.com".toUri())
 
         val storage: ManifestStorage = mock()
@@ -129,7 +129,7 @@ class WebAppIntentProcessorTest {
     }
 
     @Test
-    fun `url override is applied to session if present`() = runBlockingTest {
+    fun `url override is applied to session if present`() = runTest {
         val store = BrowserStore()
 
         val storage: ManifestStorage = mock()

--- a/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
+++ b/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
@@ -60,7 +60,6 @@ class ReaderViewFeatureTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val testDispatcher = coroutinesTestRule.testDispatcher
 
     @Before
     fun setup() {
@@ -194,7 +193,6 @@ class ReaderViewFeatureTest {
 
         store.dispatch(ReaderAction.UpdateReaderableCheckRequiredAction(tab.id, true)).joinBlocking()
 
-        testDispatcher.advanceUntilIdle()
         val tabCaptor = argumentCaptor<TabSessionState>()
         verify(readerViewFeature).checkReaderState(tabCaptor.capture())
         assertEquals(tab.id, tabCaptor.value.id)
@@ -209,7 +207,6 @@ class ReaderViewFeatureTest {
         readerViewFeature.start()
 
         store.dispatch(ReaderAction.UpdateReaderConnectRequiredAction(tab.id, true)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         val tabCaptor = argumentCaptor<TabSessionState>()
         verify(readerViewFeature).connectReaderViewContentScript(tabCaptor.capture())
         assertEquals(tab.id, tabCaptor.value.id)
@@ -232,27 +229,22 @@ class ReaderViewFeatureTest {
 
         store.dispatch(TabListAction.SelectTabAction(tab.id)).joinBlocking()
         store.dispatch(ReaderAction.UpdateReaderableAction(tab.id, true)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         assertEquals(1, readerViewStatusChanges.size)
         assertEquals(Pair(true, false), readerViewStatusChanges[0])
 
         store.dispatch(ReaderAction.UpdateReaderActiveAction(tab.id, true)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         assertEquals(2, readerViewStatusChanges.size)
         assertEquals(Pair(true, true), readerViewStatusChanges[1])
 
         store.dispatch(ReaderAction.UpdateReaderableAction(tab.id, true)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         // No change -> No notification should have been sent
         assertEquals(2, readerViewStatusChanges.size)
 
         store.dispatch(ReaderAction.UpdateReaderActiveAction(tab.id, false)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         assertEquals(3, readerViewStatusChanges.size)
         assertEquals(Pair(true, false), readerViewStatusChanges[2])
 
         store.dispatch(ReaderAction.UpdateReaderableAction(tab.id, false)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         assertEquals(4, readerViewStatusChanges.size)
         assertEquals(Pair(false, false), readerViewStatusChanges[3])
     }
@@ -317,7 +309,6 @@ class ReaderViewFeatureTest {
         store.dispatch(EngineAction.LinkEngineSessionAction(tab.id, engineSession)).joinBlocking()
         store.dispatch(TabListAction.SelectTabAction(tab.id)).joinBlocking()
         store.dispatch(ContentAction.UpdateBackNavigationStateAction(tab.id, true)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
 
         readerViewFeature.hideReaderView()
         verify(engineSession).goBack(false)
@@ -496,7 +487,6 @@ class ReaderViewFeatureTest {
         val message = argumentCaptor<JSONObject>()
         readerViewFeature.start()
         store.dispatch(ReaderAction.UpdateReaderConnectRequiredAction(tab.id, true)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         verify(controller).registerContentMessageHandler(
             eq(engineSession), messageHandler.capture(), eq(READER_VIEW_ACTIVE_CONTENT_PORT)
         )
@@ -551,7 +541,6 @@ class ReaderViewFeatureTest {
         readerViewFeature.start()
 
         store.dispatch(ReaderAction.UpdateReaderConnectRequiredAction(tab.id, true)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         verify(controller).registerContentMessageHandler(
             eq(engineSession), messageHandler.capture(), eq(READER_VIEW_ACTIVE_CONTENT_PORT)
         )

--- a/components/feature/recentlyclosed/src/test/java/mozilla/components/feature/recentlyclosed/RecentlyClosedMiddlewareTest.kt
+++ b/components/feature/recentlyclosed/src/test/java/mozilla/components/feature/recentlyclosed/RecentlyClosedMiddlewareTest.kt
@@ -7,7 +7,6 @@ package mozilla.components.feature.recentlyclosed
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.state.action.RecentlyClosedAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.action.UndoAction
@@ -24,6 +23,7 @@ import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -63,7 +63,7 @@ class RecentlyClosedMiddlewareTest {
     )
 
     @Test
-    fun `closed tab storage stores the provided tab on add tab action`() = runBlocking {
+    fun `closed tab storage stores the provided tab on add tab action`() = runTestOnMain {
         val storage = mockStorage()
         val middleware = RecentlyClosedMiddleware(lazy { storage }, 5, scope)
 
@@ -82,7 +82,7 @@ class RecentlyClosedMiddlewareTest {
     }
 
     @Test
-    fun `closed tab storage adds normal tabs removed with TabListAction`() = runBlocking {
+    fun `closed tab storage adds normal tabs removed with TabListAction`() = runTestOnMain {
         val storage = mockStorage()
         val middleware = RecentlyClosedMiddleware(lazy { storage }, 5, scope)
 
@@ -123,7 +123,7 @@ class RecentlyClosedMiddlewareTest {
     }
 
     @Test
-    fun `closed tab storage adds a normal tab removed with TabListAction`() = runBlocking {
+    fun `closed tab storage adds a normal tab removed with TabListAction`() = runTestOnMain {
         val storage = mockStorage()
         val middleware = RecentlyClosedMiddleware(lazy { storage }, 5, scope)
 
@@ -157,7 +157,7 @@ class RecentlyClosedMiddlewareTest {
     }
 
     @Test
-    fun `closed tab storage does not add a private tab removed with TabListAction`() = runBlocking {
+    fun `closed tab storage does not add a private tab removed with TabListAction`() = runTestOnMain {
         val storage = mockStorage()
         val middleware = RecentlyClosedMiddleware(lazy { storage }, 5, scope)
 
@@ -179,7 +179,7 @@ class RecentlyClosedMiddlewareTest {
     }
 
     @Test
-    fun `closed tab storage adds all normals tab removed with TabListAction RemoveAllNormalTabsAction`() = runBlocking {
+    fun `closed tab storage adds all normals tab removed with TabListAction RemoveAllNormalTabsAction`() = runTestOnMain {
         val storage = mockStorage()
         val middleware = RecentlyClosedMiddleware(lazy { storage }, 5, scope)
 
@@ -214,7 +214,7 @@ class RecentlyClosedMiddlewareTest {
     }
 
     @Test
-    fun `closed tab storage adds all normal tabs and no private tabs removed with TabListAction RemoveAllTabsAction`() = runBlocking {
+    fun `closed tab storage adds all normal tabs and no private tabs removed with TabListAction RemoveAllTabsAction`() = runTestOnMain {
         val storage = mockStorage()
         val middleware = RecentlyClosedMiddleware(lazy { storage }, 5, scope)
 
@@ -249,7 +249,7 @@ class RecentlyClosedMiddlewareTest {
     }
 
     @Test
-    fun `closed tabs storage adds tabs closed one after the other without clear actions in between`() = runBlocking {
+    fun `closed tabs storage adds tabs closed one after the other without clear actions in between`() = runTestOnMain {
         val storage = mockStorage()
         val middleware = RecentlyClosedMiddleware(lazy { storage }, 5, scope)
 
@@ -307,7 +307,7 @@ class RecentlyClosedMiddlewareTest {
     }
 
     @Test
-    fun `fetch the tabs from the recently closed storage and load into browser state on initialize tab state action`() = runBlocking {
+    fun `fetch the tabs from the recently closed storage and load into browser state on initialize tab state action`() = runTestOnMain {
         val storage = mockStorage(tabs = listOf(closedTab.state))
 
         val middleware = RecentlyClosedMiddleware(lazy { storage }, 5, scope)
@@ -325,7 +325,7 @@ class RecentlyClosedMiddlewareTest {
     }
 
     @Test
-    fun `recently closed storage removes the provided tab on remove tab action`() = runBlocking {
+    fun `recently closed storage removes the provided tab on remove tab action`() = runTestOnMain {
         val storage = mockStorage()
         val middleware = RecentlyClosedMiddleware(lazy { storage }, 5, scope)
 
@@ -348,7 +348,7 @@ class RecentlyClosedMiddlewareTest {
     }
 
     @Test
-    fun `recently closed storage removes all tabs on remove all tabs action`() = runBlocking {
+    fun `recently closed storage removes all tabs on remove all tabs action`() = runTestOnMain {
         val storage = mockStorage()
         val middleware = RecentlyClosedMiddleware(lazy { storage }, 5, scope)
         val store = BrowserStore(

--- a/components/feature/recentlyclosed/src/test/java/mozilla/components/feature/recentlyclosed/RecentlyClosedTabDaoTest.kt
+++ b/components/feature/recentlyclosed/src/test/java/mozilla/components/feature/recentlyclosed/RecentlyClosedTabDaoTest.kt
@@ -8,21 +8,27 @@ import android.content.Context
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
 import mozilla.components.feature.recentlyclosed.db.RecentlyClosedTabDao
 import mozilla.components.feature.recentlyclosed.db.RecentlyClosedTabEntity
 import mozilla.components.feature.recentlyclosed.db.RecentlyClosedTabsDatabase
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.UUID
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class RecentlyClosedTabDaoTest {
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()
 
@@ -31,13 +37,15 @@ class RecentlyClosedTabDaoTest {
 
     @Before
     fun setUp() {
-        database =
-            Room.inMemoryDatabaseBuilder(context, RecentlyClosedTabsDatabase::class.java).build()
+        database = Room
+            .inMemoryDatabaseBuilder(context, RecentlyClosedTabsDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
         tabDao = database.recentlyClosedTabDao()
     }
 
     @Test
-    fun testAddingTabs() = runBlocking(Dispatchers.IO) {
+    fun testAddingTabs() = runTestOnMain {
         val tab1 = RecentlyClosedTabEntity(
             title = "RecentlyClosedTab One",
             url = "https://www.mozilla.org",
@@ -65,7 +73,7 @@ class RecentlyClosedTabDaoTest {
     }
 
     @Test
-    fun testRemovingTab() = runBlocking(Dispatchers.IO) {
+    fun testRemovingTab() = runTestOnMain {
         val tab1 = RecentlyClosedTabEntity(
             title = "RecentlyClosedTab One",
             url = "https://www.mozilla.org",
@@ -94,7 +102,7 @@ class RecentlyClosedTabDaoTest {
     }
 
     @Test
-    fun testRemovingAllTabs() = runBlocking(Dispatchers.IO) {
+    fun testRemovingAllTabs() = runTestOnMain {
         RecentlyClosedTabEntity(
             title = "RecentlyClosedTab One",
             url = "https://www.mozilla.org",

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/middleware/SearchMiddlewareTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/middleware/SearchMiddlewareTest.kt
@@ -5,7 +5,6 @@
 package mozilla.components.feature.search.middleware
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestDispatcher
 import mozilla.components.browser.state.action.SearchAction
 import mozilla.components.browser.state.search.RegionState
@@ -23,6 +22,7 @@ import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -750,9 +750,9 @@ class SearchMiddlewareTest {
     }
 
     @Test
-    fun `Loads additional search engine and honors user choice`() {
+    fun `Loads additional search engine and honors user choice`() = runTestOnMain {
         val metadataStorage = SearchMetadataStorage(testContext, lazy { FakeSharedPreferences() })
-        runBlocking { metadataStorage.setAdditionalSearchEngines(listOf("reddit")) }
+        metadataStorage.setAdditionalSearchEngines(listOf("reddit"))
 
         val searchMiddleware = SearchMiddleware(
             testContext,
@@ -799,7 +799,7 @@ class SearchMiddlewareTest {
     }
 
     @Test
-    fun `Loads custom search engines`() {
+    fun `Loads custom search engines`() = runTestOnMain {
         val searchEngine = SearchEngine(
             id = "test-search",
             name = "Test Engine",
@@ -810,7 +810,7 @@ class SearchMiddlewareTest {
         )
 
         val storage = CustomSearchEngineStorage(testContext, dispatcher)
-        runBlocking { storage.saveSearchEngine(searchEngine) }
+        storage.saveSearchEngine(searchEngine)
 
         val store = BrowserStore(
             middleware = listOf(
@@ -833,9 +833,9 @@ class SearchMiddlewareTest {
     }
 
     @Test
-    fun `Loads default search engine ID`() {
+    fun `Loads default search engine ID`() = runTestOnMain {
         val storage = SearchMetadataStorage(testContext)
-        runBlocking { storage.setUserSelectedSearchEngine("test-id", null) }
+        storage.setUserSelectedSearchEngine("test-id", null)
 
         val middleware = SearchMiddleware(
             testContext,
@@ -1071,7 +1071,7 @@ class SearchMiddlewareTest {
 
     @Test
     fun `Custom search engines - Create, Update, Delete`() {
-        runBlocking {
+        runTestOnMain {
             val storage: SearchMiddleware.CustomStorage = mock()
             doReturn(emptyList<SearchEngine>()).`when`(storage).loadSearchEngineList()
 

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/region/RegionManagerTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/region/RegionManagerTest.kt
@@ -4,7 +4,7 @@
 
 package mozilla.components.feature.search.region
 
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.service.location.LocationService
 import mozilla.components.support.test.fakes.FakeClock
 import mozilla.components.support.test.fakes.android.FakeContext
@@ -28,7 +28,7 @@ class RegionManagerTest {
     }
 
     @Test
-    fun `First update`() {
+    fun `First update`() = runTest {
         val locationService = FakeLocationService(
             region = LocationService.Region("DE", "Germany")
         )
@@ -40,14 +40,14 @@ class RegionManagerTest {
             preferences = lazy { FakeSharedPreferences() }
         )
 
-        val updatedRegion = runBlocking { regionManager.update() }
+        val updatedRegion = regionManager.update()
         assertNotNull(updatedRegion!!)
         assertEquals("DE", updatedRegion.current)
         assertEquals("DE", updatedRegion.home)
     }
 
     @Test
-    fun `Updating to new home region`() {
+    fun `Updating to new home region`() = runTest {
         val clock = FakeClock()
 
         val locationService = FakeLocationService(
@@ -61,12 +61,12 @@ class RegionManagerTest {
             preferences = lazy { FakeSharedPreferences() }
         )
 
-        runBlocking { regionManager.update() }
+        regionManager.update()
 
         locationService.region = LocationService.Region("FR", "France")
 
         // Should not be updated since the "home" region didn't change
-        assertNull(runBlocking { regionManager.update() })
+        assertNull(regionManager.update())
         assertEquals("DE", regionManager.region()?.home)
         assertEquals("FR", regionManager.region()?.current)
 
@@ -74,14 +74,14 @@ class RegionManagerTest {
         clock.advanceBy(60L * 60L * 24L * 7L * 1000L)
 
         // Still not updated because we switch after two weeks
-        assertNull(runBlocking { regionManager.update() })
+        assertNull(regionManager.update())
         assertEquals("DE", regionManager.region()?.home)
         assertEquals("FR", regionManager.region()?.current)
 
         // Let's move the clock 8 more days into the future
         clock.advanceBy(60L * 60L * 24L * 8L * 1000L)
 
-        val updatedRegion = (runBlocking { regionManager.update() })
+        val updatedRegion = (regionManager.update())
         assertNotNull(updatedRegion!!)
         assertEquals("FR", updatedRegion.home)
         assertEquals("FR", updatedRegion.current)
@@ -90,7 +90,7 @@ class RegionManagerTest {
     }
 
     @Test
-    fun `Switching back to home region after staying in different region shortly`() {
+    fun `Switching back to home region after staying in different region shortly`() = runTest {
         val clock = FakeClock()
 
         val locationService = FakeLocationService(
@@ -104,7 +104,7 @@ class RegionManagerTest {
             preferences = lazy { FakeSharedPreferences() }
         )
 
-        runBlocking { regionManager.update() }
+        regionManager.update()
 
         // Let's jump one week into the future!
         clock.advanceBy(60L * 60L * 24L * 7L * 1000L)
@@ -112,7 +112,7 @@ class RegionManagerTest {
         locationService.region = LocationService.Region("FR", "France")
 
         // Should not be updated since the "home" region didn't change
-        assertNull(runBlocking { regionManager.update() })
+        assertNull(regionManager.update())
         assertEquals("DE", regionManager.region()?.home)
         assertEquals("FR", regionManager.region()?.current)
 
@@ -120,7 +120,7 @@ class RegionManagerTest {
         clock.advanceBy(60L * 60L * 24L * 1000L)
 
         locationService.region = LocationService.Region("DE", "Germany")
-        assertNull(runBlocking { regionManager.update() })
+        assertNull(regionManager.update())
         assertEquals("DE", regionManager.region()?.home)
         assertEquals("DE", regionManager.region()?.current)
 
@@ -131,7 +131,7 @@ class RegionManagerTest {
 
         // The "home" region should not have changed since we haven't been in the other region the
         // whole time.
-        assertNull(runBlocking { regionManager.update() })
+        assertNull(regionManager.update())
         assertEquals("DE", regionManager.region()?.home)
         assertEquals("FR", regionManager.region()?.current)
     }

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/region/RegionMiddlewareTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/region/RegionMiddlewareTest.kt
@@ -4,7 +4,6 @@
 
 package mozilla.components.feature.search.region
 
-import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.state.action.InitAction
 import mozilla.components.browser.state.search.RegionState
 import mozilla.components.browser.state.store.BrowserStore
@@ -15,6 +14,7 @@ import mozilla.components.support.test.fakes.android.FakeContext
 import mozilla.components.support.test.fakes.android.FakeSharedPreferences
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Before
@@ -83,12 +83,12 @@ class RegionMiddlewareTest {
     }
 
     @Test
-    fun `Dispatches cached home region and update later`() {
+    fun `Dispatches cached home region and update later`() = runTestOnMain {
         val middleware = RegionMiddleware(FakeContext(), locationService, dispatcher)
         middleware.regionManager = regionManager
 
         locationService.region = LocationService.Region("FR", "France")
-        runBlocking { regionManager.update() }
+        regionManager.update()
 
         val store = BrowserStore(
             middleware = listOf(middleware)
@@ -102,7 +102,7 @@ class RegionMiddlewareTest {
         assertEquals("FR", store.state.search.region!!.current)
 
         locationService.region = LocationService.Region("DE", "Germany")
-        runBlocking { regionManager.update() }
+        regionManager.update()
 
         store.dispatch(InitAction).joinBlocking()
         middleware.updateJob?.joinBlocking()

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/region/RegionMiddlewareTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/region/RegionMiddlewareTest.kt
@@ -5,7 +5,6 @@
 package mozilla.components.feature.search.region
 
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
 import mozilla.components.browser.state.action.InitAction
 import mozilla.components.browser.state.search.RegionState
 import mozilla.components.browser.state.store.BrowserStore
@@ -15,14 +14,19 @@ import mozilla.components.support.test.fakes.FakeClock
 import mozilla.components.support.test.fakes.android.FakeContext
 import mozilla.components.support.test.fakes.android.FakeSharedPreferences
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
-import org.junit.After
+import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
 class RegionMiddlewareTest {
-    private lateinit var dispatcher: TestCoroutineDispatcher
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val dispatcher = coroutinesTestRule.testDispatcher
+
     private lateinit var locationService: FakeLocationService
     private lateinit var clock: FakeClock
     private lateinit var regionManager: RegionManager
@@ -30,7 +34,6 @@ class RegionMiddlewareTest {
     @Before
     fun setUp() {
         clock = FakeClock()
-        dispatcher = TestCoroutineDispatcher()
         locationService = FakeLocationService()
         regionManager = RegionManager(
             context = FakeContext(),
@@ -38,11 +41,6 @@ class RegionMiddlewareTest {
             currentTime = clock::time,
             preferences = lazy { FakeSharedPreferences() }
         )
-    }
-
-    @After
-    fun tearDown() {
-        dispatcher.cleanupTestCoroutines()
     }
 
     @Test
@@ -76,7 +74,7 @@ class RegionMiddlewareTest {
 
         store.dispatch(InitAction).joinBlocking()
 
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
         assertEquals(RegionState.Default, store.state.search.region)

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/storage/BundledSearchEnginesStorageTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/storage/BundledSearchEnginesStorageTest.kt
@@ -5,7 +5,7 @@
 package mozilla.components.feature.search.storage
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.search.RegionState
 import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.support.test.robolectric.testContext
@@ -20,7 +20,7 @@ import java.util.Locale
 @RunWith(AndroidJUnit4::class)
 class BundledSearchEnginesStorageTest {
     @Test
-    fun `Load search engines for en-US from assets`() = runBlocking {
+    fun `Load search engines for en-US from assets`() = runTest {
         val storage = BundledSearchEnginesStorage(testContext)
 
         val engines = storage.load(RegionState("US", "US"), Locale("en", "US"))
@@ -30,7 +30,7 @@ class BundledSearchEnginesStorageTest {
     }
 
     @Test
-    fun `Load search engines for all known locales without region`() = runBlocking {
+    fun `Load search engines for all known locales without region`() = runTest {
         val storage = BundledSearchEnginesStorage(testContext)
         val locales = Locale.getAvailableLocales()
         assertTrue(locales.isNotEmpty())
@@ -43,7 +43,7 @@ class BundledSearchEnginesStorageTest {
     }
 
     @Test
-    fun `Load search engines for de-DE with global US region override`() = runBlocking {
+    fun `Load search engines for de-DE with global US region override`() = runTest {
         // Without region
         run {
             val storage = BundledSearchEnginesStorage(testContext)
@@ -67,7 +67,7 @@ class BundledSearchEnginesStorageTest {
     }
 
     @Test
-    fun `Load search engines for en-US with local RU region override`() = runBlocking {
+    fun `Load search engines for en-US with local RU region override`() = runTest {
         // Without region
         run {
             val storage = BundledSearchEnginesStorage(testContext)
@@ -92,7 +92,7 @@ class BundledSearchEnginesStorageTest {
     }
 
     @Test
-    fun `Load search engines for zh-CN_CN locale with searchDefault override`() = runBlocking {
+    fun `Load search engines for zh-CN_CN locale with searchDefault override`() = runTest {
         val storage = BundledSearchEnginesStorage(testContext)
         val engines = storage.load(RegionState("CN", "CN"), Locale("zh", "CN"))
         val searchEngines = engines.list
@@ -112,7 +112,7 @@ class BundledSearchEnginesStorageTest {
     }
 
     @Test
-    fun `Load search engines for ru_RU locale with engines not in searchOrder`() = runBlocking {
+    fun `Load search engines for ru_RU locale with engines not in searchOrder`() = runTest {
         val storage = BundledSearchEnginesStorage(testContext)
         val engines = storage.load(RegionState("RU", "RU"), Locale("ru", "RU"))
         val searchEngines = engines.list
@@ -129,7 +129,7 @@ class BundledSearchEnginesStorageTest {
     }
 
     @Test
-    fun `Load search engines for trs locale with non-google initial engines and no default`() = runBlocking {
+    fun `Load search engines for trs locale with non-google initial engines and no default`() = runTest {
         val storage = BundledSearchEnginesStorage(testContext)
         val engines = storage.load(RegionState.Default, Locale("trs", ""))
         val searchEngines = engines.list
@@ -149,7 +149,7 @@ class BundledSearchEnginesStorageTest {
     }
 
     @Test
-    fun `Load search engines for locale not in configuration`() = runBlocking {
+    fun `Load search engines for locale not in configuration`() = runTest {
         val storage = BundledSearchEnginesStorage(testContext)
         val engines = storage.load(RegionState.Default, Locale("xx", "XX"))
         val searchEngines = engines.list
@@ -175,7 +175,7 @@ class BundledSearchEnginesStorageTest {
     }
 
     @Test
-    fun `Verify values of Google search engine`() = runBlocking {
+    fun `Verify values of Google search engine`() = runTest {
         val storage = BundledSearchEnginesStorage(testContext)
 
         val engines = storage.load(RegionState("US", "US"), Locale("en", "US"))

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/storage/CustomSearchEngineStorageTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/storage/CustomSearchEngineStorageTest.kt
@@ -5,7 +5,7 @@
 package mozilla.components.feature.search.storage
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
@@ -18,7 +18,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class CustomSearchEngineStorageTest {
     @Test
-    fun `saveSearchEngine successfully saves`() = runBlockingTest {
+    fun `saveSearchEngine successfully saves`() = runTest {
         val searchEngine = SearchEngine(
             id = "id1",
             name = "example",
@@ -33,7 +33,7 @@ class CustomSearchEngineStorageTest {
     }
 
     @Test
-    fun `loadSearchEngine successfully loads after saving`() = runBlockingTest {
+    fun `loadSearchEngine successfully loads after saving`() = runTest {
         val searchEngine = SearchEngine(
             id = "id1",
             name = "example",
@@ -54,7 +54,7 @@ class CustomSearchEngineStorageTest {
 
     @Test
     @Ignore("https://github.com/mozilla-mobile/android-components/issues/8124")
-    fun `loadSearchEngineList successfully loads after saving`() = runBlockingTest {
+    fun `loadSearchEngineList successfully loads after saving`() = runTest {
         val searchEngine = SearchEngine(
             id = "id1",
             name = "example",
@@ -87,7 +87,7 @@ class CustomSearchEngineStorageTest {
     }
 
     @Test
-    fun `removeSearchEngine successfully deletes`() = runBlockingTest {
+    fun `removeSearchEngine successfully deletes`() = runTest {
         val searchEngine = SearchEngine(
             id = "id1",
             name = "example",

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/suggestions/SearchSuggestionClientTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/suggestions/SearchSuggestionClientTest.kt
@@ -5,7 +5,7 @@
 package mozilla.components.feature.search.suggestions
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.SearchState
 import mozilla.components.browser.state.store.BrowserStore
@@ -33,19 +33,17 @@ class SearchSuggestionClientTest {
     )
 
     @Test
-    fun `Get a list of results based on the Google search engine`() {
+    fun `Get a list of results based on the Google search engine`() = runTest {
         val client = SearchSuggestionClient(searchEngine, GOOGLE_MOCK_RESPONSE)
+        val expectedResults = listOf("firefox", "firefox for mac", "firefox quantum", "firefox update", "firefox esr", "firefox focus", "firefox addons", "firefox extensions", "firefox nightly", "firefox clear cache")
 
-        runBlocking {
-            val results = client.getSuggestions("firefox")
-            val expectedResults = listOf("firefox", "firefox for mac", "firefox quantum", "firefox update", "firefox esr", "firefox focus", "firefox addons", "firefox extensions", "firefox nightly", "firefox clear cache")
+        val results = client.getSuggestions("firefox")
 
-            assertEquals(expectedResults, results)
-        }
+        assertEquals(expectedResults, results)
     }
 
     @Test
-    fun `Get a list of results based on a non google search engine`() {
+    fun `Get a list of results based on a non google search engine`() = runTest {
         val qwant = createSearchEngine(
             name = "Qwant",
             url = "https://localhost?q={searchTerms}",
@@ -53,51 +51,43 @@ class SearchSuggestionClientTest {
             icon = mock()
         )
         val client = SearchSuggestionClient(qwant, QWANT_MOCK_RESPONSE)
+        val expectedResults = listOf("firefox (video game)", "firefox addons", "firefox", "firefox quantum", "firefox focus")
 
-        runBlocking {
-            val results = client.getSuggestions("firefox")
-            val expectedResults = listOf("firefox (video game)", "firefox addons", "firefox", "firefox quantum", "firefox focus")
+        val results = client.getSuggestions("firefox")
 
-            assertEquals(expectedResults, results)
-        }
+        assertEquals(expectedResults, results)
     }
 
     @Test(expected = SearchSuggestionClient.ResponseParserException::class)
-    fun `Check that a bad response will throw a parser exception`() {
+    fun `Check that a bad response will throw a parser exception`() = runTest {
         val client = SearchSuggestionClient(searchEngine, SERVER_ERROR_RESPONSE)
 
-        runBlocking {
-            client.getSuggestions("firefox")
-        }
+        client.getSuggestions("firefox")
     }
 
     @Test(expected = SearchSuggestionClient.FetchException::class)
-    fun `Check that an exception in the suggestionFetcher will re-throw an IOException`() {
+    fun `Check that an exception in the suggestionFetcher will re-throw an IOException`() = runTest {
         val client = SearchSuggestionClient(searchEngine) { throw IOException() }
 
-        runBlocking {
-            client.getSuggestions("firefox")
-        }
+        client.getSuggestions("firefox")
     }
 
     @Test
-    fun `Check that a search engine without a suggestURI will return an empty suggestion list`() {
+    fun `Check that a search engine without a suggestURI will return an empty suggestion list`() = runTest {
         val searchEngine = createSearchEngine(
             name = "Test",
             url = "https://localhost?q={searchTerms}",
             icon = mock()
         )
-
         val client = SearchSuggestionClient(searchEngine) { "no-op" }
 
-        runBlocking {
-            val results = client.getSuggestions("firefox")
-            assertEquals(emptyList<String>(), results)
-        }
+        val results = client.getSuggestions("firefox")
+
+        assertEquals(emptyList<String>(), results)
     }
 
     @Test
-    fun `Default search engine is used if search engine manager provided`() {
+    fun `Default search engine is used if search engine manager provided`() = runTest {
         val store = BrowserStore(
             BrowserState(
                 search = SearchState(
@@ -111,12 +101,10 @@ class SearchSuggestionClientTest {
             store,
             GOOGLE_MOCK_RESPONSE
         )
+        val expectedResults = listOf("firefox", "firefox for mac", "firefox quantum", "firefox update", "firefox esr", "firefox focus", "firefox addons", "firefox extensions", "firefox nightly", "firefox clear cache")
 
-        runBlocking {
-            val results = client.getSuggestions("firefox")
-            val expectedResults = listOf("firefox", "firefox for mac", "firefox quantum", "firefox update", "firefox esr", "firefox focus", "firefox addons", "firefox extensions", "firefox nightly", "firefox clear cache")
+        val results = client.getSuggestions("firefox")
 
-            assertEquals(expectedResults, results)
-        }
+        assertEquals(expectedResults, results)
     }
 }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/FullScreenFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/FullScreenFeatureTest.kt
@@ -5,11 +5,6 @@
 package mozilla.components.feature.session
 
 import android.view.WindowManager
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.BrowserState
@@ -18,13 +13,13 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
-import org.junit.After
+import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.doReturn
@@ -32,20 +27,9 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 
 class FullScreenFeatureTest {
-    private val testDispatcher = TestCoroutineDispatcher()
 
-    @Before
-    @ExperimentalCoroutinesApi
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @After
-    @ExperimentalCoroutinesApi
-    fun tearDown() {
-        Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
-    }
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
 
     @Test
     fun `Starting without tabs`() {
@@ -62,8 +46,6 @@ class FullScreenFeatureTest {
         )
 
         feature.start()
-
-        testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
 
         assertNull(viewPort)
@@ -91,8 +73,6 @@ class FullScreenFeatureTest {
         )
 
         feature.start()
-
-        testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
 
         assertNull(viewPort)
@@ -134,8 +114,6 @@ class FullScreenFeatureTest {
         )
 
         feature.start()
-
-        testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
 
         assertEquals(42, viewPort)

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
@@ -5,7 +5,7 @@
 package mozilla.components.feature.session
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.storage.FrecencyThresholdOption
 import mozilla.components.concept.storage.HistoryAutocompleteResult
 import mozilla.components.concept.storage.HistoryStorage
@@ -28,7 +28,7 @@ import org.mockito.Mockito.verify
 class HistoryDelegateTest {
 
     @Test
-    fun `history delegate passes through onVisited calls`() = runBlocking {
+    fun `history delegate passes through onVisited calls`() = runTest {
         val storage = mock<HistoryStorage>()
         val delegate = HistoryDelegate(lazy { storage })
 
@@ -43,7 +43,7 @@ class HistoryDelegateTest {
     }
 
     @Test
-    fun `history delegate passes through onTitleChanged calls`() = runBlocking {
+    fun `history delegate passes through onTitleChanged calls`() = runTest {
         val storage = mock<HistoryStorage>()
         val delegate = HistoryDelegate(lazy { storage })
 
@@ -52,7 +52,7 @@ class HistoryDelegateTest {
     }
 
     @Test
-    fun `history delegate passes through onPreviewImageChange calls`() = runBlocking {
+    fun `history delegate passes through onPreviewImageChange calls`() = runTest {
         val storage = mock<HistoryStorage>()
         val delegate = HistoryDelegate(lazy { storage })
 
@@ -65,7 +65,7 @@ class HistoryDelegateTest {
     }
 
     @Test
-    fun `history delegate passes through getVisited calls`() = runBlocking {
+    fun `history delegate passes through getVisited calls`() = runTest {
         val storage = TestHistoryStorage()
         val delegate = HistoryDelegate(lazy { storage })
 
@@ -84,7 +84,7 @@ class HistoryDelegateTest {
     }
 
     @Test
-    fun `history delegate checks with storage canAddUriCalled`() = runBlocking {
+    fun `history delegate checks with storage canAddUriCalled`() = runTest {
         val storage = TestHistoryStorage()
         val delegate = HistoryDelegate(lazy { storage })
 

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
@@ -5,7 +5,6 @@
 package mozilla.components.feature.session
 
 import android.view.View
-import kotlinx.coroutines.test.TestCoroutineScope
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.CrashAction
@@ -42,8 +41,7 @@ class SessionFeatureTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val scope = TestCoroutineScope(coroutinesTestRule.testDispatcher)
-    private val testDispatcher = coroutinesTestRule.testDispatcher
+    private val scope = coroutinesTestRule.scope
 
     @Test
     fun `start renders selected session`() {
@@ -60,7 +58,6 @@ class SessionFeatureTest {
         verify(view, never()).render(any())
 
         feature.start()
-        testDispatcher.advanceUntilIdle()
 
         store.waitUntilIdle()
         verify(view).render(engineSession)
@@ -82,7 +79,6 @@ class SessionFeatureTest {
 
         feature.start()
 
-        testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(view).render(engineSession)
@@ -103,7 +99,6 @@ class SessionFeatureTest {
         verify(view, never()).render(any())
         feature.start()
 
-        testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(view).render(engineSession)
@@ -126,12 +121,10 @@ class SessionFeatureTest {
         verify(view, never()).render(any())
 
         feature.start()
-        testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
         verify(view).render(engineSessionB)
 
         store.dispatch(TabListAction.SelectTabAction("A")).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
         verify(view).render(engineSessionA)
     }
@@ -147,7 +140,6 @@ class SessionFeatureTest {
         verify(view, never()).render(any())
 
         feature.start()
-        testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
         verify(store).dispatch(EngineAction.CreateEngineSessionAction("B"))
     }
@@ -169,14 +161,12 @@ class SessionFeatureTest {
         verify(view, never()).render(any())
 
         feature.start()
-        testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
         verify(view).render(engineSessionB)
 
         feature.stop()
 
         store.dispatch(TabListAction.SelectTabAction("A")).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
         verify(view, never()).render(engineSessionA)
     }
@@ -195,7 +185,6 @@ class SessionFeatureTest {
 
         feature.start()
 
-        testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(view).render(engineSession)
@@ -221,7 +210,6 @@ class SessionFeatureTest {
 
         feature.start()
 
-        testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(view).render(engineSession)
@@ -250,7 +238,6 @@ class SessionFeatureTest {
 
         feature.start()
 
-        testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(view).render(engineSession)
@@ -340,7 +327,6 @@ class SessionFeatureTest {
         verify(view, never()).render(any())
         feature.start()
 
-        testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
 
         verify(view).render(engineSession)
@@ -366,7 +352,6 @@ class SessionFeatureTest {
         feature.start()
 
         store.dispatch(CrashAction.SessionCrashedAction("A")).joinBlocking()
-        testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
         verify(view, atLeastOnce()).release()
         middleware.assertNotDispatched(EngineAction.CreateEngineSessionAction::class)
@@ -388,7 +373,6 @@ class SessionFeatureTest {
 
         assertEquals(0L, store.state.findTab("B")?.lastAccess)
         feature.start()
-        testDispatcher.advanceUntilIdle()
         store.waitUntilIdle()
 
         assertNotEquals(0L, store.state.findTab("B")?.lastAccess)

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -4,7 +4,7 @@
 
 package mozilla.components.feature.session
 
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.CrashAction
 import mozilla.components.browser.state.action.EngineAction
@@ -249,7 +249,7 @@ class SessionUseCasesTest {
     }
 
     @Test
-    fun stopLoading() = runBlocking {
+    fun stopLoading() = runTest {
         useCases.stopLoading()
         store.waitUntilIdle()
         verify(engineSession).stopLoading()

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/middleware/undo/UndoMiddlewareTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/middleware/undo/UndoMiddlewareTest.kt
@@ -5,7 +5,6 @@
 package mozilla.components.feature.session.middleware.undo
 
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.withContext
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.action.UndoAction
@@ -16,6 +15,7 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -28,7 +28,7 @@ class UndoMiddlewareTest {
     private val dispatcher = coroutinesTestRule.testDispatcher
 
     @Test
-    fun `Undo scenario - Removing single tab`() = runBlockingTest {
+    fun `Undo scenario - Removing single tab`() = runTestOnMain {
         val store = BrowserStore(
             middleware = listOf(
                 UndoMiddleware(clearAfterMillis = 60000)
@@ -60,7 +60,7 @@ class UndoMiddlewareTest {
     }
 
     @Test
-    fun `Undo scenario - Removing list of tabs`() = runBlockingTest {
+    fun `Undo scenario - Removing list of tabs`() = runTestOnMain {
         val store = BrowserStore(
             middleware = listOf(
                 UndoMiddleware(clearAfterMillis = 60000)
@@ -92,7 +92,7 @@ class UndoMiddlewareTest {
     }
 
     @Test
-    fun `Undo scenario - Removing all normal tabs`() = runBlockingTest {
+    fun `Undo scenario - Removing all normal tabs`() = runTestOnMain {
         val store = BrowserStore(
             middleware = listOf(
                 UndoMiddleware(clearAfterMillis = 60000)
@@ -124,7 +124,7 @@ class UndoMiddlewareTest {
     }
 
     @Test
-    fun `Undo scenario - Removing all tabs`() = runBlockingTest {
+    fun `Undo scenario - Removing all tabs`() = runTestOnMain {
         val store = BrowserStore(
             middleware = listOf(
                 UndoMiddleware(clearAfterMillis = 60000)
@@ -156,7 +156,7 @@ class UndoMiddlewareTest {
     }
 
     @Test
-    fun `Undo scenario - Removing all tabs non-recoverable`() = runBlockingTest {
+    fun `Undo scenario - Removing all tabs non-recoverable`() = runTestOnMain {
         val store = BrowserStore(
             middleware = listOf(
                 UndoMiddleware(clearAfterMillis = 60000)
@@ -189,7 +189,7 @@ class UndoMiddlewareTest {
     }
 
     @Test
-    fun `Undo History in State is written`() = runBlockingTest {
+    fun `Undo History in State is written`() = runTestOnMain {
         val store = BrowserStore(
             middleware = listOf(
                 UndoMiddleware(clearAfterMillis = 60000)
@@ -238,7 +238,7 @@ class UndoMiddlewareTest {
     }
 
     @Test
-    fun `Undo History gets cleared after time`() = runBlockingTest {
+    fun `Undo History gets cleared after time`() = runTestOnMain {
 
         val store = BrowserStore(
             middleware = listOf(

--- a/components/feature/sitepermissions/src/androidTest/java/mozilla/components/feature/sitepermissions/db/OnDeviceSitePermissionsStorageTest.kt
+++ b/components/feature/sitepermissions/src/androidTest/java/mozilla/components/feature/sitepermissions/db/OnDeviceSitePermissionsStorageTest.kt
@@ -11,7 +11,7 @@ import androidx.room.testing.MigrationTestHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.engine.permission.SitePermissions
 import mozilla.components.concept.engine.permission.SitePermissions.AutoplayStatus
 import mozilla.components.concept.engine.permission.SitePermissions.Status
@@ -56,7 +56,7 @@ class OnDeviceSitePermissionsStorageTest {
     }
 
     @Test
-    fun testStorageInteraction() = runBlockingTest {
+    fun testStorageInteraction() = runTest {
         val origin = "https://www.mozilla.org".toUri().host!!
         val sitePermissions = SitePermissions(
             origin = origin,

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/OnDiskSitePermissionsStorageTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/OnDiskSitePermissionsStorageTest.kt
@@ -10,7 +10,7 @@ import androidx.room.DatabaseConfiguration
 import androidx.room.InvalidationTracker
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.engine.DataCleanable
 import mozilla.components.concept.engine.Engine.BrowsingData
 import mozilla.components.concept.engine.permission.SitePermissions
@@ -60,7 +60,7 @@ class OnDiskSitePermissionsStorageTest {
     }
 
     @Test
-    fun `save a new SitePermission`() = runBlockingTest {
+    fun `save a new SitePermission`() = runTest {
         val sitePermissions = createNewSitePermission()
 
         storage.save(sitePermissions)
@@ -69,7 +69,7 @@ class OnDiskSitePermissionsStorageTest {
     }
 
     @Test
-    fun `update a SitePermission`() = runBlockingTest {
+    fun `update a SitePermission`() = runTest {
         val sitePermissions = createNewSitePermission()
 
         storage.update(sitePermissions)
@@ -80,14 +80,14 @@ class OnDiskSitePermissionsStorageTest {
     }
 
     @Test
-    fun `find a SitePermissions by origin`() = runBlockingTest {
+    fun `find a SitePermissions by origin`() = runTest {
         storage.findSitePermissionsBy("mozilla.org")
 
         verify(mockDAO).getSitePermissionsBy("mozilla.org")
     }
 
     @Test
-    fun `find all sitePermissions grouped by permission`() = runBlockingTest {
+    fun `find all sitePermissions grouped by permission`() = runTest {
         doReturn(dummySitePermissionEntitiesList())
             .`when`(mockDAO).getSitePermissions()
 
@@ -106,7 +106,7 @@ class OnDiskSitePermissionsStorageTest {
     }
 
     @Test
-    fun `remove a SitePermissions`() = runBlockingTest {
+    fun `remove a SitePermissions`() = runTest {
         val sitePermissions = createNewSitePermission()
 
         storage.remove(sitePermissions)
@@ -118,7 +118,7 @@ class OnDiskSitePermissionsStorageTest {
     }
 
     @Test
-    fun `remove all SitePermissions`() = runBlockingTest {
+    fun `remove all SitePermissions`() = runTest {
         storage.removeAll()
         shadowOf(getMainLooper()).idle()
 
@@ -127,7 +127,7 @@ class OnDiskSitePermissionsStorageTest {
     }
 
     @Test
-    fun `get all SitePermissions paged`() = runBlockingTest {
+    fun `get all SitePermissions paged`() = runTest {
         val mockDataSource: DataSource<Int, SitePermissionsEntity> = mock()
 
         doReturn(object : DataSource.Factory<Int, SitePermissionsEntity>() {

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsFeatureTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsFeatureTest.kt
@@ -9,8 +9,6 @@ import android.content.pm.PackageManager.PERMISSION_GRANTED
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.ContentAction.UpdatePermissionHighlightsStateAction
 import mozilla.components.browser.state.action.ContentAction.UpdatePermissionHighlightsStateAction.AutoPlayAudibleBlockingAction
@@ -58,6 +56,7 @@ import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -367,7 +366,7 @@ class SitePermissionsFeatureTest {
     }
 
     @Test
-    fun `GIVEN a new permissionRequest WHEN storeSitePermissions() THEN save(permissionRequest) is called`() = runBlockingTest {
+    fun `GIVEN a new permissionRequest WHEN storeSitePermissions() THEN save(permissionRequest) is called`() = runTestOnMain {
         // given
         val sitePermissions = SitePermissions(origin = "origin", savedAt = 0)
         doReturn(null).`when`(mockStorage).findSitePermissionsBy(ArgumentMatchers.anyString(), anyBoolean())
@@ -400,7 +399,7 @@ class SitePermissionsFeatureTest {
     }
 
     @Test
-    fun `GIVEN an already saved permissionRequest WHEN storeSitePermissions() THEN update(permissionRequest) is called`() = runBlockingTest {
+    fun `GIVEN an already saved permissionRequest WHEN storeSitePermissions() THEN update(permissionRequest) is called`() = runTestOnMain {
         // given
         val sitePermissions = SitePermissions(origin = "origin", savedAt = 0)
         doReturn(sitePermissions).`when`(mockStorage)
@@ -425,7 +424,7 @@ class SitePermissionsFeatureTest {
     }
 
     @Test
-    fun `GIVEN a permissionRequest WITH a private tab WHEN storeSitePermissions() THEN save or update MUST NOT BE called`() = runBlockingTest {
+    fun `GIVEN a permissionRequest WITH a private tab WHEN storeSitePermissions() THEN save or update MUST NOT BE called`() = runTestOnMain {
         // then
         sitePermissionFeature.storeSitePermissions(
             selectedTab.content.copy(private = true),
@@ -500,7 +499,7 @@ class SitePermissionsFeatureTest {
         doNothing().`when`(mockPermissionRequest).reject()
 
         // when
-        runBlockingTest {
+        runTestOnMain {
             sitePermissionFeature.onContentPermissionRequested(mockPermissionRequest, URL)
         }
 
@@ -510,7 +509,7 @@ class SitePermissionsFeatureTest {
     }
 
     @Test
-    fun `GIVEN location permissionRequest and shouldApplyRules is true WHEN onContentPermissionRequested() THEN handleRuledFlow is called`() = runBlockingTest {
+    fun `GIVEN location permissionRequest and shouldApplyRules is true WHEN onContentPermissionRequested() THEN handleRuledFlow is called`() = runTestOnMain {
         // given
         val mockPermissionRequest: PermissionRequest = mock {
             whenever(permissions).thenReturn(listOf(ContentGeoLocation(id = "permission")))
@@ -523,7 +522,7 @@ class SitePermissionsFeatureTest {
             .handleRuledFlow(mockPermissionRequest, URL)
 
         // when
-        runBlockingTest {
+        runTestOnMain {
             sitePermissionFeature.onContentPermissionRequested(
                 mockPermissionRequest,
                 URL,
@@ -537,7 +536,7 @@ class SitePermissionsFeatureTest {
     }
 
     @Test
-    fun `GIVEN location permissionRequest and shouldApplyRules is false WHEN onContentPermissionRequested() THEN handleNoRuledFlow is called`() = runBlockingTest {
+    fun `GIVEN location permissionRequest and shouldApplyRules is false WHEN onContentPermissionRequested() THEN handleNoRuledFlow is called`() = runTestOnMain {
         // given
         val mockPermissionRequest: PermissionRequest = mock {
             whenever(permissions).thenReturn(listOf(ContentGeoLocation(id = "permission")))
@@ -550,7 +549,7 @@ class SitePermissionsFeatureTest {
             .handleNoRuledFlow(sitePermissions, mockPermissionRequest, URL)
 
         // when
-        runBlockingTest {
+        runTestOnMain {
             sitePermissionFeature.onContentPermissionRequested(
                 mockPermissionRequest,
                 URL,
@@ -564,7 +563,7 @@ class SitePermissionsFeatureTest {
     }
 
     @Test
-    fun `GIVEN autoplay permissionRequest and shouldApplyRules is false WHEN onContentPermissionRequested() THEN handleNoRuledFlow is called`() = runBlockingTest {
+    fun `GIVEN autoplay permissionRequest and shouldApplyRules is false WHEN onContentPermissionRequested() THEN handleNoRuledFlow is called`() = runTestOnMain {
         // given
         val mockPermissionRequest: PermissionRequest = mock {
             whenever(permissions).thenReturn(listOf(ContentAutoPlayInaudible(id = "permission")))
@@ -578,7 +577,7 @@ class SitePermissionsFeatureTest {
             .handleNoRuledFlow(sitePermissions, mockPermissionRequest, URL)
 
         // when
-        runBlockingTest {
+        runTestOnMain {
             sitePermissionFeature.onContentPermissionRequested(
                 mockPermissionRequest,
                 URL,
@@ -592,7 +591,7 @@ class SitePermissionsFeatureTest {
     }
 
     @Test
-    fun `GIVEN shouldShowPrompt with isForAutoplay false AND null permissionFromStorage THEN return true`() = runBlockingTest {
+    fun `GIVEN shouldShowPrompt with isForAutoplay false AND null permissionFromStorage THEN return true`() = runTestOnMain {
         // given
         val mockPermissionRequest: PermissionRequest = mock {
             whenever(permissions).thenReturn(listOf(Permission.ContentGeoLocation(id = "permission")))
@@ -1042,7 +1041,7 @@ class SitePermissionsFeatureTest {
     }
 
     @Test
-    fun `is SitePermission granted in the storage`() = runBlockingTest {
+    fun `is SitePermission granted in the storage`() = runTestOnMain {
         val sitePermissionsList = listOf(
             ContentGeoLocation(),
             ContentNotification(),
@@ -1078,7 +1077,7 @@ class SitePermissionsFeatureTest {
     }
 
     @Test
-    fun `is SitePermission blocked in the storage`() = runBlockingTest {
+    fun `is SitePermission blocked in the storage`() = runTestOnMain {
         val sitePermissionsList = listOf(
             ContentGeoLocation(),
             ContentNotification(),
@@ -1169,7 +1168,7 @@ class SitePermissionsFeatureTest {
     }
 
     @Test
-    fun `getInitialSitePermissions - WHEN sitePermissionsRules is present the function MUST use the sitePermissionsRules values to create a SitePermissions object`() = runBlockingTest {
+    fun `getInitialSitePermissions - WHEN sitePermissionsRules is present the function MUST use the sitePermissionsRules values to create a SitePermissions object`() = runTestOnMain {
 
         val rules = SitePermissionsRules(
             location = SitePermissionsRules.Action.BLOCKED,
@@ -1200,7 +1199,7 @@ class SitePermissionsFeatureTest {
     }
 
     @Test
-    fun `any media request must be rejected WHEN system permissions are not granted first`() = runBlocking() {
+    fun `any media request must be rejected WHEN system permissions are not granted first`() = runTestOnMain {
         val permissions = listOf(
             ContentVideoCapture("", "back camera"),
             ContentVideoCamera("", "front camera"),
@@ -1228,12 +1227,10 @@ class SitePermissionsFeatureTest {
 
             mockStorage = mock()
 
-            runBlocking {
-                val prompt = sitePermissionFeature
-                    .onContentPermissionRequested(permissionRequest, URL)
-                assertNull(prompt)
-                assertFalse(grantWasCalled)
-            }
+            val prompt = sitePermissionFeature
+                .onContentPermissionRequested(permissionRequest, URL)
+            assertNull(prompt)
+            assertFalse(grantWasCalled)
         }
 
         Unit

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsFeatureTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsFeatureTest.kt
@@ -9,14 +9,8 @@ import android.content.pm.PackageManager.PERMISSION_GRANTED
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runBlockingTest
-import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.ContentAction.UpdatePermissionHighlightsStateAction
 import mozilla.components.browser.state.action.ContentAction.UpdatePermissionHighlightsStateAction.AutoPlayAudibleBlockingAction
@@ -63,13 +57,14 @@ import mozilla.components.support.test.eq
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.whenever
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
@@ -98,8 +93,9 @@ class SitePermissionsFeatureTest {
     private lateinit var mockSitePermissionRules: SitePermissionsRules
     private lateinit var selectedTab: TabSessionState
 
-    private val testCoroutineDispatcher = TestCoroutineDispatcher()
-    private val testScope = CoroutineScope(testCoroutineDispatcher)
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val scope = coroutinesTestRule.scope
 
     companion object {
         const val SESSION_ID = "testSessionId"
@@ -109,7 +105,6 @@ class SitePermissionsFeatureTest {
 
     @Before
     fun setup() {
-        Dispatchers.setMain(testCoroutineDispatcher)
         mockOnNeedToRequestPermissions = mock()
         mockStorage = mock()
         mockFragmentManager = mockFragmentManager()
@@ -135,13 +130,6 @@ class SitePermissionsFeatureTest {
                 sessionId = SESSION_ID
             )
         )
-    }
-
-    @After
-    @ExperimentalCoroutinesApi
-    fun tearDown() {
-        Dispatchers.resetMain()
-        testCoroutineDispatcher.cleanupTestCoroutines()
     }
 
     @Test
@@ -399,7 +387,7 @@ class SitePermissionsFeatureTest {
             mockContentState,
             mockPermissionRequest,
             ALLOWED,
-            testScope
+            scope
         )
 
         // then
@@ -429,7 +417,7 @@ class SitePermissionsFeatureTest {
             mockContentState,
             mockPermissionRequest,
             ALLOWED,
-            testScope
+            scope
         )
 
         // then
@@ -443,7 +431,7 @@ class SitePermissionsFeatureTest {
             selectedTab.content.copy(private = true),
             mockPermissionRequest,
             ALLOWED,
-            testScope
+            scope
         )
 
         // when
@@ -539,7 +527,7 @@ class SitePermissionsFeatureTest {
             sitePermissionFeature.onContentPermissionRequested(
                 mockPermissionRequest,
                 URL,
-                testScope
+                scope
             )
         }
 
@@ -566,7 +554,7 @@ class SitePermissionsFeatureTest {
             sitePermissionFeature.onContentPermissionRequested(
                 mockPermissionRequest,
                 URL,
-                testScope
+                scope
             )
         }
 
@@ -594,7 +582,7 @@ class SitePermissionsFeatureTest {
             sitePermissionFeature.onContentPermissionRequested(
                 mockPermissionRequest,
                 URL,
-                testScope
+                scope
             )
         }
 

--- a/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProviderTest.kt
+++ b/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProviderTest.kt
@@ -6,7 +6,7 @@ package mozilla.components.feature.syncedtabs
 
 import android.graphics.drawable.Drawable
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.storage.sync.SyncedDeviceTabs
 import mozilla.components.browser.storage.sync.Tab
 import mozilla.components.browser.storage.sync.TabEntry
@@ -38,7 +38,7 @@ class SyncedTabsStorageSuggestionProviderTest {
     }
 
     @Test
-    fun `matches remote tabs`() = runBlocking {
+    fun `matches remote tabs`() = runTest {
         val provider = SyncedTabsStorageSuggestionProvider(syncedTabs, mock(), mock(), indicatorIcon)
         val deviceTabs1 = SyncedDeviceTabs(
             Device(

--- a/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/controller/DefaultControllerTest.kt
+++ b/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/controller/DefaultControllerTest.kt
@@ -5,7 +5,6 @@
 package mozilla.components.feature.syncedtabs.controller
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.storage.sync.SyncedDeviceTabs
 import mozilla.components.concept.sync.ConstellationState
 import mozilla.components.concept.sync.DeviceConstellation
@@ -18,6 +17,7 @@ import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.service.fxa.sync.SyncReason
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -36,7 +36,7 @@ class DefaultControllerTest {
     val coroutinesTestRule = MainCoroutineRule()
 
     @Test
-    fun `update view only when no account available`() = runBlockingTest {
+    fun `update view only when no account available`() = runTestOnMain {
         val controller = DefaultController(
             storage,
             accountManager,
@@ -52,7 +52,7 @@ class DefaultControllerTest {
     }
 
     @Test
-    fun `notify if there are no other devices synced`() = runBlockingTest {
+    fun `notify if there are no other devices synced`() = runTestOnMain {
         val controller = DefaultController(
             storage,
             accountManager,
@@ -76,7 +76,7 @@ class DefaultControllerTest {
     }
 
     @Test
-    fun `notify if there are no tabs from other devices to sync`() = runBlockingTest {
+    fun `notify if there are no tabs from other devices to sync`() = runTestOnMain {
         val controller = DefaultController(
             storage,
             accountManager,
@@ -101,7 +101,7 @@ class DefaultControllerTest {
     }
 
     @Test
-    fun `display synced tabs`() = runBlockingTest {
+    fun `display synced tabs`() = runTestOnMain {
         val controller = DefaultController(
             storage,
             accountManager,
@@ -129,7 +129,7 @@ class DefaultControllerTest {
     }
 
     @Test
-    fun `WHEN syncAccount is called THEN view is loading, devices are refreshed, and sync started`() = runBlockingTest {
+    fun `WHEN syncAccount is called THEN view is loading, devices are refreshed, and sync started`() = runTestOnMain {
         val controller = DefaultController(
             storage,
             accountManager,

--- a/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/interactor/DefaultInteractorTest.kt
+++ b/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/interactor/DefaultInteractorTest.kt
@@ -4,7 +4,7 @@
 
 package mozilla.components.feature.syncedtabs.interactor
 
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.storage.sync.SyncedDeviceTabs
 import mozilla.components.feature.syncedtabs.controller.SyncedTabsController
 import mozilla.components.feature.syncedtabs.view.SyncedTabsView
@@ -21,7 +21,7 @@ class DefaultInteractorTest {
     private val controller: SyncedTabsController = mock()
 
     @Test
-    fun start() = runBlockingTest {
+    fun start() = runTest {
         val view =
             TestSyncedTabsView()
         val feature = DefaultInteractor(
@@ -37,7 +37,7 @@ class DefaultInteractorTest {
     }
 
     @Test
-    fun stop() = runBlockingTest {
+    fun stop() = runTest {
         val view =
             TestSyncedTabsView()
         val feature = DefaultInteractor(
@@ -57,7 +57,7 @@ class DefaultInteractorTest {
     }
 
     @Test
-    fun `onTabClicked invokes callback`() = runBlockingTest {
+    fun `onTabClicked invokes callback`() = runTest {
         var invoked = false
         val feature = DefaultInteractor(
             controller,
@@ -72,7 +72,7 @@ class DefaultInteractorTest {
     }
 
     @Test
-    fun `onRefresh does not update devices when there is no constellation`() = runBlockingTest {
+    fun `onRefresh does not update devices when there is no constellation`() = runTest {
         val feature = DefaultInteractor(
             controller,
             view
@@ -84,7 +84,7 @@ class DefaultInteractorTest {
     }
 
     @Test
-    fun `onRefresh updates devices when there is a constellation`() = runBlockingTest {
+    fun `onRefresh updates devices when there is a constellation`() = runTest {
         val feature = DefaultInteractor(
             controller,
             view

--- a/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/presenter/DefaultPresenterTest.kt
+++ b/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/presenter/DefaultPresenterTest.kt
@@ -8,7 +8,7 @@ import android.content.Context
 import android.os.Looper.getMainLooper
 import androidx.lifecycle.LifecycleOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.feature.syncedtabs.controller.SyncedTabsController
 import mozilla.components.feature.syncedtabs.view.SyncedTabsView
 import mozilla.components.feature.syncedtabs.view.SyncedTabsView.ErrorType
@@ -35,7 +35,7 @@ class DefaultPresenterTest {
     private val prefs = testContext.getSharedPreferences(SYNC_ENGINES_KEY, Context.MODE_PRIVATE)
 
     @Test
-    fun `start returns when there is no profile`() = runBlockingTest {
+    fun `start returns when there is no profile`() = runTest {
         val presenter = DefaultPresenter(
             context,
             controller,
@@ -50,7 +50,7 @@ class DefaultPresenterTest {
     }
 
     @Test
-    fun `start returns if sync engine is not enabled`() = runBlockingTest {
+    fun `start returns if sync engine is not enabled`() = runTest {
         val presenter = DefaultPresenter(
             context,
             controller,
@@ -87,7 +87,7 @@ class DefaultPresenterTest {
     }
 
     @Test
-    fun `start invokes syncTabs - account profile is absent`() = runBlockingTest {
+    fun `start invokes syncTabs - account profile is absent`() = runTest {
         val presenter = DefaultPresenter(
             context,
             controller,
@@ -107,7 +107,7 @@ class DefaultPresenterTest {
     }
 
     @Test
-    fun `start invokes syncTabs - account profile is present`() = runBlockingTest {
+    fun `start invokes syncTabs - account profile is present`() = runTest {
         val presenter = DefaultPresenter(
             context,
             controller,
@@ -127,7 +127,7 @@ class DefaultPresenterTest {
     }
 
     @Test
-    fun `notify on logout`() = runBlockingTest {
+    fun `notify on logout`() = runTest {
         val presenter = DefaultPresenter(
             context,
             controller,
@@ -143,7 +143,7 @@ class DefaultPresenterTest {
     }
 
     @Test
-    fun `notify on authenticated`() = runBlockingTest {
+    fun `notify on authenticated`() = runTest {
         val presenter = DefaultPresenter(
             context,
             controller,
@@ -159,7 +159,7 @@ class DefaultPresenterTest {
     }
 
     @Test
-    fun `notify on authentication problems`() = runBlockingTest {
+    fun `notify on authentication problems`() = runTest {
         val presenter = DefaultPresenter(
             context,
             controller,
@@ -175,7 +175,7 @@ class DefaultPresenterTest {
     }
 
     @Test
-    fun `sync tabs on idle status - tabs sync enabled`() = runBlockingTest {
+    fun `sync tabs on idle status - tabs sync enabled`() = runTest {
         val presenter = DefaultPresenter(
             context,
             controller,
@@ -191,7 +191,7 @@ class DefaultPresenterTest {
     }
 
     @Test
-    fun `sync tabs on idle status - tabs sync disabled`() = runBlockingTest {
+    fun `sync tabs on idle status - tabs sync disabled`() = runTest {
         val presenter = DefaultPresenter(
             context,
             controller,
@@ -208,7 +208,7 @@ class DefaultPresenterTest {
     }
 
     @Test
-    fun `show loading state on started status`() = runBlockingTest {
+    fun `show loading state on started status`() = runTest {
         val presenter = DefaultPresenter(
             context,
             controller,
@@ -223,7 +223,7 @@ class DefaultPresenterTest {
     }
 
     @Test
-    fun `notify on error`() = runBlockingTest {
+    fun `notify on error`() = runTest {
         val presenter = DefaultPresenter(
             context,
             controller,

--- a/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorageTest.kt
+++ b/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorageTest.kt
@@ -10,10 +10,7 @@
 
 package mozilla.components.feature.syncedtabs.storage
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
-import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.LastAccessAction
 import mozilla.components.browser.state.action.TabListAction
@@ -36,9 +33,11 @@ import mozilla.components.service.fxa.sync.SyncReason
 import mozilla.components.support.test.any
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
@@ -48,6 +47,9 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 
 class SyncedTabsStorageTest {
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
     private lateinit var store: BrowserStore
     private lateinit var tabsStorage: RemoteTabsStorage
     private lateinit var accountManager: FxaAccountManager
@@ -68,8 +70,6 @@ class SyncedTabsStorageTest {
         )
         tabsStorage = mock()
         accountManager = mock()
-
-        Dispatchers.setMain(TestCoroutineDispatcher())
     }
 
     @Test

--- a/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorageTest.kt
+++ b/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorageTest.kt
@@ -10,7 +10,6 @@
 
 package mozilla.components.feature.syncedtabs.storage
 
-import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.LastAccessAction
 import mozilla.components.browser.state.action.TabListAction
@@ -34,6 +33,7 @@ import mozilla.components.support.test.any
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -73,7 +73,7 @@ class SyncedTabsStorageTest {
     }
 
     @Test
-    fun `listens to browser store changes, stores state changes, and calls onStoreComplete`() = runBlockingTest {
+    fun `listens to browser store changes, stores state changes, and calls onStoreComplete`() = runTestOnMain {
         val feature = SyncedTabsStorage(
             accountManager,
             store,
@@ -98,7 +98,7 @@ class SyncedTabsStorageTest {
     }
 
     @Test
-    fun `stops listening to browser store changes on stop()`() = runBlockingTest {
+    fun `stops listening to browser store changes on stop()`() = runTestOnMain {
         val feature = SyncedTabsStorage(
             accountManager,
             store,
@@ -124,7 +124,7 @@ class SyncedTabsStorageTest {
     }
 
     @Test
-    fun `getSyncedTabs matches tabs with FxA devices`() = runBlockingTest {
+    fun `getSyncedTabs matches tabs with FxA devices`() = runTestOnMain {
         val feature = spy(
             SyncedTabsStorage(
                 accountManager,
@@ -171,7 +171,7 @@ class SyncedTabsStorageTest {
     }
 
     @Test
-    fun `getSyncedTabs returns empty list if syncClients() is null`() = runBlockingTest {
+    fun `getSyncedTabs returns empty list if syncClients() is null`() = runTestOnMain {
         val feature = spy(
             SyncedTabsStorage(
                 accountManager,
@@ -245,7 +245,7 @@ class SyncedTabsStorageTest {
     }
 
     @Test
-    fun `tabs are stored when loaded`() = runBlockingTest {
+    fun `tabs are stored when loaded`() = runTestOnMain {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(
@@ -282,7 +282,7 @@ class SyncedTabsStorageTest {
     }
 
     @Test
-    fun `only loaded tabs are stored on load`() = runBlockingTest {
+    fun `only loaded tabs are stored on load`() = runTestOnMain {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(
@@ -312,7 +312,7 @@ class SyncedTabsStorageTest {
     }
 
     @Test
-    fun `tabs are stored when selected tab changes`() = runBlockingTest {
+    fun `tabs are stored when selected tab changes`() = runTestOnMain {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(
@@ -343,7 +343,7 @@ class SyncedTabsStorageTest {
     }
 
     @Test
-    fun `tabs are stored when lastAccessed is changed for any tab`() = runBlockingTest {
+    fun `tabs are stored when lastAccessed is changed for any tab`() = runTestOnMain {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(

--- a/components/feature/tab-collections/build.gradle
+++ b/components/feature/tab-collections/build.gradle
@@ -81,6 +81,7 @@ dependencies {
     androidTestImplementation Dependencies.androidx_test_core
     androidTestImplementation Dependencies.androidx_test_runner
     androidTestImplementation Dependencies.androidx_test_rules
+    androidTestImplementation Dependencies.testing_coroutines
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/tab-collections/src/androidTest/java/mozilla/components/feature/tab/collections/TabCollectionStorageTest.kt
+++ b/components/feature/tab-collections/src/androidTest/java/mozilla/components/feature/tab/collections/TabCollectionStorageTest.kt
@@ -9,8 +9,9 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.paging.PagedList
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.state.recover.RecoverableTab
@@ -27,6 +28,7 @@ import org.junit.Test
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
+@ExperimentalCoroutinesApi // for runTest
 @Suppress("LargeClass") // Large test is large
 class TabCollectionStorageTest {
     private lateinit var context: Context
@@ -220,7 +222,7 @@ class TabCollectionStorageTest {
 
     @Test
     @Suppress("ComplexMethod")
-    fun testGettingCollections() = runBlocking {
+    fun testGettingCollections() = runTest {
         storage.createCollection(
             "Articles",
             listOf(
@@ -302,7 +304,7 @@ class TabCollectionStorageTest {
 
     @Test
     @Suppress("ComplexMethod")
-    fun testGettingCollectionsList() = runBlocking {
+    fun testGettingCollectionsList() = runTest {
         storage.createCollection(
             "Articles",
             listOf(
@@ -382,7 +384,7 @@ class TabCollectionStorageTest {
     }
 
     @Test
-    fun testGettingTabCollectionCount() = runBlocking {
+    fun testGettingTabCollectionCount() = runTest {
         assertEquals(0, storage.getTabCollectionsCount())
 
         storage.createCollection(

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
@@ -165,11 +165,11 @@ class TabsUseCasesTest {
 
         // Wait for CreateEngineSessionAction and middleware
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         // Wait for LinkEngineSessionAction and middleware
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(1, store.state.tabs.size)
         assertEquals("https://www.mozilla.org", store.state.tabs[0].content.url)
@@ -180,11 +180,13 @@ class TabsUseCasesTest {
     fun `AddNewTabUseCase forwards load flags to engine`() {
         tabsUseCases.addTab.invoke("https://www.mozilla.org", flags = LoadUrlFlags.external(), startLoading = true)
 
+        // Wait for CreateEngineSessionAction and middleware
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
+        // Wait for LinkEngineSessionAction and middleware
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(1, store.state.tabs.size)
         assertEquals("https://www.mozilla.org", store.state.tabs[0].content.url)
@@ -265,11 +267,11 @@ class TabsUseCasesTest {
 
         // Wait for CreateEngineSessionAction and middleware
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         // Wait for LinkEngineSessionAction and middleware
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(1, store.state.tabs.size)
         assertEquals("https://www.mozilla.org", store.state.tabs[0].content.url)
@@ -281,11 +283,13 @@ class TabsUseCasesTest {
     fun `AddNewPrivateTabUseCase forwards load flags to engine`() {
         tabsUseCases.addPrivateTab.invoke("https://www.mozilla.org", flags = LoadUrlFlags.external(), startLoading = true)
 
+        // Wait for CreateEngineSessionAction and middleware
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
+        // Wait for LinkEngineSessionAction and middleware
         store.waitUntilIdle()
-        dispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(1, store.state.tabs.size)
         assertEquals("https://www.mozilla.org", store.state.tabs[0].content.url)

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
@@ -4,7 +4,7 @@
 
 package mozilla.components.feature.tabs
 
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.session.storage.SessionStorage
 import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.TabListAction
@@ -349,7 +349,7 @@ class TabsUseCasesTest {
     }
 
     @Test
-    fun `RestoreUseCase - filters based on tab timeout`() = runBlocking {
+    fun `RestoreUseCase - filters based on tab timeout`() = runTest {
         val useCases = TabsUseCases(BrowserStore())
 
         val now = System.currentTimeMillis()

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/WindowFeatureTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/WindowFeatureTest.kt
@@ -29,7 +29,6 @@ class WindowFeatureTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val testDispatcher = coroutinesTestRule.testDispatcher
 
     private lateinit var store: BrowserStore
     private lateinit var engineSession: EngineSession
@@ -70,7 +69,7 @@ class WindowFeatureTest {
         whenever(windowRequest.url).thenReturn("https://www.firefox.com")
 
         store.dispatch(ContentAction.UpdateWindowRequestAction(tabId, windowRequest)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+
         verify(addTabUseCase).invoke(url = "about:blank", selectTab = true, parentId = tabId)
         verify(store).dispatch(ContentAction.ConsumeWindowRequestAction(tabId))
     }
@@ -86,7 +85,7 @@ class WindowFeatureTest {
 
         store.dispatch(TabListAction.SelectTabAction(privateTabId)).joinBlocking()
         store.dispatch(ContentAction.UpdateWindowRequestAction(privateTabId, windowRequest)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+
         verify(addTabUseCase).invoke(url = "about:blank", selectTab = true, parentId = privateTabId, private = true)
         verify(store).dispatch(ContentAction.ConsumeWindowRequestAction(privateTabId))
     }
@@ -101,7 +100,7 @@ class WindowFeatureTest {
         whenever(windowRequest.prepare()).thenReturn(engineSession)
 
         store.dispatch(ContentAction.UpdateWindowRequestAction(tabId, windowRequest)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+
         verify(removeTabUseCase).invoke(tabId)
         verify(store).dispatch(ContentAction.ConsumeWindowRequestAction(tabId))
     }
@@ -116,7 +115,7 @@ class WindowFeatureTest {
         whenever(windowRequest.type).thenReturn(WindowRequest.Type.CLOSE)
 
         store.dispatch(ContentAction.UpdateWindowRequestAction(tabId, windowRequest)).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+
         verify(removeTabUseCase, never()).invoke(tabId)
         verify(store, never()).dispatch(ContentAction.ConsumeWindowRequestAction(tabId))
     }

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
@@ -5,11 +5,6 @@
 package mozilla.components.feature.tabs.tabstray
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.TabPartition
@@ -18,13 +13,13 @@ import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.tabstray.TabsTray
 import mozilla.components.support.test.ext.joinBlocking
-import org.junit.After
+import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.spy
@@ -32,19 +27,9 @@ import org.mockito.Mockito.verifyNoMoreInteractions
 
 @RunWith(AndroidJUnit4::class)
 class TabsTrayPresenterTest {
-    private val testDispatcher = TestCoroutineDispatcher()
-
-    @Before
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @After
-    @ExperimentalCoroutinesApi
-    fun tearDown() {
-        Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
-    }
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val dispatcher = coroutinesTestRule.testDispatcher
 
     @Test
     fun `initial set of sessions will be passed to tabs tray`() {
@@ -71,7 +56,7 @@ class TabsTrayPresenterTest {
 
         presenter.start()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertNotNull(tabsTray.updateTabs)
 
@@ -106,7 +91,7 @@ class TabsTrayPresenterTest {
 
         presenter.start()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(2, tabsTray.updateTabs!!.size)
 
@@ -144,17 +129,17 @@ class TabsTrayPresenterTest {
 
         presenter.start()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(2, tabsTray.updateTabs!!.size)
 
         store.dispatch(TabListAction.RemoveTabAction("a")).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(1, tabsTray.updateTabs!!.size)
 
         store.dispatch(TabListAction.RemoveTabAction("b")).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(0, tabsTray.updateTabs!!.size)
 
@@ -184,12 +169,12 @@ class TabsTrayPresenterTest {
 
         presenter.start()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(2, tabsTray.updateTabs!!.size)
 
         store.dispatch(TabListAction.RemoveAllTabsAction()).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(0, tabsTray.updateTabs!!.size)
 
@@ -221,13 +206,13 @@ class TabsTrayPresenterTest {
         )
 
         presenter.start()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(5, tabsTray.updateTabs!!.size)
         assertEquals("a", tabsTray.selectedTabId)
 
         store.dispatch(TabListAction.SelectTabAction("d")).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         println("Selection: " + store.state.selectedTabId)
         assertEquals("d", tabsTray.selectedTabId)
@@ -255,7 +240,7 @@ class TabsTrayPresenterTest {
         )
 
         presenter.start()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertTrue(tabsTray.updateTabs?.size == 1)
     }
@@ -287,12 +272,12 @@ class TabsTrayPresenterTest {
         )
 
         presenter.start()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         Assert.assertFalse(closed)
 
         store.dispatch(TabListAction.RemoveAllTabsAction()).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertTrue(closed)
 
@@ -323,17 +308,17 @@ class TabsTrayPresenterTest {
         )
 
         presenter.start()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         Assert.assertFalse(closed)
 
         store.dispatch(TabListAction.RemoveTabAction("a")).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         Assert.assertFalse(closed)
 
         store.dispatch(TabListAction.RemoveTabAction("b")).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertTrue(closed)
 
@@ -360,7 +345,7 @@ class TabsTrayPresenterTest {
         )
 
         presenter.start()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         assertFalse(invoked)
     }

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ContainerToolbarFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ContainerToolbarFeatureTest.kt
@@ -33,7 +33,6 @@ class ContainerToolbarFeatureTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val testDispatcher = coroutinesTestRule.testDispatcher
 
     @Test
     fun `render a container action from browser state`() {
@@ -80,7 +79,7 @@ class ContainerToolbarFeatureTest {
         )
         val containerToolbarFeature = getContainerToolbarFeature(toolbar, store)
         store.dispatch(TabListAction.SelectTabAction("tab2")).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        coroutinesTestRule.testDispatcher.scheduler.advanceUntilIdle()
 
         verify(store).observeManually(any())
         verify(containerToolbarFeature, times(2)).renderContainerAction(any(), any())

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
@@ -5,7 +5,7 @@
 package mozilla.components.feature.toolbar
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.domains.Domain
 import mozilla.components.browser.domains.autocomplete.BaseDomainAutocompleteProvider
 import mozilla.components.browser.domains.autocomplete.DomainList
@@ -142,7 +142,7 @@ class ToolbarAutocompleteFeatureTest {
     }
 
     @Test
-    fun `feature can be used without providers`() {
+    fun `feature can be used without providers`() = runTest {
         val toolbar = TestToolbar()
 
         ToolbarAutocompleteFeature(toolbar)
@@ -150,9 +150,8 @@ class ToolbarAutocompleteFeatureTest {
         assertNotNull(toolbar.autocompleteFilter)
 
         val autocompleteDelegate: AutocompleteDelegate = mock()
-        runBlocking {
-            toolbar.autocompleteFilter!!("moz", autocompleteDelegate)
-        }
+        toolbar.autocompleteFilter!!("moz", autocompleteDelegate)
+
         verify(autocompleteDelegate, never()).applyAutocompleteResult(any(), any())
         verify(autocompleteDelegate, times(1)).noAutocompleteResult("moz")
     }
@@ -282,7 +281,7 @@ class ToolbarAutocompleteFeatureTest {
     }
 
     @Test
-    fun `feature triggers speculative connect for results if engine provided`() {
+    fun `feature triggers speculative connect for results if engine provided`() = runTest {
         val toolbar = TestToolbar()
         val engine: Engine = mock()
         var feature = ToolbarAutocompleteFeature(toolbar, engine)
@@ -296,9 +295,7 @@ class ToolbarAutocompleteFeatureTest {
         domains.testDomains(listOf(Domain.create("https://www.mozilla.org")))
         feature.addDomainProvider(domains)
 
-        runBlocking {
-            toolbar.autocompleteFilter!!.invoke("mo", autocompleteDelegate)
-        }
+        toolbar.autocompleteFilter!!.invoke("mo", autocompleteDelegate)
 
         val callbackCaptor = argumentCaptor<() -> Unit>()
         verify(autocompleteDelegate, times(1)).applyAutocompleteResult(any(), callbackCaptor.capture())
@@ -308,19 +305,17 @@ class ToolbarAutocompleteFeatureTest {
     }
 
     @Suppress("SameParameterValue")
-    private fun verifyNoAutocompleteResult(toolbar: TestToolbar, autocompleteDelegate: AutocompleteDelegate, query: String) {
-        runBlocking {
-            toolbar.autocompleteFilter!!(query, autocompleteDelegate)
-        }
+    private fun verifyNoAutocompleteResult(toolbar: TestToolbar, autocompleteDelegate: AutocompleteDelegate, query: String) = runTest {
+        toolbar.autocompleteFilter!!(query, autocompleteDelegate)
+
         verify(autocompleteDelegate, never()).applyAutocompleteResult(any(), any())
         verify(autocompleteDelegate, times(1)).noAutocompleteResult(query)
         reset(autocompleteDelegate)
     }
 
-    private fun verifyAutocompleteResult(toolbar: TestToolbar, autocompleteDelegate: AutocompleteDelegate, query: String, result: AutocompleteResult) {
-        runBlocking {
-            toolbar.autocompleteFilter!!.invoke(query, autocompleteDelegate)
-        }
+    private fun verifyAutocompleteResult(toolbar: TestToolbar, autocompleteDelegate: AutocompleteDelegate, query: String, result: AutocompleteResult) = runTest {
+        toolbar.autocompleteFilter!!.invoke(query, autocompleteDelegate)
+
         verify(autocompleteDelegate, times(1)).applyAutocompleteResult(eq(result), any())
         verify(autocompleteDelegate, never()).noAutocompleteResult(query)
         reset(autocompleteDelegate)

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarPresenterTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarPresenterTest.kt
@@ -4,11 +4,6 @@
 
 package mozilla.components.feature.toolbar
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.ContentAction.UpdatePermissionHighlightsStateAction
 import mozilla.components.browser.state.action.ContentAction.UpdatePermissionHighlightsStateAction.NotificationChangedAction
@@ -28,8 +23,8 @@ import mozilla.components.feature.toolbar.internal.URLRenderer
 import mozilla.components.support.test.any
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
-import org.junit.After
-import org.junit.Before
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
@@ -38,20 +33,9 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 
 class ToolbarPresenterTest {
-    private val testDispatcher = TestCoroutineDispatcher()
-
-    @Before
-    @ExperimentalCoroutinesApi
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @After
-    @ExperimentalCoroutinesApi
-    fun tearDown() {
-        Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
-    }
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val dispatcher = coroutinesTestRule.testDispatcher
 
     @Test
     fun `start with no custom tab id registers on store and renders selected tab`() {
@@ -71,7 +55,7 @@ class ToolbarPresenterTest {
 
         toolbarPresenter.start()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(store).observeManually(any())
 
@@ -100,7 +84,7 @@ class ToolbarPresenterTest {
 
         toolbarPresenter.start()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(store).observeManually(any())
         verify(toolbarPresenter).render(any())
@@ -129,7 +113,7 @@ class ToolbarPresenterTest {
 
         toolbarPresenter.start()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbar, never()).siteSecure = Toolbar.SiteSecurity.SECURE
 
@@ -144,7 +128,7 @@ class ToolbarPresenterTest {
             )
         ).joinBlocking()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbar).siteSecure = Toolbar.SiteSecurity.SECURE
     }
@@ -176,7 +160,7 @@ class ToolbarPresenterTest {
 
         toolbarPresenter.start()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbarPresenter.renderer).start()
         verify(toolbarPresenter.renderer).post("https://www.mozilla.org")
@@ -190,7 +174,7 @@ class ToolbarPresenterTest {
 
         store.dispatch(TabListAction.RemoveTabAction("tab1")).joinBlocking()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbarPresenter.renderer).post("")
         verify(toolbar).setSearchTerms("")
@@ -216,7 +200,7 @@ class ToolbarPresenterTest {
 
         toolbarPresenter.start()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbar, never()).setSearchTerms("Hello World")
 
@@ -227,7 +211,7 @@ class ToolbarPresenterTest {
             )
         ).joinBlocking()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbar).setSearchTerms("Hello World")
     }
@@ -250,7 +234,7 @@ class ToolbarPresenterTest {
 
         toolbarPresenter.start()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbar, never()).displayProgress(75)
 
@@ -258,7 +242,7 @@ class ToolbarPresenterTest {
             ContentAction.UpdateProgressAction("tab1", 75)
         ).joinBlocking()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbar).displayProgress(75)
 
@@ -268,7 +252,7 @@ class ToolbarPresenterTest {
             ContentAction.UpdateProgressAction("tab1", 90)
         ).joinBlocking()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbar).displayProgress(90)
     }
@@ -301,7 +285,7 @@ class ToolbarPresenterTest {
 
         toolbarPresenter.start()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         store.dispatch(TabListAction.RemoveTabAction("tab2")).joinBlocking()
 
@@ -354,7 +338,7 @@ class ToolbarPresenterTest {
 
         toolbarPresenter.start()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbarPresenter.renderer).start()
         verify(toolbarPresenter.renderer).post("https://www.mozilla.org")
@@ -368,7 +352,7 @@ class ToolbarPresenterTest {
 
         store.dispatch(TabListAction.SelectTabAction("tab2")).joinBlocking()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbarPresenter.renderer).post("https://www.example.org")
         verify(toolbar).setSearchTerms("Example")
@@ -407,28 +391,28 @@ class ToolbarPresenterTest {
 
         toolbarPresenter.start()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbar).siteTrackingProtection = Toolbar.SiteTrackingProtection.OFF_GLOBALLY
 
         store.dispatch(TrackingProtectionAction.ToggleAction("tab", true))
             .joinBlocking()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbar).siteTrackingProtection = Toolbar.SiteTrackingProtection.ON_NO_TRACKERS_BLOCKED
 
         store.dispatch(TrackingProtectionAction.TrackerBlockedAction("tab", mock()))
             .joinBlocking()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbar).siteTrackingProtection = Toolbar.SiteTrackingProtection.ON_TRACKERS_BLOCKED
 
         store.dispatch(TrackingProtectionAction.ToggleExclusionListAction("tab", true))
             .joinBlocking()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbar).siteTrackingProtection = Toolbar.SiteTrackingProtection.OFF_FOR_A_SITE
     }
@@ -460,26 +444,26 @@ class ToolbarPresenterTest {
 
         toolbarPresenter.start()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbar).highlight = Toolbar.Highlight.NONE
 
         store.dispatch(NotificationChangedAction("tab", true)).joinBlocking()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbar).highlight = Toolbar.Highlight.PERMISSIONS_CHANGED
 
         store.dispatch(TrackingProtectionAction.ToggleExclusionListAction("tab", true))
             .joinBlocking()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbar, times(2)).highlight = Toolbar.Highlight.PERMISSIONS_CHANGED
 
         store.dispatch(UpdatePermissionHighlightsStateAction.Reset("tab")).joinBlocking()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(toolbar).highlight = Toolbar.Highlight.NONE
     }
@@ -510,7 +494,7 @@ class ToolbarPresenterTest {
 
         presenter.start()
 
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(presenter.renderer).post("")
         verify(toolbar).setSearchTerms("")

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeatureTest.kt
@@ -41,7 +41,7 @@ class WebExtensionToolbarFeatureTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val testDispatcher = coroutinesTestRule.testDispatcher
+    private val dispatcher = coroutinesTestRule.testDispatcher
 
     @Test
     fun `render web extension actions from browser state`() {
@@ -75,7 +75,7 @@ class WebExtensionToolbarFeatureTest {
             )
         )
         val webExtToolbarFeature = getWebExtensionToolbarFeature(toolbar, store)
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(store).observeManually(any())
         verify(webExtToolbarFeature).renderWebExtensionActions(any(), any())
@@ -125,7 +125,7 @@ class WebExtensionToolbarFeatureTest {
             )
         )
         val webExtToolbarFeature = getWebExtensionToolbarFeature(toolbar, store)
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(store).observeManually(any())
         verify(webExtToolbarFeature, times(1)).renderWebExtensionActions(any(), any())
@@ -403,7 +403,7 @@ class WebExtensionToolbarFeatureTest {
             )
         )
         val webExtToolbarFeature = getWebExtensionToolbarFeature(toolbar, store)
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(store).observeManually(any())
         verify(webExtToolbarFeature).renderWebExtensionActions(any(), any())

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarTest.kt
@@ -61,7 +61,7 @@ class WebExtensionToolbarTest {
         val action = WebExtensionToolbarAction(browserAction, iconJobDispatcher = testDispatcher) {}
         action.bind(view)
         action.iconJob?.joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        testDispatcher.scheduler.advanceUntilIdle()
 
         val iconCaptor = argumentCaptor<BitmapDrawable>()
         verify(imageView).setImageDrawable(iconCaptor.capture())
@@ -95,7 +95,7 @@ class WebExtensionToolbarTest {
         val action = WebExtensionToolbarAction(browserAction, iconJobDispatcher = testDispatcher) {}
         action.bind(view)
         action.iconJob?.joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        testDispatcher.scheduler.advanceUntilIdle()
 
         verify(imageView).setImageResource(R.drawable.mozac_ic_web_extension_default_icon)
     }
@@ -170,7 +170,7 @@ class WebExtensionToolbarTest {
         assertFalse(action.iconJob?.isCancelled!!)
 
         attachListenerCaptor.value.onViewDetachedFromWindow(parent)
-        testDispatcher.advanceUntilIdle()
+        testDispatcher.scheduler.advanceUntilIdle()
         assertTrue(action.iconJob?.isCancelled!!)
     }
 }

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/internal/URLRendererTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/internal/URLRendererTest.kt
@@ -9,23 +9,20 @@ import android.text.SpannableStringBuilder
 import android.text.style.ForegroundColorSpan
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.feature.toolbar.ToolbarFeature
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
-import org.junit.After
+import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
@@ -33,18 +30,8 @@ import org.mockito.Mockito.verify
 @RunWith(AndroidJUnit4::class)
 class URLRendererTest {
 
-    @Before
-    @ExperimentalCoroutinesApi
-    fun setUp() {
-        // Execute main thread coroutines on same thread as caller.
-        Dispatchers.setMain(Dispatchers.Unconfined)
-    }
-
-    @After
-    @ExperimentalCoroutinesApi
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
 
     @Test
     fun `Lifecycle methods start and stop job`() {

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/internal/URLRendererTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/internal/URLRendererTest.kt
@@ -9,7 +9,6 @@ import android.text.SpannableStringBuilder
 import android.text.style.ForegroundColorSpan
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.feature.toolbar.ToolbarFeature
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
@@ -17,6 +16,7 @@ import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -52,7 +52,7 @@ class URLRendererTest {
 
     @Test
     fun `Render with configuration`() {
-        runBlocking {
+        runTestOnMain {
             val configuration = ToolbarFeature.UrlRenderConfiguration(
                 publicSuffixList = PublicSuffixList(testContext, Dispatchers.Unconfined),
                 registrableDomainColor = Color.RED,

--- a/components/feature/top-sites/build.gradle
+++ b/components/feature/top-sites/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     androidTestImplementation Dependencies.androidx_test_core
     androidTestImplementation Dependencies.androidx_test_runner
     androidTestImplementation Dependencies.androidx_test_rules
+    androidTestImplementation Dependencies.testing_coroutines
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/top-sites/src/androidTest/java/mozilla/components/feature/top/sites/OnDevicePinnedSitesStorageTest.kt
+++ b/components/feature/top-sites/src/androidTest/java/mozilla/components/feature/top/sites/OnDevicePinnedSitesStorageTest.kt
@@ -11,7 +11,8 @@ import androidx.room.testing.MigrationTestHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.feature.top.sites.db.Migrations
 import mozilla.components.feature.top.sites.db.TopSiteDatabase
 import org.junit.After
@@ -26,6 +27,7 @@ import java.util.concurrent.Executors
 
 private const val MIGRATION_TEST_DB = "migration-test"
 
+@ExperimentalCoroutinesApi // for runTest
 @Suppress("LargeClass")
 class OnDevicePinnedSitesStorageTest {
     private lateinit var context: Context
@@ -60,7 +62,7 @@ class OnDevicePinnedSitesStorageTest {
     }
 
     @Test
-    fun testAddingAllDefaultSites() = runBlocking {
+    fun testAddingAllDefaultSites() = runTest {
         val defaultTopSites = listOf(
             Pair("Mozilla", "https://www.mozilla.org"),
             Pair("Firefox", "https://www.firefox.com"),
@@ -90,7 +92,7 @@ class OnDevicePinnedSitesStorageTest {
     }
 
     @Test
-    fun testAddingPinnedSite() = runBlocking {
+    fun testAddingPinnedSite() = runTest {
         storage.addPinnedSite("Mozilla", "https://www.mozilla.org")
         storage.addPinnedSite("Firefox", "https://www.firefox.com", isDefault = true)
 
@@ -108,7 +110,7 @@ class OnDevicePinnedSitesStorageTest {
     }
 
     @Test
-    fun testRemovingPinnedSites() = runBlocking {
+    fun testRemovingPinnedSites() = runTest {
         storage.addPinnedSite("Mozilla", "https://www.mozilla.org")
         storage.addPinnedSite("Firefox", "https://www.firefox.com")
 
@@ -129,7 +131,7 @@ class OnDevicePinnedSitesStorageTest {
     }
 
     @Test
-    fun testGettingPinnedSites() = runBlocking {
+    fun testGettingPinnedSites() = runTest {
         storage.addPinnedSite("Mozilla", "https://www.mozilla.org")
         storage.addPinnedSite("Firefox", "https://www.firefox.com", isDefault = true)
 
@@ -153,7 +155,7 @@ class OnDevicePinnedSitesStorageTest {
     }
 
     @Test
-    fun testUpdatingPinnedSites() = runBlocking {
+    fun testUpdatingPinnedSites() = runTest {
         storage.addPinnedSite("Mozilla", "https://www.mozilla.org")
         var pinnedSites = storage.getPinnedSites()
 

--- a/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/DefaultTopSitesStorageTest.kt
+++ b/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/DefaultTopSitesStorageTest.kt
@@ -6,16 +6,18 @@ package mozilla.components.feature.top.sites
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.storage.sync.PlacesHistoryStorage
 import mozilla.components.concept.storage.FrecencyThresholdOption
 import mozilla.components.concept.storage.TopFrecentSiteInfo
 import mozilla.components.feature.top.sites.ext.toTopSite
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.anyInt
@@ -26,12 +28,15 @@ import org.mockito.Mockito.verify
 @RunWith(AndroidJUnit4::class)
 class DefaultTopSitesStorageTest {
 
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
     private val pinnedSitesStorage: PinnedSiteStorage = mock()
     private val historyStorage: PlacesHistoryStorage = mock()
     private val topSitesProvider: TopSitesProvider = mock()
 
     @Test
-    fun `default top sites are added to pinned site storage on init`() = runBlockingTest {
+    fun `default top sites are added to pinned site storage on init`() = runTestOnMain {
         val defaultTopSites = listOf(
             Pair("Mozilla", "https://mozilla.com"),
             Pair("Firefox", "https://firefox.com")
@@ -48,7 +53,7 @@ class DefaultTopSitesStorageTest {
     }
 
     @Test
-    fun `addPinnedSite`() = runBlockingTest {
+    fun `addPinnedSite`() = runTestOnMain {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
             pinnedSitesStorage = pinnedSitesStorage,
             historyStorage = historyStorage,
@@ -66,7 +71,7 @@ class DefaultTopSitesStorageTest {
     }
 
     @Test
-    fun `removeTopSite`() = runBlockingTest {
+    fun `removeTopSite`() = runTestOnMain {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
             pinnedSitesStorage = pinnedSitesStorage,
             historyStorage = historyStorage,
@@ -111,7 +116,7 @@ class DefaultTopSitesStorageTest {
     }
 
     @Test
-    fun `updateTopSite`() = runBlockingTest {
+    fun `updateTopSite`() = runTestOnMain {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
             pinnedSitesStorage = pinnedSitesStorage,
             historyStorage = historyStorage,
@@ -154,7 +159,7 @@ class DefaultTopSitesStorageTest {
     }
 
     @Test
-    fun `GIVEN frecencyConfig and providerConfig are null WHEN getTopSites is called THEN only default and pinned sites are returned`() = runBlockingTest {
+    fun `GIVEN frecencyConfig and providerConfig are null WHEN getTopSites is called THEN only default and pinned sites are returned`() = runTestOnMain {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
             pinnedSitesStorage = pinnedSitesStorage,
             historyStorage = historyStorage,
@@ -210,7 +215,7 @@ class DefaultTopSitesStorageTest {
     }
 
     @Test
-    fun `GIVEN providerConfig is specified WHEN getTopSites is called THEN default, pinned and provided top sites are returned`() = runBlockingTest {
+    fun `GIVEN providerConfig is specified WHEN getTopSites is called THEN default, pinned and provided top sites are returned`() = runTestOnMain {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
             pinnedSitesStorage = pinnedSitesStorage,
             historyStorage = historyStorage,
@@ -331,7 +336,7 @@ class DefaultTopSitesStorageTest {
     }
 
     @Test
-    fun `GIVEN providerConfig with maxThreshold is specified WHEN getTopSites is called THEN the correct number of provided top sites are returned`() = runBlockingTest {
+    fun `GIVEN providerConfig with maxThreshold is specified WHEN getTopSites is called THEN the correct number of provided top sites are returned`() = runTestOnMain {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
             pinnedSitesStorage = pinnedSitesStorage,
             historyStorage = historyStorage,
@@ -473,7 +478,7 @@ class DefaultTopSitesStorageTest {
     }
 
     @Test
-    fun `GIVEN frecencyConfig and providerConfig are specified WHEN getTopSites is called THEN default, pinned, provided and frecent top sites are returned`() = runBlockingTest {
+    fun `GIVEN frecencyConfig and providerConfig are specified WHEN getTopSites is called THEN default, pinned, provided and frecent top sites are returned`() = runTestOnMain {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
             pinnedSitesStorage = pinnedSitesStorage,
             historyStorage = historyStorage,
@@ -581,7 +586,7 @@ class DefaultTopSitesStorageTest {
     }
 
     @Test
-    fun `getTopSites returns pinned and frecent sites when frecencyConfig is specified`() = runBlockingTest {
+    fun `getTopSites returns pinned and frecent sites when frecencyConfig is specified`() = runTestOnMain {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
             pinnedSitesStorage = pinnedSitesStorage,
             historyStorage = historyStorage,
@@ -698,7 +703,7 @@ class DefaultTopSitesStorageTest {
     }
 
     @Test
-    fun `getTopSites filters out frecent sites that already exist in pinned sites`() = runBlockingTest {
+    fun `getTopSites filters out frecent sites that already exist in pinned sites`() = runTestOnMain {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
             pinnedSitesStorage = pinnedSitesStorage,
             historyStorage = historyStorage,
@@ -766,7 +771,7 @@ class DefaultTopSitesStorageTest {
     }
 
     @Test
-    fun `GIVEN providerFilter is set WHEN getTopSites is called THEN the provided top sites are filtered`() = runBlockingTest {
+    fun `GIVEN providerFilter is set WHEN getTopSites is called THEN the provided top sites are filtered`() = runTestOnMain {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
             pinnedSitesStorage = pinnedSitesStorage,
             historyStorage = historyStorage,
@@ -850,7 +855,7 @@ class DefaultTopSitesStorageTest {
     }
 
     @Test
-    fun `GIVEN frecent top sites exist as a pinned or provided site WHEN top sites are retrieved THEN filters out frecent sites that already exist in pinned or provided sites`() = runBlockingTest {
+    fun `GIVEN frecent top sites exist as a pinned or provided site WHEN top sites are retrieved THEN filters out frecent sites that already exist in pinned or provided sites`() = runTestOnMain {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
             pinnedSitesStorage = pinnedSitesStorage,
             historyStorage = historyStorage,

--- a/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/PinnedSitesStorageTest.kt
+++ b/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/PinnedSitesStorageTest.kt
@@ -4,7 +4,8 @@
 
 package mozilla.components.feature.top.sites
 
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.feature.top.sites.db.PinnedSiteDao
 import mozilla.components.feature.top.sites.db.PinnedSiteEntity
 import mozilla.components.feature.top.sites.db.TopSiteDatabase
@@ -15,10 +16,11 @@ import org.junit.Test
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.verify
 
+@ExperimentalCoroutinesApi // for runTest
 class PinnedSitesStorageTest {
 
     @Test
-    fun addAllDefaultSites() = runBlocking {
+    fun addAllDefaultSites() = runTest {
         val storage = PinnedSiteStorage(mock())
         val dao = mockDao(storage)
 
@@ -47,7 +49,7 @@ class PinnedSitesStorageTest {
     }
 
     @Test
-    fun addPinnedSite() = runBlocking {
+    fun addPinnedSite() = runTest {
         val storage = PinnedSiteStorage(mock())
         val dao = mockDao(storage)
 
@@ -66,7 +68,7 @@ class PinnedSitesStorageTest {
     }
 
     @Test
-    fun removePinnedSite() = runBlocking {
+    fun removePinnedSite() = runTest {
         val storage = PinnedSiteStorage(mock())
         val dao = mockDao(storage)
 
@@ -78,7 +80,7 @@ class PinnedSitesStorageTest {
     }
 
     @Test
-    fun getPinnedSites() = runBlocking {
+    fun getPinnedSites() = runTest {
         val storage = PinnedSiteStorage(mock())
         val dao = mockDao(storage)
 
@@ -113,7 +115,7 @@ class PinnedSitesStorageTest {
     }
 
     @Test
-    fun updatePinnedSite() = runBlocking {
+    fun updatePinnedSite() = runTest {
         val storage = PinnedSiteStorage(mock())
         val dao = mockDao(storage)
 

--- a/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/TopSitesUseCasesTest.kt
+++ b/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/TopSitesUseCasesTest.kt
@@ -5,17 +5,19 @@
 package mozilla.components.feature.top.sites
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.support.test.mock
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class TopSitesUseCasesTest {
 
     @Test
-    fun `AddPinnedSiteUseCase`() = runBlocking {
+    fun `AddPinnedSiteUseCase`() = runTest {
         val topSitesStorage: TopSitesStorage = mock()
         val useCases = TopSitesUseCases(topSitesStorage)
 
@@ -28,7 +30,7 @@ class TopSitesUseCasesTest {
     }
 
     @Test
-    fun `RemoveTopSiteUseCase`() = runBlocking {
+    fun `RemoveTopSiteUseCase`() = runTest {
         val topSitesStorage: TopSitesStorage = mock()
         val topSite: TopSite = mock()
         val useCases = TopSitesUseCases(topSitesStorage)
@@ -39,7 +41,7 @@ class TopSitesUseCasesTest {
     }
 
     @Test
-    fun `UpdateTopSiteUseCase`() = runBlocking {
+    fun `UpdateTopSiteUseCase`() = runTest {
         val topSitesStorage: TopSitesStorage = mock()
         val topSite: TopSite = mock()
         val useCases = TopSitesUseCases(topSitesStorage)

--- a/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/NativeNotificationBridgeTest.kt
+++ b/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/NativeNotificationBridgeTest.kt
@@ -5,14 +5,18 @@
 package mozilla.components.feature.webnotifications
 
 import android.app.Notification
+import android.app.Notification.BigTextStyle
 import android.app.Notification.EXTRA_SUB_TEXT
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.icons.Icon
 import mozilla.components.browser.icons.IconRequest
+import mozilla.components.browser.icons.IconRequest.Resource
+import mozilla.components.browser.icons.IconRequest.Resource.Type.MANIFEST_ICON
+import mozilla.components.browser.icons.IconRequest.Size.DEFAULT
 import mozilla.components.concept.engine.webnotifications.WebNotification
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
@@ -34,8 +38,8 @@ private const val TEST_TEXT = "test text"
 private const val TEST_URL = "mozilla.org"
 private const val TEST_CHANNEL = "testChannel"
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
-@ExperimentalCoroutinesApi
 class NativeNotificationBridgeTest {
     private val blankNotification = WebNotification(
         TEST_TITLE, TEST_TAG, TEST_TEXT, TEST_URL, null, null,
@@ -55,7 +59,7 @@ class NativeNotificationBridgeTest {
     }
 
     @Test
-    fun `create blank notification`() = runBlockingTest {
+    fun `create blank notification`() = runTest {
         val notification = bridge.convertToAndroidNotification(
             blankNotification,
             testContext,
@@ -73,7 +77,7 @@ class NativeNotificationBridgeTest {
     }
 
     @Test
-    fun `set when`() = runBlockingTest {
+    fun `set when`() = runTest {
         val notification = bridge.convertToAndroidNotification(
             blankNotification.copy(timestamp = 1234567890),
             testContext,
@@ -86,7 +90,7 @@ class NativeNotificationBridgeTest {
     }
 
     @Test
-    fun `icon is loaded from BrowserIcons`() = runBlockingTest {
+    fun `icon is loaded from BrowserIcons`() = runTest {
         bridge.convertToAndroidNotification(
             blankNotification.copy(sourceUrl = "https://example.com", iconUrl = "https://example.com/large.png"),
             testContext,
@@ -98,11 +102,11 @@ class NativeNotificationBridgeTest {
         verify(icons).loadIcon(
             IconRequest(
                 url = "https://example.com",
-                size = IconRequest.Size.DEFAULT,
+                size = DEFAULT,
                 resources = listOf(
-                    IconRequest.Resource(
+                    Resource(
                         url = "https://example.com/large.png",
-                        type = IconRequest.Resource.Type.MANIFEST_ICON
+                        type = MANIFEST_ICON
                     )
                 ),
                 isPrivate = true
@@ -111,7 +115,7 @@ class NativeNotificationBridgeTest {
     }
 
     @Test
-    fun `android notification sets BigTextStyle`() = runBlockingTest {
+    fun `android notification sets BigTextStyle`() = runTest {
         val notification = bridge.convertToAndroidNotification(
             blankNotification.copy(iconUrl = "https://example.com/large.png"),
             testContext,
@@ -120,7 +124,7 @@ class NativeNotificationBridgeTest {
             0
         )
 
-        val expectedStyle = Notification.BigTextStyle().javaClass.name
+        val expectedStyle = BigTextStyle().javaClass.name
         assertEquals(expectedStyle, notification.extras.getString(Notification.EXTRA_TEMPLATE))
 
         val noBodyNotification = bridge.convertToAndroidNotification(

--- a/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/WebNotificationFeatureTest.kt
+++ b/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/WebNotificationFeatureTest.kt
@@ -8,7 +8,6 @@ import android.app.NotificationManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.icons.Icon
 import mozilla.components.browser.icons.Icon.Source
@@ -21,7 +20,10 @@ import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
@@ -34,6 +36,10 @@ import org.mockito.Mockito.verify
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 class WebNotificationFeatureTest {
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
     private val context = spy(testContext)
     private val browserIcons: BrowserIcons = mock()
     private val icon: Icon = mock()
@@ -84,7 +90,7 @@ class WebNotificationFeatureTest {
     }
 
     @Test
-    fun `engine notifies to show notification`() = runBlockingTest {
+    fun `engine notifies to show notification`() = runTestOnMain {
         val notification = testNotification.copy(sourceUrl = "https://mozilla.org:443")
         val feature = WebNotificationFeature(
             context,
@@ -105,7 +111,7 @@ class WebNotificationFeatureTest {
     }
 
     @Test
-    fun `notification ignored if permissions are not allowed`() = runBlockingTest {
+    fun `notification ignored if permissions are not allowed`() = runTestOnMain {
         val notification = testNotification.copy(sourceUrl = "https://mozilla.org:443")
         val feature = WebNotificationFeature(
             context,
@@ -134,7 +140,7 @@ class WebNotificationFeatureTest {
     }
 
     @Test
-    fun `notifications always allowed for web extensions`() = runBlockingTest {
+    fun `notifications always allowed for web extensions`() = runTestOnMain {
         val webExtensionNotification = WebNotification(
             "Mozilla",
             "mozilla.org",

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/CrashReporterTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/CrashReporterTest.kt
@@ -9,7 +9,6 @@ import android.app.PendingIntent
 import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
 import mozilla.components.concept.base.crash.Breadcrumb
 import mozilla.components.lib.crash.service.CrashReporterService
 import mozilla.components.lib.crash.service.CrashTelemetryService
@@ -43,7 +42,7 @@ class CrashReporterTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val scope = TestCoroutineScope(coroutinesTestRule.testDispatcher)
+    private val scope = coroutinesTestRule.scope
 
     @Before
     fun setUp() {

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/handler/CrashHandlerServiceTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/handler/CrashHandlerServiceTest.kt
@@ -7,10 +7,8 @@ package mozilla.components.lib.crash.handler
 import android.content.ComponentName
 import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineScope
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
@@ -36,7 +34,7 @@ class CrashHandlerServiceTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val scope: CoroutineScope = TestCoroutineScope(coroutinesTestRule.testDispatcher)
+    private val scope = coroutinesTestRule.scope
 
     @Before
     fun setUp() {
@@ -83,7 +81,7 @@ class CrashHandlerServiceTest {
         doNothing().`when`(reporter)!!.sendCrashReport(any(), any())
 
         intent.putExtra("processType", "MAIN")
-        service!!.handleCrashIntent(intent, scope)
+        service!!.handleCrashIntent(intent, coroutinesTestRule.scope)
         verify(reporter)!!.onCrash(any(), any())
         verify(reporter)!!.sendCrashReport(any(), any())
         verify(reporter, never())!!.sendNonFatalCrashIntent(any(), any())
@@ -94,7 +92,7 @@ class CrashHandlerServiceTest {
         doNothing().`when`(reporter)!!.sendCrashReport(any(), any())
 
         intent.putExtra("processType", "FOREGROUND_CHILD")
-        service!!.handleCrashIntent(intent, scope)
+        service!!.handleCrashIntent(intent, coroutinesTestRule.scope)
         verify(reporter)!!.onCrash(any(), any())
         verify(reporter)!!.sendNonFatalCrashIntent(any(), any())
         verify(reporter, never())!!.sendCrashReport(any(), any())
@@ -105,7 +103,7 @@ class CrashHandlerServiceTest {
         doNothing().`when`(reporter)!!.sendCrashReport(any(), any())
 
         intent.putExtra("processType", "BACKGROUND_CHILD")
-        service!!.handleCrashIntent(intent, scope)
+        service!!.handleCrashIntent(intent, coroutinesTestRule.scope)
         verify(reporter)!!.onCrash(any(), any())
         verify(reporter)!!.sendCrashReport(any(), any())
         verify(reporter, never())!!.sendNonFatalCrashIntent(any(), any())

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/handler/CrashHandlerServiceTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/handler/CrashHandlerServiceTest.kt
@@ -8,12 +8,12 @@ import android.content.ComponentName
 import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -77,7 +77,7 @@ class CrashHandlerServiceTest {
     }
 
     @Test
-    fun `CrashHandlerService forwards main process native code crash to crash reporter`() = runBlocking {
+    fun `CrashHandlerService forwards main process native code crash to crash reporter`() = runTestOnMain {
         doNothing().`when`(reporter)!!.sendCrashReport(any(), any())
 
         intent.putExtra("processType", "MAIN")
@@ -88,7 +88,7 @@ class CrashHandlerServiceTest {
     }
 
     @Test
-    fun `CrashHandlerService forwards foreground child process native code crash to crash reporter`() = runBlocking {
+    fun `CrashHandlerService forwards foreground child process native code crash to crash reporter`() = runTestOnMain {
         doNothing().`when`(reporter)!!.sendCrashReport(any(), any())
 
         intent.putExtra("processType", "FOREGROUND_CHILD")
@@ -99,7 +99,7 @@ class CrashHandlerServiceTest {
     }
 
     @Test
-    fun `CrashHandlerService forwards background child process native code crash to crash reporter`() = runBlocking {
+    fun `CrashHandlerService forwards background child process native code crash to crash reporter`() = runTestOnMain {
         doNothing().`when`(reporter)!!.sendCrashReport(any(), any())
 
         intent.putExtra("processType", "BACKGROUND_CHILD")

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/handler/ExceptionHandlerTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/handler/ExceptionHandlerTest.kt
@@ -6,7 +6,6 @@ package mozilla.components.lib.crash.handler
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
 import mozilla.components.concept.base.crash.Breadcrumb
 import mozilla.components.lib.crash.Crash
 import mozilla.components.lib.crash.CrashReporter
@@ -29,7 +28,7 @@ class ExceptionHandlerTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val scope = TestCoroutineScope(coroutinesTestRule.testDispatcher)
+    private val scope = coroutinesTestRule.scope
 
     @Test
     fun `ExceptionHandler forwards crashes to CrashReporter`() {

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/prompt/CrashReporterActivityTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/prompt/CrashReporterActivityTest.kt
@@ -15,7 +15,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.lib.crash.Crash
 import mozilla.components.lib.crash.CrashReporter
@@ -35,6 +35,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations.openMocks
+import kotlin.coroutines.CoroutineContext
 
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
@@ -42,7 +43,7 @@ class CrashReporterActivityTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val scope = TestCoroutineScope(coroutinesTestRule.testDispatcher)
+    private val scope = coroutinesTestRule.scope
 
     @Mock
     lateinit var service: CrashReporterService
@@ -62,7 +63,7 @@ class CrashReporterActivityTest {
         ).install(testContext)
 
         val crash = Crash.UncaughtExceptionCrash(0, RuntimeException("Hello World"), arrayListOf())
-        val scenario = launchActivityWith(crash)
+        val scenario = coroutineContext.launchActivityWithCrash(crash)
 
         scenario.onActivity { activity ->
             // When
@@ -86,7 +87,7 @@ class CrashReporterActivityTest {
         ).install(testContext)
 
         val crash = Crash.UncaughtExceptionCrash(0, RuntimeException("Hello World"), arrayListOf())
-        val scenario = launchActivityWith(crash)
+        val scenario = coroutineContext.launchActivityWithCrash(crash)
 
         scenario.onActivity { activity ->
             // When
@@ -113,7 +114,7 @@ class CrashReporterActivityTest {
         ).install(testContext)
 
         val crash = Crash.UncaughtExceptionCrash(0, RuntimeException("Hello World"), arrayListOf())
-        val scenario = launchActivityWith(crash)
+        val scenario = coroutineContext.launchActivityWithCrash(crash)
 
         scenario.onActivity { activity ->
             // Then
@@ -131,7 +132,7 @@ class CrashReporterActivityTest {
         ).install(testContext)
 
         val crash = Crash.UncaughtExceptionCrash(0, RuntimeException("Hello World"), arrayListOf())
-        val scenario = launchActivityWith(crash)
+        val scenario = coroutineContext.launchActivityWithCrash(crash)
 
         scenario.onActivity { activity ->
             // When
@@ -165,7 +166,7 @@ class CrashReporterActivityTest {
             Crash.NativeCodeCrash.PROCESS_TYPE_MAIN,
             arrayListOf()
         )
-        val scenario = launchActivityWith(crash)
+        val scenario = coroutineContext.launchActivityWithCrash(crash)
 
         scenario.onActivity { activity ->
             assertEquals(activity.restartButton.visibility, View.VISIBLE)
@@ -189,7 +190,7 @@ class CrashReporterActivityTest {
             Crash.NativeCodeCrash.PROCESS_TYPE_BACKGROUND_CHILD,
             arrayListOf()
         )
-        val scenario = launchActivityWith(crash)
+        val scenario = coroutineContext.launchActivityWithCrash(crash)
 
         scenario.onActivity { activity ->
             assertEquals(activity.restartButton.visibility, View.GONE)
@@ -201,7 +202,7 @@ class CrashReporterActivityTest {
  * Launch activity scenario for certain [crash].
  */
 @ExperimentalCoroutinesApi
-private fun TestCoroutineScope.launchActivityWith(
+private fun CoroutineContext.launchActivityWithCrash(
     crash: Crash
 ): ActivityScenario<CrashReporterActivity> = run {
     val intent = Intent(testContext, CrashReporterActivity::class.java)
@@ -209,7 +210,7 @@ private fun TestCoroutineScope.launchActivityWith(
 
     launch<CrashReporterActivity>(intent).apply {
         onActivity { activity ->
-            activity.reporterCoroutineContext = coroutineContext
+            activity.reporterCoroutineContext = this@run
         }
     }
 }

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/prompt/CrashReporterActivityTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/prompt/CrashReporterActivityTest.kt
@@ -16,7 +16,6 @@ import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.lib.crash.Crash
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.lib.crash.prompt.CrashReporterActivity.Companion.PREFERENCE_KEY_SEND_REPORT
@@ -25,6 +24,7 @@ import mozilla.components.lib.crash.service.CrashReporterService
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -54,7 +54,7 @@ class CrashReporterActivityTest {
     }
 
     @Test
-    fun `Pressing close button sends report`() = runBlockingTest {
+    fun `Pressing close button sends report`() = runTestOnMain {
         CrashReporter(
             context = testContext,
             shouldPrompt = CrashReporter.Prompt.ALWAYS,
@@ -78,7 +78,7 @@ class CrashReporterActivityTest {
     }
 
     @Test
-    fun `Pressing restart button sends report`() = runBlockingTest {
+    fun `Pressing restart button sends report`() = runTestOnMain {
         CrashReporter(
             context = testContext,
             shouldPrompt = CrashReporter.Prompt.ALWAYS,
@@ -102,7 +102,7 @@ class CrashReporterActivityTest {
     }
 
     @Test
-    fun `Custom message is set on CrashReporterActivity`() = runBlockingTest {
+    fun `Custom message is set on CrashReporterActivity`() = runTestOnMain {
         CrashReporter(
             context = testContext,
             shouldPrompt = CrashReporter.Prompt.ALWAYS,
@@ -123,7 +123,7 @@ class CrashReporterActivityTest {
     }
 
     @Test
-    fun `Sending crash report saves checkbox state`() = runBlockingTest {
+    fun `Sending crash report saves checkbox state`() = runTestOnMain {
         CrashReporter(
             context = testContext,
             shouldPrompt = CrashReporter.Prompt.ALWAYS,
@@ -150,7 +150,7 @@ class CrashReporterActivityTest {
     }
 
     @Test
-    fun `Restart button visible for main process crash`() = runBlockingTest {
+    fun `Restart button visible for main process crash`() = runTestOnMain {
         CrashReporter(
             context = testContext,
             shouldPrompt = CrashReporter.Prompt.ALWAYS,
@@ -174,7 +174,7 @@ class CrashReporterActivityTest {
     }
 
     @Test
-    fun `Restart button hidden for background child process crash`() = runBlockingTest {
+    fun `Restart button hidden for background child process crash`() = runTestOnMain {
         CrashReporter(
             context = testContext,
             shouldPrompt = CrashReporter.Prompt.ALWAYS,

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SendCrashReportServiceTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SendCrashReportServiceTest.kt
@@ -8,7 +8,6 @@ import android.content.ComponentName
 import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
 import mozilla.components.concept.base.crash.Breadcrumb
 import mozilla.components.lib.crash.Crash
 import mozilla.components.lib.crash.CrashReporter
@@ -37,7 +36,7 @@ class SendCrashReportServiceTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val scope = TestCoroutineScope(coroutinesTestRule.testDispatcher)
+    private val scope = coroutinesTestRule.scope
 
     @Before
     fun setUp() {

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SendCrashTelemetryServiceTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SendCrashTelemetryServiceTest.kt
@@ -8,7 +8,6 @@ import android.content.ComponentName
 import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
 import mozilla.components.lib.crash.Crash
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.support.test.any
@@ -35,7 +34,7 @@ class SendCrashTelemetryServiceTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val scope = TestCoroutineScope(coroutinesTestRule.testDispatcher)
+    private val scope = coroutinesTestRule.scope
 
     @Before
     fun setUp() {

--- a/components/lib/publicsuffixlist/build.gradle
+++ b/components/lib/publicsuffixlist/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_coroutines
 }
 
 apply from: '../../../publish.gradle'

--- a/components/lib/publicsuffixlist/src/test/java/mozilla/components/lib/publicsuffixlist/PublicSuffixListTest.kt
+++ b/components/lib/publicsuffixlist/src/test/java/mozilla/components/lib/publicsuffixlist/PublicSuffixListTest.kt
@@ -5,7 +5,8 @@
 package mozilla.components.lib.publicsuffixlist
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -14,6 +15,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class PublicSuffixListTest {
 
@@ -21,7 +23,7 @@ class PublicSuffixListTest {
         get() = PublicSuffixList(testContext)
 
     @Test
-    fun `Verify getPublicSuffixPlusOne for known domains`() = runBlocking {
+    fun `Verify getPublicSuffixPlusOne for known domains`() = runTest {
         assertEquals(
             "mozilla.org",
             publicSuffixList.getPublicSuffixPlusOne("www.mozilla.org").await()
@@ -69,7 +71,7 @@ class PublicSuffixListTest {
     }
 
     @Test
-    fun `Verify getPublicSuffix for known domains`() = runBlocking {
+    fun `Verify getPublicSuffix for known domains`() = runTest {
         assertEquals(
             "org",
             publicSuffixList.getPublicSuffix("www.mozilla.org").await()
@@ -117,7 +119,7 @@ class PublicSuffixListTest {
     }
 
     @Test
-    fun `Verify stripPublicSuffix for known domains`() = runBlocking {
+    fun `Verify stripPublicSuffix for known domains`() = runTest {
         assertEquals(
             "www.mozilla",
             publicSuffixList.stripPublicSuffix("www.mozilla.org").await()
@@ -169,7 +171,7 @@ class PublicSuffixListTest {
      * https://raw.githubusercontent.com/publicsuffix/list/master/tests/test_psl.txt
      */
     @Test
-    fun `Verify getPublicSuffixPlusOne against official test data`() = runBlocking {
+    fun `Verify getPublicSuffixPlusOne against official test data`() = runTest {
         // empty input
         assertNull(publicSuffixList.getPublicSuffixPlusOne("").await())
 
@@ -410,7 +412,7 @@ class PublicSuffixListTest {
     }
 
     @Test
-    fun `Accessing with and without prefetch`() = runBlocking {
+    fun `Accessing with and without prefetch`() = runTest {
         run {
             val publicSuffixList = PublicSuffixList(testContext)
             assertEquals("org", publicSuffixList.getPublicSuffix("mozilla.org").await())
@@ -425,7 +427,7 @@ class PublicSuffixListTest {
     }
 
     @Test
-    fun `Verify isPublicSuffix with known and unknown suffixes`() = runBlocking {
+    fun `Verify isPublicSuffix with known and unknown suffixes`() = runTest {
         assertTrue(publicSuffixList.isPublicSuffix("org").await())
         assertTrue(publicSuffixList.isPublicSuffix("com").await())
         assertTrue(publicSuffixList.isPublicSuffix("us").await())
@@ -454,7 +456,7 @@ class PublicSuffixListTest {
      * https://github.com/google/guava/blob/master/guava-tests/test/com/google/common/net/InternetDomainNameTest.java
      */
     @Test
-    fun `Verify getPublicSuffix can handle obscure and invalid input`() = runBlocking {
+    fun `Verify getPublicSuffix can handle obscure and invalid input`() = runTest {
         assertEquals("cOM", publicSuffixList.getPublicSuffix("f-_-o.cOM").await())
         assertEquals("com", publicSuffixList.getPublicSuffix("f11-1.com").await())
         assertNull(publicSuffixList.getPublicSuffix("www").await())

--- a/components/lib/state/src/test/java/mozilla/components/lib/state/ext/FragmentKtTest.kt
+++ b/components/lib/state/src/test/java/mozilla/components/lib/state/ext/FragmentKtTest.kt
@@ -13,7 +13,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.test.setMain
 import mozilla.components.lib.state.Store
 import mozilla.components.lib.state.TestAction

--- a/components/lib/state/src/test/java/mozilla/components/lib/state/ext/StoreExtensionsKtTest.kt
+++ b/components/lib/state/src/test/java/mozilla/components/lib/state/ext/StoreExtensionsKtTest.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import mozilla.components.lib.state.Store
 import mozilla.components.lib.state.TestAction
 import mozilla.components.lib.state.TestState
@@ -28,6 +27,7 @@ import mozilla.components.lib.state.reducer
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -48,7 +48,7 @@ class StoreExtensionsKtTest {
     val coroutinesTestRule = MainCoroutineRule()
 
     @Test
-    fun `Observer will not get registered if lifecycle is already destroyed`() {
+    fun `Observer will not get registered if lifecycle is already destroyed`() = runTestOnMain {
         val owner = MockedLifecycleOwner(Lifecycle.State.DESTROYED)
 
         val store = Store(
@@ -138,7 +138,7 @@ class StoreExtensionsKtTest {
     @Test
     @Synchronized
     @ExperimentalCoroutinesApi // Channel
-    fun `Reading state updates from channel`() {
+    fun `Reading state updates from channel`() = runTestOnMain {
         val owner = MockedLifecycleOwner(Lifecycle.State.INITIALIZED)
 
         val store = Store(
@@ -183,7 +183,7 @@ class StoreExtensionsKtTest {
         assertEquals(26, receivedValue)
         latch = CountDownLatch(1)
 
-        runBlocking { job.cancelAndJoin() }
+        job.cancelAndJoin()
         assertTrue(channel.isClosedForReceive)
 
         store.dispatch(TestAction.IncrementAction).joinBlocking()
@@ -207,7 +207,7 @@ class StoreExtensionsKtTest {
     @Test
     @Synchronized
     @ExperimentalCoroutinesApi
-    fun `Reading state updates from Flow with lifecycle owner`() {
+    fun `Reading state updates from Flow with lifecycle owner`() = runTestOnMain {
         val owner = MockedLifecycleOwner(Lifecycle.State.INITIALIZED)
 
         val store = Store(
@@ -253,7 +253,7 @@ class StoreExtensionsKtTest {
         assertEquals(26, receivedValue)
         latch = CountDownLatch(1)
 
-        runBlocking { job.cancelAndJoin() }
+        job.cancelAndJoin()
 
         // Receiving nothing anymore since coroutine is cancelled
         store.dispatch(TestAction.IncrementAction).joinBlocking()
@@ -312,7 +312,7 @@ class StoreExtensionsKtTest {
     @Test
     @Synchronized
     @ExperimentalCoroutinesApi
-    fun `Reading state updates from Flow without lifecycle owner`() {
+    fun `Reading state updates from Flow without lifecycle owner`() = runTestOnMain {
         val store = Store(
             TestState(counter = 23),
             ::reducer
@@ -351,7 +351,7 @@ class StoreExtensionsKtTest {
 
         latch = CountDownLatch(1)
 
-        runBlocking { job.cancelAndJoin() }
+        job.cancelAndJoin()
 
         // Receiving nothing anymore since coroutine is cancelled
         store.dispatch(TestAction.IncrementAction).joinBlocking()
@@ -512,7 +512,7 @@ class StoreExtensionsKtTest {
     }
 
     @Test
-    fun `Observer bound to view will not get notified about state changes until the view is attached`() {
+    fun `Observer bound to view will not get notified about state changes until the view is attached`() = runTestOnMain {
         val activity = Robolectric.buildActivity(Activity::class.java).create().get()
         val view = View(testContext)
 

--- a/components/lib/state/src/test/java/mozilla/components/lib/state/ext/StoreExtensionsKtTest.kt
+++ b/components/lib/state/src/test/java/mozilla/components/lib/state/ext/StoreExtensionsKtTest.kt
@@ -19,10 +19,8 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.consumeEach
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineScope
 import mozilla.components.lib.state.Store
 import mozilla.components.lib.state.TestAction
 import mozilla.components.lib.state.TestState
@@ -48,7 +46,6 @@ class StoreExtensionsKtTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val testDispatcher = coroutinesTestRule.testDispatcher
 
     @Test
     fun `Observer will not get registered if lifecycle is already destroyed`() {
@@ -223,7 +220,7 @@ class StoreExtensionsKtTest {
 
         val flow = store.flow(owner)
 
-        val job = TestCoroutineScope(testDispatcher).launch {
+        val job = coroutinesTestRule.scope.launch {
             flow.collect { state ->
                 receivedValue = state.counter
                 latch.countDown()

--- a/components/lib/state/src/test/java/mozilla/components/lib/state/helpers/AbstractBindingTest.kt
+++ b/components/lib/state/src/test/java/mozilla/components/lib/state/helpers/AbstractBindingTest.kt
@@ -6,7 +6,6 @@ package mozilla.components.lib.state.helpers
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import mozilla.components.lib.state.Store
 import mozilla.components.lib.state.TestAction
 import mozilla.components.lib.state.TestState

--- a/components/service/contile/build.gradle
+++ b/components/service/contile/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     testImplementation Dependencies.androidx_work_testing
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_coroutines
 
     testImplementation project(':support-test')
 }

--- a/components/service/contile/src/test/java/mozilla/components/service/contile/ContileTopSitesProviderTest.kt
+++ b/components/service/contile/src/test/java/mozilla/components/service/contile/ContileTopSitesProviderTest.kt
@@ -5,7 +5,8 @@
 package mozilla.components.service.contile
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Response
 import mozilla.components.support.test.any
@@ -27,11 +28,12 @@ import java.io.File
 import java.io.IOException
 import java.util.Date
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class ContileTopSitesProviderTest {
 
     @Test
-    fun `GIVEN a successful status response WHEN top sites are fetched THEN response should contain top sites`() = runBlocking {
+    fun `GIVEN a successful status response WHEN top sites are fetched THEN response should contain top sites`() = runTest {
         val client = prepareClient()
         val provider = ContileTopSitesProvider(testContext, client)
         val topSites = provider.getTopSites()
@@ -56,7 +58,7 @@ class ContileTopSitesProviderTest {
     }
 
     @Test(expected = IOException::class)
-    fun `GIVEN a 500 status response WHEN top sites are fetched THEN throw an exception`() = runBlocking {
+    fun `GIVEN a 500 status response WHEN top sites are fetched THEN throw an exception`() = runTest {
         val client = prepareClient(status = 500)
         val provider = ContileTopSitesProvider(testContext, client)
         provider.getTopSites()
@@ -64,7 +66,7 @@ class ContileTopSitesProviderTest {
     }
 
     @Test
-    fun `GIVEN a cache configuration is allowed and not expired WHEN top sites are fetched THEN read from the disk cache`() = runBlocking {
+    fun `GIVEN a cache configuration is allowed and not expired WHEN top sites are fetched THEN read from the disk cache`() = runTest {
         val client = prepareClient()
         val provider = spy(ContileTopSitesProvider(testContext, client))
 
@@ -83,7 +85,7 @@ class ContileTopSitesProviderTest {
     }
 
     @Test
-    fun `GIVEN a cache configuration is allowed WHEN top sites are fetched THEN write response to cache`() = runBlocking {
+    fun `GIVEN a cache configuration is allowed WHEN top sites are fetched THEN write response to cache`() = runTest {
         val jsonResponse = loadResourceAsString("/contile/contile.json")
         val client = prepareClient(jsonResponse)
         val provider = spy(ContileTopSitesProvider(testContext, client))
@@ -175,7 +177,7 @@ class ContileTopSitesProviderTest {
     }
 
     @Test
-    fun `GIVEN cache is not expired WHEN top sites are refreshed THEN do nothing`() = runBlocking {
+    fun `GIVEN cache is not expired WHEN top sites are refreshed THEN do nothing`() = runTest {
         val provider = spy(
             ContileTopSitesProvider(
                 testContext,
@@ -192,7 +194,7 @@ class ContileTopSitesProviderTest {
     }
 
     @Test
-    fun `GIVEN cache is expired WHEN top sites are refreshed THEN fetch and write new response to cache`() = runBlocking {
+    fun `GIVEN cache is expired WHEN top sites are refreshed THEN fetch and write new response to cache`() = runTest {
         val jsonResponse = loadResourceAsString("/contile/contile.json")
         val provider = spy(
             ContileTopSitesProvider(

--- a/components/service/contile/src/test/java/mozilla/components/service/contile/ContileTopSitesUpdaterTest.kt
+++ b/components/service/contile/src/test/java/mozilla/components/service/contile/ContileTopSitesUpdaterTest.kt
@@ -10,7 +10,8 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.await
 import androidx.work.testing.WorkManagerTestInitHelper
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.service.contile.ContileTopSitesUpdater.Companion.PERIODIC_WORK_TAG
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
@@ -23,6 +24,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class ContileTopSitesUpdaterTest {
 
@@ -40,7 +42,7 @@ class ContileTopSitesUpdaterTest {
     }
 
     @Test
-    fun `WHEN periodic work is started THEN work is queued`() = runBlocking {
+    fun `WHEN periodic work is started THEN work is queued`() = runTest {
         val updater = ContileTopSitesUpdater(testContext, provider = mock())
         val workManager = WorkManager.getInstance(testContext)
         var workInfo = workManager.getWorkInfosForUniqueWork(PERIODIC_WORK_TAG).await()
@@ -62,7 +64,7 @@ class ContileTopSitesUpdaterTest {
     }
 
     @Test
-    fun `GIVEN periodic work is started WHEN period work is stopped THEN no work is queued`() = runBlocking {
+    fun `GIVEN periodic work is started WHEN period work is stopped THEN no work is queued`() = runTest {
         val updater = ContileTopSitesUpdater(testContext, provider = mock())
         val workManager = WorkManager.getInstance(testContext)
         var workInfo = workManager.getWorkInfosForUniqueWork(PERIODIC_WORK_TAG).await()

--- a/components/service/contile/src/test/java/mozilla/components/service/contile/ContileTopSitesUpdaterWorkerTest.kt
+++ b/components/service/contile/src/test/java/mozilla/components/service/contile/ContileTopSitesUpdaterWorkerTest.kt
@@ -8,7 +8,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.ListenableWorker
 import androidx.work.await
 import androidx.work.testing.TestListenableWorkerBuilder
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.whenever
@@ -20,6 +21,7 @@ import org.mockito.Mockito.anyBoolean
 import org.mockito.Mockito.spy
 import java.io.IOException
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class ContileTopSitesUpdaterWorkerTest {
 
@@ -29,7 +31,7 @@ class ContileTopSitesUpdaterWorkerTest {
     }
 
     @Test
-    fun `WHEN worker does successful work THEN return a success result`() = runBlocking {
+    fun `WHEN worker does successful work THEN return a success result`() = runTest {
         val provider: ContileTopSitesProvider = mock()
         val worker = spy(
             TestListenableWorkerBuilder<ContileTopSitesUpdaterWorker>(testContext)
@@ -46,7 +48,7 @@ class ContileTopSitesUpdaterWorkerTest {
     }
 
     @Test
-    fun `WHEN worker does unsuccessful work THEN return a failure result`() = runBlocking {
+    fun `WHEN worker does unsuccessful work THEN return a failure result`() = runTest {
         val provider: ContileTopSitesProvider = mock()
         val worker = spy(
             TestListenableWorkerBuilder<ContileTopSitesUpdaterWorker>(testContext)

--- a/components/service/contile/src/test/java/mozilla/components/service/contile/ContileTopSitesUseCasesTest.kt
+++ b/components/service/contile/src/test/java/mozilla/components/service/contile/ContileTopSitesUseCasesTest.kt
@@ -5,7 +5,8 @@
 package mozilla.components.service.contile
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
@@ -15,11 +16,12 @@ import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.Mockito.verify
 import java.io.IOException
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class ContileTopSitesUseCasesTest {
 
     @Test
-    fun `WHEN refresh contile top site use case is called THEN call the provider to fetch top sites bypassing the cache`() = runBlocking {
+    fun `WHEN refresh contile top site use case is called THEN call the provider to fetch top sites bypassing the cache`() = runTest {
         val provider: ContileTopSitesProvider = mock()
 
         ContileTopSitesUseCases.initialize(provider)
@@ -34,7 +36,7 @@ class ContileTopSitesUseCasesTest {
     }
 
     @Test(expected = IOException::class)
-    fun `GIVEN the provider fails to fetch contile top sites WHEN refresh contile top site use case is called THEN an exception is thrown`() = runBlocking {
+    fun `GIVEN the provider fails to fetch contile top sites WHEN refresh contile top site use case is called THEN an exception is thrown`() = runTest {
         val provider: ContileTopSitesProvider = mock()
         val throwable = IOException("test")
 

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -7,9 +7,10 @@ package mozilla.components.service.fxa
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.base.crash.CrashReporting
 import mozilla.components.concept.sync.AccessTokenInfo
 import mozilla.components.concept.sync.AccountEventsObserver
@@ -112,6 +113,7 @@ internal open class TestableFxaAccountManager(
 const val EXPECTED_AUTH_STATE = "goodAuthState"
 const val UNEXPECTED_AUTH_STATE = "badAuthState"
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class FxaAccountManagerTest {
 
@@ -185,7 +187,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `migrating an account via copyAccountAsync - creating a new session token`() = runBlocking {
+    fun `migrating an account via copyAccountAsync - creating a new session token`() = runTest {
         // We'll test three scenarios:
         // - hitting a network issue during migration
         // - hitting an auth issue during migration (bad credentials)
@@ -257,7 +259,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `migrating an account via migrateAccountAsync - reusing existing session token`() = runBlocking {
+    fun `migrating an account via migrateAccountAsync - reusing existing session token`() = runTest {
         // We'll test three scenarios:
         // - hitting a network issue during migration
         // - hitting an auth issue during migration (bad credentials)
@@ -329,7 +331,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `migrating an account via migrateAccountAsync - retry scenario`() = runBlocking {
+    fun `migrating an account via migrateAccountAsync - retry scenario`() = runTest {
         val accountStorage: AccountStorage = mock()
         val profile = Profile("testUid", "test@example.com", null, "Test Profile")
         val constellation: DeviceConstellation = mockDeviceConstellation()
@@ -388,7 +390,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `restored account has an in-flight migration, retries and fails`() = runBlocking {
+    fun `restored account has an in-flight migration, retries and fails`() = runTest {
         val accountStorage: AccountStorage = mock()
         val profile = Profile("testUid", "test@example.com", null, "Test Profile")
         val constellation: DeviceConstellation = mockDeviceConstellation()
@@ -425,7 +427,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `restored account has an in-flight migration, retries and succeeds`() = runBlocking {
+    fun `restored account has an in-flight migration, retries and succeeds`() = runTest {
         val accountStorage: AccountStorage = mock()
         val profile = Profile("testUid", "test@example.com", null, "Test Profile")
         val constellation: DeviceConstellation = mockDeviceConstellation()
@@ -459,7 +461,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `restored account state persistence`() = runBlocking {
+    fun `restored account state persistence`() = runTest {
         val accountStorage: AccountStorage = mock()
         val profile = Profile("testUid", "test@example.com", null, "Test Profile")
         val constellation: DeviceConstellation = mockDeviceConstellation()
@@ -491,7 +493,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `restored account state persistence, finalizeDevice hit an intermittent error`() = runBlocking {
+    fun `restored account state persistence, finalizeDevice hit an intermittent error`() = runTest {
         val accountStorage: AccountStorage = mock()
         val profile = Profile("testUid", "test@example.com", null, "Test Profile")
         val constellation: DeviceConstellation = mockDeviceConstellation()
@@ -526,7 +528,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `restored account state persistence, hit an auth error`() = runBlocking {
+    fun `restored account state persistence, hit an auth error`() = runTest {
         val accountStorage: AccountStorage = mock()
         val profile = Profile("testUid", "test@example.com", null, "Test Profile")
         val constellation: DeviceConstellation = mockDeviceConstellation()
@@ -561,7 +563,7 @@ class FxaAccountManagerTest {
     }
 
     @Test(expected = FxaPanicException::class)
-    fun `restored account state persistence, hit an fxa panic which is re-thrown`() = runBlocking {
+    fun `restored account state persistence, hit an fxa panic which is re-thrown`() = runTest {
         val accountStorage: AccountStorage = mock()
         val profile = Profile("testUid", "test@example.com", null, "Test Profile")
         val constellation: DeviceConstellation = mock()
@@ -594,7 +596,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `newly authenticated account state persistence`() = runBlocking {
+    fun `newly authenticated account state persistence`() = runTest {
         val accountStorage: AccountStorage = mock()
         val profile = Profile(uid = "testUID", avatar = null, email = "test@example.com", displayName = "test profile")
         val constellation: DeviceConstellation = mockDeviceConstellation()
@@ -636,7 +638,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `auth state verification while finishing authentication`() = runBlocking {
+    fun `auth state verification while finishing authentication`() = runTest {
         val accountStorage: AccountStorage = mock()
         val profile = Profile(uid = "testUID", avatar = null, email = "test@example.com", displayName = "test profile")
         val constellation: DeviceConstellation = mockDeviceConstellation()
@@ -793,7 +795,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `error reading persisted account`() = runBlocking {
+    fun `error reading persisted account`() = runTest {
         val accountStorage = mock<AccountStorage>()
         val readException = FxaNetworkException("pretend we failed to fetch the account")
         `when`(accountStorage.read()).thenThrow(readException)
@@ -827,7 +829,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `no persisted account`() = runBlocking {
+    fun `no persisted account`() = runTest {
         val accountStorage = mock<AccountStorage>()
         // There's no account at the start.
         `when`(accountStorage.read()).thenReturn(null)
@@ -856,7 +858,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `with persisted account and profile`() = runBlocking {
+    fun `with persisted account and profile`() = runTest {
         val accountStorage = mock<AccountStorage>()
         val mockAccount: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
@@ -924,7 +926,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `happy authentication and profile flow`() = runBlocking {
+    fun `happy authentication and profile flow`() = runTest {
         val mockAccount: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
         `when`(mockAccount.deviceConstellation()).thenReturn(constellation)
@@ -968,7 +970,7 @@ class FxaAccountManagerTest {
     }
 
     @Test(expected = FxaPanicException::class)
-    fun `fxa panic during initDevice flow`() = runBlocking {
+    fun `fxa panic during initDevice flow`() = runTest {
         val mockAccount: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
         `when`(mockAccount.deviceConstellation()).thenReturn(constellation)
@@ -995,7 +997,7 @@ class FxaAccountManagerTest {
     }
 
     @Test(expected = FxaPanicException::class)
-    fun `fxa panic during pairing flow`() = runBlocking {
+    fun `fxa panic during pairing flow`() = runTest {
         val mockAccount: OAuthAccount = mock()
         `when`(mockAccount.deviceConstellation()).thenReturn(mock())
         val profile = Profile(uid = "testUID", avatar = null, email = "test@example.com", displayName = "test profile")
@@ -1023,7 +1025,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `happy pairing authentication and profile flow`() = runBlocking {
+    fun `happy pairing authentication and profile flow`() = runTest {
         val mockAccount: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
         `when`(mockAccount.deviceConstellation()).thenReturn(constellation)
@@ -1059,7 +1061,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `repeated unfinished authentication attempts succeed`() = runBlocking {
+    fun `repeated unfinished authentication attempts succeed`() = runTest {
         val mockAccount: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
         `when`(mockAccount.deviceConstellation()).thenReturn(constellation)
@@ -1102,7 +1104,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `unhappy authentication flow`() = runBlocking {
+    fun `unhappy authentication flow`() = runTest {
         val accountStorage = mock<AccountStorage>()
         val mockAccount: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
@@ -1149,7 +1151,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `unhappy pairing authentication flow`() = runBlocking {
+    fun `unhappy pairing authentication flow`() = runTest {
         val accountStorage = mock<AccountStorage>()
         val mockAccount: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
@@ -1196,7 +1198,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `authentication issues are propagated via AccountObserver`() = runBlocking {
+    fun `authentication issues are propagated via AccountObserver`() = runTest {
         val mockAccount: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
         `when`(mockAccount.deviceConstellation()).thenReturn(constellation)
@@ -1249,7 +1251,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `authentication issues are recoverable via checkAuthorizationState`() = runBlocking {
+    fun `authentication issues are recoverable via checkAuthorizationState`() = runTest {
         val mockAccount: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
         `when`(mockAccount.deviceConstellation()).thenReturn(constellation)
@@ -1295,7 +1297,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `authentication recovery flow has a circuit breaker`() = runBlocking {
+    fun `authentication recovery flow has a circuit breaker`() = runTest {
         val mockAccount: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
         `when`(mockAccount.deviceConstellation()).thenReturn(constellation)
@@ -1384,7 +1386,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `unhappy profile fetching flow`() = runBlocking {
+    fun `unhappy profile fetching flow`() = runTest {
         val accountStorage = mock<AccountStorage>()
         val mockAccount: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
@@ -1448,7 +1450,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `profile fetching flow hit an unrecoverable auth problem`() = runBlocking {
+    fun `profile fetching flow hit an unrecoverable auth problem`() = runTest {
         val accountStorage = mock<AccountStorage>()
         val mockAccount: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
@@ -1507,7 +1509,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `profile fetching flow hit an unrecoverable auth problem for which we can't determine a recovery state`() = runBlocking {
+    fun `profile fetching flow hit an unrecoverable auth problem for which we can't determine a recovery state`() = runTest {
         val accountStorage = mock<AccountStorage>()
         val mockAccount: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
@@ -1566,7 +1568,7 @@ class FxaAccountManagerTest {
     }
 
     @Test
-    fun `profile fetching flow hit a recoverable auth problem`() = runBlocking {
+    fun `profile fetching flow hit a recoverable auth problem`() = runTest {
         val accountStorage = mock<AccountStorage>()
         val mockAccount: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
@@ -1645,7 +1647,7 @@ class FxaAccountManagerTest {
     }
 
     @Test(expected = FxaPanicException::class)
-    fun `profile fetching flow hit an fxa panic, which is re-thrown`() = runBlocking {
+    fun `profile fetching flow hit an fxa panic, which is re-thrown`() = runTest {
         val accountStorage = mock<AccountStorage>()
         val mockAccount: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
@@ -1797,9 +1799,7 @@ class FxaAccountManagerTest {
 
         manager.register(accountObserver)
 
-        runBlocking(coroutineContext) {
-            manager.start()
-        }
+        manager.start()
 
         return manager
     }

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaDeviceConstellationTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaDeviceConstellationTest.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.plus
-import kotlinx.coroutines.runBlocking
 import mozilla.appservices.fxaclient.FxaException
 import mozilla.appservices.fxaclient.IncomingDeviceCommand
 import mozilla.appservices.fxaclient.SendTabPayload
@@ -34,6 +33,7 @@ import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -75,7 +75,7 @@ class FxaDeviceConstellationTest {
     }
 
     @Test
-    fun `finalize device`() = runBlocking(coroutinesTestRule.testDispatcher) {
+    fun `finalize device`() = runTestOnMain {
         fun expectedFinalizeAction(authType: AuthType): FxaDeviceConstellation.DeviceFinalizeAction = when (authType) {
             AuthType.Existing -> FxaDeviceConstellation.DeviceFinalizeAction.EnsureCapabilities
             AuthType.Signin -> FxaDeviceConstellation.DeviceFinalizeAction.Initialize
@@ -117,7 +117,7 @@ class FxaDeviceConstellationTest {
 
     @Test
     @ExperimentalCoroutinesApi
-    fun `updating device name`() = runBlocking(coroutinesTestRule.testDispatcher) {
+    fun `updating device name`() = runTestOnMain {
         val currentDevice = testDevice("currentTestDevice", true)
         `when`(account.getDevices()).thenReturn(arrayOf(currentDevice))
 
@@ -158,7 +158,7 @@ class FxaDeviceConstellationTest {
 
     @Test
     @ExperimentalCoroutinesApi
-    fun `set device push subscription`() = runBlocking(coroutinesTestRule.testDispatcher) {
+    fun `set device push subscription`() = runTestOnMain {
         val subscription = DevicePushSubscription("http://endpoint.com", "pk", "auth key")
         constellation.setDevicePushSubscription(subscription)
 
@@ -167,7 +167,7 @@ class FxaDeviceConstellationTest {
 
     @Test
     @ExperimentalCoroutinesApi
-    fun `process raw device command`() = runBlocking(coroutinesTestRule.testDispatcher) {
+    fun `process raw device command`() = runTestOnMain {
         // No commands, no observer.
         `when`(account.handlePushMessage("raw events payload")).thenReturn(emptyArray())
         assertTrue(constellation.processRawEvent("raw events payload"))
@@ -205,7 +205,7 @@ class FxaDeviceConstellationTest {
     }
 
     @Test
-    fun `send command to device`() = runBlocking(coroutinesTestRule.testDispatcher) {
+    fun `send command to device`() = runTestOnMain {
         `when`(account.gatherTelemetry()).thenReturn("{}")
         assertTrue(
             constellation.sendCommandToDevice(
@@ -217,7 +217,7 @@ class FxaDeviceConstellationTest {
     }
 
     @Test
-    fun `send command to device will report exceptions`() = runBlocking(coroutinesTestRule.testDispatcher) {
+    fun `send command to device will report exceptions`() = runTestOnMain {
         val exception = FxaException.Other("")
         val exceptionCaptor = argumentCaptor<SendCommandException>()
         doAnswer { throw exception }.`when`(account).sendSingleTab(any(), any(), any())
@@ -232,7 +232,7 @@ class FxaDeviceConstellationTest {
     }
 
     @Test
-    fun `send command to device won't report network exceptions`() = runBlocking(coroutinesTestRule.testDispatcher) {
+    fun `send command to device won't report network exceptions`() = runTestOnMain {
         val exception = FxaException.Network("timeout!")
         doAnswer { throw exception }.`when`(account).sendSingleTab(any(), any(), any())
 
@@ -247,7 +247,7 @@ class FxaDeviceConstellationTest {
 
     @Test
     @ExperimentalCoroutinesApi
-    fun `refreshing constellation`() = runBlocking(coroutinesTestRule.testDispatcher) {
+    fun `refreshing constellation`() = runTestOnMain {
         // No devices, no observers.
         `when`(account.getDevices()).thenReturn(emptyArray())
 
@@ -332,7 +332,7 @@ class FxaDeviceConstellationTest {
 
     @Test
     @ExperimentalCoroutinesApi
-    fun `polling for commands triggers observers`() = runBlocking(coroutinesTestRule.testDispatcher) {
+    fun `polling for commands triggers observers`() = runTestOnMain {
         // No commands, no observers.
         `when`(account.gatherTelemetry()).thenReturn("{}")
         `when`(account.pollDeviceCommands()).thenReturn(emptyArray())

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/UtilsKtTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/UtilsKtTest.kt
@@ -4,7 +4,8 @@
 
 package mozilla.components.service.fxa
 
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.sync.AuthFlowUrl
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.concept.sync.ServiceResult
@@ -25,9 +26,10 @@ import org.mockito.Mockito.reset
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 
+@ExperimentalCoroutinesApi // for runTest
 class UtilsKtTest {
     @Test
-    fun `handleFxaExceptions form 1 returns correct data back`() = runBlocking {
+    fun `handleFxaExceptions form 1 returns correct data back`() = runTest {
         assertEquals(
             1,
             handleFxaExceptions(
@@ -52,7 +54,7 @@ class UtilsKtTest {
     }
 
     @Test
-    fun `handleFxaExceptions form 1 does not swallow non-panics`() = runBlocking {
+    fun `handleFxaExceptions form 1 does not swallow non-panics`() = runTest {
         val accountManager: FxaAccountManager = mock()
         GlobalAccountManager.setInstance(accountManager)
 
@@ -113,7 +115,7 @@ class UtilsKtTest {
     }
 
     @Test(expected = IllegalStateException::class)
-    fun `handleFxaExceptions form 1 re-throws non-fxa exceptions`() = runBlocking {
+    fun `handleFxaExceptions form 1 re-throws non-fxa exceptions`() = runTest {
         handleFxaExceptions(
             mock(), "test op",
             {
@@ -124,7 +126,7 @@ class UtilsKtTest {
     }
 
     @Test(expected = FxaPanicException::class)
-    fun `handleFxaExceptions form 1 re-throws fxa panic exceptions`() = runBlocking {
+    fun `handleFxaExceptions form 1 re-throws fxa panic exceptions`() = runTest {
         handleFxaExceptions(
             mock(), "test op",
             {
@@ -135,7 +137,7 @@ class UtilsKtTest {
     }
 
     @Test
-    fun `handleFxaExceptions form 2 works`() = runBlocking {
+    fun `handleFxaExceptions form 2 works`() = runTest {
         val accountManager: FxaAccountManager = mock()
         GlobalAccountManager.setInstance(accountManager)
 
@@ -173,7 +175,7 @@ class UtilsKtTest {
     }
 
     @Test(expected = IllegalStateException::class)
-    fun `handleFxaExceptions form 2 re-throws non-fxa exceptions`() = runBlocking {
+    fun `handleFxaExceptions form 2 re-throws non-fxa exceptions`() = runTest {
         val accountManager: FxaAccountManager = mock()
         GlobalAccountManager.setInstance(accountManager)
 
@@ -184,7 +186,7 @@ class UtilsKtTest {
     }
 
     @Test(expected = FxaPanicException::class)
-    fun `handleFxaExceptions form 2 re-throws fxa panic exceptions`() = runBlocking {
+    fun `handleFxaExceptions form 2 re-throws fxa panic exceptions`() = runTest {
         val accountManager: FxaAccountManager = mock()
         GlobalAccountManager.setInstance(accountManager)
 
@@ -196,7 +198,7 @@ class UtilsKtTest {
     }
 
     @Test
-    fun `handleFxaExceptions form 3 works`() = runBlocking {
+    fun `handleFxaExceptions form 3 works`() = runTest {
         val accountManager: FxaAccountManager = mock()
         GlobalAccountManager.setInstance(accountManager)
 
@@ -238,7 +240,7 @@ class UtilsKtTest {
     }
 
     @Test(expected = IllegalStateException::class)
-    fun `handleFxaExceptions form 3 re-throws non-fxa exceptions`() = runBlocking {
+    fun `handleFxaExceptions form 3 re-throws non-fxa exceptions`() = runTest {
         val accountManager: FxaAccountManager = mock()
         GlobalAccountManager.setInstance(accountManager)
 
@@ -249,7 +251,7 @@ class UtilsKtTest {
     }
 
     @Test(expected = FxaPanicException::class)
-    fun `handleFxaExceptions form 3 re-throws fxa panic exceptions`() = runBlocking {
+    fun `handleFxaExceptions form 3 re-throws fxa panic exceptions`() = runTest {
         val accountManager: FxaAccountManager = mock()
         GlobalAccountManager.setInstance(accountManager)
 
@@ -260,7 +262,7 @@ class UtilsKtTest {
     }
 
     @Test
-    fun `withRetries immediate success`() = runBlocking {
+    fun `withRetries immediate success`() = runTest {
         when (val res = withRetries(mock(), 3) { true }) {
             is Result.Success -> assertTrue(res.value)
             is Result.Failure -> fail()
@@ -277,7 +279,7 @@ class UtilsKtTest {
     }
 
     @Test
-    fun `withRetries immediate failure`() = runBlocking {
+    fun `withRetries immediate failure`() = runTest {
         when (withRetries(mock(), 3) { false }) {
             is Result.Success -> fail()
             is Result.Failure -> {}
@@ -289,7 +291,7 @@ class UtilsKtTest {
     }
 
     @Test
-    fun `withRetries eventual success`() = runBlocking {
+    fun `withRetries eventual success`() = runTest {
         val eventual = SucceedOn(2, true)
         when (val res = withRetries(mock(), 5) { eventual.nullFailure() }) {
             is Result.Success -> {
@@ -309,7 +311,7 @@ class UtilsKtTest {
     }
 
     @Test
-    fun `withRetries eventual failure`() = runBlocking {
+    fun `withRetries eventual failure`() = runTest {
         val eventual = SucceedOn(6, true)
         when (withRetries(mock(), 5) { eventual.nullFailure() }) {
             is Result.Success -> fail()
@@ -327,7 +329,7 @@ class UtilsKtTest {
     }
 
     @Test
-    fun `withServiceRetries immediate success`() = runBlocking {
+    fun `withServiceRetries immediate success`() = runTest {
         when (withServiceRetries(mock(), 3, suspend { ServiceResult.Ok })) {
             is ServiceResult.Ok -> {}
             else -> fail()
@@ -335,7 +337,7 @@ class UtilsKtTest {
     }
 
     @Test
-    fun `withServiceRetries generic failure keeps retrying`() = runBlocking {
+    fun `withServiceRetries generic failure keeps retrying`() = runTest {
         // keeps retrying on generic error
         val eventual = SucceedOn(0, ServiceResult.Ok, ServiceResult.OtherError)
         when (withServiceRetries(mock(), 3) { eventual.reifiedFailure() }) {
@@ -347,7 +349,7 @@ class UtilsKtTest {
     }
 
     @Test
-    fun `withServiceRetries auth failure short circuit`() = runBlocking {
+    fun `withServiceRetries auth failure short circuit`() = runTest {
         // keeps retrying on generic error
         val eventual = SucceedOn(0, ServiceResult.Ok, ServiceResult.AuthError)
         when (withServiceRetries(mock(), 3) { eventual.reifiedFailure() }) {
@@ -359,7 +361,7 @@ class UtilsKtTest {
     }
 
     @Test
-    fun `withServiceRetries eventual success`() = runBlocking {
+    fun `withServiceRetries eventual success`() = runTest {
         val eventual = SucceedOn(3, ServiceResult.Ok, ServiceResult.OtherError)
         when (withServiceRetries(mock(), 5) { eventual.reifiedFailure() }) {
             is ServiceResult.Ok -> {
@@ -370,7 +372,7 @@ class UtilsKtTest {
     }
 
     @Test
-    fun `as auth flow pairing`() = runBlocking {
+    fun `as auth flow pairing`() = runTest {
         val account: OAuthAccount = mock()
         val authFlowUrl: AuthFlowUrl = mock()
         `when`(account.beginPairingFlow(eq("http://pairing.url"), eq(emptySet()), anyString())).thenReturn(authFlowUrl)
@@ -379,7 +381,7 @@ class UtilsKtTest {
     }
 
     @Test
-    fun `as auth flow regular`() = runBlocking {
+    fun `as auth flow regular`() = runTest {
         val account: OAuthAccount = mock()
         val authFlowUrl: AuthFlowUrl = mock()
         `when`(account.beginOAuthFlow(eq(emptySet()), anyString())).thenReturn(authFlowUrl)

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/manager/GlobalAccountManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/manager/GlobalAccountManagerTest.kt
@@ -4,14 +4,16 @@
 
 package mozilla.components.service.fxa.manager
 
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.support.test.mock
 import org.junit.Test
 import org.mockito.Mockito
 
 class GlobalAccountManagerTest {
+    @ExperimentalCoroutinesApi
     @Test
-    fun `GlobalAccountManager authError processing`() = runBlocking {
+    fun `GlobalAccountManager authError processing`() = runTest {
         val manager: FxaAccountManager = mock()
         GlobalAccountManager.setInstance(manager)
 

--- a/components/service/location/build.gradle
+++ b/components/service/location/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_mockwebserver
+    testImplementation Dependencies.testing_coroutines
 
     testImplementation project(':lib-fetch-httpurlconnection')
 }

--- a/components/service/location/src/test/java/mozilla/components/service/location/LocationServiceTest.kt
+++ b/components/service/location/src/test/java/mozilla/components/service/location/LocationServiceTest.kt
@@ -5,13 +5,16 @@
 package mozilla.components.service.location
 
 import junit.framework.TestCase.assertNull
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 class LocationServiceTest {
+    @ExperimentalCoroutinesApi
     @Test
     fun `dummy implementation returns null`() {
-        runBlocking {
+        runTest(UnconfinedTestDispatcher()) {
             assertNull(LocationService.dummy().fetchRegion(false))
             assertNull(LocationService.dummy().fetchRegion(true))
             assertNull(LocationService.dummy().fetchRegion(false))

--- a/components/service/location/src/test/java/mozilla/components/service/location/MozillaLocationServiceTest.kt
+++ b/components/service/location/src/test/java/mozilla/components/service/location/MozillaLocationServiceTest.kt
@@ -5,7 +5,8 @@
 package mozilla.components.service.location
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.MutableHeaders
 import mozilla.components.concept.fetch.Request
@@ -30,6 +31,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import java.io.IOException
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class MozillaLocationServiceTest {
     @Before
@@ -39,7 +41,7 @@ class MozillaLocationServiceTest {
     }
 
     @Test
-    fun `WHEN calling fetchRegion AND the service returns a region THEN a Region object is returned`() {
+    fun `WHEN calling fetchRegion AND the service returns a region THEN a Region object is returned`() = runTest {
         val server = MockWebServer()
         server.enqueue(MockResponse().setBody("{\"country_name\": \"Germany\", \"country_code\": \"DE\"}"))
 
@@ -53,7 +55,7 @@ class MozillaLocationServiceTest {
                 serviceUrl = server.url("/").toString()
             )
 
-            val region = runBlocking { service.fetchRegion() }
+            val region = service.fetchRegion()
 
             assertNotNull(region!!)
 
@@ -69,18 +71,18 @@ class MozillaLocationServiceTest {
     }
 
     @Test
-    fun `WHEN client throws IOException THEN the returned region is null`() {
+    fun `WHEN client throws IOException THEN the returned region is null`() = runTest {
         val client: Client = mock()
         doThrow(IOException()).`when`(client).fetch(any())
 
         val service = MozillaLocationService(testContext, client, apiKey = "test")
-        val region = runBlocking { service.fetchRegion() }
+        val region = service.fetchRegion()
 
         assertNull(region)
     }
 
     @Test
-    fun `WHEN fetching region THEN request is sent to the location service`() {
+    fun `WHEN fetching region THEN request is sent to the location service`() = runTest {
         val client: Client = mock()
         val response = Response(
             url = "http://example.org",
@@ -91,7 +93,7 @@ class MozillaLocationServiceTest {
         doReturn(response).`when`(client).fetch(any())
 
         val service = MozillaLocationService(testContext, client, apiKey = "test")
-        val region = runBlocking { service.fetchRegion() }
+        val region = service.fetchRegion()
 
         assertNotNull(region!!)
 
@@ -106,7 +108,7 @@ class MozillaLocationServiceTest {
     }
 
     @Test
-    fun `WHEN fetching region AND service returns 404 THEN region is null`() {
+    fun `WHEN fetching region AND service returns 404 THEN region is null`() = runTest {
         val client: Client = mock()
         val response = Response(
             url = "http://example.org",
@@ -117,13 +119,13 @@ class MozillaLocationServiceTest {
         doReturn(response).`when`(client).fetch(any())
 
         val service = MozillaLocationService(testContext, client, apiKey = "test")
-        val region = runBlocking { service.fetchRegion() }
+        val region = service.fetchRegion()
 
         assertNull(region)
     }
 
     @Test
-    fun `WHEN fetching region AND service returns 500 THEN region is null`() {
+    fun `WHEN fetching region AND service returns 500 THEN region is null`() = runTest {
         val client: Client = mock()
         val response = Response(
             url = "http://example.org",
@@ -134,13 +136,13 @@ class MozillaLocationServiceTest {
         doReturn(response).`when`(client).fetch(any())
 
         val service = MozillaLocationService(testContext, client, apiKey = "test")
-        val region = runBlocking { service.fetchRegion() }
+        val region = service.fetchRegion()
 
         assertNull(region)
     }
 
     @Test
-    fun `WHEN fetching region AND service returns broken JSON THEN region is null`() {
+    fun `WHEN fetching region AND service returns broken JSON THEN region is null`() = runTest {
         val client: Client = mock()
         val response = Response(
             url = "http://example.org",
@@ -151,13 +153,13 @@ class MozillaLocationServiceTest {
         doReturn(response).`when`(client).fetch(any())
 
         val service = MozillaLocationService(testContext, client, apiKey = "test")
-        val region = runBlocking { service.fetchRegion() }
+        val region = service.fetchRegion()
 
         assertNull(region)
     }
 
     @Test
-    fun `WHEN fetching region AND service returns empty JSON object THEN region is null`() {
+    fun `WHEN fetching region AND service returns empty JSON object THEN region is null`() = runTest {
         val client: Client = mock()
         val response = Response(
             url = "http://example.org",
@@ -168,13 +170,13 @@ class MozillaLocationServiceTest {
         doReturn(response).`when`(client).fetch(any())
 
         val service = MozillaLocationService(testContext, client, apiKey = "test")
-        val region = runBlocking { service.fetchRegion() }
+        val region = service.fetchRegion()
 
         assertNull(region)
     }
 
     @Test
-    fun `WHEN fetching region AND service returns incomplete JSON THEN region is null`() {
+    fun `WHEN fetching region AND service returns incomplete JSON THEN region is null`() = runTest {
         val client: Client = mock()
         val response = Response(
             url = "http://example.org",
@@ -185,13 +187,13 @@ class MozillaLocationServiceTest {
         doReturn(response).`when`(client).fetch(any())
 
         val service = MozillaLocationService(testContext, client, apiKey = "test")
-        val region = runBlocking { service.fetchRegion() }
+        val region = service.fetchRegion()
 
         assertNull(region)
     }
 
     @Test
-    fun `WHEN fetching region for the second time THEN region is read from cache`() {
+    fun `WHEN fetching region for the second time THEN region is read from cache`() = runTest {
         run {
             val client: Client = mock()
             val response = Response(
@@ -203,7 +205,7 @@ class MozillaLocationServiceTest {
             doReturn(response).`when`(client).fetch(any())
 
             val service = MozillaLocationService(testContext, client, apiKey = "test")
-            val region = runBlocking { service.fetchRegion() }
+            val region = service.fetchRegion()
 
             assertNotNull(region!!)
 
@@ -217,7 +219,7 @@ class MozillaLocationServiceTest {
             val client: Client = mock()
 
             val service = MozillaLocationService(testContext, client, apiKey = "test")
-            val region = runBlocking { service.fetchRegion() }
+            val region = service.fetchRegion()
 
             assertNotNull(region!!)
 
@@ -229,7 +231,7 @@ class MozillaLocationServiceTest {
     }
 
     @Test
-    fun `WHEN fetching region for the second time and setting readFromCache = false THEN request is sent again`() {
+    fun `WHEN fetching region for the second time and setting readFromCache = false THEN request is sent again`() = runTest {
         run {
             val client: Client = mock()
             val response = Response(
@@ -241,7 +243,7 @@ class MozillaLocationServiceTest {
             doReturn(response).`when`(client).fetch(any())
 
             val service = MozillaLocationService(testContext, client, apiKey = "test")
-            val region = runBlocking { service.fetchRegion() }
+            val region = service.fetchRegion()
 
             assertNotNull(region!!)
 
@@ -262,7 +264,7 @@ class MozillaLocationServiceTest {
             doReturn(response).`when`(client).fetch(any())
 
             val service = MozillaLocationService(testContext, client, apiKey = "test")
-            val region = runBlocking { service.fetchRegion(readFromCache = false) }
+            val region = service.fetchRegion(readFromCache = false)
 
             assertNotNull(region!!)
 

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketStoriesServiceTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketStoriesServiceTest.kt
@@ -5,7 +5,8 @@
 package mozilla.components.service.pocket
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.service.pocket.helpers.assertConstructorsVisibility
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
@@ -43,8 +44,9 @@ class PocketStoriesServiceTest {
         verify(service.scheduler).stopPeriodicRefreshes(any())
     }
 
+    @ExperimentalCoroutinesApi
     @Test
-    fun `GIVEN PocketStoriesService WHEN getStories THEN getStoriesUsecase should return`() = runBlocking {
+    fun `GIVEN PocketStoriesService WHEN getStories THEN getStoriesUsecase should return`() = runTest {
         val stories = listOf(mock<PocketRecommendedStory>())
         whenever(service.getStoriesUsecase.invoke()).thenReturn(stories)
 

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/stories/PocketRecommendationsRepositoryTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/stories/PocketRecommendationsRepositoryTest.kt
@@ -5,7 +5,8 @@
 package mozilla.components.service.pocket.stories
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.service.pocket.helpers.PocketTestResources
 import mozilla.components.service.pocket.stories.db.PocketRecommendationsDao
 import mozilla.components.service.pocket.stories.ext.toPartialTimeShownUpdate
@@ -21,6 +22,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class PocketRecommendationsRepositoryTest {
 
@@ -35,7 +37,7 @@ class PocketRecommendationsRepositoryTest {
 
     @Test
     fun `GIVEN PocketRecommendationsRepository WHEN getPocketRecommendedStories is called THEN return db entities mapped to domain type`() {
-        runBlocking {
+        runTest {
             val dbStory = PocketTestResources.dbExpectedPocketStory
             `when`(dao.getPocketStories()).thenReturn(listOf(dbStory))
 
@@ -49,7 +51,7 @@ class PocketRecommendationsRepositoryTest {
 
     @Test
     fun `GIVEN PocketRecommendationsRepository WHEN addAllPocketApiStories is called THEN persist the received story to db`() {
-        runBlocking {
+        runTest {
             val apiStories = PocketTestResources.apiExpectedPocketStoriesRecommendations
             val apiStoriesMappedForDb = apiStories.map { it.toPocketLocalStory() }
 
@@ -61,7 +63,7 @@ class PocketRecommendationsRepositoryTest {
 
     @Test
     fun `GIVEN PocketRecommendationsRepository WHEN updateShownPocketRecommendedStories should persist the received story to db`() {
-        runBlocking {
+        runTest {
             val clientStories = listOf(PocketTestResources.clientExpectedPocketStory)
             val clientStoriesPartialUpdate = clientStories.map { it.toPartialTimeShownUpdate() }
 

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/stories/db/PocketRecommendationsDaoTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/stories/db/PocketRecommendationsDaoTest.kt
@@ -10,8 +10,7 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.service.pocket.helpers.PocketTestResources
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -52,7 +51,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN an empty table WHEN a story is inserted and then queried THEN return the same story`() = runBlockingTest {
+    fun `GIVEN an empty table WHEN a story is inserted and then queried THEN return the same story`() = runTest {
         val story = PocketTestResources.dbExpectedPocketStory
 
         dao.insertPocketStories(listOf(story))
@@ -62,7 +61,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN a story already persisted WHEN another story with identical url is tried to be inserted THEN add that to the table`() = runBlockingTest {
+    fun `GIVEN a story already persisted WHEN another story with identical url is tried to be inserted THEN add that to the table`() = runTest {
         val story = PocketTestResources.dbExpectedPocketStory
         val newStory = story.copy(
             url = "updated" + story.url
@@ -76,7 +75,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN a story with the same url exists WHEN another story with updated title is tried to be inserted THEN don't update the table`() = runBlockingTest {
+    fun `GIVEN a story with the same url exists WHEN another story with updated title is tried to be inserted THEN don't update the table`() = runTest {
         val story = PocketTestResources.dbExpectedPocketStory
         val updatedStory = story.copy(
             title = "updated" + story.title
@@ -91,7 +90,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN a story with the same url exists WHEN another story with updated imageUrl is tried to be inserted THEN don't update the table`() = runBlockingTest {
+    fun `GIVEN a story with the same url exists WHEN another story with updated imageUrl is tried to be inserted THEN don't update the table`() = runTest {
         val story = PocketTestResources.dbExpectedPocketStory
         val updatedStory = story.copy(
             imageUrl = "updated" + story.imageUrl
@@ -105,7 +104,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN a story with the same url exists WHEN another story with updated publisher is tried to be inserted THEN don't update the table`() = runBlockingTest {
+    fun `GIVEN a story with the same url exists WHEN another story with updated publisher is tried to be inserted THEN don't update the table`() = runTest {
         val story = PocketTestResources.dbExpectedPocketStory
         val updatedStory = story.copy(
             publisher = "updated" + story.publisher
@@ -119,7 +118,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN a story with the same url exists WHEN another story with updated category is tried to be inserted THEN don't update the table`() = runBlockingTest {
+    fun `GIVEN a story with the same url exists WHEN another story with updated category is tried to be inserted THEN don't update the table`() = runTest {
         val story = PocketTestResources.dbExpectedPocketStory
         val updatedStory = story.copy(
             category = "updated" + story.category
@@ -133,7 +132,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN a story with the same url exists WHEN another story with updated timeToRead is tried to be inserted THEN don't update the table`() = runBlockingTest {
+    fun `GIVEN a story with the same url exists WHEN another story with updated timeToRead is tried to be inserted THEN don't update the table`() = runTest {
         val story = PocketTestResources.dbExpectedPocketStory
         val updatedStory = story.copy(
             timesShown = story.timesShown * 2
@@ -147,7 +146,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN a story with the same url exists WHEN another story with updated timesShown is tried to be inserted THEN don't update the table`() = runBlockingTest {
+    fun `GIVEN a story with the same url exists WHEN another story with updated timesShown is tried to be inserted THEN don't update the table`() = runTest {
         val story = PocketTestResources.dbExpectedPocketStory
         val updatedStory = story.copy(
             timesShown = story.timesShown * 2
@@ -161,7 +160,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN stories already persisted WHEN asked to delete some THEN remove them from the table`() = runBlockingTest {
+    fun `GIVEN stories already persisted WHEN asked to delete some THEN remove them from the table`() = runTest {
         val story1 = PocketTestResources.dbExpectedPocketStory
         val story2 = PocketTestResources.dbExpectedPocketStory.copy(url = story1.url + "2")
         val story3 = PocketTestResources.dbExpectedPocketStory.copy(url = story1.url + "3")
@@ -175,7 +174,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN stories already persisted WHEN asked to delete one not present in the table THEN don't update the table`() = runBlockingTest {
+    fun `GIVEN stories already persisted WHEN asked to delete one not present in the table THEN don't update the table`() = runTest {
         val story1 = PocketTestResources.dbExpectedPocketStory
         val story2 = PocketTestResources.dbExpectedPocketStory.copy(url = story1.url + "2")
         val story3 = PocketTestResources.dbExpectedPocketStory.copy(url = story1.url + "3")
@@ -189,7 +188,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN stories already persisted WHEN asked to update timesShown for one THEN update only that story`() = runBlockingTest {
+    fun `GIVEN stories already persisted WHEN asked to update timesShown for one THEN update only that story`() = runTest {
         val story1 = PocketTestResources.dbExpectedPocketStory
         val story2 = PocketTestResources.dbExpectedPocketStory.copy(
             url = story1.url + "2",
@@ -222,7 +221,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN stories already persisted WHEN asked to update timesShown for one not present in the table THEN don't update the table`() = runBlockingTest {
+    fun `GIVEN stories already persisted WHEN asked to update timesShown for one not present in the table THEN don't update the table`() = runTest {
         val story1 = PocketTestResources.dbExpectedPocketStory
         val story2 = PocketTestResources.dbExpectedPocketStory.copy(
             url = story1.url + "2",
@@ -246,7 +245,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN stories already persisted WHEN asked to clean and insert new ones THEN remove from table all stories not found in the new list`() = runBlocking {
+    fun `GIVEN stories already persisted WHEN asked to clean and insert new ones THEN remove from table all stories not found in the new list`() = runTest {
         setupDatabseForTransactions()
         val story1 = PocketTestResources.dbExpectedPocketStory
         val story2 = PocketTestResources.dbExpectedPocketStory.copy(url = story1.url + "2")
@@ -261,7 +260,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN stories already persisted WHEN asked to clean and insert new ones THEN update stories with new urls`() = runBlocking {
+    fun `GIVEN stories already persisted WHEN asked to clean and insert new ones THEN update stories with new urls`() = runTest {
         setupDatabseForTransactions()
         val story1 = PocketTestResources.dbExpectedPocketStory
         val story2 = PocketTestResources.dbExpectedPocketStory.copy(url = story1.url + "2")
@@ -278,7 +277,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN stories already persisted WHEN asked to clean and insert new ones THEN update stories with new image urls`() = runBlocking {
+    fun `GIVEN stories already persisted WHEN asked to clean and insert new ones THEN update stories with new image urls`() = runTest {
         setupDatabseForTransactions()
         val story1 = PocketTestResources.dbExpectedPocketStory
         val story2 = PocketTestResources.dbExpectedPocketStory.copy(url = story1.url + "2")
@@ -294,7 +293,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN stories already persisted WHEN asked to clean and insert new ones THEN don't update story if only title changed`() = runBlocking {
+    fun `GIVEN stories already persisted WHEN asked to clean and insert new ones THEN don't update story if only title changed`() = runTest {
         setupDatabseForTransactions()
         val story1 = PocketTestResources.dbExpectedPocketStory
         val story2 = PocketTestResources.dbExpectedPocketStory.copy(url = story1.url + "2")
@@ -310,7 +309,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN stories already persisted WHEN asked to clean and insert new ones THEN don't update story if only publisher changed`() = runBlocking {
+    fun `GIVEN stories already persisted WHEN asked to clean and insert new ones THEN don't update story if only publisher changed`() = runTest {
         setupDatabseForTransactions()
         val story1 = PocketTestResources.dbExpectedPocketStory
         val story2 = PocketTestResources.dbExpectedPocketStory.copy(url = story1.url + "2")
@@ -326,7 +325,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN stories already persisted WHEN asked to clean and insert new ones THEN don't update story if only category changed`() = runBlocking {
+    fun `GIVEN stories already persisted WHEN asked to clean and insert new ones THEN don't update story if only category changed`() = runTest {
         setupDatabseForTransactions()
         val story1 = PocketTestResources.dbExpectedPocketStory
         val story2 = PocketTestResources.dbExpectedPocketStory.copy(url = story1.url + "2")
@@ -342,7 +341,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN stories already persisted WHEN asked to clean and insert new ones THEN don't update story if only timeToRead changed`() = runBlocking {
+    fun `GIVEN stories already persisted WHEN asked to clean and insert new ones THEN don't update story if only timeToRead changed`() = runTest {
         setupDatabseForTransactions()
         val story1 = PocketTestResources.dbExpectedPocketStory
         val story2 = PocketTestResources.dbExpectedPocketStory.copy(url = story1.url + "2")
@@ -358,7 +357,7 @@ class PocketRecommendationsDaoTest {
     }
 
     @Test
-    fun `GIVEN stories already persisted WHEN asked to clean and insert new ones THEN don't update story if only timesShown changed`() = runBlocking {
+    fun `GIVEN stories already persisted WHEN asked to clean and insert new ones THEN don't update story if only timesShown changed`() = runTest {
         setupDatabseForTransactions()
         val story1 = PocketTestResources.dbExpectedPocketStory
         val story2 = PocketTestResources.dbExpectedPocketStory.copy(url = story1.url + "2")
@@ -375,7 +374,7 @@ class PocketRecommendationsDaoTest {
 
     /**
      * Sets an executor to be used for database transactions.
-     * Needs to be used along with "runBlockingTest" to ensure waiting for transactions to finish but not hang tests.
+     * Needs to be used along with "runTest" to ensure waiting for transactions to finish but not hang tests.
      */
     private fun setupDatabseForTransactions() {
         database = Room

--- a/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorageTest.kt
+++ b/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorageTest.kt
@@ -5,7 +5,8 @@
 package mozilla.components.service.sync.autofill
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.storage.CreditCard
 import mozilla.components.concept.storage.CreditCardNumber
 import mozilla.components.concept.storage.NewCreditCardFields
@@ -24,25 +25,27 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class AutofillCreditCardsAddressesStorageTest {
+
     private lateinit var storage: AutofillCreditCardsAddressesStorage
     private lateinit var securePrefs: SecureAbove22Preferences
 
     @Before
-    fun setup() = runBlocking {
+    fun setup() {
         // forceInsecure is set in the tests because a keystore wouldn't be configured in the test environment.
         securePrefs = SecureAbove22Preferences(testContext, "autofill", forceInsecure = true)
         storage = AutofillCreditCardsAddressesStorage(testContext, lazy { securePrefs })
     }
 
     @After
-    fun cleanup() = runBlocking {
+    fun cleanup() {
         storage.close()
     }
 
     @Test
-    fun `add credit card`() = runBlocking {
+    fun `add credit card`() = runTest {
         val plaintextNumber = CreditCardNumber.Plaintext("4111111111111111")
         val creditCardFields = NewCreditCardFields(
             billingName = "Jon Doe",
@@ -72,7 +75,7 @@ class AutofillCreditCardsAddressesStorageTest {
     }
 
     @Test
-    fun `get credit card`() = runBlocking {
+    fun `get credit card`() = runTest {
         val plaintextNumber = CreditCardNumber.Plaintext("5500000000000004")
         val creditCardFields = NewCreditCardFields(
             billingName = "Jon Doe",
@@ -88,12 +91,12 @@ class AutofillCreditCardsAddressesStorageTest {
     }
 
     @Test
-    fun `GIVEN a non-existent credit card guid WHEN getCreditCard is called THEN null is returned`() = runBlocking {
+    fun `GIVEN a non-existent credit card guid WHEN getCreditCard is called THEN null is returned`() = runTest {
         assertNull(storage.getCreditCard("guid"))
     }
 
     @Test
-    fun `get all credit cards`() = runBlocking {
+    fun `get all credit cards`() = runTest {
         val plaintextNumber1 = CreditCardNumber.Plaintext("5500000000000004")
         val creditCardFields1 = NewCreditCardFields(
             billingName = "Jane Fields",
@@ -141,7 +144,7 @@ class AutofillCreditCardsAddressesStorageTest {
     }
 
     @Test
-    fun `update credit card`() = runBlocking {
+    fun `update credit card`() = runTest {
         val creditCardFields = NewCreditCardFields(
             billingName = "Jon Doe",
             plaintextCardNumber = CreditCardNumber.Plaintext("4111111111111111"),
@@ -199,7 +202,7 @@ class AutofillCreditCardsAddressesStorageTest {
     }
 
     @Test
-    fun `delete credit card`() = runBlocking {
+    fun `delete credit card`() = runTest {
         val creditCardFields = NewCreditCardFields(
             billingName = "Jon Doe",
             plaintextCardNumber = CreditCardNumber.Plaintext("30000000000004"),
@@ -219,7 +222,7 @@ class AutofillCreditCardsAddressesStorageTest {
     }
 
     @Test
-    fun `add address`() = runBlocking {
+    fun `add address`() = runTest {
         val addressFields = UpdatableAddressFields(
             givenName = "John",
             additionalName = "",
@@ -253,7 +256,7 @@ class AutofillCreditCardsAddressesStorageTest {
     }
 
     @Test
-    fun `get address`() = runBlocking {
+    fun `get address`() = runTest {
         val addressFields = UpdatableAddressFields(
             givenName = "John",
             additionalName = "",
@@ -274,12 +277,12 @@ class AutofillCreditCardsAddressesStorageTest {
     }
 
     @Test
-    fun `GIVEN a non-existent address guid WHEN getAddress is called THEN null is returned`() = runBlocking {
+    fun `GIVEN a non-existent address guid WHEN getAddress is called THEN null is returned`() = runTest {
         assertNull(storage.getAddress("guid"))
     }
 
     @Test
-    fun `get all addresses`() = runBlocking {
+    fun `get all addresses`() = runTest {
         val addressFields1 = UpdatableAddressFields(
             givenName = "John",
             additionalName = "",
@@ -337,7 +340,7 @@ class AutofillCreditCardsAddressesStorageTest {
     }
 
     @Test
-    fun `update address`() = runBlocking {
+    fun `update address`() = runTest {
         val addressFields = UpdatableAddressFields(
             givenName = "John",
             additionalName = "",
@@ -389,7 +392,7 @@ class AutofillCreditCardsAddressesStorageTest {
     }
 
     @Test
-    fun `delete address`() = runBlocking {
+    fun `delete address`() = runTest {
         val addressFields = UpdatableAddressFields(
             givenName = "John",
             additionalName = "",
@@ -415,7 +418,7 @@ class AutofillCreditCardsAddressesStorageTest {
     }
 
     @Test
-    fun `WHEN warmUp method is called THEN the database connection is established`(): Unit = runBlocking {
+    fun `WHEN warmUp method is called THEN the database connection is established`(): Unit = runTest {
         val storageSpy = spy(storage)
         storageSpy.warmUp()
 

--- a/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/AutofillCryptoTest.kt
+++ b/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/AutofillCryptoTest.kt
@@ -5,7 +5,8 @@
 package mozilla.components.service.sync.autofill
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.storage.CreditCardNumber
 import mozilla.components.concept.storage.KeyGenerationReason
 import mozilla.components.concept.storage.ManagedKey
@@ -21,8 +22,10 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 
+@ExperimentalCoroutinesApi // for runTest
 @RunWith(AndroidJUnit4::class)
 class AutofillCryptoTest {
+
     private lateinit var securePrefs: SecureAbove22Preferences
 
     @Before
@@ -32,7 +35,7 @@ class AutofillCryptoTest {
     }
 
     @Test
-    fun `get key - new`() = runBlocking {
+    fun `get key - new`() = runTest {
         val storage = mock<AutofillCreditCardsAddressesStorage>()
         val crypto = AutofillCrypto(testContext, securePrefs, storage)
         val key = crypto.getOrGenerateKey()
@@ -47,7 +50,7 @@ class AutofillCryptoTest {
     }
 
     @Test
-    fun `get key - lost`() = runBlocking {
+    fun `get key - lost`() = runTest {
         val storage = mock<AutofillCreditCardsAddressesStorage>()
         val crypto = AutofillCrypto(testContext, securePrefs, storage)
         val key = crypto.getOrGenerateKey()
@@ -63,7 +66,7 @@ class AutofillCryptoTest {
     }
 
     @Test
-    fun `get key - corrupted`() = runBlocking {
+    fun `get key - corrupted`() = runTest {
         val storage = mock<AutofillCreditCardsAddressesStorage>()
         val crypto = AutofillCrypto(testContext, securePrefs, storage)
         val key = crypto.getOrGenerateKey()
@@ -80,7 +83,7 @@ class AutofillCryptoTest {
     }
 
     @Test
-    fun `get key - corrupted subtly`() = runBlocking {
+    fun `get key - corrupted subtly`() = runTest {
         val storage = mock<AutofillCreditCardsAddressesStorage>()
         val crypto = AutofillCrypto(testContext, securePrefs, storage)
         val key = crypto.getOrGenerateKey()
@@ -98,7 +101,7 @@ class AutofillCryptoTest {
     }
 
     @Test
-    fun `encrypt and decrypt card - normal`() = runBlocking {
+    fun `encrypt and decrypt card - normal`() = runTest {
         val crypto = AutofillCrypto(testContext, securePrefs, mock())
         val key = crypto.getOrGenerateKey()
         val plaintext1 = CreditCardNumber.Plaintext("4111111111111111")
@@ -115,7 +118,7 @@ class AutofillCryptoTest {
     }
 
     @Test
-    fun `encrypt and decrypt card - bad keys`() = runBlocking {
+    fun `encrypt and decrypt card - bad keys`() = runTest {
         val crypto = AutofillCrypto(testContext, securePrefs, mock())
         val plaintext = CreditCardNumber.Plaintext("4111111111111111")
 

--- a/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/GeckoCreditCardsAddressesStorageDelegateTest.kt
+++ b/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/GeckoCreditCardsAddressesStorageDelegateTest.kt
@@ -7,9 +7,6 @@ package mozilla.components.service.sync.autofill
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import mozilla.components.concept.storage.CreditCard
 import mozilla.components.concept.storage.CreditCardEntry
 import mozilla.components.concept.storage.CreditCardNumber
@@ -19,8 +16,11 @@ import mozilla.components.lib.dataprotect.SecureAbove22Preferences
 import mozilla.components.support.ktx.kotlin.last4Digits
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
@@ -31,18 +31,20 @@ import org.mockito.Mockito.verify
 @RunWith(AndroidJUnit4::class)
 class GeckoCreditCardsAddressesStorageDelegateTest {
 
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val scope = coroutinesTestRule.scope
+
     private lateinit var storage: AutofillCreditCardsAddressesStorage
     private lateinit var securePrefs: SecureAbove22Preferences
     private lateinit var delegate: GeckoCreditCardsAddressesStorageDelegate
-    private lateinit var scope: TestScope
 
     init {
         testContext.getDatabasePath(AUTOFILL_DB_NAME)!!.parentFile!!.mkdirs()
     }
 
     @Before
-    fun before() = runBlocking {
-        scope = TestScope(UnconfinedTestDispatcher())
+    fun before() {
         // forceInsecure is set in the tests because a keystore wouldn't be configured in the test environment.
         securePrefs = SecureAbove22Preferences(testContext, "autofill", forceInsecure = true)
         storage = AutofillCreditCardsAddressesStorage(testContext, lazy { securePrefs })
@@ -51,7 +53,7 @@ class GeckoCreditCardsAddressesStorageDelegateTest {
 
     @Test
     fun `GIVEN a newly added credit card WHEN decrypt is called THEN it returns the plain credit card number`() =
-        runBlocking {
+        runTestOnMain {
             val plaintextNumber = CreditCardNumber.Plaintext("4111111111111111")
             val creditCardFields = NewCreditCardFields(
                 billingName = "Jon Doe",

--- a/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/GeckoCreditCardsAddressesStorageDelegateTest.kt
+++ b/components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/GeckoCreditCardsAddressesStorageDelegateTest.kt
@@ -8,7 +8,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import mozilla.components.concept.storage.CreditCard
 import mozilla.components.concept.storage.CreditCardEntry
 import mozilla.components.concept.storage.CreditCardNumber
@@ -33,7 +34,7 @@ class GeckoCreditCardsAddressesStorageDelegateTest {
     private lateinit var storage: AutofillCreditCardsAddressesStorage
     private lateinit var securePrefs: SecureAbove22Preferences
     private lateinit var delegate: GeckoCreditCardsAddressesStorageDelegate
-    private lateinit var scope: TestCoroutineScope
+    private lateinit var scope: TestScope
 
     init {
         testContext.getDatabasePath(AUTOFILL_DB_NAME)!!.parentFile!!.mkdirs()
@@ -41,7 +42,7 @@ class GeckoCreditCardsAddressesStorageDelegateTest {
 
     @Before
     fun before() = runBlocking {
-        scope = TestCoroutineScope()
+        scope = TestScope(UnconfinedTestDispatcher())
         // forceInsecure is set in the tests because a keystore wouldn't be configured in the test environment.
         securePrefs = SecureAbove22Preferences(testContext, "autofill", forceInsecure = true)
         storage = AutofillCreditCardsAddressesStorage(testContext, lazy { securePrefs })

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ViewTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ViewTest.kt
@@ -15,7 +15,6 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import mozilla.components.support.base.android.Padding
@@ -45,7 +44,6 @@ import java.util.concurrent.TimeUnit
 @RunWith(AndroidJUnit4::class)
 class ViewTest {
 
-    @ExperimentalCoroutinesApi
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
 

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlinx/coroutines/UtilsKtTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlinx/coroutines/UtilsKtTest.kt
@@ -5,7 +5,8 @@
 package mozilla.components.support.ktx.kotlinx.coroutines
 
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
@@ -13,7 +14,7 @@ import org.junit.Test
 class UtilsKtTest {
 
     @Test
-    fun throttle() = runBlockingTest {
+    fun throttle() = runTest(UnconfinedTestDispatcher()) {
         val skipTime = 300L
         var value = 0
         val throttleBlock = throttleLatest<Int>(skipTime, coroutineScope = this) {

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlinx/coroutines/flow/FlowKtTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlinx/coroutines/flow/FlowKtTest.kt
@@ -6,7 +6,7 @@ package mozilla.components.support.ktx.kotlinx.coroutines.flow
 
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -17,10 +17,10 @@ class FlowKtTest {
     data class IntState(val value: Int)
 
     @Test
-    fun `ifChanged operator`() {
+    fun `ifChanged operator`() = runTest {
         val originalFlow = flowOf("A", "B", "B", "C", "A", "A", "A", "D", "A")
 
-        val items = runBlocking { originalFlow.ifChanged().toList() }
+        val items = originalFlow.ifChanged().toList()
 
         assertEquals(
             listOf("A", "B", "C", "A", "D", "A"),
@@ -29,12 +29,10 @@ class FlowKtTest {
     }
 
     @Test
-    fun `ifChanged operator with block`() {
+    fun `ifChanged operator with block`() = runTest {
         val originalFlow = flowOf("banana", "bus", "apple", "big", "coconut", "circle", "home")
 
-        val items = runBlocking {
-            originalFlow.ifChanged { item -> item[0] }.toList()
-        }
+        val items = originalFlow.ifChanged { item -> item[0] }.toList()
 
         assertEquals(
             listOf("banana", "apple", "big", "coconut", "home"),
@@ -43,7 +41,7 @@ class FlowKtTest {
     }
 
     @Test
-    fun `ifChanged operator uses structural equality`() {
+    fun `ifChanged operator uses structural equality`() = runTest {
         val originalFlow = flowOf(
             StringState("A"),
             StringState("B"),
@@ -56,7 +54,7 @@ class FlowKtTest {
             StringState("A")
         )
 
-        val items = runBlocking { originalFlow.ifChanged().toList() }
+        val items = originalFlow.ifChanged().toList()
 
         assertEquals(
             listOf(
@@ -72,12 +70,10 @@ class FlowKtTest {
     }
 
     @Test
-    fun `ifAnyChanged operator with block`() {
+    fun `ifAnyChanged operator with block`() = runTest {
         val originalFlow = flowOf("banana", "bandanna", "bus", "apple", "big", "coconut", "circle", "home")
 
-        val items = runBlocking {
-            originalFlow.ifAnyChanged { item -> arrayOf(item[0], item[1]) }.toList()
-        }
+        val items = originalFlow.ifAnyChanged { item -> arrayOf(item[0], item[1]) }.toList()
 
         assertEquals(
             listOf("banana", "bus", "apple", "big", "coconut", "circle", "home"),
@@ -86,15 +82,14 @@ class FlowKtTest {
     }
 
     @Test
-    fun `ifAnyChanged operator uses structural equality`() {
+    fun `ifAnyChanged operator uses structural equality`() = runTest {
         val originalFlow = flowOf("banana", "bandanna", "bus", "apple", "big", "coconut", "circle", "home")
 
-        val items = runBlocking {
+        val items =
             originalFlow.ifAnyChanged {
                 item ->
                 arrayOf(CharState(item[0]), CharState(item[1]))
             }.toList()
-        }
 
         assertEquals(
             listOf("banana", "bus", "apple", "big", "coconut", "circle", "home"),
@@ -103,25 +98,25 @@ class FlowKtTest {
     }
 
     @Test
-    fun `filterChanged operator`() {
+    fun `filterChanged operator`() = runTest {
         val intFlow = flowOf(listOf(0), listOf(0, 1), listOf(0, 1, 2, 3), listOf(4), listOf(5, 6, 7, 8))
-        val identityItems = runBlocking { intFlow.filterChanged { item -> item }.toList() }
+        val identityItems = intFlow.filterChanged { item -> item }.toList()
         assertEquals(listOf(0, 1, 2, 3, 4, 5, 6, 7, 8), identityItems)
 
         val moduloFlow = flowOf(listOf(1), listOf(1, 2), listOf(3, 4, 5), listOf(3, 4))
-        val moduloItems = runBlocking { moduloFlow.filterChanged { item -> item % 2 }.toList() }
+        val moduloItems = moduloFlow.filterChanged { item -> item % 2 }.toList()
         assertEquals(listOf(1, 2, 3, 4, 5), moduloItems)
 
         // Here we simulate a non-pure transform function (a function with a side-effect), causing
         // the transformed values to be different for the same input.
         var counter = 0
         val sideEffectFlow = flowOf(listOf(0), listOf(0, 1), listOf(0, 1, 2, 3), listOf(4), listOf(5, 6, 7, 8))
-        val sideEffectItems = runBlocking { sideEffectFlow.filterChanged { item -> item + counter++ }.toList() }
+        val sideEffectItems = sideEffectFlow.filterChanged { item -> item + counter++ }.toList()
         assertEquals(listOf(0, 0, 1, 0, 1, 2, 3, 4, 5, 6, 7, 8), sideEffectItems)
     }
 
     @Test
-    fun `filterChanged operator check for structural equality`() {
+    fun `filterChanged operator check for structural equality`() = runTest {
         val intFlow = flowOf(
             listOf(IntState(0)),
             listOf(IntState(0), IntState(1)),
@@ -130,7 +125,7 @@ class FlowKtTest {
             listOf(IntState(5), IntState(6), IntState(7), IntState(8))
         )
 
-        val identityItems = runBlocking { intFlow.filterChanged { item -> item }.toList() }
+        val identityItems = intFlow.filterChanged { item -> item }.toList()
         assertEquals(
             listOf(
                 IntState(0),

--- a/components/support/locale/src/test/java/mozilla/components/support/locale/LocaleMiddlewareTest.kt
+++ b/components/support/locale/src/test/java/mozilla/components/support/locale/LocaleMiddlewareTest.kt
@@ -6,7 +6,7 @@ package mozilla.components.support.locale
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.state.action.LocaleAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.store.BrowserStore
@@ -41,7 +41,7 @@ class LocaleMiddlewareTest {
     @Test
     @Ignore("Failing intermittently. To be fixed for https://github.com/mozilla-mobile/android-components/issues/9954")
     @Config(qualifiers = "en-rUS")
-    fun `GIVEN a locale has been chosen in the app WHEN we restore state THEN locale is retrieved from storage`() = runBlockingTest {
+    fun `GIVEN a locale has been chosen in the app WHEN we restore state THEN locale is retrieved from storage`() = runTest {
         val localeManager = spy(LocaleManager)
         val currentLocale = localeManager.getCurrentLocale(testContext)
         assertNull(currentLocale)
@@ -70,7 +70,7 @@ class LocaleMiddlewareTest {
 
     @Test
     @Config(qualifiers = "en-rUS")
-    fun `WHEN we update the locale THEN the locale manager is updated`() = runBlockingTest {
+    fun `WHEN we update the locale THEN the locale manager is updated`() = runTest {
         val localeManager = spy(LocaleManager)
         val currentLocale = localeManager.getCurrentLocale(testContext)
         assertNull(currentLocale)

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/AddonMigrationTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/AddonMigrationTest.kt
@@ -5,7 +5,7 @@
 package mozilla.components.support.migration
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.webextension.DisabledFlags
 import mozilla.components.concept.engine.webextension.Metadata
@@ -36,7 +36,7 @@ class AddonMigrationTest {
     val coroutinesTestRule = MainCoroutineRule()
 
     @Test
-    fun `No addons installed`() = runBlocking {
+    fun `No addons installed`() = runTest {
         val engine: Engine = mock()
         val callbackCaptor = argumentCaptor<((List<WebExtension>) -> Unit)>()
         whenever(engine.listInstalledWebExtensions(callbackCaptor.capture(), any())).thenAnswer {
@@ -51,7 +51,7 @@ class AddonMigrationTest {
     }
 
     @Test
-    fun `All addons migrated successfully`() = runBlocking {
+    fun `All addons migrated successfully`() = runTest {
         val addon1: WebExtension = mock()
         whenever(addon1.id).thenReturn("addon1")
         whenever(addon1.isBuiltIn()).thenReturn(false)
@@ -92,7 +92,7 @@ class AddonMigrationTest {
     }
 
     @Test
-    fun `Failure when querying installed addons`() = runBlocking {
+    fun `Failure when querying installed addons`() = runTest {
         val engine: Engine = mock()
         val errorCallback = argumentCaptor<((Throwable) -> Unit)>()
         whenever(engine.listInstalledWebExtensions(any(), errorCallback.capture())).thenAnswer {
@@ -113,7 +113,7 @@ class AddonMigrationTest {
     }
 
     @Test
-    fun `Failure when migrating some addons`() = runBlocking {
+    fun `Failure when migrating some addons`() = runTest {
         val addon1: WebExtension = mock()
         val addon2: WebExtension = mock()
         val addon3: WebExtension = mock()
@@ -160,7 +160,7 @@ class AddonMigrationTest {
     }
 
     @Test
-    fun `Unsupported addons are disabled during migration`() = runBlocking {
+    fun `Unsupported addons are disabled during migration`() = runTest {
         val addon1: WebExtension = mock()
         whenever(addon1.isBuiltIn()).thenReturn(false)
 
@@ -195,7 +195,7 @@ class AddonMigrationTest {
     }
 
     @Test
-    fun `Supported addons remain enabled during migration`() = runBlocking {
+    fun `Supported addons remain enabled during migration`() = runTest {
         val addon1: WebExtension = mock()
         whenever(addon1.id).thenReturn("supportedAddon")
         whenever(addon1.isEnabled()).thenReturn(true)
@@ -247,7 +247,7 @@ class AddonMigrationTest {
     }
 
     @Test
-    fun `Previously unsupported addons are enabled during migration if supported`() = runBlocking {
+    fun `Previously unsupported addons are enabled during migration if supported`() = runTest {
         val metadata: Metadata = mock()
         whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(DisabledFlags.APP_SUPPORT))
 
@@ -293,7 +293,7 @@ class AddonMigrationTest {
     }
 
     @Test
-    fun `Fall back to hardcoded list of supported addons`() = runBlocking {
+    fun `Fall back to hardcoded list of supported addons`() = runTest {
         val addon1: WebExtension = mock()
         whenever(addon1.id).thenReturn("supportedAddon")
         whenever(addon1.isEnabled()).thenReturn(true)

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/AddonMigrationTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/AddonMigrationTest.kt
@@ -5,12 +5,7 @@
 package mozilla.components.support.migration
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.webextension.DisabledFlags
 import mozilla.components.concept.engine.webextension.Metadata
@@ -22,37 +17,23 @@ import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.whenever
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.verify
-import java.lang.IllegalArgumentException
 
 @RunWith(AndroidJUnit4::class)
 class AddonMigrationTest {
 
-    @ExperimentalCoroutinesApi
-    private val testDispatcher = TestCoroutineDispatcher()
-
-    @ExperimentalCoroutinesApi
-    @Before
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @ExperimentalCoroutinesApi
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
-    }
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
 
     @Test
     fun `No addons installed`() = runBlocking {

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/FennecFxaMigrationTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/FennecFxaMigrationTest.kt
@@ -5,7 +5,7 @@
 package mozilla.components.support.migration
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.service.fxa.manager.MigrationResult
 import mozilla.components.service.fxa.sharing.ShareableAccount
@@ -29,7 +29,7 @@ import java.io.File
 @RunWith(AndroidJUnit4::class)
 class FennecFxaMigrationTest {
     @Test
-    fun `no state`() = runBlocking {
+    fun `no state`() = runTest {
         val fxaPath = File(getTestPath("fxa"), "no-file.json")
         val accountManager: FxaAccountManager = mock()
 
@@ -41,7 +41,7 @@ class FennecFxaMigrationTest {
     }
 
     @Test
-    fun `separated fxa state v4`() = runBlocking {
+    fun `separated fxa state v4`() = runTest {
         val fxaPath = File(getTestPath("fxa"), "separated-v4.json")
         val accountManager: FxaAccountManager = mock()
 
@@ -59,7 +59,7 @@ class FennecFxaMigrationTest {
     }
 
     @Test
-    fun `doghouse fxa state v4`() = runBlocking {
+    fun `doghouse fxa state v4`() = runTest {
         val fxaPath = File(getTestPath("fxa"), "doghouse-v4.json")
         val accountManager: FxaAccountManager = mock()
 
@@ -77,7 +77,7 @@ class FennecFxaMigrationTest {
     }
 
     @Test
-    fun `married fxa state v4 successfull sign-in`() = runBlocking {
+    fun `married fxa state v4 successfull sign-in`() = runTest {
         val fxaPath = File(getTestPath("fxa"), "married-v4.json")
         val accountManager: FxaAccountManager = mock()
 
@@ -99,7 +99,7 @@ class FennecFxaMigrationTest {
     }
 
     @Test
-    fun `cohabiting fxa state v4 successful sign-in`() = runBlocking {
+    fun `cohabiting fxa state v4 successful sign-in`() = runTest {
         val fxaPath = File(getTestPath("fxa"), "cohabiting-v4.json")
         val accountManager: FxaAccountManager = mock()
 
@@ -121,7 +121,7 @@ class FennecFxaMigrationTest {
     }
 
     @Test
-    fun `cohabiting fxa state v4 will retry sign-in`() = runBlocking {
+    fun `cohabiting fxa state v4 will retry sign-in`() = runTest {
         val fxaPath = File(getTestPath("fxa"), "cohabiting-v4.json")
         val accountManager: FxaAccountManager = mock()
 
@@ -143,7 +143,7 @@ class FennecFxaMigrationTest {
     }
 
     @Test
-    fun `married fxa state v4 failed sign-in`() = runBlocking {
+    fun `married fxa state v4 failed sign-in`() = runTest {
         val fxaPath = File(getTestPath("fxa"), "married-v4.json")
         val accountManager: FxaAccountManager = mock()
 
@@ -167,7 +167,7 @@ class FennecFxaMigrationTest {
     }
 
     @Test
-    fun `custom token server`() = runBlocking {
+    fun `custom token server`() = runTest {
         val fxaPath = File(getTestPath("fxa"), "custom-sync-config-token.json")
         val accountManager: FxaAccountManager = mock()
 
@@ -181,7 +181,7 @@ class FennecFxaMigrationTest {
     }
 
     @Test
-    fun `custom idp server`() = runBlocking {
+    fun `custom idp server`() = runTest {
         val fxaPath = File(getTestPath("fxa"), "custom-sync-config-idp.json")
         val accountManager: FxaAccountManager = mock()
 
@@ -195,7 +195,7 @@ class FennecFxaMigrationTest {
     }
 
     @Test
-    fun `custom idp and token servers`() = runBlocking {
+    fun `custom idp and token servers`() = runTest {
         val fxaPath = File(getTestPath("fxa"), "custom-sync-config-idp-token.json")
         val accountManager: FxaAccountManager = mock()
 
@@ -209,7 +209,7 @@ class FennecFxaMigrationTest {
     }
 
     @Test
-    fun `china idp and token servers`() = runBlocking {
+    fun `china idp and token servers`() = runTest {
         customServerAssertAllowed("china-sync-config-idp-token.json")
     }
 
@@ -235,7 +235,7 @@ class FennecFxaMigrationTest {
     }
 
     @Test
-    fun `custom idp and token servers - allowed, but failed sign-in`() = runBlocking {
+    fun `custom idp and token servers - allowed, but failed sign-in`() = runTest {
         val fxaPath = File(getTestPath("fxa"), "china-sync-config-idp-token.json")
         val accountManager: FxaAccountManager = mock()
 
@@ -259,7 +259,7 @@ class FennecFxaMigrationTest {
     }
 
     @Test
-    fun `cohabiting fxa state v4 failed sign-in`() = runBlocking {
+    fun `cohabiting fxa state v4 failed sign-in`() = runTest {
         val fxaPath = File(getTestPath("fxa"), "cohabiting-v4.json")
         val accountManager: FxaAccountManager = mock()
 
@@ -283,7 +283,7 @@ class FennecFxaMigrationTest {
     }
 
     @Test
-    fun `corrupt married fxa state v4`() = runBlocking {
+    fun `corrupt married fxa state v4`() = runTest {
         val fxaPath = File(getTestPath("fxa"), "corrupt-married-v4.json")
         val accountManager: FxaAccountManager = mock()
 
@@ -305,7 +305,7 @@ class FennecFxaMigrationTest {
     }
 
     @Test
-    fun `corrupt missing versions fxa state v4`() = runBlocking {
+    fun `corrupt missing versions fxa state v4`() = runTest {
         val fxaPath = File(getTestPath("fxa"), "corrupt-separated-missing-versions-v4.json")
         val accountManager: FxaAccountManager = mock()
 
@@ -327,7 +327,7 @@ class FennecFxaMigrationTest {
     }
 
     @Test
-    fun `corrupt bad fxa state`() = runBlocking {
+    fun `corrupt bad fxa state`() = runTest {
         val fxaPath = File(getTestPath("fxa"), "separated-bad-state.json")
         val accountManager: FxaAccountManager = mock()
 
@@ -349,7 +349,7 @@ class FennecFxaMigrationTest {
     }
 
     @Test
-    fun `separated - bad account version`() = runBlocking {
+    fun `separated - bad account version`() = runTest {
         val fxaPath = File(getTestPath("fxa"), "separated-bad-account-version-v4.json")
         val accountManager: FxaAccountManager = mock()
 
@@ -374,7 +374,7 @@ class FennecFxaMigrationTest {
     }
 
     @Test
-    fun `separated - bad pickle version`() = runBlocking {
+    fun `separated - bad pickle version`() = runTest {
         val fxaPath = File(getTestPath("fxa"), "separated-bad-pickle-version-v4.json")
         val accountManager: FxaAccountManager = mock()
 
@@ -399,7 +399,7 @@ class FennecFxaMigrationTest {
     }
 
     @Test
-    fun `separated - bad state version`() = runBlocking {
+    fun `separated - bad state version`() = runTest {
         val fxaPath = File(getTestPath("fxa"), "separated-bad-state-version-v10.json")
         val accountManager: FxaAccountManager = mock()
 

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
@@ -6,12 +6,8 @@ package mozilla.components.support.migration
 
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.appservices.places.uniffi.PlacesException
 import mozilla.components.browser.state.action.BrowserAction
@@ -38,14 +34,15 @@ import mozilla.components.support.test.eq
 import mozilla.components.support.test.middleware.CaptureActionsMiddleware
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.whenever
 import org.json.JSONObject
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyBoolean
@@ -60,22 +57,14 @@ import java.io.File
 @RunWith(AndroidJUnit4::class)
 class FennecMigratorTest {
     private lateinit var securePrefs: SecureAbove22Preferences
-    @ExperimentalCoroutinesApi
-    private val testDispatcher = TestCoroutineDispatcher()
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
 
     @Before
     @ExperimentalCoroutinesApi
     fun setup() {
         // forceInsecure is set in the tests because a keystore wouldn't be configured in the test environment.
         securePrefs = SecureAbove22Preferences(testContext, "test_prefs", forceInsecure = true)
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @ExperimentalCoroutinesApi
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
     }
 
     @Test

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
@@ -7,7 +7,7 @@ package mozilla.components.support.migration
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.appservices.places.uniffi.PlacesException
 import mozilla.components.browser.state.action.BrowserAction
@@ -68,7 +68,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `no-op migration`() = runBlocking {
+    fun `no-op migration`() = runTest {
         val migrator = FennecMigrator.Builder(testContext, mock())
             .setCoroutineContext(this.coroutineContext)
             .build()
@@ -148,7 +148,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `is not a fennec install detected`() = runBlocking {
+    fun `is not a fennec install detected`() = runTest {
         val historyStore = PlacesHistoryStorage(testContext)
 
         val migrator1 = FennecMigrator.Builder(testContext, mock())
@@ -175,7 +175,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `migrations versioning basics`() = runBlocking {
+    fun `migrations versioning basics`() = runTest {
         val historyStore = PlacesHistoryStorage(testContext)
         val bookmarksStore = PlacesBookmarksStorage(testContext)
         val topSiteStorage = mock<PinnedSiteStorage>()
@@ -282,7 +282,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `pinned sites migration`() = runBlocking {
+    fun `pinned sites migration`() = runTest {
         val historyStore = PlacesHistoryStorage(testContext)
         val bookmarksStore = PlacesBookmarksStorage(testContext)
         val topSiteStorage = mock<PinnedSiteStorage>()
@@ -342,7 +342,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `failing migrations are reported - case 1`() = runBlocking {
+    fun `failing migrations are reported - case 1`() = runTest {
         val historyStorage = PlacesHistoryStorage(testContext)
 
         // DB path is set, but db is corrupt.
@@ -365,7 +365,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `failing migrations are reported - case 2`() = runBlocking {
+    fun `failing migrations are reported - case 2`() = runTest {
         val historyStorage: PlacesHistoryStorage = mock()
 
         // Fail during history migration.
@@ -400,7 +400,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `failing migrations are reported - case 4`() = runBlocking {
+    fun `failing migrations are reported - case 4`() = runTest {
         val bookmarkStorage: PlacesBookmarksStorage = mock()
         val historyStorage: PlacesHistoryStorage = mock()
 
@@ -448,7 +448,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `failing migrations are reported - case 5`() = runBlocking {
+    fun `failing migrations are reported - case 5`() = runTest {
         val bookmarkStorage: PlacesBookmarksStorage = mock()
         val historyStorage: PlacesHistoryStorage = mock()
 
@@ -487,7 +487,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `failing migrations are reported - case 6`() = runBlocking {
+    fun `failing migrations are reported - case 6`() = runTest {
         // Open tabs migration without configured path to sessions.
         val migrator = FennecMigrator.Builder(testContext, mock())
             .migrateOpenTabs(mock())
@@ -503,7 +503,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `failing migrations are reported - case 7, corrupt fxa state`() = runBlocking {
+    fun `failing migrations are reported - case 7, corrupt fxa state`() = runTest {
         val accountManager: FxaAccountManager = mock()
         val migrator = FennecMigrator.Builder(testContext, mock())
             .migrateFxa(lazy { accountManager })
@@ -522,7 +522,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `failing migrations are reported - case 8, unsupported pickle version`() = runBlocking {
+    fun `failing migrations are reported - case 8, unsupported pickle version`() = runTest {
         val accountManager: FxaAccountManager = mock()
         val migrator = FennecMigrator.Builder(testContext, mock())
             .migrateFxa(lazy { accountManager })
@@ -541,7 +541,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `failing migrations are reported - case 8, unsupported state version`() = runBlocking {
+    fun `failing migrations are reported - case 8, unsupported state version`() = runTest {
         val accountManager: FxaAccountManager = mock()
         val migrator = FennecMigrator.Builder(testContext, mock())
             .migrateFxa(lazy { accountManager })
@@ -560,7 +560,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `fxa migration - no account`() = runBlocking {
+    fun `fxa migration - no account`() = runTest {
         // FxA migration without configured path to pickle file (test environment path isn't the same as real path).
         val accountManager: FxaAccountManager = mock()
         val migrator = FennecMigrator.Builder(testContext, mock())
@@ -586,7 +586,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `fxa migration - unauthenticated account`() = runBlocking {
+    fun `fxa migration - unauthenticated account`() = runTest {
         // FxA migration without configured path to pickle file (test environment path isn't the same as real path).
         val accountManager: FxaAccountManager = mock()
         val migrator = FennecMigrator.Builder(testContext, mock())
@@ -613,7 +613,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `fxa migration - authenticated account, sign-in succeeded`() = runBlocking {
+    fun `fxa migration - authenticated account, sign-in succeeded`() = runTest {
         val accountManager: FxaAccountManager = mock()
         val migrator = FennecMigrator.Builder(testContext, mock())
             .migrateFxa(lazy { accountManager })
@@ -650,7 +650,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `fxa migration - authenticated account, sign-in will retry`() = runBlocking {
+    fun `fxa migration - authenticated account, sign-in will retry`() = runTest {
         val accountManager: FxaAccountManager = mock()
         val migrator = FennecMigrator.Builder(testContext, mock())
             .migrateFxa(lazy { accountManager })
@@ -687,7 +687,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `fxa migration - authenticated account, sign-in failed`() = runBlocking {
+    fun `fxa migration - authenticated account, sign-in failed`() = runTest {
         val accountManager: FxaAccountManager = mock()
         val migrator = FennecMigrator.Builder(testContext, mock())
             .migrateFxa(lazy { accountManager })
@@ -725,7 +725,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `logins migrations - no master password`() = runBlocking {
+    fun `logins migrations - no master password`() = runTest {
         val crashReporter: CrashReporting = mock()
         val loginStorage = SyncableLoginsStorage(testContext, lazy { securePrefs }).also {
             it.wipeLocal()
@@ -780,7 +780,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `logins migrations - with master password`() = runBlocking {
+    fun `logins migrations - with master password`() = runTest {
         val crashReporter: CrashReporting = mock()
         val loginStorage = SyncableLoginsStorage(testContext, lazy { securePrefs })
         val migrator = FennecMigrator.Builder(testContext, crashReporter)
@@ -808,7 +808,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `logins migrations - with mp and empty key4db`() = runBlocking {
+    fun `logins migrations - with mp and empty key4db`() = runTest {
         val crashReporter: CrashReporting = mock()
         val loginStorage = SyncableLoginsStorage(testContext, lazy { securePrefs }).also {
             it.wipeLocal()
@@ -836,7 +836,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `logins migrations - with mp and no nss in key4db`() = runBlocking {
+    fun `logins migrations - with mp and no nss in key4db`() = runTest {
         val crashReporter: CrashReporting = mock()
         val loginStorage = SyncableLoginsStorage(testContext, lazy { securePrefs })
         val migrator = FennecMigrator.Builder(testContext, crashReporter)
@@ -863,7 +863,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `logins migrations - missing profile`() = runBlocking {
+    fun `logins migrations - missing profile`() = runTest {
         val crashReporter: CrashReporting = mock()
         val loginStorage = SyncableLoginsStorage(testContext, lazy { securePrefs }).also {
             it.wipeLocal()
@@ -887,7 +887,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `logins migrations - with master password, old signons version`() = runBlocking {
+    fun `logins migrations - with master password, old signons version`() = runTest {
         val crashReporter: CrashReporting = mock()
         val loginStorage = SyncableLoginsStorage(testContext, lazy { securePrefs })
         val migrator = FennecMigrator.Builder(testContext, crashReporter)
@@ -913,7 +913,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `logins migrations - without master password, old signons version`() = runBlocking {
+    fun `logins migrations - without master password, old signons version`() = runTest {
         val crashReporter: CrashReporting = mock()
         val loginStorage = SyncableLoginsStorage(testContext, lazy { securePrefs })
         val migrator = FennecMigrator.Builder(testContext, crashReporter)
@@ -938,7 +938,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `settings migration - no fennec prefs`() = runBlocking {
+    fun `settings migration - no fennec prefs`() = runTest {
         // Fennec SharedPreferences are missing / empty
         val crashReporter: CrashReporting = mock()
         val migrator = FennecMigrator.Builder(testContext, crashReporter)
@@ -956,7 +956,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `settings migration - missing FHR value`() = runBlocking {
+    fun `settings migration - missing FHR value`() = runTest {
         val fennecAppPrefs = testContext.getSharedPreferences(FennecSettingsMigration.FENNEC_APP_SHARED_PREFS_NAME, Context.MODE_PRIVATE)
 
         // Make prefs non-empty.
@@ -982,7 +982,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `addon migration - no addons installed`() = runBlocking {
+    fun `addon migration - no addons installed`() = runTest {
         val addonUpdater: AddonUpdater = mock()
         val addonCollectionProvider: AddonCollectionProvider = mock()
         val engine: Engine = mock()
@@ -1007,7 +1007,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `addon migration - successful migration`() = runBlocking {
+    fun `addon migration - successful migration`() = runTest {
         val addon1: WebExtension = mock()
         val addon2: WebExtension = mock()
 
@@ -1040,7 +1040,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `addon migration - failed to query installed addons`() = runBlocking {
+    fun `addon migration - failed to query installed addons`() = runTest {
         val addonUpdater: AddonUpdater = mock()
         val addonCollectionProvider: AddonCollectionProvider = mock()
         val engine: Engine = mock()
@@ -1070,7 +1070,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `addon migration - failed to migrate some addons`() = runBlocking {
+    fun `addon migration - failed to migrate some addons`() = runTest {
         val addon1: WebExtension = mock()
         val addon2: WebExtension = mock()
         val addon3: WebExtension = mock()
@@ -1124,7 +1124,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `gecko migration - no prefs_js`() = runBlocking {
+    fun `gecko migration - no prefs_js`() = runTest {
         val crashReporter: CrashReporting = mock()
         val migrator = FennecMigrator.Builder(testContext, crashReporter)
             .migrateGecko()
@@ -1146,7 +1146,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `gecko migration - invalid prefs_js removed`() = runBlocking {
+    fun `gecko migration - invalid prefs_js removed`() = runTest {
         val crashReporter: CrashReporting = mock()
         val migrator = FennecMigrator.Builder(testContext, crashReporter)
             .migrateGecko()
@@ -1168,7 +1168,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `gecko migration - prefs_js migrated`() = runBlocking {
+    fun `gecko migration - prefs_js migrated`() = runTest {
         val crashReporter: CrashReporting = mock()
         val migrator = FennecMigrator.Builder(testContext, crashReporter)
             .migrateGecko()
@@ -1190,7 +1190,7 @@ class FennecMigratorTest {
     }
 
     @Test
-    fun `gecko migration - prefs_js no prefs to migrate`() = runBlocking {
+    fun `gecko migration - prefs_js no prefs to migrate`() = runTest {
         val crashReporter: CrashReporting = mock()
         val migrator = FennecMigrator.Builder(testContext, crashReporter)
             .migrateGecko()

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/MigrationObserverTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/MigrationObserverTest.kt
@@ -27,7 +27,7 @@ class MigrationObserverTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
-    private val testDispatcher = coroutinesTestRule.testDispatcher
+    private val dispatcher = coroutinesTestRule.testDispatcher
 
     @Test
     fun `listener is invoked on state observation`() {
@@ -42,7 +42,7 @@ class MigrationObserverTest {
         verify(listener).onMigrationCompleted(any())
 
         store.dispatch(MigrationAction.Started).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(listener).onMigrationStateChanged(eq(MigrationProgress.MIGRATING), any())
     }
@@ -59,7 +59,7 @@ class MigrationObserverTest {
         observer.stop()
 
         store.dispatch(MigrationAction.Started).joinBlocking()
-        testDispatcher.advanceUntilIdle()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify(listener, never()).onMigrationStateChanged(any(), any())
     }

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/SearchEngineMigrationTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/SearchEngineMigrationTest.kt
@@ -8,7 +8,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import mozilla.components.browser.state.action.SearchAction
 import mozilla.components.browser.state.search.RegionState
 import mozilla.components.browser.state.state.selectedOrDefaultSearchEngine
@@ -208,7 +208,7 @@ private fun migrate(
 }
 
 private fun storeFor(language: String, country: String, region: String): BrowserStore {
-    val dispatcher = TestCoroutineDispatcher()
+    val dispatcher = UnconfinedTestDispatcher()
 
     Locale.setDefault(Locale(language, country))
 
@@ -228,7 +228,7 @@ private fun storeFor(language: String, country: String, region: String): Browser
     store.waitUntilIdle()
 
     // Now we wait for the Middleware that may need to asynchronously process an action the test dispatched
-    dispatcher.advanceUntilIdle()
+    dispatcher.scheduler.advanceUntilIdle()
 
     // Since the Middleware may have dispatched an action, we now wait for the store again.
     store.waitUntilIdle()

--- a/components/support/test/src/main/java/mozilla/components/support/test/rule/Helpers.kt
+++ b/components/support/test/src/main/java/mozilla/components/support/test/rule/Helpers.kt
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE") // for TestMainDispatcher
+
+package mozilla.components.support.test.rule
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestResult
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.internal.TestMainDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.reflect.full.companionObject
+import kotlin.reflect.full.companionObjectInstance
+import kotlin.reflect.full.memberProperties
+
+/**
+ * `coroutines.test` default timeout to use when waiting for asynchronous completions of the coroutines
+ * managed by a [TestCoroutineScheduler].
+ */
+private const val DEFAULT_DISPATCH_TIMEOUT_MS = 60_000L
+
+/**
+ * Convenience method of executing [testBody] in a new coroutine running with the
+ * [TestDispatcher] previously set through [Dispatchers.setMain].
+ *
+ * Running a test with a shared [TestDispatcher] allows
+ * - newly created coroutines inside it will automatically be reparented to the test coroutine context.
+ * - leveraging an already set strategy for entering launch / async blocks.
+ * - easier scheduling control.
+ *
+ * @see runTest
+ * @see Dispatchers.setMain
+ * @see TestDispatcher
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+fun runTestOnMain(
+    dispatchTimeoutMs: Long = DEFAULT_DISPATCH_TIMEOUT_MS,
+    testBody: suspend TestScope.() -> Unit
+): TestResult {
+    val mainDispatcher = Dispatchers.Main
+    require(mainDispatcher is TestMainDispatcher) {
+        "A TestDispatcher is not available. Use MainCoroutineRule or Dispatchers.setMain to set one before calling this method"
+    }
+
+    // Get the TestDispatcher set through `Dispatchers.setMain(..)`.
+    val companionObject = mainDispatcher::class.companionObject
+    val companionInstance = mainDispatcher::class.companionObjectInstance
+    val testDispatcher = companionObject!!.memberProperties.first().getter.call(companionInstance) as TestDispatcher
+
+    // Delegate to the original implementation of `runTest`. Just with a previously set TestDispatcher.
+    runTest(testDispatcher, dispatchTimeoutMs, testBody)
+}

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/RunWhenReadyQueueTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/RunWhenReadyQueueTest.kt
@@ -5,11 +5,12 @@
 package mozilla.components.support.utils
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.inOrder
 import org.mockito.Mockito.never
@@ -18,10 +19,12 @@ import org.mockito.Mockito.verify
 @ExperimentalCoroutinesApi
 class RunWhenReadyQueueTest {
 
-    private val scope = TestCoroutineScope()
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val scope = coroutinesTestRule.scope
 
     @Test
-    fun `task should not run until ready is called`() = scope.runBlockingTest {
+    fun `task should not run until ready is called`() = runBlockingTest {
         val task = mock<() -> Unit>()
         val queue = RunWhenReadyQueue(scope)
 
@@ -36,7 +39,7 @@ class RunWhenReadyQueueTest {
     }
 
     @Test
-    fun `task should run if ready was called`() = scope.runBlockingTest {
+    fun `task should run if ready was called`() = runBlockingTest {
         val task = mock<() -> Unit>()
         val queue = RunWhenReadyQueue(scope)
         queue.ready()
@@ -49,7 +52,7 @@ class RunWhenReadyQueueTest {
     }
 
     @Test
-    fun `tasks should run in the order they were queued`() = scope.runBlockingTest {
+    fun `tasks should run in the order they were queued`() = runBlockingTest {
         val task1 = mock<() -> Unit>()
         val task2 = mock<() -> Unit>()
         val task3 = mock<() -> Unit>()

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/RunWhenReadyQueueTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/RunWhenReadyQueueTest.kt
@@ -5,9 +5,9 @@
 package mozilla.components.support.utils
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -24,7 +24,7 @@ class RunWhenReadyQueueTest {
     private val scope = coroutinesTestRule.scope
 
     @Test
-    fun `task should not run until ready is called`() = runBlockingTest {
+    fun `task should not run until ready is called`() = runTestOnMain {
         val task = mock<() -> Unit>()
         val queue = RunWhenReadyQueue(scope)
 
@@ -39,7 +39,7 @@ class RunWhenReadyQueueTest {
     }
 
     @Test
-    fun `task should run if ready was called`() = runBlockingTest {
+    fun `task should run if ready was called`() = runTestOnMain {
         val task = mock<() -> Unit>()
         val queue = RunWhenReadyQueue(scope)
         queue.ready()
@@ -52,7 +52,7 @@ class RunWhenReadyQueueTest {
     }
 
     @Test
-    fun `tasks should run in the order they were queued`() = runBlockingTest {
+    fun `tasks should run in the order they were queued`() = runTestOnMain {
         val task1 = mock<() -> Unit>()
         val task2 = mock<() -> Unit>()
         val task3 = mock<() -> Unit>()

--- a/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
+++ b/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
@@ -5,10 +5,6 @@
 package mozilla.components.support.webextensions
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.CustomTabListAction
 import mozilla.components.browser.state.action.EngineAction
@@ -37,6 +33,7 @@ import mozilla.components.support.test.eq
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.whenever
 import mozilla.components.support.webextensions.WebExtensionSupport.toState
 import mozilla.components.support.webextensions.facts.WebExtensionFacts.Items.WEB_EXTENSIONS_INITIALIZED
@@ -47,7 +44,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
@@ -60,17 +57,11 @@ import mozilla.components.support.base.facts.Action as FactsAction
 @RunWith(AndroidJUnit4::class)
 class WebExtensionSupportTest {
 
-    private val testDispatcher = TestCoroutineDispatcher()
-
-    @Before
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
         WebExtensionSupport.installedExtensions.clear()
     }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,7 +13,7 @@ permalink: /changelog/
 
 * **support-test**
   * ⚠️ **This is a breaking change**: `MainCoroutineRule` constructor now takes a `TestDispatcher` instead of deprecated `TestCoroutineDispatcher`. Default is `UnconfinedTestDispatcher`.
-  * ⚠️ **This is a breaking change**: `MainCoroutineRule.runBlockingTest` is not available anymore since `runBlockingTest` is deprecated.
+  * ⚠️ **This is a breaking change**: `MainCoroutineRule.runBlockingTest` is replaced with a `runTestOnMain` top level function. . This method is preferred over the global `runTest` because it reparents new child coroutines to the test coroutine context.
 
 * **concept-engine**:
   * Added support for `SelectAddress` prompt request. See [issue #12060](https://github.com/mozilla-mobile/android-components/issues/12060)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **support-test**
+  * ⚠️ **This is a breaking change**: `MainCoroutineRule` constructor now takes a `TestDispatcher` instead of deprecated `TestCoroutineDispatcher`. Default is `UnconfinedTestDispatcher`.
+  * ⚠️ **This is a breaking change**: `MainCoroutineRule.runBlockingTest` is not available anymore since `runBlockingTest` is deprecated.
+
 * **concept-engine**:
   * Added support for `SelectAddress` prompt request. See [issue #12060](https://github.com/mozilla-mobile/android-components/issues/12060)
 


### PR DESCRIPTION
Started fresh since it wasn't easy to follow what still needed to be migrated over Grisha's patch from https://github.com/mozilla-mobile/android-components/pull/11516/files which also contained some extraneous changes - not needed for this upgrade.

Based the work mainly on https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-test/MIGRATION.md
Went with favoring `UnconfinedTestDispatcher` mainly because it eagerly enters `launch` and `async` blocks and so the migration process should be a bit less painful while our tests don't really on the exact order of execution to require the `StandardTestDispatcher` and incremental virtual time advancements.

------

To future reviewers: the patch though big is meant to be straightforward:
- goal was to refactor out `TestCoroutineScope`, `TestCoroutineDispatcher` and `runBlockingTest` since they are deprecated and would fail the build (if not suppressing the deprecation)
- as recommended I also tried to remove as many `runBlocking` usages as possible but in some cases with more intricate scenarios where interacting with other dispatchers / threads was needed some `runBlocking` calls were kept.
- `runTest` replaces all `runBlocking` and `runBlockingTest` usages.
`TestScope`, `UnconfinedTestDispatcher` and `StandardTestDispatcher` replaces all usages of `TestCoroutineScope`, `TestCoroutineDispatcher` as per the official documentation.
- `runTestOnMain` was used where we'd set the main dispatcher to be able to syncronize runs/code in tests/system under test. Occasionally when the `runTest` replacement would have the test fail I added the `MainCoroutineTest` rule and saw that the test passed with also using `runTestOnMain`.
- there are no modifications in the code being tested and no modifications in the tests logic. This seems like a good guarantee that if all tests pass on CI then the changes are good.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
