### PR TITLE
For #12217 - Add support for onPromptUpdate

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/ext/GeckoChoice.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/ext/GeckoChoice.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.ext
+
+import mozilla.components.browser.engine.gecko.prompt.GeckoChoice
+import mozilla.components.concept.engine.prompt.Choice
+
+/**
+ * Converts a GeckoView [GeckoChoice] to an Android Components [Choice].
+ */
+private fun GeckoChoice.toChoice(): Choice {
+    val choiceChildren = items?.map { it.toChoice() }?.toTypedArray()
+    // On the GeckoView docs states that label is a @NonNull, but on run-time
+    // we are getting null values
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1771149
+    @Suppress("USELESS_ELVIS")
+    return Choice(id, !disabled, label ?: "", selected, separator, choiceChildren)
+}
+
+/**
+ * Convert an array of [GeckoChoice] to Choice array.
+ * @return array of Choice
+ */
+fun convertToChoices(
+    geckoChoices: Array<out GeckoChoice>
+): Array<Choice> = geckoChoices.map { geckoChoice ->
+    val choice = geckoChoice.toChoice()
+    choice
+}.toTypedArray()

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/ChoicePromptUpdateDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/ChoicePromptUpdateDelegate.kt
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.prompt
+
+import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.browser.engine.gecko.ext.convertToChoices
+import mozilla.components.concept.engine.prompt.PromptRequest
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.BasePrompt
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.ChoicePrompt
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.PromptInstanceDelegate
+
+/**
+ * Implementation of [PromptInstanceDelegate] used to update a
+ * prompt request when onPromptUpdate is invoked.
+ *
+ * @param geckoSession [GeckoEngineSession] used to notify the engine observer
+ * with the onPromptUpdate callback.
+ * @param previousPrompt [PromptRequest] to be updated.
+ */
+internal class ChoicePromptUpdateDelegate(
+    private val geckoSession: GeckoEngineSession,
+    private var previousPrompt: PromptRequest,
+) : PromptInstanceDelegate {
+
+    override fun onPromptUpdate(prompt: BasePrompt) {
+        if (prompt is ChoicePrompt) {
+            val promptRequest = updatePromptChoices(prompt)
+            if (promptRequest != null) {
+                geckoSession.notifyObservers {
+                    this.onPromptUpdate(previousPrompt.uid, promptRequest)
+                }
+                previousPrompt = promptRequest
+            }
+        }
+    }
+
+    /**
+     * Use the received prompt to create the updated [PromptRequest]
+     * @param updatedPrompt The [ChoicePrompt] with the updated choices.
+     */
+    private fun updatePromptChoices(updatedPrompt: ChoicePrompt): PromptRequest? {
+        return when (previousPrompt) {
+            is PromptRequest.MenuChoice -> {
+                (previousPrompt as PromptRequest.MenuChoice)
+                    .copy(choices = convertToChoices(updatedPrompt.choices))
+            }
+            is PromptRequest.SingleChoice -> {
+                (previousPrompt as PromptRequest.SingleChoice)
+                    .copy(choices = convertToChoices(updatedPrompt.choices))
+            }
+            is PromptRequest.MultipleChoice -> {
+                (previousPrompt as PromptRequest.MultipleChoice)
+                    .copy(choices = convertToChoices(updatedPrompt.choices))
+            }
+            else -> null
+        }
+    }
+}

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.net.Uri
 import androidx.annotation.VisibleForTesting
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.browser.engine.gecko.ext.convertToChoices
 import mozilla.components.browser.engine.gecko.ext.toAddress
 import mozilla.components.browser.engine.gecko.ext.toAutocompleteAddress
 import mozilla.components.browser.engine.gecko.ext.toAutocompleteCreditCard
@@ -256,6 +257,11 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
             )
             else -> throw InvalidParameterException("${geckoPrompt.type} is not a valid Gecko @Choice.ChoiceType")
         }
+
+        geckoPrompt.delegate = ChoicePromptUpdateDelegate(
+            geckoEngineSession,
+            promptRequest
+        )
 
         geckoEngineSession.notifyObservers {
             onPromptRequest(promptRequest)
@@ -671,28 +677,6 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
             )
         }
         return geckoResult
-    }
-
-    private fun GeckoChoice.toChoice(): Choice {
-        val choiceChildren = items?.map { it.toChoice() }?.toTypedArray()
-        // On the GeckoView docs states that label is a @NonNull, but on run-time
-        // we are getting null values
-        @Suppress("USELESS_ELVIS")
-        return Choice(id, !disabled, label ?: "", selected, separator, choiceChildren)
-    }
-
-    /**
-     * Convert an array of [GeckoChoice] to Choice array.
-     * @return array of Choice
-     */
-    private fun convertToChoices(
-        geckoChoices: Array<out GeckoChoice>
-    ): Array<Choice> {
-
-        return geckoChoices.map { geckoChoice ->
-            val choice = geckoChoice.toChoice()
-            choice
-        }.toTypedArray()
     }
 
     @Suppress("LongParameterList")

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/ChoicePromptUpdateDelegateTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/ChoicePromptUpdateDelegateTest.kt
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package mozilla.components.browser.engine.gecko.prompt
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.prompt.PromptRequest
+import mozilla.components.support.test.mock
+import mozilla.components.test.ReflectionUtils
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.geckoview.GeckoSession
+
+@RunWith(AndroidJUnit4::class)
+class ChoicePromptUpdateDelegateTest {
+
+    @Test
+    fun `WHEN onPromptUpdate is called from GeckoView THEN notifyObservers is invoked with onPromptUpdate`() {
+        val mockSession = GeckoEngineSession(mock())
+        var isOnPromptUpdateCalled = false
+        var isOnConfirmCalled = false
+        var isOnDismissCalled = false
+        var observedPrompt: PromptRequest? = null
+        var observedUID: String? = null
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptUpdate(
+                previousPromptRequestUid: String,
+                promptRequest: PromptRequest
+            ) {
+                observedPrompt = promptRequest
+                observedUID = previousPromptRequestUid
+                isOnPromptUpdateCalled = true
+            }
+        })
+        val prompt = PromptRequest.SingleChoice(
+            arrayOf(),
+            { isOnConfirmCalled = true },
+            { isOnDismissCalled = true }
+        )
+        val delegate = ChoicePromptUpdateDelegate(mockSession, prompt)
+        val updatedPrompt = mock<GeckoSession.PromptDelegate.ChoicePrompt>()
+        ReflectionUtils.setField(updatedPrompt, "choices", arrayOf<GeckoChoice>())
+
+        delegate.onPromptUpdate(updatedPrompt)
+
+        assertTrue(isOnPromptUpdateCalled)
+        assertEquals(prompt.uid, observedUID)
+        // Verify if the onConfirm and onDismiss callbacks were changed
+        (observedPrompt as PromptRequest.SingleChoice).onConfirm(mock())
+        (observedPrompt as PromptRequest.SingleChoice).onDismiss()
+        assertTrue(isOnDismissCalled)
+        assertTrue(isOnConfirmCalled)
+    }
+}

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -597,6 +597,15 @@ sealed class ContentAction : BrowserAction() {
         ContentAction()
 
     /**
+     * Replaces a prompt request from [ContentState] with [promptRequest] based on the [previousPromptUid].
+     */
+    data class ReplacePromptRequestAction(
+        val sessionId: String,
+        val previousPromptUid: String,
+        val promptRequest: PromptRequest
+    ) : ContentAction()
+
+    /**
      * Adds a [FindResultState] to the [ContentState] with the given [sessionId].
      */
     data class AddFindResultAction(val sessionId: String, val findResult: FindResultState) :

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/engine/EngineObserver.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/engine/EngineObserver.kt
@@ -266,6 +266,12 @@ internal class EngineObserver(
         )
     }
 
+    override fun onPromptUpdate(previousPromptRequestUid: String, promptRequest: PromptRequest) {
+        store.dispatch(
+            ContentAction.ReplacePromptRequestAction(tabId, previousPromptRequestUid, promptRequest)
+        )
+    }
+
     override fun onRepostPromptCancelled() {
         store.dispatch(ContentAction.UpdateRefreshCanceledStateAction(tabId, true))
     }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
@@ -113,6 +113,15 @@ internal object ContentStateReducer {
             is ContentAction.ConsumePromptRequestAction -> updateContentState(state, action.sessionId) {
                 it.copy(promptRequests = it.promptRequests - action.promptRequest)
             }
+            is ContentAction.ReplacePromptRequestAction -> updateContentState(
+                state,
+                action.sessionId
+            ) { contentState ->
+                val updated = contentState.promptRequests
+                    .filter { it.uid != action.previousPromptUid }
+                    .plus(action.promptRequest)
+                contentState.copy(promptRequests = updated)
+            }
             is ContentAction.AddFindResultAction -> updateContentState(state, action.sessionId) {
                 it.copy(findResults = it.findResults + action.findResult)
             }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
@@ -865,6 +865,23 @@ class EngineObserverTest {
     }
 
     @Test
+    fun engineObserverHandlesOnPromptUpdate() {
+        val promptRequest: PromptRequest = mock()
+        val store: BrowserStore = mock()
+        val observer = EngineObserver("tab-id", store)
+        val previousPromptUID = "prompt-uid"
+
+        observer.onPromptUpdate(previousPromptUID, promptRequest)
+        verify(store).dispatch(
+            ContentAction.ReplacePromptRequestAction(
+                "tab-id",
+                previousPromptUID,
+                promptRequest
+            )
+        )
+    }
+
+    @Test
     fun engineObserverHandlesWindowRequest() {
         val windowRequest: WindowRequest = mock()
         val store: BrowserStore = mock()

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -88,6 +88,11 @@ abstract class EngineSession(
         fun onPromptDismissed(promptRequest: PromptRequest) = Unit
 
         /**
+         * The engine has requested a prompt update.
+         */
+        fun onPromptUpdate(previousPromptRequestUid: String, promptRequest: PromptRequest) = Unit
+
+        /**
          * User cancelled a repost prompt. Page will not be reloaded.
          */
         fun onRepostPromptCancelled() = Unit

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -851,6 +851,23 @@ class PromptFeature private constructor(
         dialog.feature = this
 
         if (canShowThisPrompt(promptRequest)) {
+            // If the ChoiceDialogFragment's choices data were updated,
+            // we need to dismiss the previous dialog
+            activePrompt?.get()?.let { promptDialog ->
+                // ChoiceDialogFragment could update their choices data,
+                // and we need to dismiss the previous UI dialog,
+                // without consuming the engine callbacks, and allow to create a new dialog with the
+                // updated data.
+                if (promptDialog is ChoiceDialogFragment &&
+                    !session.content.promptRequests.any { it.uid == promptDialog.promptRequestUID }
+                ) {
+                    // We want to avoid consuming the engine callbacks and allow a new dialog
+                    // to be created with the updated data.
+                    promptDialog.feature = null
+                    promptDialog.dismiss()
+                }
+            }
+
             dialog.show(fragmentManager, FRAGMENT_TAG)
             activePrompt = WeakReference(dialog)
 

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
@@ -2255,6 +2255,38 @@ class PromptFeatureTest {
         verify(dialogFragment).dismissAllowingStateLoss()
     }
 
+    @Test
+    fun `WHEN promptRequest is updated THEN the replaced active prompt will be dismissed`() {
+        val feature = spy(
+            PromptFeature(
+                activity = mock(),
+                store = store,
+                fragmentManager = fragmentManager,
+                shareDelegate = mock()
+            ) { }
+        )
+        feature.start()
+
+        val previousPrompt = SingleChoice(
+            choices = arrayOf(),
+            onConfirm = {},
+            onDismiss = {}
+        )
+        val updatedPrompt = SingleChoice(
+            choices = arrayOf(),
+            onConfirm = {},
+            onDismiss = {}
+        )
+        store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, previousPrompt)).joinBlocking()
+
+        val fragment = mock<ChoiceDialogFragment>()
+        whenever(fragment.shouldDismissOnLoad).thenReturn(true)
+        feature.activePrompt = WeakReference(fragment)
+
+        store.dispatch(ContentAction.ReplacePromptRequestAction(tabId, previousPrompt.uid, updatedPrompt)).joinBlocking()
+        verify(fragment).dismiss()
+    }
+
     private fun mockFragmentManager(): FragmentManager {
         val fragmentManager: FragmentManager = mock()
         val transaction: FragmentTransaction = mock()


### PR DESCRIPTION
Add support for `onPromptUpdate` and handle `ChoicePrompt` updates.
Fixes Fenix [24145](https://github.com/mozilla-mobile/fenix/issues/24145).

Behavior can be tested using [this site](https://codepen.io/alexp7777/pen/xxYqQoX) which uses the code originally submitted in the Fenix issue.

https://user-images.githubusercontent.com/35462038/169828394-7998b16e-dcf6-4675-a500-d1b4fe5f82e0.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
