### PR TITLE
Don't try to parse migration metrics from importLoginsAsync

### DIFF
--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/LoginsStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/LoginsStorage.kt
@@ -5,7 +5,6 @@
 package mozilla.components.concept.storage
 
 import kotlinx.coroutines.Deferred
-import org.json.JSONObject
 
 /**
  * A login stored in the database
@@ -219,9 +218,8 @@ interface LoginsStorage : AutoCloseable {
      * the same GUID.
      *
      * @param logins A list of [Login] records to be imported.
-     * @return JSON object with detailed information about imported logins.
      */
-    suspend fun importLoginsAsync(logins: List<Login>): JSONObject
+    suspend fun importLoginsAsync(logins: List<Login>)
 
     /**
      * Fetch the list of logins for some origin from the underlying storage layer.

--- a/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/SyncableLoginsStorage.kt
+++ b/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/SyncableLoginsStorage.kt
@@ -20,7 +20,6 @@ import mozilla.components.concept.sync.SyncableStore
 import mozilla.components.lib.dataprotect.SecureAbove22Preferences
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.utils.logElapsedTime
-import org.json.JSONObject
 import java.io.Closeable
 
 // Older database that was encrypted using SQLCipher
@@ -243,8 +242,8 @@ class SyncableLoginsStorage(
      * (IO failure, rust panics, etc).
      */
     @Throws(CryptoException::class, LoginsStorageException::class)
-    override suspend fun importLoginsAsync(logins: List<Login>): JSONObject = withContext(coroutineContext) {
-        JSONObject(conn.getStorage().importMultiple(logins.map { it.toLogin() }, crypto.getOrGenerateKey().key))
+    override suspend fun importLoginsAsync(logins: List<Login>): Unit = withContext(coroutineContext) {
+        conn.getStorage().importMultiple(logins.map { it.toLogin() }, crypto.getOrGenerateKey().key)
     }
 
     /**

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/FennecLoginsMigration.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/FennecLoginsMigration.kt
@@ -155,26 +155,13 @@ internal object FennecLoginsMigration {
             return Result.Failure(LoginMigrationException(LoginsMigrationResult.Failure.GetLoginsThrew(e)))
         }
 
-        val migrationMetrics = try {
-            loginsStorage.importLoginsAsync(fennecRecords.records)
-        } catch (e: Exception) {
-            return Result.Failure(LoginMigrationException(LoginsMigrationResult.Failure.RustImportThrew(e)))
-        }
-
-        // TODO process login migration metrics properly:
-        // See https://github.com/mozilla/application-services/commit/d1a12d98a8c428567a3fff9e4333869b980952a8
-        val failedToImport = try {
-            migrationMetrics.getInt("num_failed")
-        } catch (e: Exception) {
-            crashReporter.submitCaughtException(e)
-            0
-        }
+        loginsStorage.importLoginsAsync(fennecRecords.records)
 
         return Result.Success(
             LoginsMigrationResult.Success.ImportedLoginRecords(
                 totalRecordsDetected = fennecRecords.totalRecordsDetected,
                 failedToProcess = (fennecRecords.totalRecordsDetected - fennecRecords.records.size),
-                failedToImport = failedToImport
+                failedToImport = 0,
             )
         )
     }


### PR DESCRIPTION
A change in AS v93.6.0 made it so the underlying function
`LoginsStore.import_multiple` no longer returns the metrics as a JSON
string string.  Instead it just encodes the unit struct. This was a
breaking change, but it's not listed properly in the CHANGELOG.

The fix is pretty simple: just assume that no logins failed to import.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
