### PR TITLE
Refresh tabs in synced tab feature only when syncs are completed.

### DIFF
--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/controller/DefaultController.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/controller/DefaultController.kt
@@ -29,8 +29,6 @@ internal class DefaultController(
      * See [SyncedTabsController.refreshSyncedTabs]
      */
     override fun refreshSyncedTabs() {
-        view.startLoading()
-
         scope.launch {
             accountManager.withConstellation {
                 val syncedDeviceTabs = provider.getSyncedDeviceTabs()
@@ -39,7 +37,7 @@ internal class DefaultController(
                 scope.launch(Dispatchers.Main) {
                     if (syncedDeviceTabs.isEmpty() && otherDevices?.isEmpty() == true) {
                         view.onError(ErrorType.MULTIPLE_DEVICES_UNAVAILABLE)
-                    } else if (!syncedDeviceTabs.any { it.tabs.isNotEmpty() }) {
+                    } else if (syncedDeviceTabs.all { it.tabs.isEmpty() }) {
                         view.onError(ErrorType.NO_TABS_AVAILABLE)
                     } else {
                         view.displaySyncedTabs(syncedDeviceTabs)
@@ -57,6 +55,7 @@ internal class DefaultController(
      * See [SyncedTabsController.syncAccount]
      */
     override fun syncAccount() {
+        view.startLoading()
         scope.launch {
             accountManager.withConstellation { refreshDevices() }
             accountManager.syncNow(SyncReason.User, customEngineSubset = listOf(SyncEngine.Tabs))

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/presenter/DefaultPresenter.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/presenter/DefaultPresenter.kt
@@ -77,7 +77,6 @@ internal class DefaultPresenter(
             return
         }
 
-        controller.refreshSyncedTabs()
         controller.syncAccount()
     }
 
@@ -86,8 +85,11 @@ internal class DefaultPresenter(
     }
 
     companion object {
+        // This status isn't always set before it's inspected. This causes erroneous reports of the
+        // sync engine being unavailable. Tabs are included in sync by default, so it's safe to
+        // default to true until they are deliberately disabled.
         private fun isSyncedTabsEngineEnabled(context: Context): Boolean {
-            return SyncEnginesStorage(context).getStatus()[SyncEngine.Tabs] ?: false
+            return SyncEnginesStorage(context).getStatus()[SyncEngine.Tabs] ?: true
         }
     }
 
@@ -103,7 +105,6 @@ internal class DefaultPresenter(
         override fun onAuthenticated(account: OAuthAccount, authType: AuthType) {
             CoroutineScope(Dispatchers.Main).launch {
                 controller.syncAccount()
-                controller.refreshSyncedTabs()
             }
         }
 


### PR DESCRIPTION
This is to close the loop on some odd behavior I was noticing while working on [Fenix #24665](https://github.com/mozilla-mobile/fenix/issues/24665). This addresses the following:

- The first `refreshSyncedTabs` would always cause a `NO_TABS_AVAILABLE` error, because the underlying sync manager wasn't able to provide tabs yet.
- Frequently would receive `SYNC_ENGINE_UNAVAILABLE` because the sync engine status hadn't been directly set to true, as `DefaultPresenter::start` would complete before the first sync (which updates the status of the engines).
- Calling `view.startLoading` from `syncAccount` will cause the view to show loading across the length of the sync, instead of just the time it takes to retrieve tabs from disk. 



### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
