### PR TITLE
For #12258 - Retry deleting Pocket profile if initially failed

### DIFF
--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/update/DeleteSpocsProfileWorker.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/update/DeleteSpocsProfileWorker.kt
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket.update
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import mozilla.components.service.pocket.GlobalDependencyProvider
+
+/**
+ * WorkManager Worker used for deleting the profile used for downloading Pocket sponsored stories.
+ */
+internal class DeleteSpocsProfileWorker(
+    context: Context,
+    params: WorkerParameters
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        return withContext(Dispatchers.IO) {
+            if (GlobalDependencyProvider.SponsoredStories.useCases?.deleteProfile?.invoke() == true) {
+                Result.success()
+            } else {
+                Result.retry()
+            }
+        }
+    }
+
+    internal companion object {
+        const val DELETE_SPOCS_PROFILE_WORK_TAG =
+            "mozilla.components.feature.pocket.spocs.profile.delete.work.tag"
+    }
+}

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketStoriesServiceTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketStoriesServiceTest.kt
@@ -12,7 +12,6 @@ import mozilla.components.service.pocket.PocketStory.PocketRecommendedStory
 import mozilla.components.service.pocket.PocketStory.PocketSponsoredStory
 import mozilla.components.service.pocket.helpers.assertConstructorsVisibility
 import mozilla.components.service.pocket.spocs.SpocsUseCases
-import mozilla.components.service.pocket.spocs.SpocsUseCases.DeleteProfile
 import mozilla.components.service.pocket.spocs.SpocsUseCases.GetSponsoredStories
 import mozilla.components.service.pocket.spocs.SpocsUseCases.RecordImpression
 import mozilla.components.service.pocket.stories.PocketStoriesUseCases
@@ -23,7 +22,6 @@ import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -31,8 +29,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
-import org.mockito.Mockito.spy
-import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import java.util.UUID
 import kotlin.reflect.KVisibility
@@ -77,7 +73,7 @@ class PocketStoriesServiceTest {
     }
 
     @Test
-    fun `GIVEN PocketStoriesService is initialized with a valid profile WHEN called to start periodic refreshes THEN persist dependencies and schedule stories refresh`() {
+    fun `GIVEN PocketStoriesService is initialized with a valid profile WHEN called to start periodic refreshes THEN persist dependencies, cancel profile deletion and schedule stories refresh`() {
         val client: Client = mock()
         val profileId = UUID.randomUUID()
         val appId = "test"
@@ -97,6 +93,7 @@ class PocketStoriesServiceTest {
         service.startPeriodicSponsoredStoriesRefresh()
 
         assertNotNull(GlobalDependencyProvider.SponsoredStories.useCases)
+        verify(service.spocsRefreshscheduler).stopProfileDeletion(any())
         verify(service.spocsRefreshscheduler).schedulePeriodicRefreshes(any())
     }
 
@@ -119,7 +116,7 @@ class PocketStoriesServiceTest {
     }
 
     @Test
-    fun `GIVEN PocketStoriesService WHEN called to stop periodic refreshes THEN stop refreshing stories and clear dependencies`() {
+    fun `GIVEN PocketStoriesService WHEN called to stop periodic refreshes THEN stop refreshing stories`() {
         // Mock periodic refreshes were started previously and profile details were set.
         // Now they will have to be cleaned.
         GlobalDependencyProvider.SponsoredStories.initialize(mock())
@@ -128,7 +125,6 @@ class PocketStoriesServiceTest {
         service.stopPeriodicSponsoredStoriesRefresh()
 
         verify(service.spocsRefreshscheduler).stopPeriodicRefreshes(any())
-        assertNull(GlobalDependencyProvider.SponsoredStories.useCases)
     }
 
     @Test
@@ -168,17 +164,46 @@ class PocketStoriesServiceTest {
     }
 
     @Test
-    fun `GIVEN PocketStoriesService WHEN deleteProfile THEN delegate to spocs useCases`() = runTest {
-        val mockedService = spy(service)
-        val noProfileResponse = mockedService.deleteProfile()
-        assertFalse(noProfileResponse)
+    fun `GIVEN PocketStoriesService is initialized with a valid profile WHEN called to delete profile THEN persist dependencies, cancel stories refresh and schedule profile deletion`() {
+        val client: Client = mock()
+        val profileId = UUID.randomUUID()
+        val appId = "test"
+        val service = PocketStoriesService(
+            context = testContext,
+            pocketStoriesConfig = PocketStoriesConfig(
+                client = client,
+                profile = Profile(
+                    profileId = profileId,
+                    appId = appId
+                )
+            )
+        ).apply {
+            spocsRefreshscheduler = mock()
+        }
 
-        val deleteProfileUseCase: DeleteProfile = mock()
-        doReturn(deleteProfileUseCase).`when`(spocsUseCases).deleteProfile
-        doReturn(true).`when`(deleteProfileUseCase).invoke()
-        val existingProfileResponse = mockedService.deleteProfile()
-        assertTrue(existingProfileResponse)
-        verify(mockedService, times(2)).stopPeriodicSponsoredStoriesRefresh()
+        service.deleteProfile()
+
+        assertNotNull(GlobalDependencyProvider.SponsoredStories.useCases)
+        verify(service.spocsRefreshscheduler).stopPeriodicRefreshes(any())
+        verify(service.spocsRefreshscheduler).scheduleProfileDeletion(any())
+    }
+
+    @Test
+    fun `GIVEN PocketStoriesService is initialized with an invalid profile WHEN called to delete profile THEN don't schedule profile deletion and don't persist dependencies`() {
+        val service = PocketStoriesService(
+            context = testContext,
+            pocketStoriesConfig = PocketStoriesConfig(
+                client = mock(),
+                profile = null
+            )
+        ).apply {
+            spocsRefreshscheduler = mock()
+        }
+
+        service.deleteProfile()
+
+        verify(service.spocsRefreshscheduler, never()).scheduleProfileDeletion(any())
+        assertNull(GlobalDependencyProvider.SponsoredStories.useCases)
     }
 
     @Test

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/update/DeleteSpocsProfileWorkerTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/update/DeleteSpocsProfileWorkerTest.kt
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket.update
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.ListenableWorker.Result
+import androidx.work.await
+import androidx.work.testing.TestListenableWorkerBuilder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import mozilla.components.service.pocket.GlobalDependencyProvider
+import mozilla.components.service.pocket.helpers.assertClassVisibility
+import mozilla.components.service.pocket.spocs.SpocsUseCases
+import mozilla.components.service.pocket.spocs.SpocsUseCases.DeleteProfile
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doReturn
+import kotlin.reflect.KVisibility.INTERNAL
+
+@ExperimentalCoroutinesApi // for runTestOnMain
+@RunWith(AndroidJUnit4::class)
+class DeleteSpocsProfileWorkerTest {
+    @get:Rule
+    val mainCoroutineRule = MainCoroutineRule()
+
+    @Test
+    fun `GIVEN a DeleteSpocsProfileWorker THEN its visibility is internal`() {
+        assertClassVisibility(RefreshSpocsWorker::class, INTERNAL)
+    }
+
+    @Test
+    fun `GIVEN a DeleteSpocsProfileWorker WHEN profile deletion is successful THEN return success`() = runTestOnMain {
+        val useCases: SpocsUseCases = mock()
+        val deleteProfileUseCase: DeleteProfile = mock()
+        doReturn(true).`when`(deleteProfileUseCase).invoke()
+        doReturn(deleteProfileUseCase).`when`(useCases).deleteProfile
+        GlobalDependencyProvider.SponsoredStories.initialize(useCases)
+        val worker = TestListenableWorkerBuilder<DeleteSpocsProfileWorker>(testContext).build()
+
+        val result = worker.startWork().await()
+
+        assertEquals(Result.success(), result)
+    }
+
+    @Test
+    fun `GIVEN a DeleteSpocsProfileWorker WHEN profile deletion fails THEN work should be retried`() = runTestOnMain {
+        val useCases: SpocsUseCases = mock()
+        val deleteProfileUseCase: DeleteProfile = mock()
+        doReturn(false).`when`(deleteProfileUseCase).invoke()
+        doReturn(deleteProfileUseCase).`when`(useCases).deleteProfile
+        GlobalDependencyProvider.SponsoredStories.initialize(useCases)
+        val worker = TestListenableWorkerBuilder<DeleteSpocsProfileWorker>(testContext).build()
+
+        val result = worker.startWork().await()
+
+        assertEquals(Result.retry(), result)
+    }
+}

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/update/SpocsRefreshSchedulerTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/update/SpocsRefreshSchedulerTest.kt
@@ -5,24 +5,30 @@
 package mozilla.components.service.pocket.update
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.BackoffPolicy
 import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.service.pocket.PocketStoriesConfig
 import mozilla.components.service.pocket.helpers.assertClassVisibility
+import mozilla.components.service.pocket.update.DeleteSpocsProfileWorker.Companion.DELETE_SPOCS_PROFILE_WORK_TAG
 import mozilla.components.service.pocket.update.RefreshSpocsWorker.Companion.REFRESH_SPOCS_WORK_TAG
 import mozilla.components.support.base.worker.Frequency
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import java.util.concurrent.TimeUnit
@@ -31,12 +37,12 @@ import kotlin.reflect.KVisibility
 @RunWith(AndroidJUnit4::class)
 class SpocsRefreshSchedulerTest {
     @Test
-    fun `GIVEN a SpocsRefreshScheduler THEN its visibility is internal`() {
+    fun `GIVEN a spocs refresh scheduler THEN its visibility is internal`() {
         assertClassVisibility(SpocsRefreshScheduler::class, KVisibility.INTERNAL)
     }
 
     @Test
-    fun `GIVEN a SpocsRefreshScheduler WHEN schedulePeriodicRefreshes THEN a RefreshPocketWorker is created and enqueued`() {
+    fun `GIVEN a spocs refresh scheduler WHEN scheduling stories refresh THEN a RefreshPocketWorker is created and enqueued`() {
         val client: HttpURLConnectionClient = mock()
         val scheduler = spy(
             SpocsRefreshScheduler(
@@ -48,7 +54,7 @@ class SpocsRefreshSchedulerTest {
         val workManager = mock<WorkManager>()
         val worker = mock<PeriodicWorkRequest>()
         doReturn(workManager).`when`(scheduler).getWorkManager(any())
-        doReturn(worker).`when`(scheduler).createPeriodicWorkerRequest(any())
+        doReturn(worker).`when`(scheduler).createPeriodicRefreshWorkerRequest(any())
 
         scheduler.schedulePeriodicRefreshes(testContext)
 
@@ -56,7 +62,7 @@ class SpocsRefreshSchedulerTest {
     }
 
     @Test
-    fun `GIVEN a SpocsRefreshScheduler WHEN stopPeriodicRefreshes THEN it should cancel all unfinished work`() {
+    fun `GIVEN a spocs refresh scheduler WHEN stopping stories refresh THEN it should cancel all unfinished work`() {
         val scheduler = spy(SpocsRefreshScheduler(mock()))
         val workManager = mock<WorkManager>()
         doReturn(workManager).`when`(scheduler).getWorkManager(any())
@@ -68,10 +74,42 @@ class SpocsRefreshSchedulerTest {
     }
 
     @Test
-    fun `GIVEN a SpocsRefreshScheduler WHEN createPeriodicWorkerRequest THEN a properly configured PeriodicWorkRequest is returned`() {
+    fun `GIVEN a spocs refresh scheduler WHEN scheduling profile deletion THEN a RefreshPocketWorker is created and enqueued`() {
+        val client: HttpURLConnectionClient = mock()
+        val scheduler = spy(
+            SpocsRefreshScheduler(
+                PocketStoriesConfig(
+                    client, Frequency(1, TimeUnit.HOURS)
+                )
+            )
+        )
+        val workManager = mock<WorkManager>()
+        val worker = mock<OneTimeWorkRequest>()
+        doReturn(workManager).`when`(scheduler).getWorkManager(any())
+        doReturn(worker).`when`(scheduler).createOneTimeProfileDeletionWorkerRequest()
+
+        scheduler.scheduleProfileDeletion(testContext)
+
+        verify(workManager).enqueueUniqueWork(DELETE_SPOCS_PROFILE_WORK_TAG, ExistingWorkPolicy.KEEP, worker)
+    }
+
+    @Test
+    fun `GIVEN a spocs refresh scheduler WHEN cancelling profile deletion THEN it should cancel all unfinished work`() {
+        val scheduler = spy(SpocsRefreshScheduler(mock()))
+        val workManager = mock<WorkManager>()
+        doReturn(workManager).`when`(scheduler).getWorkManager(any())
+
+        scheduler.stopProfileDeletion(testContext)
+
+        verify(workManager).cancelAllWorkByTag(DELETE_SPOCS_PROFILE_WORK_TAG)
+        verify(workManager, never()).cancelAllWork()
+    }
+
+    @Test
+    fun `GIVEN a spocs refresh scheduler WHEN creating a periodic worker THEN a properly configured PeriodicWorkRequest is returned`() {
         val scheduler = spy(SpocsRefreshScheduler(mock()))
 
-        val result = scheduler.createPeriodicWorkerRequest(
+        val result = scheduler.createPeriodicRefreshWorkerRequest(
             Frequency(1, TimeUnit.HOURS)
         )
 
@@ -87,7 +125,26 @@ class SpocsRefreshSchedulerTest {
     }
 
     @Test
-    fun `GIVEN SpocsRefreshScheduler THEN Worker constraints should be to have Internet`() {
+    fun `GIVEN a spocs refresh scheduler WHEN creating a one time worker THEN a properly configured OneTimeWorkRequest is returned`() {
+        val scheduler = spy(SpocsRefreshScheduler(mock()))
+
+        val result = scheduler.createOneTimeProfileDeletionWorkerRequest()
+
+        verify(scheduler).getWorkerConstrains()
+        assertEquals(0, result.workSpec.intervalDuration)
+        assertEquals(0, result.workSpec.initialDelay)
+        assertEquals(BackoffPolicy.EXPONENTIAL, result.workSpec.backoffPolicy)
+        assertFalse(result.workSpec.constraints.requiresBatteryNotLow())
+        assertFalse(result.workSpec.constraints.requiresCharging())
+        assertFalse(result.workSpec.constraints.hasContentUriTriggers())
+        assertFalse(result.workSpec.constraints.requiresStorageNotLow())
+        assertFalse(result.workSpec.constraints.requiresDeviceIdle())
+        assertTrue(result.workSpec.constraints.requiredNetworkType == NetworkType.CONNECTED)
+        assertTrue(result.tags.contains(DELETE_SPOCS_PROFILE_WORK_TAG))
+    }
+
+    @Test
+    fun `GIVEN a spocs refresh scheduler THEN Worker constraints should be to have Internet`() {
         val scheduler = SpocsRefreshScheduler(mock())
 
         val result = scheduler.getWorkerConstrains()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **service-pocket**
+  * Ensure sponsored stories profile deletion is retried in background until successful or the feature is re-enabled. [#12258](https://github.com/mozilla-mobile/android-components/issues/12258)
+
 * **feature-prompts**:
   * Added optional `addressPickerView` and `onManageAddresses` parameters through `AddressDelegate` to `PromptFeature` for a new `AddressPicker` to display a view for selecting addresses to autofill into a site. [#12061](https://github.com/mozilla-mobile/android-components/issues/12061)
 


### PR DESCRIPTION
It's important to ensure the profile is deleted when the sponsored stories
feature is disabled but since this involves a network call which may fail we
need to support retrying a previous failed request until profile deletion is
successful or the sponsored stories functionality is started again.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
