### PR TITLE
Issue #12365 - Return an address label based on the available address properties

### DIFF
--- a/components/concept/storage/build.gradle
+++ b/components/concept/storage/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     api Dependencies.kotlin_coroutines
 
     implementation project(':support-ktx')
+    implementation Dependencies.androidx_annotation
 
     testImplementation project(':support-test')
     testImplementation Dependencies.testing_junit

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/CreditCardsAddressesStorage.kt
@@ -6,6 +6,7 @@ package mozilla.components.concept.storage
 
 import android.annotation.SuppressLint
 import android.os.Parcelable
+import androidx.annotation.VisibleForTesting
 import kotlinx.parcelize.Parcelize
 import mozilla.components.concept.storage.CreditCard.Companion.ellipsesEnd
 import mozilla.components.concept.storage.CreditCard.Companion.ellipsesStart
@@ -372,6 +373,30 @@ data class Address(
         get() = listOf(givenName, additionalName, familyName)
             .filter { it.isNotEmpty() }
             .joinToString(" ")
+
+    /**
+     * Returns a label for the [Address]. The ordering is based on the
+     * priorities defined by the desktop code found here:
+     * https://searchfox.org/mozilla-central/rev/d989c65584ded72c2de85cb40bede7ac2f176387/toolkit/components/formautofill/FormAutofillUtils.jsm#323
+     */
+    val addressLabel: String
+        get() = listOf(
+            streetAddress.toOneLineAddress(),
+            addressLevel3,
+            addressLevel2,
+            organization,
+            addressLevel1,
+            country,
+            postalCode,
+            tel,
+            email
+        ).filter { it.isNotEmpty() }.joinToString(", ")
+
+    companion object {
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        internal fun String.toOneLineAddress(): String =
+            this.split("\n").joinToString(separator = " ") { it.trim() }
+    }
 }
 
 /**

--- a/components/concept/storage/src/test/java/mozilla/components/concept/storage/AddressTest.kt
+++ b/components/concept/storage/src/test/java/mozilla/components/concept/storage/AddressTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.concept.storage
 
+import mozilla.components.concept.storage.Address.Companion.toOneLineAddress
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -42,6 +43,62 @@ class AddressTest {
         val fullName = address.fullName
 
         assertEquals(address.familyName, fullName)
+    }
+
+    @Test
+    fun `WHEN all address properties are present THEN full address present in label`() {
+        val address = generateAddress()
+        val expected =
+            "${address.streetAddress}, ${address.addressLevel3}, ${address.addressLevel2}, " +
+                "${address.organization}, ${address.addressLevel1}, ${address.country}, " +
+                "${address.postalCode}, ${address.tel}, ${address.email}"
+
+        assertEquals(expected, address.addressLabel)
+    }
+
+    @Test
+    fun `WHEN any address properties are missing THEN label only includes only properties that are available`() {
+        val address = generateAddress(
+            addressLevel3 = "",
+            organization = "",
+            email = "",
+        )
+        val expected =
+            "${address.streetAddress}, ${address.addressLevel2}, ${address.addressLevel1}, " +
+                "${address.country}, ${address.postalCode}, ${address.tel}"
+
+        assertEquals(expected, address.addressLabel)
+    }
+
+    @Test
+    fun `WHEN no address properties are present THEN label is the empty string`() {
+        val address = generateAddress(
+            givenName = "",
+            additionalName = "",
+            familyName = "",
+            organization = "",
+            streetAddress = "",
+            addressLevel3 = "",
+            addressLevel2 = "",
+            addressLevel1 = "",
+            postalCode = "",
+            country = "",
+            tel = "",
+            email = ""
+        )
+
+        assertEquals("", address.addressLabel)
+    }
+
+    @Test
+    fun `GIVEN multiline street address WHEN one line address is called THEN an one line address is returned`() {
+        val streetAddress = """
+            line1
+            line2
+            line3
+        """.trimIndent()
+
+        assertEquals("line1 line2 line3", streetAddress.toOneLineAddress())
     }
 
     private fun generateAddress(

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/address/AddressAdapter.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/address/AddressAdapter.kt
@@ -59,16 +59,10 @@ internal class AddressViewHolder(
 
     fun bind(address: Address) {
         this.address = address
-        itemView.findViewById<TextView>(R.id.address_name)?.text = address.displayFormat()
+        itemView.findViewById<TextView>(R.id.address_name)?.text = address.addressLabel
     }
 
     override fun onClick(v: View?) {
         onAddressSelected(address)
     }
 }
-
-/**
- * Format the address details to be displayed to the user.
- */
-fun Address.displayFormat(): String =
-    "${this.streetAddress}, ${this.addressLevel2}, ${this.addressLevel1}, ${this.postalCode}"

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/address/AddressAdapterTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/address/AddressAdapterTest.kt
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package mozilla.components.feature.prompts.address
 
@@ -56,19 +59,21 @@ class AddressAdapterTest {
     @Test
     fun `WHEN an address is bound to the adapter THEN set the address display name`() {
         val view =
-            LayoutInflater.from(testContext).inflate(R.layout.mozac_feature_prompts_address_list_item, null)
+            LayoutInflater.from(testContext)
+                .inflate(R.layout.mozac_feature_prompts_address_list_item, null)
         val addressName: TextView = view.findViewById(R.id.address_name)
 
-        AddressViewHolder(view) {}.bind(address)
+        AddressViewHolder(view, onAddressSelected = {}).bind(address)
 
-        assertEquals(address.displayFormat(), addressName.text)
+        assertEquals(address.addressLabel, addressName.text)
     }
 
     @Test
     fun `WHEN an address item is clicked THEN call the onAddressSelected callback`() {
         var addressSelected = false
         val view =
-            LayoutInflater.from(testContext).inflate(R.layout.mozac_feature_prompts_address_list_item, null)
+            LayoutInflater.from(testContext)
+                .inflate(R.layout.mozac_feature_prompts_address_list_item, null)
         val onAddressSelect: (Address) -> Unit = { addressSelected = true }
 
         AddressViewHolder(view, onAddressSelect).bind(address)


### PR DESCRIPTION
Fixes #12365.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
