### PR TITLE
Close #12109: Support removing edit action end in edit toolbar

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -324,6 +324,13 @@ class BrowserToolbar @JvmOverloads constructor(
     }
 
     /**
+     * Removes an action end of the URL in edit mode.
+     */
+    override fun removeEditActionEnd(action: Toolbar.Action) {
+        edit.removeEditActionEnd(action)
+    }
+
+    /**
      * Switches to URL editing mode.
      */
     override fun editMode() {

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
@@ -248,6 +248,10 @@ class EditToolbar internal constructor(
         views.editActionsEnd.addAction(action)
     }
 
+    internal fun removeEditActionEnd(action: Toolbar.Action) {
+        views.editActionsEnd.removeAction(action)
+    }
+
     /**
      * Updates the text of the URL input field. Note: this does *not* affect the value of url itself
      * and is only a visual change

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -493,6 +493,22 @@ class BrowserToolbarTest {
     }
 
     @Test
+    fun `WHEN removing action end THEN it will be forwarded to the edit toolbar`() {
+        val toolbar = BrowserToolbar(testContext)
+
+        val edit: EditToolbar = mock()
+        toolbar.edit = edit
+
+        val action = BrowserToolbar.Button(mock(), "QR code scanner") {
+            // Do nothing
+        }
+
+        toolbar.removeEditActionEnd(action)
+
+        verify(edit).removeEditActionEnd(action)
+    }
+
+    @Test
     fun `cast to view`() {
         // Given
         val toolbar = BrowserToolbar(testContext)

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -153,14 +153,19 @@ interface Toolbar {
     fun addNavigationAction(action: Action)
 
     /**
-     * Adds an action to be displayed in edit mode.
+     * Adds an action to be displayed at the start of the URL in edit mode.
      */
     fun addEditActionStart(action: Action)
 
     /**
-     * Adds an action to be displayed in edit mode.
+     * Adds an action to be displayed at the end of the URL in edit mode.
      */
     fun addEditActionEnd(action: Action)
+
+    /**
+     * Removes an action at the end of the URL in edit mode.
+     */
+    fun removeEditActionEnd(action: Action)
 
     /**
      * Casts this toolbar to an Android View object.

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/CustomTabSessionTitleObserverTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/CustomTabSessionTitleObserverTest.kt
@@ -90,6 +90,7 @@ class CustomTabSessionTitleObserverTest {
         override fun removeNavigationAction(action: Toolbar.Action) = Unit
         override fun addEditActionStart(action: Toolbar.Action) = Unit
         override fun addEditActionEnd(action: Toolbar.Action) = Unit
+        override fun removeEditActionEnd(action: Toolbar.Action) = Unit
         override fun setOnEditListener(listener: Toolbar.OnEditListener) = Unit
         override fun displayMode() = Unit
         override fun editMode() = Unit

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
@@ -112,6 +112,10 @@ class ToolbarAutocompleteFeatureTest {
             fail()
         }
 
+        override fun removeEditActionEnd(action: Toolbar.Action) {
+            fail()
+        }
+
         override fun invalidateActions() {
             fail()
         }

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
@@ -97,6 +97,10 @@ class ToolbarInteractorTest {
             fail()
         }
 
+        override fun removeEditActionEnd(action: Toolbar.Action) {
+            fail()
+        }
+
         override fun invalidateActions() {
             fail()
         }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
