### PR TITLE
  Display firefox suggest header in the correct order 

### DIFF
--- a/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/AwesomeBar.kt
+++ b/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/AwesomeBar.kt
@@ -92,7 +92,7 @@ fun AwesomeBar(
             .background(colors.background)
     ) {
         val fetcher = remember(groups) { SuggestionFetcher(groups, profiler) }
-        val suggestions = derivedStateOf { fetcher.state.value }.value
+        val suggestions = derivedStateOf { fetcher.state.value }.value.toSortedMap(compareBy { it.title })
 
         LaunchedEffect(text, fetcher) {
             fetcher.fetch(text)

--- a/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/Suggestions.kt
+++ b/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/Suggestions.kt
@@ -16,11 +16,12 @@ import androidx.compose.ui.platform.testTag
 import mozilla.components.compose.browser.awesomebar.AwesomeBarColors
 import mozilla.components.compose.browser.awesomebar.AwesomeBarOrientation
 import mozilla.components.concept.awesomebar.AwesomeBar
+import java.util.SortedMap
 
 @Composable
 @Suppress("LongParameterList")
 internal fun Suggestions(
-    suggestions: Map<AwesomeBar.SuggestionProviderGroup, List<AwesomeBar.Suggestion>>,
+    suggestions: SortedMap<AwesomeBar.SuggestionProviderGroup, List<AwesomeBar.Suggestion>>,
     colors: AwesomeBarColors,
     orientation: AwesomeBarOrientation,
     onSuggestionClicked: (AwesomeBar.SuggestionProviderGroup, AwesomeBar.Suggestion) -> Unit,


### PR DESCRIPTION
Fixes an issue that occurred with #12518 

### Issue : The FirefoxSuggest header was coming at top of all the suggestions clubbed
![Screenshot_20220720-141452](https://user-images.githubusercontent.com/29518411/180053560-74453709-c925-47c5-943e-f50decb7dcbc.png)

### Expected : The non-library suggestions should show first, then the Firefox suggest header and then library suggestions.
![Screenshot_20220720-135608](https://user-images.githubusercontent.com/29518411/180052476-75d792d1-a067-47e3-8a60-322b818886c7.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.


### GitHub Automation
Fixes #12443