### PR TITLE
Correct Padding for Suggestion Group header

### DIFF
--- a/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/SuggestionGroup.kt
+++ b/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/SuggestionGroup.kt
@@ -26,7 +26,7 @@ internal fun SuggestionGroup(
         color = colors.groupTitle,
         modifier = Modifier
             .padding(
-                vertical = 24.dp,
+                vertical = 12.dp,
                 horizontal = 16.dp
             )
             .fillMaxWidth(),


### PR DESCRIPTION
According to figma
<img width="294" alt="Screen Shot 2022-07-20 at 1 13 22 PM" src="https://user-images.githubusercontent.com/29518411/180287492-9bb6a6fd-af87-44eb-bdec-788a4cec6e2f.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
