### PR TITLE
For #12310 - Really catch database exceptions

### DIFF
--- a/components/feature/recentlyclosed/build.gradle
+++ b/components/feature/recentlyclosed/build.gradle
@@ -71,6 +71,11 @@ dependencies {
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.kotlin_coroutines
     testImplementation Dependencies.testing_coroutines
+
+    androidTestImplementation project(':support-test-fakes')
+
+    androidTestImplementation Dependencies.androidx_test_core
+    androidTestImplementation Dependencies.androidx_test_runner
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/recentlyclosed/src/androidTest/java/mozilla/components/feature/recentlyclosed/RecentlyClosedTabsStorageOnDeviceTest.kt
+++ b/components/feature/recentlyclosed/src/androidTest/java/mozilla/components/feature/recentlyclosed/RecentlyClosedTabsStorageOnDeviceTest.kt
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.recentlyclosed
+
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.state.state.recover.RecoverableTab
+import mozilla.components.browser.state.state.recover.TabState
+import mozilla.components.concept.base.crash.Breadcrumb
+import mozilla.components.concept.base.crash.CrashReporting
+import mozilla.components.concept.engine.EngineSessionState
+import mozilla.components.concept.engine.EngineSessionStateStorage
+import mozilla.components.support.test.fakes.engine.FakeEngine
+import mozilla.components.support.test.fakes.engine.FakeEngineSessionState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RecentlyClosedTabsStorageOnDeviceTest {
+    private val engineState = FakeEngineSessionState("testId")
+    private val storage = RecentlyClosedTabsStorage(
+        context = ApplicationProvider.getApplicationContext(),
+        engine = FakeEngine(),
+        crashReporting = FakeCrashReporting(),
+        engineStateStorage = FakeEngineSessionStateStorage()
+    )
+
+    @Test
+    fun testRowTooBigExceptionCaughtAndStorageCleared() = runBlocking {
+        val closedTab1 = RecoverableTab(
+            engineSessionState = engineState,
+            state = TabState(
+                id = "test",
+                title = "Pocket",
+                url = "test",
+                lastAccess = System.currentTimeMillis()
+            )
+        )
+        val closedTab2 = closedTab1.copy(
+            state = closedTab1.state.copy(
+                url = "test".repeat(1_000_000), // much more than 2MB of data. Just to be sure.
+            )
+        )
+
+        // First check what happens if too large tabs are persisted and then asked for
+        storage.addTabsToCollectionWithMax(listOf(closedTab1, closedTab2), 2)
+        assertFalse((storage.engineStateStorage() as FakeEngineSessionStateStorage).data.isEmpty())
+        val corruptedTabsResult = storage.getTabs().first()
+        assertTrue(corruptedTabsResult.isEmpty())
+        assertTrue((storage.engineStateStorage() as FakeEngineSessionStateStorage).data.isEmpty())
+
+        // Then check that new data is persisted and queried successfully
+        val closedTab3 = RecoverableTab(
+            engineSessionState = engineState,
+            state = TabState(
+                id = "test2",
+                title = "Pocket2",
+                url = "test2",
+                lastAccess = System.currentTimeMillis()
+            )
+        )
+        storage.addTabState(closedTab3)
+        val recentlyClosedTabsResult = storage.getTabs().first()
+        assertEquals(listOf(closedTab3.state), recentlyClosedTabsResult)
+        assertEquals(1, (storage.engineStateStorage() as FakeEngineSessionStateStorage).data.size)
+    }
+}
+
+private class FakeCrashReporting : CrashReporting {
+    override fun submitCaughtException(throwable: Throwable): Job {
+        return MainScope().launch {}
+    }
+
+    override fun recordCrashBreadcrumb(breadcrumb: Breadcrumb) {}
+}
+
+private class FakeEngineSessionStateStorage : EngineSessionStateStorage {
+    val data: MutableMap<String, EngineSessionState?> = mutableMapOf()
+
+    override suspend fun write(uuid: String, state: EngineSessionState): Boolean {
+        data[uuid] = state
+        return true
+    }
+
+    override suspend fun read(uuid: String): EngineSessionState? {
+        return data[uuid]
+    }
+
+    override suspend fun delete(uuid: String) {
+        data.remove(uuid)
+    }
+
+    override suspend fun deleteAll() {
+        data.clear()
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **feature-recentlyclosed**
+  * 🚒 Bug fixed [issue #12310](https://github.com/mozilla-mobile/android-components/issues/12310) - Catch all database exceptions thrown when querying recently closed tabs and clean the storage for corrupted data.
+
 * **feature-media**
   *  App should not be locked in landscape when a tab or custom tab loads while in pip mode. [#12298] (https://github.com/mozilla-mobile/android-components/issues/12298)
 


### PR DESCRIPTION
Using a UI test to validate the functionality was needed since the
SQLiteBlobTooBigException was not being thrown for an in-memory database used
in unit tests.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
