### PR TITLE
For #12061 - Add support to display AddressPicker

### DIFF
--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/address/AddressAdapter.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/address/AddressAdapter.kt
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts.address
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.annotation.VisibleForTesting
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.concept.storage.Address
+import mozilla.components.feature.prompts.R
+
+@VisibleForTesting
+internal object AddressDiffCallback : DiffUtil.ItemCallback<Address>() {
+    override fun areItemsTheSame(oldItem: Address, newItem: Address) =
+        oldItem.guid == newItem.guid
+
+    override fun areContentsTheSame(oldItem: Address, newItem: Address) =
+        oldItem == newItem
+}
+
+/**
+ * RecyclerView adapter for displaying address items.
+ */
+internal class AddressAdapter(
+    private val onAddressSelected: (Address) -> Unit
+) : ListAdapter<Address, AddressViewHolder>(AddressDiffCallback) {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AddressViewHolder {
+        val view = LayoutInflater
+            .from(parent.context)
+            .inflate(R.layout.mozac_feature_prompts_address_list_item, parent, false)
+        return AddressViewHolder(view, onAddressSelected)
+    }
+
+    override fun onBindViewHolder(holder: AddressViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+}
+
+/**
+ * View holder for a address item.
+ */
+@VisibleForTesting
+internal class AddressViewHolder(
+    itemView: View,
+    private val onAddressSelected: (Address) -> Unit
+) : RecyclerView.ViewHolder(itemView), View.OnClickListener {
+    @VisibleForTesting
+    lateinit var address: Address
+
+    init {
+        itemView.setOnClickListener(this)
+    }
+
+    fun bind(address: Address) {
+        this.address = address
+        itemView.findViewById<TextView>(R.id.address_name)?.text = address.displayFormat()
+    }
+
+    override fun onClick(v: View?) {
+        onAddressSelected(address)
+    }
+}
+
+/**
+ * Format the address details to be displayed to the user.
+ */
+fun Address.displayFormat(): String =
+    "${this.streetAddress}, ${this.addressLevel2}, ${this.addressLevel1}, ${this.postalCode}"

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/address/AddressDelegate.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/address/AddressDelegate.kt
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts.address
+
+import mozilla.components.concept.storage.Address
+import mozilla.components.feature.prompts.concept.SelectablePromptView
+
+/**
+ * Delegate for address picker
+ */
+interface AddressDelegate {
+    /**
+     * The [SelectablePromptView] used for [AddressPicker] to display a
+     * selectable prompt list of address options.
+     */
+    val addressPickerView: SelectablePromptView<Address>?
+
+    /**
+     * Callback invoked when the user clicks "Manage addresses" from
+     * select address prompt.
+     */
+    val onManageAddresses: () -> Unit
+}
+
+/**
+ * Default implementation for address picker delegate
+ */
+class DefaultAddressDelegate(
+    override val addressPickerView: SelectablePromptView<Address>? = null,
+    override val onManageAddresses: () -> Unit = {}
+) : AddressDelegate

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/address/AddressPicker.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/address/AddressPicker.kt
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts.address
+
+import mozilla.components.browser.state.action.ContentAction
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.engine.prompt.PromptRequest
+import mozilla.components.concept.storage.Address
+import mozilla.components.feature.prompts.concept.SelectablePromptView
+import mozilla.components.feature.prompts.consumePromptFrom
+import mozilla.components.support.base.log.logger.Logger
+
+/**
+ * Interactor that implements [SelectablePromptView.Listener] and notifies the feature about actions
+ * the user performed in the address picker.
+ *
+ * @property store The [BrowserStore] this feature should subscribe to.
+ * @property addressSelectBar The [SelectablePromptView] view into which the select address
+ * prompt will be inflated.
+ * @property onManageAddresses Callback invoked when user clicks on "Manage adresses" button from
+ * select address prompt.
+ * @property sessionId The session ID which requested the prompt.
+ */
+class AddressPicker(
+    private val store: BrowserStore,
+    private val addressSelectBar: SelectablePromptView<Address>,
+    private val onManageAddresses: () -> Unit = {},
+    private var sessionId: String? = null
+) : SelectablePromptView.Listener<Address> {
+
+    init {
+        addressSelectBar.listener = this
+    }
+
+    /**
+     * Shows the select address prompt in response to the [PromptRequest] event.
+     *
+     * @param request The [PromptRequest] containing the the address request data to be shown.
+     */
+    internal fun handleSelectAddressRequest(request: PromptRequest.SelectAddress) {
+        addressSelectBar.showPrompt(request.addresses)
+    }
+
+    /**
+     * Dismisses the active [PromptRequest.SelectAddress] request.
+     *
+     * @param promptRequest The current active [PromptRequest.SelectAddress] or null
+     * otherwise.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    fun dismissSelectAddressRequest(promptRequest: PromptRequest.SelectAddress? = null) {
+        addressSelectBar.hidePrompt()
+
+        try {
+            if (promptRequest != null) {
+                promptRequest.onDismiss()
+                sessionId?.let {
+                    store.dispatch(ContentAction.ConsumePromptRequestAction(it, promptRequest))
+                }
+                return
+            }
+
+            store.consumePromptFrom<PromptRequest.SelectAddress>(sessionId) {
+                it.onDismiss()
+            }
+        } catch (e: RuntimeException) {
+            Logger.error("Can't dismiss select address prompt", e)
+        }
+    }
+
+    override fun onOptionSelect(option: Address) {
+        store.consumePromptFrom<PromptRequest.SelectAddress>(sessionId) {
+            it.onConfirm(option)
+        }
+
+        addressSelectBar.hidePrompt()
+    }
+
+    override fun onManageOptions() {
+        onManageAddresses.invoke()
+        dismissSelectAddressRequest()
+    }
+}

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/address/AddressSelectBar.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/address/AddressSelectBar.kt
@@ -1,0 +1,147 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts.address
+
+import android.content.Context
+import android.content.res.ColorStateList
+import android.util.AttributeSet
+import android.view.View
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.withStyledAttributes
+import androidx.core.view.isVisible
+import androidx.core.widget.ImageViewCompat
+import androidx.core.widget.TextViewCompat
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.concept.storage.Address
+import mozilla.components.feature.prompts.R
+import mozilla.components.feature.prompts.concept.SelectablePromptView
+import mozilla.components.support.ktx.android.view.hideKeyboard
+
+/**
+ * A customizable "Select addresses" bar implementing [SelectablePromptView].
+ */
+class AddressSelectBar @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : ConstraintLayout(context, attrs, defStyleAttr), SelectablePromptView<Address> {
+
+    private var view: View? = null
+    private var recyclerView: RecyclerView? = null
+    private var headerView: AppCompatTextView? = null
+    private var expanderView: AppCompatImageView? = null
+    private var manageAddressesView: AppCompatTextView? = null
+    private var headerTextStyle: Int? = null
+
+    private val listAdapter = AddressAdapter { address ->
+        listener?.apply {
+            onOptionSelect(address)
+        }
+    }
+
+    override var listener: SelectablePromptView.Listener<Address>? = null
+
+    init {
+        context.withStyledAttributes(
+            attrs,
+            R.styleable.AddressSelectBar,
+            defStyleAttr,
+            0
+        ) {
+            val textStyle =
+                getResourceId(
+                    R.styleable.AddressSelectBar_mozacSelectAddressHeaderTextStyle,
+                    0
+                )
+
+            if (textStyle > 0) {
+                headerTextStyle = textStyle
+            }
+        }
+    }
+
+    override fun hidePrompt() {
+        this.isVisible = false
+        recyclerView?.isVisible = false
+        manageAddressesView?.isVisible = false
+
+        listAdapter.submitList(null)
+
+        toggleSelectAddressHeader(shouldExpand = false)
+    }
+
+    override fun showPrompt(options: List<Address>) {
+        if (view == null) {
+            view = View.inflate(context, LAYOUT_ID, this)
+            bindViews()
+        }
+
+        listAdapter.submitList(options)
+        view?.isVisible = true
+    }
+
+    private fun bindViews() {
+        recyclerView = findViewById<RecyclerView>(R.id.address_list).apply {
+            layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
+            adapter = listAdapter
+        }
+
+        headerView = findViewById<AppCompatTextView>(R.id.select_address_header).apply {
+            setOnClickListener {
+                toggleSelectAddressHeader(shouldExpand = recyclerView?.isVisible != true)
+            }
+
+            headerTextStyle?.let { appearance ->
+                TextViewCompat.setTextAppearance(this, appearance)
+                currentTextColor.let { color ->
+                    TextViewCompat.setCompoundDrawableTintList(this, ColorStateList.valueOf(color))
+                }
+            }
+        }
+
+        expanderView =
+            findViewById<AppCompatImageView>(R.id.mozac_feature_address_expander).apply {
+                headerView?.currentTextColor?.let {
+                    ImageViewCompat.setImageTintList(this, ColorStateList.valueOf(it))
+                }
+            }
+
+        manageAddressesView = findViewById<AppCompatTextView>(R.id.manage_addresses).apply {
+            setOnClickListener {
+                listener?.onManageOptions()
+            }
+        }
+    }
+
+    /**
+     * Toggles the visibility of the list of address items in the prompt.
+     *
+     * @param shouldExpand True if the list of addresses should be displayed, false otherwise.
+     */
+    private fun toggleSelectAddressHeader(shouldExpand: Boolean) {
+        recyclerView?.isVisible = shouldExpand
+        manageAddressesView?.isVisible = shouldExpand
+
+        if (shouldExpand) {
+            view?.hideKeyboard()
+            expanderView?.rotation = ROTATE_180
+            headerView?.contentDescription =
+                context.getString(R.string.mozac_feature_prompts_collapse_address_content_description)
+        } else {
+            expanderView?.rotation = 0F
+            headerView?.contentDescription =
+                context.getString(R.string.mozac_feature_prompts_expand_address_content_description)
+        }
+    }
+
+    companion object {
+        val LAYOUT_ID = R.layout.mozac_feature_prompts_address_select_prompt
+
+        private const val ROTATE_180 = 180F
+    }
+}

--- a/components/feature/prompts/src/main/res/layout/mozac_feature_prompts_address_list_item.xml
+++ b/components/feature/prompts/src/main/res/layout/mozac_feature_prompts_address_list_item.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/address_item"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?android:attr/selectableItemBackground"
+    android:minHeight="?android:attr/listPreferredItemHeight">
+
+    <TextView
+        android:id="@+id/address_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:clickable="false"
+        android:focusable="false"
+        android:importantForAutofill="no"
+        android:textAppearance="?android:attr/textAppearanceListItem"
+        android:textIsSelectable="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="1230 Main St, Los Angeles, CA 90237" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/components/feature/prompts/src/main/res/layout/mozac_feature_prompts_address_select_prompt.xml
+++ b/components/feature/prompts/src/main/res/layout/mozac_feature_prompts_address_select_prompt.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
+
+    <ScrollView
+        android:id="@+id/address_scroll_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/scroll_child"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/select_address_header"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:background="?android:selectableItemBackground"
+                android:contentDescription="@string/mozac_feature_prompts_expand_address_content_description"
+                android:drawablePadding="24dp"
+                android:gravity="center_vertical"
+                android:paddingStart="16dp"
+                android:paddingEnd="56dp"
+                android:text="@string/mozac_feature_prompts_select_address"
+                android:textColor="?android:colorEdgeEffect"
+                android:textSize="16sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/mozac_feature_address_expander"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:clickable="false"
+                android:focusable="false"
+                android:importantForAccessibility="no"
+                android:padding="16dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/mozac_ic_arrowhead_down"
+                app:tint="?android:colorEdgeEffect" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/address_list"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:visibility="gone"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintTop_toBottomOf="@id/mozac_feature_address_expander"
+                tools:listitem="@layout/mozac_feature_prompts_address_list_item" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/manage_addresses"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:background="?android:selectableItemBackground"
+                android:drawablePadding="24dp"
+                android:gravity="center_vertical"
+                android:paddingStart="24dp"
+                android:paddingEnd="0dp"
+                android:text="@string/mozac_feature_prompts_manage_address"
+                android:textColor="?android:textColorPrimary"
+                android:textSize="16sp"
+                android:visibility="gone"
+                app:drawableStartCompat="@drawable/mozac_ic_settings"
+                app:drawableTint="?android:textColorPrimary"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/address_list" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
+</merge>

--- a/components/feature/prompts/src/main/res/values/attrs.xml
+++ b/components/feature/prompts/src/main/res/values/attrs.xml
@@ -16,4 +16,8 @@
     <declare-styleable name="CreditCardSelectBar">
         <attr name="mozacSelectCreditCardHeaderTextStyle" format="reference"/>
     </declare-styleable>
+
+    <declare-styleable name="AddressSelectBar">
+        <attr name="mozacSelectAddressHeaderTextStyle" format="reference"/>
+    </declare-styleable>
 </resources>

--- a/components/feature/prompts/src/main/res/values/strings.xml
+++ b/components/feature/prompts/src/main/res/values/strings.xml
@@ -116,4 +116,14 @@
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Update card expiration date?</string>
     <!-- Subtitle text displayed under the title of the save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body">Card number will be encrypted. Security code won’t be saved.</string>
+
+    <!-- Address Autofill -->
+    <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
+    <string name="mozac_feature_prompts_select_address">Select addresses</string>
+    <!-- Content description for expanding the select addresses options in the select address prompt. -->
+    <string name="mozac_feature_prompts_expand_address_content_description">Expand suggested addresses</string>
+    <!-- Content description for collapsing the select address options in the select address prompt. -->
+    <string name="mozac_feature_prompts_collapse_address_content_description">Collapse suggested addresses</string>
+    <!-- Text for the manage addresses button. -->
+    <string name="mozac_feature_prompts_manage_address">Manage addresses</string>
 </resources>

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
@@ -38,9 +38,12 @@ import mozilla.components.concept.engine.prompt.PromptRequest.MultipleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.SingleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.TextPrompt
 import mozilla.components.concept.engine.prompt.ShareData
+import mozilla.components.concept.storage.Address
 import mozilla.components.concept.storage.CreditCardEntry
 import mozilla.components.concept.storage.Login
 import mozilla.components.concept.storage.LoginEntry
+import mozilla.components.feature.prompts.address.AddressDelegate
+import mozilla.components.feature.prompts.address.AddressPicker
 import mozilla.components.feature.prompts.concept.SelectablePromptView
 import mozilla.components.feature.prompts.creditcard.CreditCardPicker
 import mozilla.components.feature.prompts.creditcard.CreditCardSaveDialogFragment
@@ -89,6 +92,7 @@ class PromptFeatureTest {
     private lateinit var fragmentManager: FragmentManager
     private lateinit var loginPicker: LoginPicker
     private lateinit var creditCardPicker: CreditCardPicker
+    private lateinit var addressPicker: AddressPicker
 
     private val tabId = "test-tab"
     private fun tab(): TabSessionState? {
@@ -111,6 +115,7 @@ class PromptFeatureTest {
         )
         loginPicker = mock()
         creditCardPicker = mock()
+        addressPicker = mock()
         fragmentManager = mockFragmentManager()
     }
 
@@ -590,6 +595,64 @@ class PromptFeatureTest {
         feature.dismissSelectPrompts()
 
         verify(feature.creditCardPicker!!).dismissSelectCreditCardRequest(selectCreditCardRequest)
+    }
+
+    @Test
+    fun `WHEN dismissSelectPrompts is called THEN the active addressPicker dismiss should be called`() {
+        val addressPickerView: SelectablePromptView<Address> = mock()
+        val addressDelegate: AddressDelegate = mock()
+        val feature = spy(
+            PromptFeature(
+                mock<Activity>(),
+                store,
+                fragmentManager = fragmentManager,
+                addressDelegate = addressDelegate
+            ) { }
+        )
+        feature.addressPicker = addressPicker
+        feature.activePromptRequest = mock()
+
+        whenever(addressDelegate.addressPickerView).thenReturn(addressPickerView)
+        whenever(addressPickerView.asView()).thenReturn(mock())
+        whenever(addressPickerView.asView().visibility).thenReturn(View.VISIBLE)
+
+        feature.dismissSelectPrompts()
+        verify(feature.addressPicker!!, never()).dismissSelectAddressRequest(any())
+
+        val selectAddressPromptRequest = mock<PromptRequest.SelectAddress>()
+        feature.activePromptRequest = selectAddressPromptRequest
+
+        feature.dismissSelectPrompts()
+
+        verify(feature.addressPicker!!).dismissSelectAddressRequest(selectAddressPromptRequest)
+
+        store.waitUntilIdle()
+        assertTrue(tab()!!.content.promptRequests.isEmpty())
+    }
+
+    @Test
+    fun `GIVEN addressPickerView is not visible WHEN dismissSelectPrompts is called THEN dismissSelectPrompts returns false`() {
+        val addressPickerView: SelectablePromptView<Address> = mock()
+        val addressDelegate: AddressDelegate = mock()
+        val feature = spy(
+            PromptFeature(
+                mock<Activity>(),
+                store,
+                fragmentManager = fragmentManager,
+                addressDelegate = addressDelegate
+            ) { }
+        )
+        val selectAddressRequest = mock<PromptRequest.SelectAddress>()
+        feature.addressPicker = addressPicker
+        feature.activePromptRequest = selectAddressRequest
+
+        whenever(addressDelegate.addressPickerView).thenReturn(addressPickerView)
+        whenever(addressPickerView.asView()).thenReturn(mock())
+        whenever(addressPickerView.asView().visibility).thenReturn(View.GONE)
+
+        val result = feature.dismissSelectPrompts()
+
+        assertEquals(false, result)
     }
 
     @Test

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/address/AddressAdapterTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/address/AddressAdapterTest.kt
@@ -1,0 +1,79 @@
+
+package mozilla.components.feature.prompts.address
+
+import android.view.LayoutInflater
+import android.widget.TextView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.concept.storage.Address
+import mozilla.components.feature.prompts.R
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AddressAdapterTest {
+
+    private val address = Address(
+        guid = "1",
+        givenName = "Location",
+        additionalName = "Location",
+        familyName = "Location",
+        organization = "Mozilla",
+        streetAddress = "1230 Main st",
+        addressLevel3 = "Location3",
+        addressLevel2 = "Location2",
+        addressLevel1 = "Location1",
+        postalCode = "90237",
+        country = "USA",
+        tel = "00",
+        email = "email"
+    )
+
+    @Test
+    fun testAddressDiffCallback() {
+        val address2 = address.copy()
+
+        assertTrue(
+            AddressDiffCallback.areItemsTheSame(address, address2)
+        )
+        assertTrue(
+            AddressDiffCallback.areContentsTheSame(address, address2)
+        )
+
+        val address3 = address.copy(guid = "2")
+
+        assertFalse(
+            AddressDiffCallback.areItemsTheSame(address, address3)
+        )
+        assertFalse(
+            AddressDiffCallback.areItemsTheSame(address, address3)
+        )
+    }
+
+    @Test
+    fun `WHEN an address is bound to the adapter THEN set the address display name`() {
+        val view =
+            LayoutInflater.from(testContext).inflate(R.layout.mozac_feature_prompts_address_list_item, null)
+        val addressName: TextView = view.findViewById(R.id.address_name)
+
+        AddressViewHolder(view) {}.bind(address)
+
+        assertEquals(address.displayFormat(), addressName.text)
+    }
+
+    @Test
+    fun `WHEN an address item is clicked THEN call the onAddressSelected callback`() {
+        var addressSelected = false
+        val view =
+            LayoutInflater.from(testContext).inflate(R.layout.mozac_feature_prompts_address_list_item, null)
+        val onAddressSelect: (Address) -> Unit = { addressSelected = true }
+
+        AddressViewHolder(view, onAddressSelect).bind(address)
+        view.performClick()
+
+        assertTrue(addressSelected)
+    }
+}

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/address/AddressPickerTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/address/AddressPickerTest.kt
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts.address
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.ContentState
+import mozilla.components.browser.state.state.CustomTabSessionState
+import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.engine.prompt.PromptRequest
+import mozilla.components.concept.storage.Address
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class AddressPickerTest {
+
+    private lateinit var store: BrowserStore
+    private lateinit var state: BrowserState
+    private lateinit var addressPicker: AddressPicker
+    private lateinit var addressSelectBar: AddressSelectBar
+
+    private val address = Address(
+        guid = "1",
+        givenName = "Location",
+        additionalName = "Location",
+        familyName = "Location",
+        organization = "Mozilla",
+        streetAddress = "1230 Main st",
+        addressLevel3 = "Location3",
+        addressLevel2 = "Location2",
+        addressLevel1 = "Location1",
+        postalCode = "90237",
+        country = "USA",
+        tel = "00",
+        email = "email"
+    )
+
+    private var onDismissCalled = false
+    private var confirmedAddress: Address? = null
+
+    private val promptRequest = PromptRequest.SelectAddress(
+        addresses = listOf(address),
+        onDismiss = { onDismissCalled = true },
+        onConfirm = { confirmedAddress = it }
+    )
+
+    @Before
+    fun setup() {
+        store = mock()
+        state = mock()
+        addressSelectBar = mock()
+        addressPicker = AddressPicker(
+            store = store,
+            addressSelectBar = addressSelectBar
+        )
+
+        whenever(store.state).thenReturn(state)
+    }
+
+    @Test
+    fun `WHEN onOptionSelect is called with an address THEN selectAddressCallback is invoked and prompt is hidden`() {
+        val content: ContentState = mock()
+        whenever(content.promptRequests).thenReturn(listOf(promptRequest))
+        val selectedTab = TabSessionState("browser-tab", content, mock(), mock())
+        whenever(state.selectedTabId).thenReturn(selectedTab.id)
+        whenever(state.tabs).thenReturn(listOf(selectedTab))
+
+        addressPicker.onOptionSelect(address)
+
+        verify(addressSelectBar).hidePrompt()
+        assertEquals(address, confirmedAddress)
+    }
+
+    @Test
+    fun `GIVEN a prompt request WHEN handleSelectAddressRequest is called THEN the prompt is shown with the provided addresses`() {
+        addressPicker.handleSelectAddressRequest(promptRequest)
+
+        verify(addressSelectBar).showPrompt(promptRequest.addresses)
+    }
+
+    @Test
+    fun `GIVEN a custom tab and a prompt request WHEN handleSelectAddressRequest is called THEN the prompt is shown with the provided addresses`() {
+        val customTabContent: ContentState = mock()
+        val customTab = CustomTabSessionState("custom-tab", customTabContent, mock(), mock())
+        whenever(customTabContent.promptRequests).thenReturn(listOf(promptRequest))
+        whenever(state.customTabs).thenReturn(listOf(customTab))
+
+        addressPicker.handleSelectAddressRequest(promptRequest)
+
+        verify(addressSelectBar).showPrompt(promptRequest.addresses)
+    }
+}

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/address/AddressSelectBarTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/address/AddressSelectBarTest.kt
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts.address
+
+import android.widget.LinearLayout
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.concept.storage.Address
+import mozilla.components.feature.prompts.R
+import mozilla.components.feature.prompts.concept.SelectablePromptView
+import mozilla.components.support.test.ext.appCompatContext
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class AddressSelectBarTest {
+
+    private lateinit var addressSelectBar: AddressSelectBar
+
+    private val address = Address(
+        guid = "1",
+        givenName = "Location",
+        additionalName = "Location",
+        familyName = "Location",
+        organization = "Mozilla",
+        streetAddress = "1230 Main st",
+        addressLevel3 = "Location3",
+        addressLevel2 = "Location2",
+        addressLevel1 = "Location1",
+        postalCode = "90237",
+        country = "USA",
+        tel = "00",
+        email = "email"
+    )
+
+    @Before
+    fun setup() {
+        addressSelectBar = AddressSelectBar(appCompatContext)
+    }
+
+    @Test
+    fun `WHEN showPrompt is called THEN the select bar is shown`() {
+        val addresses = listOf(address)
+
+        addressSelectBar.showPrompt(addresses)
+
+        assertTrue(addressSelectBar.isVisible)
+    }
+
+    @Test
+    fun `WHEN hidePrompt is called THEN the select bar is hidden`() {
+        assertTrue(addressSelectBar.isVisible)
+
+        addressSelectBar.hidePrompt()
+
+        assertFalse(addressSelectBar.isVisible)
+    }
+
+    @Test
+    fun `WHEN the selectBar header is clicked two times THEN the list of addresses is shown, then hidden`() {
+        addressSelectBar.showPrompt(listOf(address))
+        addressSelectBar.findViewById<AppCompatTextView>(R.id.select_address_header).performClick()
+
+        assertTrue(addressSelectBar.findViewById<RecyclerView>(R.id.address_list).isVisible)
+
+        addressSelectBar.findViewById<AppCompatTextView>(R.id.select_address_header).performClick()
+
+        assertFalse(addressSelectBar.findViewById<RecyclerView>(R.id.address_list).isVisible)
+    }
+
+    @Test
+    fun `GIVEN a listener WHEN an address is clicked THEN onOptionSelected is called`() {
+        val listener: SelectablePromptView.Listener<Address> = mock()
+
+        assertNull(addressSelectBar.listener)
+
+        addressSelectBar.listener = listener
+
+        addressSelectBar.showPrompt(listOf(address))
+        val adapter = addressSelectBar.findViewById<RecyclerView>(R.id.address_list).adapter as AddressAdapter
+        val holder = adapter.onCreateViewHolder(LinearLayout(testContext), 0)
+        adapter.bindViewHolder(holder, 0)
+
+        holder.itemView.performClick()
+
+        verify(listener).onOptionSelect(address)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **feature-prompts**:
+  * Added optional `addressPickerView` and `onManageAddresses` parameters through `AddressDelegate` to `PromptFeature` for a new `AddressPicker` to display a view for selecting addresses to autofill into a site. [#12061](https://github.com/mozilla-mobile/android-components/issues/12061)
+
 # 102.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v101.0.0...v102.0.1)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/149?closed=1)


### PR DESCRIPTION
Added support to display AddressPicker. Following the designs from [here](https://www.figma.com/file/cSKRUEvfJSzNBv2Mp65Pdv/Mobile-CC-Autofill?node-id=1183%3A35239)

![Screenshot_20220511_184310](https://user-images.githubusercontent.com/35462038/167895713-29456ca0-1211-4a2b-b948-7b24098ffdc1.jpeg)

![Screenshot_20220513_142727](https://user-images.githubusercontent.com/35462038/168275399-784933ca-b825-4c3b-9bf6-aad17fe381da.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
