### PR TITLE
For #12079 - Add 'additionalValidation' parameter to context menu options builders

### DIFF
--- a/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
+++ b/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
@@ -92,19 +92,28 @@ data class ContextMenuCandidate(
 
         /**
          * Context Menu item: "Open Link in New Tab".
+         *
+         * @param context [Context] used for various system interactions.
+         * @param tabsUseCases [TabsUseCases] used for adding new tabs.
+         * @param snackBarParentView The view in which to find a suitable parent for displaying the `Snackbar`.
+         * @param snackbarDelegate [SnackbarDelegate] used to actually show a `Snackbar`.
+         * @param additionalValidation Callback for the final validation in deciding whether this menu option
+         * will be shown. Will only be called if all the intrinsic validations passed.
          */
         fun createOpenInNewTabCandidate(
             context: Context,
             tabsUseCases: TabsUseCases,
             snackBarParentView: View,
-            snackbarDelegate: SnackbarDelegate = DefaultSnackbarDelegate()
+            snackbarDelegate: SnackbarDelegate = DefaultSnackbarDelegate(),
+            additionalValidation: (SessionState, HitResult) -> Boolean = { _, _ -> true },
         ) = ContextMenuCandidate(
             id = "mozac.feature.contextmenu.open_in_new_tab",
             label = context.getString(R.string.mozac_feature_contextmenu_open_link_in_new_tab),
             showFor = { tab, hitResult ->
                 tab.isUrlSchemeAllowed(hitResult.getLink()) &&
                     hitResult.isHttpLink() &&
-                    !tab.content.private
+                    !tab.content.private &&
+                    additionalValidation(tab, hitResult)
             },
             action = { parent, hitResult ->
                 val tab = tabsUseCases.addTab(
@@ -128,18 +137,26 @@ data class ContextMenuCandidate(
 
         /**
          * Context Menu item: "Open Link in Private Tab".
-         */
+         *
+         * @param context [Context] used for various system interactions.
+         * @param tabsUseCases [TabsUseCases] used for adding new tabs.
+         * @param snackBarParentView The view in which to find a suitable parent for displaying the `Snackbar`.
+         * @param snackbarDelegate [SnackbarDelegate] used to actually show a `Snackbar`.
+         * @param additionalValidation Callback for the final validation in deciding whether this menu option
+         * will be shown. Will only be called if all the intrinsic validations passed.         */
         fun createOpenInPrivateTabCandidate(
             context: Context,
             tabsUseCases: TabsUseCases,
             snackBarParentView: View,
-            snackbarDelegate: SnackbarDelegate = DefaultSnackbarDelegate()
+            snackbarDelegate: SnackbarDelegate = DefaultSnackbarDelegate(),
+            additionalValidation: (SessionState, HitResult) -> Boolean = { _, _ -> true },
         ) = ContextMenuCandidate(
             id = "mozac.feature.contextmenu.open_in_private_tab",
             label = context.getString(R.string.mozac_feature_contextmenu_open_link_in_private_tab),
             showFor = { tab, hitResult ->
                 tab.isUrlSchemeAllowed(hitResult.getLink()) &&
-                    hitResult.isHttpLink()
+                    hitResult.isHttpLink() &&
+                    additionalValidation(tab, hitResult)
             },
             action = { parent, hitResult ->
                 val tab = tabsUseCases.addTab(
@@ -163,16 +180,23 @@ data class ContextMenuCandidate(
 
         /**
          * Context Menu item: "Open Link in external App".
+         *
+         * @param context [Context] used for various system interactions.
+         * @param appLinksUseCases [AppLinksUseCases] used to interact with urls that can be opened in 3rd party apps.
+         * @param additionalValidation Callback for the final validation in deciding whether this menu option
+         * will be shown. Will only be called if all the intrinsic validations passed.
          */
         fun createOpenInExternalAppCandidate(
             context: Context,
-            appLinksUseCases: AppLinksUseCases
+            appLinksUseCases: AppLinksUseCases,
+            additionalValidation: (SessionState, HitResult) -> Boolean = { _, _ -> true },
         ) = ContextMenuCandidate(
             id = "mozac.feature.contextmenu.open_in_external_app",
             label = context.getString(R.string.mozac_feature_contextmenu_open_link_in_external_app),
             showFor = { tab, hitResult ->
                 tab.isUrlSchemeAllowed(hitResult.getLink()) &&
-                    hitResult.canOpenInExternalApp(appLinksUseCases)
+                    hitResult.canOpenInExternalApp(appLinksUseCases) &&
+                    additionalValidation(tab, hitResult)
             },
             action = { _, hitResult ->
                 val link = hitResult.getLink()
@@ -189,47 +213,67 @@ data class ContextMenuCandidate(
 
         /**
          * Context Menu item: "Add to contact".
+         *
+         * @param context [Context] used for various system interactions.
+         * @param additionalValidation Callback for the final validation in deciding whether this menu option
+         * will be shown. Will only be called if all the intrinsic validations passed.
          */
         fun createAddContactCandidate(
-            context: Context
+            context: Context,
+            additionalValidation: (SessionState, HitResult) -> Boolean = { _, _ -> true },
         ) = ContextMenuCandidate(
             id = "mozac.feature.contextmenu.add_to_contact",
             label = context.getString(R.string.mozac_feature_contextmenu_add_to_contact),
             showFor = { tab, hitResult ->
                 tab.isUrlSchemeAllowed(hitResult.getLink()) &&
-                    hitResult.isMailto()
+                    hitResult.isMailto() &&
+                    additionalValidation(tab, hitResult)
             },
             action = { _, hitResult -> context.addContact(hitResult.getLink().stripMailToProtocol()) }
         )
 
         /**
          * Context Menu item: "Share email address".
+         *
+         * @param context [Context] used for various system interactions.
+         * @param additionalValidation Callback for the final validation in deciding whether this menu option
+         * will be shown. Will only be called if all the intrinsic validations passed.
          */
         fun createShareEmailAddressCandidate(
-            context: Context
+            context: Context,
+            additionalValidation: (SessionState, HitResult) -> Boolean = { _, _ -> true },
         ) = ContextMenuCandidate(
             id = "mozac.feature.contextmenu.share_email",
             label = context.getString(R.string.mozac_feature_contextmenu_share_email_address),
             showFor = { tab, hitResult ->
                 tab.isUrlSchemeAllowed(hitResult.getLink()) &&
-                    hitResult.isMailto()
+                    hitResult.isMailto() &&
+                    additionalValidation(tab, hitResult)
             },
             action = { _, hitResult -> context.share(hitResult.getLink().stripMailToProtocol()) }
         )
 
         /**
          * Context Menu item: "Copy email address".
+         *
+         * @param context [Context] used for various system interactions.
+         * @param snackBarParentView The view in which to find a suitable parent for displaying the `Snackbar`.
+         * @param snackbarDelegate [SnackbarDelegate] used to actually show a `Snackbar`.
+         * @param additionalValidation Callback for the final validation in deciding whether this menu option
+         * will be shown. Will only be called if all the intrinsic validations passed.
          */
         fun createCopyEmailAddressCandidate(
             context: Context,
             snackBarParentView: View,
-            snackbarDelegate: SnackbarDelegate = DefaultSnackbarDelegate()
+            snackbarDelegate: SnackbarDelegate = DefaultSnackbarDelegate(),
+            additionalValidation: (SessionState, HitResult) -> Boolean = { _, _ -> true },
         ) = ContextMenuCandidate(
             id = "mozac.feature.contextmenu.copy_email_address",
             label = context.getString(R.string.mozac_feature_contextmenu_copy_email_address),
             showFor = { tab, hitResult ->
                 tab.isUrlSchemeAllowed(hitResult.getLink()) &&
-                    hitResult.isMailto()
+                    hitResult.isMailto() &&
+                    additionalValidation(tab, hitResult)
             },
             action = { _, hitResult ->
                 val email = hitResult.getLink().stripMailToProtocol()
@@ -243,18 +287,27 @@ data class ContextMenuCandidate(
 
         /**
          * Context Menu item: "Open Image in New Tab".
+         *
+         * @param context [Context] used for various system interactions.
+         * @param tabsUseCases [TabsUseCases] used for adding new tabs.
+         * @param snackBarParentView The view in which to find a suitable parent for displaying the `Snackbar`.
+         * @param snackbarDelegate [SnackbarDelegate] used to actually show a `Snackbar`.
+         * @param additionalValidation Callback for the final validation in deciding whether this menu option
+         * will be shown. Will only be called if all the intrinsic validations passed.
          */
         fun createOpenImageInNewTabCandidate(
             context: Context,
             tabsUseCases: TabsUseCases,
             snackBarParentView: View,
-            snackbarDelegate: SnackbarDelegate = DefaultSnackbarDelegate()
+            snackbarDelegate: SnackbarDelegate = DefaultSnackbarDelegate(),
+            additionalValidation: (SessionState, HitResult) -> Boolean = { _, _ -> true },
         ) = ContextMenuCandidate(
             id = "mozac.feature.contextmenu.open_image_in_new_tab",
             label = context.getString(R.string.mozac_feature_contextmenu_open_image_in_new_tab),
             showFor = { tab, hitResult ->
                 tab.isUrlSchemeAllowed(hitResult.getLink()) &&
-                    hitResult.isImage()
+                    hitResult.isImage() &&
+                    additionalValidation(tab, hitResult)
             },
             action = { parent, hitResult ->
                 val tab = tabsUseCases.addTab(
@@ -279,16 +332,23 @@ data class ContextMenuCandidate(
 
         /**
          * Context Menu item: "Save image".
+         *
+         * @param context [Context] used for various system interactions.
+         * @param contextMenuUseCases [ContextMenuUseCases] used to integrate other features.
+         * @param additionalValidation Callback for the final validation in deciding whether this menu option
+         * will be shown. Will only be called if all the intrinsic validations passed.
          */
         fun createSaveImageCandidate(
             context: Context,
-            contextMenuUseCases: ContextMenuUseCases
+            contextMenuUseCases: ContextMenuUseCases,
+            additionalValidation: (SessionState, HitResult) -> Boolean = { _, _ -> true },
         ) = ContextMenuCandidate(
             id = "mozac.feature.contextmenu.save_image",
             label = context.getString(R.string.mozac_feature_contextmenu_save_image),
             showFor = { tab, hitResult ->
                 tab.isUrlSchemeAllowed(hitResult.getLink()) &&
-                    hitResult.isImage()
+                    hitResult.isImage() &&
+                    additionalValidation(tab, hitResult)
             },
             action = { tab, hitResult ->
                 contextMenuUseCases.injectDownload(
@@ -300,16 +360,23 @@ data class ContextMenuCandidate(
 
         /**
          * Context Menu item: "Save video".
+         *
+         * @param context [Context] used for various system interactions.
+         * @param contextMenuUseCases [ContextMenuUseCases] used to integrate other features.
+         * @param additionalValidation Callback for the final validation in deciding whether this menu option
+         * will be shown. Will only be called if all the intrinsic validations passed.
          */
         fun createSaveVideoAudioCandidate(
             context: Context,
-            contextMenuUseCases: ContextMenuUseCases
+            contextMenuUseCases: ContextMenuUseCases,
+            additionalValidation: (SessionState, HitResult) -> Boolean = { _, _ -> true },
         ) = ContextMenuCandidate(
             id = "mozac.feature.contextmenu.save_video",
             label = context.getString(R.string.mozac_feature_contextmenu_save_file_to_device),
             showFor = { tab, hitResult ->
                 tab.isUrlSchemeAllowed(hitResult.getLink()) &&
-                    hitResult.isVideoAudio()
+                    hitResult.isVideoAudio() &&
+                    additionalValidation(tab, hitResult)
             },
             action = { tab, hitResult ->
                 contextMenuUseCases.injectDownload(
@@ -321,16 +388,23 @@ data class ContextMenuCandidate(
 
         /**
          * Context Menu item: "Save link".
+         *
+         * @param context [Context] used for various system interactions.
+         * @param contextMenuUseCases [ContextMenuUseCases] used to integrate other features.
+         * @param additionalValidation Callback for the final validation in deciding whether this menu option
+         * will be shown. Will only be called if all the intrinsic validations passed.
          */
         fun createDownloadLinkCandidate(
             context: Context,
-            contextMenuUseCases: ContextMenuUseCases
+            contextMenuUseCases: ContextMenuUseCases,
+            additionalValidation: (SessionState, HitResult) -> Boolean = { _, _ -> true },
         ) = ContextMenuCandidate(
             id = "mozac.feature.contextmenu.download_link",
             label = context.getString(R.string.mozac_feature_contextmenu_download_link),
             showFor = { tab, hitResult ->
                 tab.isUrlSchemeAllowed(hitResult.getLink()) &&
-                    hitResult.isLinkForOtherThanWebpage()
+                    hitResult.isLinkForOtherThanWebpage() &&
+                    additionalValidation(tab, hitResult)
             },
             action = { tab, hitResult ->
                 contextMenuUseCases.injectDownload(
@@ -342,15 +416,21 @@ data class ContextMenuCandidate(
 
         /**
          * Context Menu item: "Share Link".
+         *
+         * @param context [Context] used for various system interactions.
+         * @param additionalValidation Callback for the final validation in deciding whether this menu option
+         * will be shown. Will only be called if all the intrinsic validations passed.
          */
         fun createShareLinkCandidate(
-            context: Context
+            context: Context,
+            additionalValidation: (SessionState, HitResult) -> Boolean = { _, _ -> true },
         ) = ContextMenuCandidate(
             id = "mozac.feature.contextmenu.share_link",
             label = context.getString(R.string.mozac_feature_contextmenu_share_link),
             showFor = { tab, hitResult ->
                 tab.isUrlSchemeAllowed(hitResult.getLink()) &&
-                    (hitResult.isUri() || hitResult.isImage() || hitResult.isVideoAudio())
+                    (hitResult.isUri() || hitResult.isImage() || hitResult.isVideoAudio()) &&
+                    additionalValidation(tab, hitResult)
             },
             action = { _, hitResult ->
                 val intent = Intent(Intent.ACTION_SEND).apply {
@@ -428,16 +508,23 @@ data class ContextMenuCandidate(
 
         /**
          * Context Menu item: "Share image"
+         *
+         * @param context [Context] used for various system interactions.
+         * @param contextMenuUseCases [ContextMenuUseCases] used to integrate other features.
+         * @param additionalValidation Callback for the final validation in deciding whether this menu option
+         * will be shown. Will only be called if all the intrinsic validations passed.
          */
         fun createShareImageCandidate(
             context: Context,
-            contextMenuUseCases: ContextMenuUseCases
+            contextMenuUseCases: ContextMenuUseCases,
+            additionalValidation: (SessionState, HitResult) -> Boolean = { _, _ -> true },
         ) = ContextMenuCandidate(
             id = "mozac.feature.contextmenu.share_image",
             label = context.getString(R.string.mozac_feature_contextmenu_share_image),
             showFor = { tab, hitResult ->
                 tab.isUrlSchemeAllowed(hitResult.getLink()) &&
-                    hitResult.isImage()
+                    hitResult.isImage() &&
+                    additionalValidation(tab, hitResult)
             },
             action = { tab, hitResult ->
                 contextMenuUseCases.injectShareFromInternet(
@@ -452,17 +539,25 @@ data class ContextMenuCandidate(
 
         /**
          * Context Menu item: "Copy Link".
+         *
+         * @param context [Context] used for various system interactions.
+         * @param snackBarParentView The view in which to find a suitable parent for displaying the `Snackbar`.
+         * @param snackbarDelegate [SnackbarDelegate] used to actually show a `Snackbar`.
+         * @param additionalValidation Callback for the final validation in deciding whether this menu option
+         * will be shown. Will only be called if all the intrinsic validations passed.
          */
         fun createCopyLinkCandidate(
             context: Context,
             snackBarParentView: View,
-            snackbarDelegate: SnackbarDelegate = DefaultSnackbarDelegate()
+            snackbarDelegate: SnackbarDelegate = DefaultSnackbarDelegate(),
+            additionalValidation: (SessionState, HitResult) -> Boolean = { _, _ -> true },
         ) = ContextMenuCandidate(
             id = "mozac.feature.contextmenu.copy_link",
             label = context.getString(R.string.mozac_feature_contextmenu_copy_link),
             showFor = { tab, hitResult ->
                 tab.isUrlSchemeAllowed(hitResult.getLink()) &&
-                    (hitResult.isUri() || hitResult.isImage() || hitResult.isVideoAudio())
+                    (hitResult.isUri() || hitResult.isImage() || hitResult.isVideoAudio()) &&
+                    additionalValidation(tab, hitResult)
             },
             action = { _, hitResult ->
                 clipPlaintText(
@@ -475,17 +570,25 @@ data class ContextMenuCandidate(
 
         /**
          * Context Menu item: "Copy Image Location".
+         *
+         * @param context [Context] used for various system interactions.
+         * @param snackBarParentView The view in which to find a suitable parent for displaying the `Snackbar`.
+         * @param snackbarDelegate [SnackbarDelegate] used to actually show a `Snackbar`.
+         * @param additionalValidation Callback for the final validation in deciding whether this menu option
+         * will be shown. Will only be called if all the intrinsic validations passed.
          */
         fun createCopyImageLocationCandidate(
             context: Context,
             snackBarParentView: View,
-            snackbarDelegate: SnackbarDelegate = DefaultSnackbarDelegate()
+            snackbarDelegate: SnackbarDelegate = DefaultSnackbarDelegate(),
+            additionalValidation: (SessionState, HitResult) -> Boolean = { _, _ -> true },
         ) = ContextMenuCandidate(
             id = "mozac.feature.contextmenu.copy_image_location",
             label = context.getString(R.string.mozac_feature_contextmenu_copy_image_location),
             showFor = { tab, hitResult ->
                 tab.isUrlSchemeAllowed(hitResult.getLink()) &&
-                    hitResult.isImage()
+                    hitResult.isImage() &&
+                    additionalValidation(tab, hitResult)
             },
             action = { _, hitResult ->
                 clipPlaintText(

--- a/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
+++ b/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
@@ -15,6 +15,7 @@ import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.ContentState
 import mozilla.components.browser.state.state.EngineState
+import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.content.ShareInternetResourceState
 import mozilla.components.browser.state.state.createTab
@@ -104,6 +105,30 @@ class ContextMenuCandidateTest {
             openInNewTab.showFor(
                 createTab("https://www.mozilla.org"),
                 HitResult.VIDEO("https://www.mozilla.org")
+            )
+        )
+    }
+
+    @Test
+    fun `Candidate 'Open Link in New Tab' allows for an additional validation for it to be shown`() {
+        val additionalValidation = { _: SessionState, _: HitResult -> false }
+        val openInNewTab = ContextMenuCandidate.createOpenInNewTabCandidate(
+            testContext, mock(), mock(), snackbarDelegate, additionalValidation
+        )
+
+        // By default in the below cases the candidate will be shown. 'additionalValidation' changes that.
+
+        assertFalse(
+            openInNewTab.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.UNKNOWN("https://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            openInNewTab.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.IMAGE_SRC("https://www.mozilla.org", "https://www.mozilla.org")
             )
         )
     }
@@ -276,6 +301,37 @@ class ContextMenuCandidateTest {
             openInPrivateTab.showFor(
                 createTab("https://www.mozilla.org"),
                 HitResult.VIDEO("https://www.mozilla.org")
+            )
+        )
+    }
+
+    @Test
+    fun `Candidate 'Open Link in Private Tab' allows for an additional validation for it to be shown`() {
+        val additionalValidation = { _: SessionState, _: HitResult -> false }
+        val openInPrivateTab = ContextMenuCandidate.createOpenInPrivateTabCandidate(
+            testContext, mock(), mock(), snackbarDelegate, additionalValidation
+        )
+
+        // By default in the below cases the candidate will be shown. 'additionalValidation' changes that.
+
+        assertFalse(
+            openInPrivateTab.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.UNKNOWN("https://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            openInPrivateTab.showFor(
+                createTab("https://www.mozilla.org", private = true),
+                HitResult.UNKNOWN("https://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            openInPrivateTab.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.IMAGE_SRC("https://www.mozilla.org", "https://www.mozilla.org")
             )
         )
     }
@@ -459,6 +515,30 @@ class ContextMenuCandidateTest {
     }
 
     @Test
+    fun `Candidate 'Open Image in New Tab' allows for an additional validation for it to be shown`() {
+        val additionalValidation = { _: SessionState, _: HitResult -> false }
+        val openImageInTab = ContextMenuCandidate.createOpenImageInNewTabCandidate(
+            testContext, mock(), mock(), snackbarDelegate, additionalValidation
+        )
+
+        // By default in the below cases the candidate will be shown. 'additionalValidation' changes that.
+
+        assertFalse(
+            openImageInTab.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.IMAGE_SRC("https://www.mozilla.org", "https://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            openImageInTab.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.IMAGE("https://www.mozilla.org")
+            )
+        )
+    }
+
+    @Test
     fun `Candidate 'Open Image in New Tab' opens in private tab if session is private`() {
         val store = BrowserStore(
             initialState = BrowserState(
@@ -602,6 +682,30 @@ class ContextMenuCandidateTest {
     }
 
     @Test
+    fun `Candidate 'Save image' allows for an additional validation for it to be shown`() {
+        val additionalValidation = { _: SessionState, _: HitResult -> false }
+        val saveImage = ContextMenuCandidate.createSaveImageCandidate(
+            testContext, mock(), additionalValidation
+        )
+
+        // By default in the below cases the candidate will be shown. 'additionalValidation' changes that.
+
+        assertFalse(
+            saveImage.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.IMAGE_SRC("https://www.mozilla.org", "https://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            saveImage.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.IMAGE("https://www.mozilla.org")
+            )
+        )
+    }
+
+    @Test
     fun `Candidate 'Save video and audio'`() {
         val store = BrowserStore(
             initialState = BrowserState(
@@ -683,6 +787,30 @@ class ContextMenuCandidateTest {
 
         assertTrue(
             store.state.tabs.first().content.download!!.private
+        )
+    }
+
+    @Test
+    fun `Candidate 'Save video and audio' allows for an additional validation for it to be shown`() {
+        val additionalValidation = { _: SessionState, _: HitResult -> false }
+        val saveVideoAudio = ContextMenuCandidate.createSaveVideoAudioCandidate(
+            testContext, mock(), additionalValidation
+        )
+
+        // By default in the below cases the candidate will be shown. 'additionalValidation' changes that.
+
+        assertFalse(
+            saveVideoAudio.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.VIDEO("https://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            saveVideoAudio.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.AUDIO("https://www.mozilla.org")
+            )
         )
     }
 
@@ -798,6 +926,37 @@ class ContextMenuCandidateTest {
         )
 
         assertTrue(store.state.tabs.first().content.download!!.private)
+    }
+
+    @Test
+    fun `Candidate 'download link' allows for an additional validation for it to be shown`() {
+        val additionalValidation = { _: SessionState, _: HitResult -> false }
+        val downloadLink = ContextMenuCandidate.createDownloadLinkCandidate(
+            testContext, mock(), additionalValidation
+        )
+
+        // By default in the below cases the candidate will be shown. 'additionalValidation' changes that.
+
+        assertFalse(
+            downloadLink.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.UNKNOWN("https://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            downloadLink.showFor(
+                createTab("https://www.mozilla.org", private = true),
+                HitResult.UNKNOWN("https://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            downloadLink.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.IMAGE_SRC("https://www.mozilla.org", "https://www.mozilla.org")
+            )
+        )
     }
 
     @Test
@@ -944,6 +1103,58 @@ class ContextMenuCandidateTest {
     }
 
     @Test
+    fun `Candidate 'Share Link' allows for an additional validation for it to be shown`() {
+        val additionalValidation = { _: SessionState, _: HitResult -> false }
+        val shareLink = ContextMenuCandidate.createShareLinkCandidate(
+            testContext, additionalValidation
+        )
+
+        // By default in the below cases the candidate will be shown. 'additionalValidation' changes that.
+
+        assertFalse(
+            shareLink.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.UNKNOWN("https://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            shareLink.showFor(
+                createTab("https://www.mozilla.org", private = true),
+                HitResult.UNKNOWN("https://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            shareLink.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.IMAGE_SRC("https://www.mozilla.org", "https://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            shareLink.showFor(
+                createTab("test://www.mozilla.org"),
+                HitResult.UNKNOWN("test://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            shareLink.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.IMAGE("https://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            shareLink.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.VIDEO("https://www.mozilla.org")
+            )
+        )
+    }
+
+    @Test
     fun `Candidate 'Share image'`() {
         val store = BrowserStore(
             initialState = BrowserState(
@@ -990,6 +1201,30 @@ class ContextMenuCandidateTest {
         verify(shareUsecase).invoke(eq("123"), shareStateCaptor.capture())
         assertEquals("https://firefox.com", shareStateCaptor.value.url)
         assertEquals(store.state.tabs.first().content.private, shareStateCaptor.value.private)
+    }
+
+    @Test
+    fun `Candidate 'Share image' allows for an additional validation for it to be shown`() {
+        val additionalValidation = { _: SessionState, _: HitResult -> false }
+        val shareImage = ContextMenuCandidate.createShareImageCandidate(
+            testContext, mock(), additionalValidation
+        )
+
+        // By default in the below cases the candidate will be shown. 'additionalValidation' changes that.
+
+        assertFalse(
+            shareImage.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.IMAGE("https://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            shareImage.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.IMAGE_SRC("https://www.mozilla.org", "https://www.mozilla.org")
+            )
+        )
     }
 
     @Test
@@ -1070,6 +1305,58 @@ class ContextMenuCandidateTest {
     }
 
     @Test
+    fun `Candidate 'Copy Link' allows for an additional validation for it to be shown`() {
+        val additionalValidation = { _: SessionState, _: HitResult -> false }
+        val copyLink = ContextMenuCandidate.createCopyLinkCandidate(
+            testContext, mock(), snackbarDelegate, additionalValidation
+        )
+
+        // By default in the below cases the candidate will be shown. 'additionalValidation' changes that.
+
+        assertFalse(
+            copyLink.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.UNKNOWN("https://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            copyLink.showFor(
+                createTab("https://www.mozilla.org", private = true),
+                HitResult.UNKNOWN("https://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            copyLink.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.IMAGE_SRC("https://www.mozilla.org", "https://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            copyLink.showFor(
+                createTab("test://www.mozilla.org"),
+                HitResult.UNKNOWN("test://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            copyLink.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.IMAGE("https://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            copyLink.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.VIDEO("https://www.mozilla.org")
+            )
+        )
+    }
+
+    @Test
     fun `Candidate 'Copy Image Location'`() {
         val parentView = CoordinatorLayout(testContext)
 
@@ -1136,6 +1423,30 @@ class ContextMenuCandidateTest {
         assertEquals(
             "https://firefox.com",
             clipboardManager.primaryClip!!.getItemAt(0).text
+        )
+    }
+
+    @Test
+    fun `Candidate 'Copy Image Location' allows for an additional validation for it to be shown`() {
+        val additionalValidation = { _: SessionState, _: HitResult -> false }
+        val copyImageLocation = ContextMenuCandidate.createCopyImageLocationCandidate(
+            testContext, mock(), snackbarDelegate, additionalValidation
+        )
+
+        // By default in the below cases the candidate will be shown. 'additionalValidation' changes that.
+
+        assertFalse(
+            copyImageLocation.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.IMAGE_SRC("https://www.mozilla.org", "https://www.mozilla.org")
+            )
+        )
+
+        assertFalse(
+            copyImageLocation.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.IMAGE("https://www.mozilla.org")
+            )
         )
     }
 
@@ -1239,6 +1550,56 @@ class ContextMenuCandidateTest {
     }
 
     @Test
+    fun `Candidate 'Open in external app' allows for an additional validation for it to be shown`() {
+        val tab = createTab("https://www.mozilla.org")
+        val getAppLinkRedirectMock: AppLinksUseCases.GetAppLinkRedirect = mock()
+        doReturn(
+            AppLinkRedirect(mock(), null, null)
+        ).`when`(getAppLinkRedirectMock).invoke(eq("https://www.example.com"))
+        doReturn(
+            AppLinkRedirect(null, null, mock())
+        ).`when`(getAppLinkRedirectMock).invoke(eq("intent:www.example.com#Intent;scheme=https;package=org.mozilla.fenix;end"))
+        val openAppLinkRedirectMock: AppLinksUseCases.OpenAppLinkRedirect = mock()
+        val appLinksUseCasesMock: AppLinksUseCases = mock()
+        doReturn(getAppLinkRedirectMock).`when`(appLinksUseCasesMock).appLinkRedirectIncludeInstall
+        doReturn(openAppLinkRedirectMock).`when`(appLinksUseCasesMock).openAppLink
+        val additionalValidation = { _: SessionState, _: HitResult -> false }
+        val openLinkInExternalApp = ContextMenuCandidate.createOpenInExternalAppCandidate(
+            testContext, appLinksUseCasesMock, additionalValidation
+        )
+
+        // By default in the below cases the candidate will be shown. 'additionalValidation' changes that.
+
+        assertFalse(
+            openLinkInExternalApp.showFor(
+                tab,
+                HitResult.UNKNOWN("https://www.example.com")
+            )
+        )
+
+        assertFalse(
+            openLinkInExternalApp.showFor(
+                tab,
+                HitResult.UNKNOWN("intent:www.example.com#Intent;scheme=https;package=org.mozilla.fenix;end")
+            )
+        )
+
+        assertFalse(
+            openLinkInExternalApp.showFor(
+                tab,
+                HitResult.VIDEO("https://www.example.com")
+            )
+        )
+
+        assertFalse(
+            openLinkInExternalApp.showFor(
+                tab,
+                HitResult.AUDIO("https://www.example.com")
+            )
+        )
+    }
+
+    @Test
     fun `Candidate 'Copy email address'`() {
         val parentView = CoordinatorLayout(testContext)
 
@@ -1302,6 +1663,30 @@ class ContextMenuCandidateTest {
     }
 
     @Test
+    fun `Candidate 'Copy email address' allows for an additional validation for it to be shown`() {
+        val additionalValidation = { _: SessionState, _: HitResult -> false }
+        val copyEmailAddress = ContextMenuCandidate.createCopyEmailAddressCandidate(
+            testContext, mock(), snackbarDelegate, additionalValidation
+        )
+
+        // By default in the below cases the candidate will be shown. 'additionalValidation' changes that.
+
+        assertFalse(
+            copyEmailAddress.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.UNKNOWN("mailto:example@example.com")
+            )
+        )
+
+        assertFalse(
+            copyEmailAddress.showFor(
+                createTab("https://www.mozilla.org", private = true),
+                HitResult.UNKNOWN("mailto:example.com")
+            )
+        )
+    }
+
+    @Test
     fun `Candidate 'Share email address'`() {
         val context = spy(testContext)
 
@@ -1357,6 +1742,30 @@ class ContextMenuCandidateTest {
     }
 
     @Test
+    fun `Candidate 'Share email address' allows for an additional validation for it to be shown`() {
+        val additionalValidation = { _: SessionState, _: HitResult -> false }
+        val shareEmailAddress = ContextMenuCandidate.createShareEmailAddressCandidate(
+            testContext, additionalValidation
+        )
+
+        // By default in the below cases the candidate will be shown. 'additionalValidation' changes that.
+
+        assertFalse(
+            shareEmailAddress.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.UNKNOWN("mailto:example@example.com")
+            )
+        )
+
+        assertFalse(
+            shareEmailAddress.showFor(
+                createTab("https://www.mozilla.org", private = true),
+                HitResult.UNKNOWN("mailto:example.com")
+            )
+        )
+    }
+
+    @Test
     fun `Candidate 'Add to contacts'`() {
         val context = spy(testContext)
 
@@ -1409,6 +1818,30 @@ class ContextMenuCandidateTest {
         )
 
         verify(context).startActivity(any())
+    }
+
+    @Test
+    fun `Candidate 'Add to contacts' allows for an additional validation for it to be shown`() {
+        val additionalValidation = { _: SessionState, _: HitResult -> false }
+        val addToContacts = ContextMenuCandidate.createAddContactCandidate(
+            testContext, additionalValidation
+        )
+
+        // By default in the below cases the candidate will be shown. 'additionalValidation' changes that.
+
+        assertFalse(
+            addToContacts.showFor(
+                createTab("https://www.mozilla.org"),
+                HitResult.UNKNOWN("mailto:example@example.com")
+            )
+        )
+
+        assertFalse(
+            addToContacts.showFor(
+                createTab("https://www.mozilla.org", private = true),
+                HitResult.UNKNOWN("mailto:example.com")
+            )
+        )
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **feature-contextmenu**
+  * 🌟 Add new `additionalValidation` parameter to context menu options builders allowing clients to know when these options to be shown and potentially block showing them.
+
 # 101.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v100.0.0...v101.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/148?closed=1)


### PR DESCRIPTION
This will allow clients know when the context menu is opened and what options
it contains while also allowing clients to lazily control what options are
shown without the need for complex if-else conditions when the menu is set up.

Tests copy the already existing tests where the candidate is checked to be
shown by default and check that `additionalValidation` is called and can change
that.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
