### PR TITLE
For #12060 - Add support for select address prompt request

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/ext/Address.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/ext/Address.kt
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.ext
+
+import mozilla.components.concept.storage.Address
+import org.mozilla.geckoview.Autocomplete
+
+/**
+ * Converts a GeckoView [Autocomplete.Address] to an Android Components [Address].
+ */
+fun Autocomplete.Address.toAddress() = Address(
+    guid = guid ?: "",
+    givenName = givenName,
+    additionalName = additionalName,
+    familyName = familyName,
+    organization = organization,
+    streetAddress = streetAddress,
+    addressLevel3 = addressLevel3,
+    addressLevel2 = addressLevel2,
+    addressLevel1 = addressLevel1,
+    postalCode = postalCode,
+    country = country,
+    tel = tel,
+    email = email
+)
+
+/**
+ * Converts an Android Components [Address] to a GeckoView [Autocomplete.Address].
+ */
+fun Address.toAutocompleteAddress() = Autocomplete.Address.Builder()
+    .guid(guid)
+    .givenName(givenName)
+    .additionalName(additionalName)
+    .familyName(familyName)
+    .organization(organization)
+    .streetAddress(streetAddress)
+    .addressLevel3(addressLevel3)
+    .addressLevel2(addressLevel2)
+    .addressLevel1(addressLevel1)
+    .postalCode(postalCode)
+    .country(country)
+    .tel(tel)
+    .email(email)
+    .build()

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -8,6 +8,7 @@ import android.net.Uri
 import android.os.Looper.getMainLooper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.browser.engine.gecko.ext.toAutocompleteAddress
 import mozilla.components.browser.engine.gecko.ext.toAutocompleteCreditCard
 import mozilla.components.browser.engine.gecko.ext.toLoginEntry
 import mozilla.components.concept.engine.EngineSession
@@ -15,6 +16,7 @@ import mozilla.components.concept.engine.prompt.Choice
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.prompt.PromptRequest.MultipleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.SingleChoice
+import mozilla.components.concept.storage.Address
 import mozilla.components.concept.storage.CreditCardEntry
 import mozilla.components.concept.storage.Login
 import mozilla.components.concept.storage.LoginEntry
@@ -1436,6 +1438,96 @@ class GeckoPromptDelegateTest {
         verify(geckoResult, never()).complete(any())
     }
 
+    @Test
+    fun `WHEN onAddressSelect is called THEN SelectAddress prompt request must be provided with the correct callbacks`() {
+        val mockSession = GeckoEngineSession(runtime)
+
+        var isOnConfirmCalled = false
+        var isOnDismissCalled = false
+
+        var selectAddressPrompt: PromptRequest.SelectAddress = mock()
+
+        val promptDelegate = spy(GeckoPromptDelegate(mockSession))
+
+        // Capture the SelectAddress prompt request
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                selectAddressPrompt = promptRequest as PromptRequest.SelectAddress
+            }
+        })
+
+        val address = Address(
+            guid = "1",
+            givenName = "Firefox",
+            additionalName = "-",
+            familyName = "-",
+            organization = "-",
+            streetAddress = "street",
+            addressLevel3 = "address3",
+            addressLevel2 = "address2",
+            addressLevel1 = "address1",
+            postalCode = "1",
+            country = "Country",
+            tel = "1",
+            email = "@"
+        )
+        val addressSelectOption =
+            Autocomplete.AddressSelectOption(address.toAutocompleteAddress())
+
+        var geckoPrompt =
+            geckoSelectAddressPrompt(arrayOf(addressSelectOption))
+
+        var geckoResult = promptDelegate.onAddressSelect(
+            mock(),
+            geckoPrompt
+        )
+
+        // Verify that the onDismiss callback was called
+        geckoResult.accept {
+            isOnDismissCalled = true
+        }
+
+        selectAddressPrompt.onDismiss()
+        shadowOf(getMainLooper()).idle()
+        assertTrue(isOnDismissCalled)
+
+        // Verify that the onConfirm callback was called
+        geckoPrompt =
+            geckoSelectAddressPrompt(arrayOf(addressSelectOption))
+
+        geckoResult = promptDelegate.onAddressSelect(
+            mock(),
+            geckoPrompt
+        )
+
+        geckoResult.accept {
+            isOnConfirmCalled = true
+        }
+
+        selectAddressPrompt.onConfirm(selectAddressPrompt.addresses.first())
+        shadowOf(getMainLooper()).idle()
+        assertTrue(isOnConfirmCalled)
+
+        // Verify that when the prompt request is already completed and onConfirm callback is called,
+        // then onConfirm callback is not executed
+        isOnConfirmCalled = false
+        geckoPrompt =
+            geckoSelectAddressPrompt(arrayOf(addressSelectOption), true)
+
+        geckoResult = promptDelegate.onAddressSelect(
+            mock(),
+            geckoPrompt
+        )
+
+        geckoResult.accept {
+            isOnConfirmCalled = true
+        }
+
+        selectAddressPrompt.onConfirm(selectAddressPrompt.addresses.first())
+        shadowOf(getMainLooper()).idle()
+        assertFalse(isOnConfirmCalled)
+    }
+
     private fun geckoChoicePrompt(
         title: String,
         message: String,
@@ -1593,6 +1685,17 @@ class GeckoPromptDelegateTest {
         val prompt: GeckoSession.PromptDelegate.AutocompleteRequest<Autocomplete.CreditCardSelectOption> =
             mock()
         ReflectionUtils.setField(prompt, "options", creditCards)
+        return prompt
+    }
+
+    private fun geckoSelectAddressPrompt(
+        addresses: Array<Autocomplete.AddressSelectOption>,
+        isComplete: Boolean = false
+    ): GeckoSession.PromptDelegate.AutocompleteRequest<Autocomplete.AddressSelectOption> {
+        val prompt: GeckoSession.PromptDelegate.AutocompleteRequest<Autocomplete.AddressSelectOption> =
+            mock()
+        whenever(prompt.isComplete).thenReturn(isComplete)
+        ReflectionUtils.setField(prompt, "options", addresses)
         return prompt
     }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
@@ -9,6 +9,7 @@ import android.net.Uri
 import mozilla.components.concept.engine.prompt.PromptRequest.Authentication.Level
 import mozilla.components.concept.engine.prompt.PromptRequest.Authentication.Method
 import mozilla.components.concept.engine.prompt.PromptRequest.TimeSelection.Type
+import mozilla.components.concept.storage.Address
 import mozilla.components.concept.storage.CreditCardEntry
 import mozilla.components.concept.storage.Login
 import mozilla.components.concept.storage.LoginEntry
@@ -127,6 +128,21 @@ sealed class PromptRequest(
     data class SelectLoginPrompt(
         val logins: List<Login>,
         val onConfirm: (Login) -> Unit,
+        override val onDismiss: () -> Unit
+    ) : PromptRequest(), Dismissible
+
+    /**
+     * Value type that represents a request for a select address prompt.
+     *
+     * This prompt is triggered by the user focusing on an address field.
+     *
+     * @property addresses List of addresses for the user to choose from.
+     * @property onConfirm Callback used to confirm the selected address.
+     * @property onDismiss Callback used to dismiss the address prompt.
+     */
+    data class SelectAddress(
+        val addresses: List<Address>,
+        val onConfirm: (Address) -> Unit,
         override val onDismiss: () -> Unit
     ) : PromptRequest(), Dismissible
 

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt
@@ -20,6 +20,7 @@ import mozilla.components.concept.engine.prompt.PromptRequest.SingleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.TextPrompt
 import mozilla.components.concept.engine.prompt.PromptRequest.TimeSelection
 import mozilla.components.concept.engine.prompt.PromptRequest.TimeSelection.Type
+import mozilla.components.concept.storage.Address
 import mozilla.components.concept.storage.CreditCardEntry
 import mozilla.components.concept.storage.Login
 import mozilla.components.concept.storage.LoginEntry
@@ -311,5 +312,53 @@ class PromptRequestTest {
         assertTrue(onDismissCalled)
         assertFalse(onConfirmCalled)
         assertNull(confirmedCreditCard)
+    }
+
+    @Test
+    fun `WHEN calling confirm or dismiss on the SelectAddress prompt request THEN the respective callback is invoked`() {
+        val address = Address(
+            guid = "1",
+            givenName = "Firefox",
+            additionalName = "-",
+            familyName = "-",
+            organization = "-",
+            streetAddress = "street",
+            addressLevel3 = "address3",
+            addressLevel2 = "address2",
+            addressLevel1 = "address1",
+            postalCode = "1",
+            country = "Country",
+            tel = "1",
+            email = "@"
+        )
+        var onDismissCalled = false
+        var onConfirmCalled = false
+        var confirmedAddress: Address? = null
+
+        val selectAddresPromptRequest = PromptRequest.SelectAddress(
+            addresses = listOf(address),
+            onDismiss = {
+                onDismissCalled = true
+            },
+            onConfirm = {
+                confirmedAddress = it
+                onConfirmCalled = true
+            }
+        )
+
+        assertEquals(selectAddresPromptRequest.addresses, listOf(address))
+
+        selectAddresPromptRequest.onConfirm(address)
+
+        assertTrue(onConfirmCalled)
+        assertFalse(onDismissCalled)
+        assertEquals(address, confirmedAddress)
+
+        onConfirmCalled = false
+
+        selectAddresPromptRequest.onDismiss()
+
+        assertTrue(onDismissCalled)
+        assertFalse(onConfirmCalled)
     }
 }

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
@@ -328,10 +328,10 @@ data class Address(
     val country: String,
     val tel: String,
     val email: String,
-    val timeCreated: Long,
-    val timeLastUsed: Long?,
-    val timeLastModified: Long,
-    val timesUsed: Long
+    val timeCreated: Long = 0L,
+    val timeLastUsed: Long? = 0L,
+    val timeLastModified: Long = 0L,
+    val timesUsed: Long = 0L
 ) : Parcelable
 
 /**

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -34,6 +34,7 @@ import mozilla.components.concept.engine.prompt.PromptRequest.MultipleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.Popup
 import mozilla.components.concept.engine.prompt.PromptRequest.Repost
 import mozilla.components.concept.engine.prompt.PromptRequest.SaveLoginPrompt
+import mozilla.components.concept.engine.prompt.PromptRequest.SelectAddress
 import mozilla.components.concept.engine.prompt.PromptRequest.SelectCreditCard
 import mozilla.components.concept.engine.prompt.PromptRequest.SelectLoginPrompt
 import mozilla.components.concept.engine.prompt.PromptRequest.Share
@@ -791,6 +792,7 @@ class PromptFeature private constructor(
             is SelectLoginPrompt,
             is SelectCreditCard,
             is Share -> true
+            is SelectAddress -> false
             is Alert, is TextPrompt, is Confirm, is Repost, is Popup -> promptAbuserDetector.shouldShowMoreDialogs
         }
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **concept-engine**:
+  * Added support for `SelectAddress` prompt request. See [issue #12060](https://github.com/mozilla-mobile/android-components/issues/12060)
+
 * **feature-autofill**
   * 🚒 Bug fixed [issue #11893](https://github.com/mozilla-mobile/android-components/issues/11893) - Fix issue with autofilling in 3rd party applications not being immediately available after unlocking the autofill service.
 


### PR DESCRIPTION
Added support for SelectAddress prompt request, following the changes in [10213](https://github.com/mozilla-mobile/android-components/pull/10213/files).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
