### PR TITLE
Bug 1779797 - Let mergify automatically approve l10n bumps on release…

### DIFF
--- a/.github/workflows/sync-strings.yml
+++ b/.github/workflows/sync-strings.yml
@@ -43,4 +43,3 @@ jobs:
           branch: automation/sync-strings-${{ steps.ac-version-for-fenix-beta.outputs.major-ac-version }}
           title: "Uplift Strings from main to releases/${{steps.ac-version-for-fenix-beta.outputs.major-ac-version}}.0"
           body: "This (automated) PR sync strings from `main` to `releases/${{steps.ac-version-for-fenix-beta.outputs.major-ac-version}}.0`"
-          labels: "🕵️‍♀️ needs review"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,7 +24,7 @@ pull_request_rules:
         rebase_fallback: none
   - name: L10N - Auto Merge
     conditions:
-      - author=mozilla-l10n-automation-bot
+      - author~=(mozilla-l10n-automation-bot|github-actions\[bot\])
       - status-success=complete-pr
       - files~=(strings.xml|l10n.toml)
     actions:


### PR DESCRIPTION
… branches

This was tested in this PR https://github.com/JohanLorenzo/android-components/pull/5. I made a few adjustments to: 
 * spin up an l10n bump at will
 * avoid spawning Taskcluster on my fork. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
