### PR TITLE
No issue: Disable Glean UI tests for intermittents

### DIFF
--- a/samples/glean/src/androidTest/java/org/mozilla/samples/glean/MainActivityTest.kt
+++ b/samples/glean/src/androidTest/java/org/mozilla/samples/glean/MainActivityTest.kt
@@ -14,6 +14,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.testing.GleanTestLocalServer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -30,6 +31,7 @@ class MainActivityTest {
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()
 
+    @Ignore("Intermittent: https://github.com/mozilla-mobile/android-components/issues/12311")
     @Test
     fun checkGleanClickData() {
         // We don't reset the storage in this test as the GleanTestRule does not

--- a/samples/glean/src/androidTest/java/org/mozilla/samples/glean/pings/BaselinePingTest.kt
+++ b/samples/glean/src/androidTest/java/org/mozilla/samples/glean/pings/BaselinePingTest.kt
@@ -18,6 +18,7 @@ import okhttp3.mockwebserver.RecordedRequest
 import org.json.JSONObject
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -107,6 +108,7 @@ class BaselinePingTest {
         return null
     }
 
+    @Ignore("Intermittent: https://github.com/mozilla-mobile/android-components/issues/12359")
     @Test
     fun validateBaselinePing() {
         // Wait for the app to be idle/ready.


### PR DESCRIPTION
The sample Glean instrumented tests under androidTest have been intermittent daily for a while now. Let's disable them and then figure out what's going on.

`checkGleanClickData` https://github.com/mozilla-mobile/android-components/issues/12311
`validateBaselinePing` https://github.com/mozilla-mobile/android-components/issues/12359