### PR TITLE
For #12298:  App should not be locked in landscape when a tab or custom tab loads while in pip mode

### DIFF
--- a/components/feature/media/src/main/java/mozilla/components/feature/media/fullscreen/MediaSessionFullscreenFeature.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/fullscreen/MediaSessionFullscreenFeature.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
+import mozilla.components.browser.state.selector.findCustomTabOrSelectedTab
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.lib.state.ext.flowScoped
@@ -22,7 +23,8 @@ import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
  */
 class MediaSessionFullscreenFeature(
     private val activity: Activity,
-    private val store: BrowserStore
+    private val store: BrowserStore,
+    private val tabId: String?,
 ) : LifecycleAwareFeature {
 
     private var scope: CoroutineScope? = null
@@ -48,7 +50,7 @@ class MediaSessionFullscreenFeature(
             return
         }
 
-        if (store.state.selectedTabId == activeState.id) {
+        if (store.state.findCustomTabOrSelectedTab(tabId)?.id == activeState.id) {
             when (activeState.mediaSessionState?.elementMetadata?.portrait) {
                 true ->
                     activity.requestedOrientation =

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/fullscreen/MediaSessionFullscreenFeatureTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/fullscreen/MediaSessionFullscreenFeatureTest.kt
@@ -9,17 +9,22 @@ import android.content.pm.ActivityInfo
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.state.action.ContentAction
+import mozilla.components.browser.state.action.CustomTabListAction
 import mozilla.components.browser.state.action.MediaSessionAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.MediaSessionState
+import mozilla.components.browser.state.state.SessionState
+import mozilla.components.browser.state.state.createCustomTab
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.mediasession.MediaSession
+import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -55,7 +60,8 @@ class MediaSessionFullscreenFeatureTest {
         val store = BrowserStore(initialState)
         val feature = MediaSessionFullscreenFeature(
             activity,
-            store
+            store,
+            null
         )
 
         feature.start()
@@ -84,7 +90,8 @@ class MediaSessionFullscreenFeatureTest {
         val store = BrowserStore(initialState)
         val feature = MediaSessionFullscreenFeature(
             activity,
-            store
+            store,
+            null
         )
 
         feature.start()
@@ -113,7 +120,8 @@ class MediaSessionFullscreenFeatureTest {
         val store = BrowserStore(initialState)
         val feature = MediaSessionFullscreenFeature(
             activity,
-            store
+            store,
+            null
         )
 
         feature.start()
@@ -144,7 +152,8 @@ class MediaSessionFullscreenFeatureTest {
         val store = BrowserStore(initialState)
         val feature = MediaSessionFullscreenFeature(
             activity,
-            store
+            store,
+            null
         )
 
         feature.start()
@@ -181,7 +190,8 @@ class MediaSessionFullscreenFeatureTest {
         val store = BrowserStore(initialState)
         val feature = MediaSessionFullscreenFeature(
             activity,
-            store
+            store,
+            null
         )
 
         feature.start()
@@ -230,7 +240,8 @@ class MediaSessionFullscreenFeatureTest {
         val store = BrowserStore(initialState)
         val feature = MediaSessionFullscreenFeature(
             activity,
-            store
+            store,
+            null
         )
 
         feature.start()
@@ -253,5 +264,60 @@ class MediaSessionFullscreenFeatureTest {
         store.waitUntilIdle()
 
         assertEquals(ActivityInfo.SCREEN_ORIENTATION_USER, activity.requestedOrientation)
+    }
+
+    @Suppress("Deprecation")
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.N])
+    fun `GIVEN the currently selected tab is in pip mode WHEN a custom tab loads THEN display custom tab in device's current orientation`() {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val elementMetadata = MediaSession.ElementMetadata()
+        val initialState = BrowserState(
+            tabs = listOf(
+                createTab(
+                    "https://www.mozilla.org", id = "tab1",
+                    mediaSessionState = MediaSessionState(
+                        mock(),
+                        elementMetadata = elementMetadata,
+                        playbackState = MediaSession.PlaybackState.PLAYING,
+                        fullscreen = true
+                    )
+                )
+            ),
+            selectedTabId = "tab1"
+        )
+        val store = BrowserStore(initialState)
+
+        val feature = MediaSessionFullscreenFeature(
+            activity,
+            store,
+            null
+        )
+
+        feature.start()
+        activity.enterPictureInPictureMode()
+        store.waitUntilIdle()
+
+        store.dispatch(ContentAction.PictureInPictureChangedAction("tab1", true))
+        store.waitUntilIdle()
+        assertEquals(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED, activity.requestedOrientation)
+
+        val customTab = createCustomTab(
+            "https://www.mozilla.org",
+            source = SessionState.Source.Internal.CustomTab,
+            id = "tab2"
+        )
+        store.dispatch(CustomTabListAction.AddCustomTabAction(customTab)).joinBlocking()
+        val externalActivity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        assertEquals(1, store.state.customTabs.size)
+        store.waitUntilIdle()
+        val featureForExternalAppBrowser = MediaSessionFullscreenFeature(
+            externalActivity,
+            store,
+            "tab2"
+        )
+        featureForExternalAppBrowser.start()
+
+        assertNotEquals(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE, externalActivity.requestedOrientation)
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **feature-media**
+  *  App should not be locked in landscape when a tab or custom tab loads while in pip mode. [#12298] (https://github.com/mozilla-mobile/android-components/issues/12298)
+
 * **browser-toolbar**
   * Expand toolbar when url changes. [#12215](https://github.com/mozilla-mobile/android-components/issues/12215)
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -121,7 +121,8 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         mediaSessionFullscreenFeature.set(
             feature = MediaSessionFullscreenFeature(
                 requireActivity(),
-                components.store
+                components.store,
+                sessionId
             ),
             owner = this,
             view = binding.root


### PR DESCRIPTION
App should not be locked in landscape while in pip mode when a tab or custom tab loads

This allows a tab or custom tab to be loaded in device's current orientation while pip mode is active

Co-Authored-By: Mugurell <Mugurell@users.noreply.github.com>

https://user-images.githubusercontent.com/12825812/172154727-29e46490-d5e6-46ac-a3bc-cbd74cb14a92.mp4

@Mugurell, this check will ensure that the orientation will be applied only for the tab or the custom tab that have the corresponding active media state which is being filtered in the flow. 
   https://github.com/indurs/android-components/blob/issuefix25413/components/feature/media/src/main/java/mozilla/components/feature/media/fullscreen/MediaSessionFullscreenFeature.kt#L53

We need to pass the customTabSessionId (if there is one otherwise null) to MediaSessionFullscreenFeature.  BaseBrowserFragment in Fenix and Focus has to be updated to pass the customTabSessionId  to MediaSessionFullscreenFeature.

Please let me know if I've missed anything.

I've also tested for the following scenarios while in pip mode
Search widget, Home Shortcut, Focus share, links






### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
