### PR TITLE
Issue #12348 - Pass the full name to the Autocomplete.Address.Builder

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/ext/Address.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/ext/Address.kt
@@ -31,6 +31,7 @@ fun Autocomplete.Address.toAddress() = Address(
  */
 fun Address.toAutocompleteAddress() = Autocomplete.Address.Builder()
     .guid(guid)
+    .name(fullName)
     .givenName(givenName)
     .additionalName(additionalName)
     .familyName(familyName)

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
@@ -362,7 +362,17 @@ data class Address(
     val timeLastUsed: Long? = 0L,
     val timeLastModified: Long = 0L,
     val timesUsed: Long = 0L
-) : Parcelable
+) : Parcelable {
+    /**
+     * Returns the full name for the [Address]. The combination of names is based on desktop code
+     * found here:
+     * https://searchfox.org/mozilla-central/rev/d989c65584ded72c2de85cb40bede7ac2f176387/toolkit/components/formautofill/FormAutofillNameUtils.jsm#400
+     */
+    val fullName: String
+        get() = listOf(givenName, additionalName, familyName)
+            .filter { it.isNotEmpty() }
+            .joinToString(" ")
+}
 
 /**
  * Information about a new address. This is what you pass to create or update an address.

--- a/components/concept/storage/src/test/java/mozilla/components/concept/storage/AddressTest.kt
+++ b/components/concept/storage/src/test/java/mozilla/components/concept/storage/AddressTest.kt
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.storage
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AddressTest {
+
+    @Test
+    fun `WHEN all name fields are populated THEN full name includes all names`() {
+        val address = generateAddress()
+        val fullName = address.fullName
+
+        assertEquals(
+            "${address.givenName} ${address.additionalName} ${address.familyName}",
+            fullName
+        )
+    }
+
+    @Test
+    fun `WHEN additional name is missing THEN full name is given and family name combined`() {
+        val address = generateAddress(additionalName = "")
+        val fullName = address.fullName
+
+        assertEquals("${address.givenName} ${address.familyName}", fullName)
+    }
+
+    @Test
+    fun `WHEN only additional and family name are available THEN full name is additional and family name combined`() {
+        val address = generateAddress(givenName = "")
+        val fullName = address.fullName
+
+        assertEquals("${address.additionalName} ${address.familyName}", fullName)
+    }
+
+    @Test
+    fun `WHEN only family name is available THEN full name is family name`() {
+        val address = generateAddress(givenName = "", additionalName = "")
+        val fullName = address.fullName
+
+        assertEquals(address.familyName, fullName)
+    }
+
+    private fun generateAddress(
+        guid: String = "",
+        givenName: String = "Firefox",
+        additionalName: String = "The",
+        familyName: String = "Browser",
+        organization: String = "Mozilla",
+        streetAddress: String = "street",
+        addressLevel3: String = "3",
+        addressLevel2: String = "2",
+        addressLevel1: String = "1",
+        postalCode: String = "code",
+        country: String = "country",
+        tel: String = "tel",
+        email: String = "email",
+    ) = Address(
+        guid = guid,
+        givenName = givenName,
+        additionalName = additionalName,
+        familyName = familyName,
+        organization = organization,
+        streetAddress = streetAddress,
+        addressLevel3 = addressLevel3,
+        addressLevel2 = addressLevel2,
+        addressLevel1 = addressLevel1,
+        postalCode = postalCode,
+        country = country,
+        tel = tel,
+        email = email,
+    )
+}


### PR DESCRIPTION
Fixes #12348
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
