### PR TITLE
For #9684: Check a11y enabled state when sending a11y event.

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -27,6 +27,7 @@ import mozilla.components.browser.toolbar.R
 import mozilla.components.browser.toolbar.internal.ActionContainer
 import mozilla.components.concept.menu.MenuController
 import mozilla.components.concept.toolbar.Toolbar
+import mozilla.components.support.ktx.android.content.isScreenReaderEnabled
 
 /**
  * Sub-component of the browser toolbar responsible for displaying the URL and related controls ("display mode").
@@ -560,7 +561,9 @@ class DisplayToolbar internal constructor(
             maxScrollY = views.progress.max
         }
 
-        views.progress.parent.requestSendAccessibilityEvent(views.progress, event)
+        if (context.isScreenReaderEnabled) {
+            views.progress.parent.requestSendAccessibilityEvent(views.progress, event)
+        }
 
         if (progress >= views.progress.max) {
             // Loading is done, hide progress bar.

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt
@@ -264,7 +264,7 @@ fun Context.addContact(
  * (via https://stackoverflow.com/a/12362545/512580)
  */
 inline val Context.isScreenReaderEnabled: Boolean
-    get() = getSystemService<AccessibilityManager>()!!.isTouchExplorationEnabled
+    get() = getSystemService<AccessibilityManager>()?.isTouchExplorationEnabled ?: false
 
 @VisibleForTesting
 internal var isMainProcess: Boolean? = null


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
