### PR TITLE
Close #12008: Support auto hiding edit action end in browser toolbar

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -411,6 +411,7 @@ class BrowserToolbar @JvmOverloads constructor(
      * @param imageDrawable The drawable to be shown.
      * @param contentDescription The content description to use.
      * @param visible Lambda that returns true or false to indicate whether this button should be shown.
+     * @param autoHide Lambda that returns true or false to indicate whether this button should auto hide.
      * @param background A custom (stateful) background drawable resource to be used.
      * @param padding a custom [Padding] for this Button.
      * @param iconTintColorResource Optional ID of color resource to tint the icon.
@@ -422,6 +423,7 @@ class BrowserToolbar @JvmOverloads constructor(
         imageDrawable: Drawable,
         contentDescription: String,
         visible: () -> Boolean = { true },
+        autoHide: () -> Boolean = { false },
         @DrawableRes background: Int = 0,
         val padding: Padding = DEFAULT_PADDING,
         @ColorRes iconTintColorResource: Int = NO_ID,
@@ -431,6 +433,7 @@ class BrowserToolbar @JvmOverloads constructor(
         imageDrawable,
         contentDescription,
         visible,
+        autoHide,
         background,
         padding,
         iconTintColorResource,

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
@@ -312,6 +312,8 @@ class EditToolbar internal constructor(
 
     private fun onTextChanged(text: String) {
         views.clear.isVisible = text.isNotBlank()
+        views.editActionsEnd.autoHideAction(text.isEmpty())
+
         /*
         We use margin_gone instead of margin to take into account both the actionContainer(which in
         most cases is gone) and the clear button.

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/internal/ActionContainer.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/internal/ActionContainer.kt
@@ -10,6 +10,7 @@ import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
 import android.widget.LinearLayout
+import androidx.core.view.isVisible
 import mozilla.components.browser.toolbar.R
 import mozilla.components.concept.toolbar.Toolbar
 
@@ -90,6 +91,14 @@ internal class ActionContainer @JvmOverloads constructor(
         }
 
         visibility = updatedVisibility
+    }
+
+    fun autoHideAction(isVisible: Boolean) {
+        for (action in actions) {
+            if (action.actual.autoHide()) {
+                action.view?.isVisible = isVisible
+            }
+        }
     }
 
     private fun addActionView(view: View) {

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -854,4 +854,20 @@ class BrowserToolbarTest {
 
         verify(behavior).forceCollapse(toolbar)
     }
+
+    @Test
+    fun `WHEN search terms changes THEN edit listener is notified`() {
+        val toolbar = BrowserToolbar(testContext)
+        toolbar.edit = spy(toolbar.edit)
+        toolbar.edit.editListener = mock()
+
+        toolbar.setSearchTerms("")
+        toolbar.editMode()
+
+        toolbar.setSearchTerms("test")
+        verify(toolbar.edit.editListener)?.onTextChanged("test")
+
+        toolbar.setSearchTerms("")
+        verify(toolbar.edit.editListener)?.onTextChanged("")
+    }
 }

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -242,6 +242,9 @@ interface Toolbar {
         val visible: () -> Boolean
             get() = { true }
 
+        val autoHide: () -> Boolean
+            get() = { false }
+
         fun createView(parent: ViewGroup): View
 
         fun bind(view: View)
@@ -253,6 +256,7 @@ interface Toolbar {
      * @param imageDrawable The drawable to be shown.
      * @param contentDescription The content description to use.
      * @param visible Lambda that returns true or false to indicate whether this button should be shown.
+     * @param autoHide Lambda that returns true or false to indicate whether this button should auto hide.
      * @param padding A optional custom padding.
      * @param iconTintColorResource Optional ID of color resource to tint the icon.
      * @param longClickListener Callback that will be invoked whenever the button is long-pressed.
@@ -263,6 +267,7 @@ interface Toolbar {
         val imageDrawable: Drawable? = null,
         val contentDescription: String,
         override val visible: () -> Boolean = { true },
+        override val autoHide: () -> Boolean = { false },
         private val background: Int = 0,
         private val padding: Padding? = null,
         @ColorRes val iconTintColorResource: Int = ViewGroup.NO_ID,

--- a/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionButtonTest.kt
+++ b/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionButtonTest.kt
@@ -44,7 +44,7 @@ class ActionButtonTest {
     @Test
     fun `constructor with drawables`() {
         val visibilityListener = { false }
-        val button = Toolbar.ActionButton(mock(), "image", visibilityListener, 0, null) { }
+        val button = Toolbar.ActionButton(mock(), "image", visibilityListener, { false }, 0, null) { }
         assertNotNull(button.imageDrawable)
         assertEquals("image", button.contentDescription)
         assertEquals(visibilityListener, button.visible)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
