### PR TITLE
Set the same margin to toolbar background for display as for edit

### DIFF
--- a/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_displaytoolbar.xml
+++ b/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_displaytoolbar.xml
@@ -29,6 +29,7 @@
         android:layout_width="0dp"
         android:layout_height="40dp"
         android:layout_marginTop="8dp"
+        android:layout_marginHorizontal="8dp"
         android:importantForAccessibility="no"
         app:layout_constraintEnd_toStartOf="@+id/mozac_browser_toolbar_browser_actions"
         app:layout_constraintStart_toEndOf="@+id/mozac_browser_toolbar_navigation_actions"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
   * `SyncStatus` can now be `LoggedOut`.
   * `SyncStoreSupport` will update the `SyncStore` with `LoggedOut` when observed.
 
+* **browser-toolbar**
+  * 🚒 Bug fixed [issue #12497](https://github.com/mozilla-mobile/android-components/issues/12497) - Set the same margin to toolbar background for display as for edit
+  * 
 * **feature-recentlyclosed**
   * 🚒 Bug fixed [issue #12470](https://github.com/mozilla-mobile/android-components/issues/12470) - Set autoMirrored to true to fix RTL issues
 


### PR DESCRIPTION
For #12497

https://user-images.githubusercontent.com/11731652/178984706-f7a8ec47-d050-4497-9cb0-38add06f0fe5.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
Fixes #12497