### PR TITLE
Bug 1774550 - Use patched Glean Gradle plugin to fix Windows build issues

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -33,6 +33,9 @@ object Versions {
     const val mozilla_appservices = "93.5.0"
 
     const val mozilla_glean = "50.1.0"
+    // FIXME(bug 1775073): Hack to deploy a tiny bug fix without requiring a full Glean update
+    // Will be removed with the next update again.
+    const val mozilla_glean_plugin = "50.1.1"
 
     const val material = "1.2.1"
 

--- a/components/browser/engine-gecko/build.gradle
+++ b/components/browser/engine-gecko/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
 
         dependencies {
-            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean}"
+            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean_plugin}"
         }
     }
 }

--- a/components/lib/crash/build.gradle
+++ b/components/lib/crash/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
 
         dependencies {
-            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean}"
+            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean_plugin}"
         }
     }
 }

--- a/components/support/migration/build.gradle
+++ b/components/support/migration/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
 
         dependencies {
-            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean}"
+            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean_plugin}"
         }
     }
 }

--- a/components/support/sync-telemetry/build.gradle
+++ b/components/support/sync-telemetry/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
 
         dependencies {
-            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean}"
+            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean_plugin}"
         }
     }
 }

--- a/components/tooling/glean-gradle-plugin/build.gradle
+++ b/components/tooling/glean-gradle-plugin/build.gradle
@@ -23,7 +23,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 dependencies {
     implementation gradleApi()
     implementation localGroovy()
-    implementation "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean}"
+    implementation "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean_plugin}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 

--- a/samples/glean/build.gradle
+++ b/samples/glean/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
 
         dependencies {
-            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean}"
+            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean_plugin}"
         }
     }
 }

--- a/samples/glean/samples-glean-library/build.gradle
+++ b/samples/glean/samples-glean-library/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
 
         dependencies {
-            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean}"
+            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean_plugin}"
         }
     }
 }


### PR DESCRIPTION
The plugin has a single small change:
https://github.com/mozilla/glean/commit/1c9577144a9e0a3f960bf1e47b246c527585da4a

--- 
Releasing Glean takes a bit more time and requires us to update in m-c first.
We can for now just pick the plugin update here to unblock Windows builds.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
