### PR TITLE
For #12118 : Set default screen orientation if playing media in pip

### DIFF
--- a/components/feature/media/src/main/java/mozilla/components/feature/media/fullscreen/MediaSessionFullscreenFeature.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/fullscreen/MediaSessionFullscreenFeature.kt
@@ -6,6 +6,7 @@ package mozilla.components.feature.media.fullscreen
 
 import android.app.Activity
 import android.content.pm.ActivityInfo
+import android.os.Build
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collect
@@ -47,14 +48,20 @@ class MediaSessionFullscreenFeature(
             return
         }
 
-        when (activeState.mediaSessionState?.elementMetadata?.portrait) {
-            true ->
-                activity.requestedOrientation =
-                    ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
-            false ->
-                activity.requestedOrientation =
-                    ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
-            else -> activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
+        if (store.state.selectedTabId == activeState.id) {
+            when (activeState.mediaSessionState?.elementMetadata?.portrait) {
+                true ->
+                    activity.requestedOrientation =
+                        ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
+                false ->
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && activity.isInPictureInPictureMode) {
+                        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+                    } else {
+                        activity.requestedOrientation =
+                            ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+                    }
+                else -> activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
+            }
         }
     }
 

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/fullscreen/MediaSessionFullscreenFeatureTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/fullscreen/MediaSessionFullscreenFeatureTest.kt
@@ -6,8 +6,11 @@ package mozilla.components.feature.media.fullscreen
 
 import android.app.Activity
 import android.content.pm.ActivityInfo
+import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.MediaSessionAction
+import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.MediaSessionState
 import mozilla.components.browser.state.state.createTab
@@ -16,10 +19,14 @@ import mozilla.components.concept.engine.mediasession.MediaSession
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 class MediaSessionFullscreenFeatureTest {
@@ -28,13 +35,42 @@ class MediaSessionFullscreenFeatureTest {
     val coroutinesTestRule = MainCoroutineRule()
 
     @Test
-    fun `screen orientation is updated correctly`() {
-        val mockActivity: Activity = mock()
+    fun `GIVEN the currently selected tab is not in fullscreen WHEN the feature is running THEN orientation is set to default`() {
+        val activity: Activity = mock()
         val elementMetadata = MediaSession.ElementMetadata()
         val initialState = BrowserState(
             tabs = listOf(
                 createTab(
-                    "https://www.mozilla.org",
+                    "https://www.mozilla.org", id = "tab1",
+                    mediaSessionState = MediaSessionState(
+                        mock(),
+                        elementMetadata = elementMetadata,
+                        playbackState = MediaSession.PlaybackState.PLAYING,
+                        fullscreen = false
+                    )
+                )
+            ),
+            selectedTabId = "tab1"
+        )
+        val store = BrowserStore(initialState)
+        val feature = MediaSessionFullscreenFeature(
+            activity,
+            store
+        )
+
+        feature.start()
+
+        verify(activity).setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER)
+    }
+
+    @Test
+    fun `GIVEN the currently selected tab plays portrait media WHEN the feature is running THEN orientation is set to portrait`() {
+        val activity: Activity = mock()
+        val elementMetadata = MediaSession.ElementMetadata(width = 360, height = 640)
+        val initialState = BrowserState(
+            tabs = listOf(
+                createTab(
+                    "https://www.mozilla.org", id = "tab1",
                     mediaSessionState = MediaSessionState(
                         mock(),
                         elementMetadata = elementMetadata,
@@ -42,27 +78,180 @@ class MediaSessionFullscreenFeatureTest {
                         fullscreen = true
                     )
                 )
-            )
+            ),
+            selectedTabId = "tab1"
         )
         val store = BrowserStore(initialState)
         val feature = MediaSessionFullscreenFeature(
-            mockActivity,
+            activity,
             store
         )
 
         feature.start()
-        verify(mockActivity).setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE)
+
+        verify(activity).setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT)
+    }
+
+    @Test
+    fun `GIVEN the currently selected tab plays landscape media WHEN it enters fullscreen THEN set orientation to landscape`() {
+        val activity: Activity = mock()
+        val elementMetadata = MediaSession.ElementMetadata(width = 640, height = 360)
+        val initialState = BrowserState(
+            tabs = listOf(
+                createTab(
+                    "https://www.mozilla.org", id = "tab1",
+                    mediaSessionState = MediaSessionState(
+                        mock(),
+                        elementMetadata = elementMetadata,
+                        playbackState = MediaSession.PlaybackState.PLAYING,
+                        fullscreen = true
+                    )
+                )
+            ),
+            selectedTabId = "tab1"
+        )
+        val store = BrowserStore(initialState)
+        val feature = MediaSessionFullscreenFeature(
+            activity,
+            store
+        )
+
+        feature.start()
+
+        verify(activity).setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE)
+    }
+
+    @Suppress("Deprecation")
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.N])
+    fun `GIVEN the currently selected tab plays landscape media WHEN it enters pip mode THEN set orientation to unspecified`() {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val elementMetadata = MediaSession.ElementMetadata()
+        val initialState = BrowserState(
+            tabs = listOf(
+                createTab(
+                    "https://www.mozilla.org", id = "tab1",
+                    mediaSessionState = MediaSessionState(
+                        mock(),
+                        elementMetadata = elementMetadata,
+                        playbackState = MediaSession.PlaybackState.PLAYING,
+                        fullscreen = true
+                    )
+                )
+            ),
+            selectedTabId = "tab1"
+        )
+        val store = BrowserStore(initialState)
+        val feature = MediaSessionFullscreenFeature(
+            activity,
+            store
+        )
+
+        feature.start()
+        activity.enterPictureInPictureMode()
+        store.waitUntilIdle()
+
+        assertTrue(activity.isInPictureInPictureMode)
+        store.dispatch(ContentAction.PictureInPictureChangedAction("tab1", true))
+        store.waitUntilIdle()
+
+        assertEquals(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED, activity.requestedOrientation)
+    }
+
+    @Suppress("Deprecation")
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.N])
+    fun `GIVEN the currently selected tab is in pip mode WHEN an external intent arrives THEN set orientation to default`() {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val elementMetadata = MediaSession.ElementMetadata()
+        val initialState = BrowserState(
+            tabs = listOf(
+                createTab(
+                    "https://www.mozilla.org", id = "tab1",
+                    mediaSessionState = MediaSessionState(
+                        mock(),
+                        elementMetadata = elementMetadata,
+                        playbackState = MediaSession.PlaybackState.PLAYING,
+                        fullscreen = true
+                    )
+                )
+            ),
+            selectedTabId = "tab1"
+        )
+        val store = BrowserStore(initialState)
+        val feature = MediaSessionFullscreenFeature(
+            activity,
+            store
+        )
+
+        feature.start()
+        activity.enterPictureInPictureMode()
+        store.waitUntilIdle()
+        store.dispatch(ContentAction.PictureInPictureChangedAction("tab1", true))
+        store.waitUntilIdle()
+        assertEquals(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED, activity.requestedOrientation)
+
+        val tab2 = createTab(
+            url = "https://firefox.com", id = "tab2"
+        )
+        store.dispatch(TabListAction.AddTabAction(tab2, select = true))
+        store.dispatch(
+            MediaSessionAction.UpdateMediaFullscreenAction(
+                store.state.tabs[0].id,
+                false,
+                MediaSession.ElementMetadata()
+            )
+        )
+        store.waitUntilIdle()
+        assertEquals(ActivityInfo.SCREEN_ORIENTATION_USER, activity.requestedOrientation)
+        assertEquals(tab2.id, store.state.selectedTabId)
+    }
+
+    @Suppress("Deprecation")
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.N])
+    fun `GIVEN the currently selected tab is in pip mode WHEN it exits pip mode THEN set orientation to default`() {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val elementMetadata = MediaSession.ElementMetadata()
+        val initialState = BrowserState(
+            tabs = listOf(
+                createTab(
+                    "https://www.mozilla.org", id = "tab1",
+                    mediaSessionState = MediaSessionState(
+                        mock(),
+                        elementMetadata = elementMetadata,
+                        playbackState = MediaSession.PlaybackState.PLAYING,
+                        fullscreen = true
+                    )
+                )
+            ),
+            selectedTabId = "tab1"
+        )
+        val store = BrowserStore(initialState)
+        val feature = MediaSessionFullscreenFeature(
+            activity,
+            store
+        )
+
+        feature.start()
+        activity.enterPictureInPictureMode()
+        store.waitUntilIdle()
+
+        assertTrue(activity.isInPictureInPictureMode)
+        store.dispatch(ContentAction.PictureInPictureChangedAction("tab1", true))
+        store.waitUntilIdle()
+
+        assertEquals(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED, activity.requestedOrientation)
 
         store.dispatch(
             MediaSessionAction.UpdateMediaFullscreenAction(
                 store.state.tabs[0].id,
-                true,
-                MediaSession.ElementMetadata(height = 1L)
+                false,
+                MediaSession.ElementMetadata()
             )
         )
-
         store.waitUntilIdle()
 
-        verify(mockActivity).setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT)
+        assertEquals(ActivityInfo.SCREEN_ORIENTATION_USER, activity.requestedOrientation)
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -34,6 +34,10 @@ permalink: /changelog/
 * **feature-prompts**:
   * Add a `CreditCardSaveDialogFragment` that is displayed for a `SaveCreditCard` prompt request to handle saving and updating a credit card. [#11338](https://github.com/mozilla-mobile/android-components/issues/11338)
 
+* **feature-media**
+  * Set default screen orientation if playing media in pip
+    [issue # 12118](https://github.com/mozilla-mobile/android-components/issues/12118)
+
 * **concept-storage**:
   * Added `CreditCardValidationDelegate` which is a delegate that will check against the `CreditCardsAddressesStorage` to determine if a `CreditCard` can be persisted in storage. [#9838](https://github.com/mozilla-mobile/android-components/issues/9838)
   * Refactors `CreditCard` from `concept-engine` to `CreditCardEntry` in `concept-storage` so that it can validated with the `CreditCardValidationDelegate`. [#9838](https://github.com/mozilla-mobile/android-components/issues/9838)


### PR DESCRIPTION
This prevents the activity being locked in landscape mode while it's opened for new intents when the pip mode is active

Co-Authored-By: Mugurell <Mugurell@users.noreply.github.com>

When the search widget is clicked


https://user-images.githubusercontent.com/12825812/168533587-871f0354-0dda-4193-8da1-ffb51f809a1e.mp4

From shortcut 

https://user-images.githubusercontent.com/12825812/168533629-20336e3f-1292-4c67-a899-9308e4dbda38.mp4

When a page is shared to Fenix

https://user-images.githubusercontent.com/12825812/168533674-5b0f236c-582c-4a0c-a1a1-fc1392244bf8.mp4

When a link is shared to Fenix

https://user-images.githubusercontent.com/12825812/168534175-c492049c-b3be-44ad-8d54-d0541b850b36.mp4

@Mugurell , 
Following changes have been made to MediaSessionFullscreenFeature

Activity's screen orientation is set to ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED while in pip mode.
Also added a condition to check whether the tab is an active media session tab before setting the orientation. 
In some scenarios the flow in MediaSessionFullscreenFeature filters the tab that has fullscreeen enabled in mediasessionState even after a  page is loaded(For instance when a page is shared from Focus). And this results in processFullscreen() being called and the activity is set to landscape. So the condition will check whether the selected tab is an active media tab before setting the orientation. 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
