### PR TITLE
Set autoMirrored to true for mozac_ic_arrowhead_right

### DIFF
--- a/components/ui/icons/src/main/res/drawable/mozac_ic_arrowhead_right.xml
+++ b/components/ui/icons/src/main/res/drawable/mozac_ic_arrowhead_right.xml
@@ -6,7 +6,8 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:autoMirrored="true">
     <path android:fillColor="@color/mozac_ui_icons_fill"
         android:pathData="M14.289,12 L7.57,5.28a0.75,0.75 0,1 1,1.061 -1.061l7.37,7.37v0.821l-7.37,7.37a0.748,0.748 0,0 1,-1.061 0,0.75 0.75,0 0,1 0,-1.061L14.289,12z" />
 </vector>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **feature-recentlyclosed**
+  * 🚒 Bug fixed [issue #12470](https://github.com/mozilla-mobile/android-components/issues/12470) - Set autoMirrored to true to fix RTL issues
+
 * **browser-awesomebar**:
   * 🚒 Bug fixed [issue #12469](https://github.com/mozilla-mobile/android-components/issues/12469) Cancel previous queries before new suggestions requests.
 


### PR DESCRIPTION
For #12470
Set autoMirrored to true for mozac_ic_arrowhead_right to fix rtl issues

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

Fixes #12470