### PR TITLE
Revert "for #11990 - The Play/Pause button remains displayed on the media notification"

### DIFF
--- a/components/feature/media/src/main/java/mozilla/components/feature/media/service/MediaSessionServiceDelegate.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/service/MediaSessionServiceDelegate.kt
@@ -104,7 +104,7 @@ internal class MediaSessionServiceDelegate(
 
         when (intent?.action) {
             AbstractMediaSessionService.ACTION_LAUNCH -> {
-                startForegroundNotificationIfNeeded()
+                startForegroundNotification()
             }
             AbstractMediaSessionService.ACTION_PLAY -> {
                 controller?.play()

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/service/MediaSessionServiceDelegateTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/service/MediaSessionServiceDelegateTest.kt
@@ -153,7 +153,7 @@ class MediaSessionServiceDelegateTest {
                 service::class.java
             )
         )
-        verify(service, times(1)).startForeground(ArgumentMatchers.anyInt(), any())
+        verify(service, times(2)).startForeground(ArgumentMatchers.anyInt(), any())
 
         delegate.onStartCommand(
             AbstractMediaSessionService.launchIntent(
@@ -161,7 +161,7 @@ class MediaSessionServiceDelegateTest {
                 service::class.java
             )
         )
-        verify(service, times(1)).startForeground(ArgumentMatchers.anyInt(), any())
+        verify(service, times(3)).startForeground(ArgumentMatchers.anyInt(), any())
     }
 
     @Test
@@ -269,7 +269,7 @@ class MediaSessionServiceDelegateTest {
             )
         )
 
-        verify(service, times(1)).startForeground(ArgumentMatchers.anyInt(), any())
+        verify(service, times(2)).startForeground(ArgumentMatchers.anyInt(), any())
 
         delegate.onStartCommand(
             AbstractMediaSessionService.pauseIntent(
@@ -279,7 +279,7 @@ class MediaSessionServiceDelegateTest {
         )
         verify(controller).pause()
         mediaSessionCallback.onPause()
-        verify(service, times(1)).startForeground(ArgumentMatchers.anyInt(), any())
+        verify(service, times(2)).startForeground(ArgumentMatchers.anyInt(), any())
 
         mediaSessionCallback.onPlay()
         verify(controller, times(1)).play()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,9 +23,6 @@ permalink: /changelog/
 * **feature-media**
   * Media playback is now paused when AudioManager.ACTION_AUDIO_BECOMING_NOISY is broadcast by the system.
 
-* **feature-media**
-  * The Play/Pause button remains displayed on the media notification  
-
 # 100.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v99.0.0...v100.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/147?closed=1)


### PR DESCRIPTION
This reverts commit a8e3e61a274c39d595df434a3de45eed7a2e1bbd.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
