### PR TITLE
Display the web content that triggered the app redirect, if the user navigate to the browser through the launcher icon or coming back from the app

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -96,6 +96,8 @@ class GeckoEngineSession(
     internal var currentUrl: String? = null
     internal var lastLoadRequestUri: String? = null
     internal var pageLoadingUrl: String? = null
+    internal var appRedirectUrl: String? = null
+    internal var isLastAppRedirectedUri: Boolean = false
     internal var scrollY: Int = 0
     // The Gecko site permissions for the loaded site.
     internal var geckoPermissions: List<ContentPermission> = emptyList()
@@ -473,6 +475,11 @@ class GeckoEngineSession(
                 return
             }
 
+            if (isLastAppRedirectedUri && url == appRedirectUrl) {
+                goBack(false)
+                return
+            }
+
             currentUrl = url
             initialLoad = false
             initialLoadRequest = null
@@ -589,6 +596,8 @@ class GeckoEngineSession(
                         is InterceptionResponse.Content -> loadData(data, mimeType, encoding)
                         is InterceptionResponse.Url -> loadUrl(url)
                         is InterceptionResponse.AppIntent -> {
+                            isLastAppRedirectedUri = true
+                            appRedirectUrl = lastLoadRequestUri
                             notifyObservers {
                                 onLaunchIntentRequest(url = url, appIntent = appIntent)
                             }
@@ -603,6 +612,8 @@ class GeckoEngineSession(
             }
 
             if (interceptionResponse !is InterceptionResponse.AppIntent) {
+                isLastAppRedirectedUri = false
+                appRedirectUrl = ""
                 lastLoadRequestUri = request.uri
             }
             return interceptionResponse
@@ -691,7 +702,9 @@ class GeckoEngineSession(
             // - non-top level visits (i.e. iframes).
             if (privateMode ||
                 (flags and GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL) == 0 ||
-                (flags and GeckoSession.HistoryDelegate.VISIT_UNRECOVERABLE_ERROR) != 0
+                (flags and GeckoSession.HistoryDelegate.VISIT_UNRECOVERABLE_ERROR) != 0 ||
+                (isLastAppRedirectedUri && url == appRedirectUrl)
+
             ) {
                 return GeckoResult.fromValue(false)
             }
@@ -850,22 +863,24 @@ class GeckoEngineSession(
         }
 
         override fun onTitleChange(session: GeckoSession, title: String?) {
-            if (!privateMode) {
-                currentUrl?.let { url ->
-                    settings.historyTrackingDelegate?.let { delegate ->
-                        if (delegate.shouldStoreUri(url)) {
-                            // NB: There's no guarantee that the title change will be processed by the
-                            // delegate before the session is closed (and the corresponding coroutine
-                            // job is cancelled). Observers will always be notified of the title
-                            // change though.
-                            launch(coroutineContext) {
-                                delegate.onTitleChanged(url, title ?: "")
+            if (!isLastAppRedirectedUri) {
+                if (!privateMode) {
+                    currentUrl?.let { url ->
+                        settings.historyTrackingDelegate?.let { delegate ->
+                            if (delegate.shouldStoreUri(url)) {
+                                // NB: There's no guarantee that the title change will be processed by the
+                                // delegate before the session is closed (and the corresponding coroutine
+                                // job is cancelled). Observers will always be notified of the title
+                                // change though.
+                                launch(coroutineContext) {
+                                    delegate.onTitleChanged(url, title ?: "")
+                                }
                             }
                         }
                     }
                 }
+                notifyObservers { onTitleChange(title ?: "") }
             }
-            notifyObservers { onTitleChange(title ?: "") }
         }
 
         override fun onPreviewImage(session: GeckoSession, previewImageUrl: String) {


### PR DESCRIPTION
Display the web content that triggered the app redirect, if the user navigate to the browser through the launcher icon or coming back from the app

Co-Authored-By: Mugurell <Mugurell@users.noreply.github.com>

Open in App enabled

https://user-images.githubusercontent.com/12825812/177329160-d0728a3b-eb3a-41c6-aa5e-21b0ea87261a.mp4

Open in App disabled

https://user-images.githubusercontent.com/12825812/177329219-9ab1e446-2534-409f-bdfa-3c15086fe55a.mp4




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
