### PR TITLE
Close #12143: Fix intermittent failing tests in PromptFeatureTest

### DIFF
--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
@@ -2096,7 +2096,9 @@ class PromptFeatureTest {
         val feature = PromptFeature(
             activity = mock(),
             store = store,
-            fragmentManager = fragmentManager
+            fragmentManager = fragmentManager,
+            isCreditCardAutofillEnabled = { true },
+            creditCardValidationDelegate = mock()
         ) { }
         val creditCardEntry = CreditCardEntry(
             guid = "1",


### PR DESCRIPTION
This particular test does not care about the effects when starting the
feature, so instead of trying to make those async effects into sync, we
can just disable them for the test.

It does show that there is a flaw in the logic of the feature which is a
discussion that can continue on the linked issue instead.

Co-authored-by: Christian Sadilek

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
