### PR TITLE
Close #12538: Crash notification will always trigger the crash prompt dialog

### DIFF
--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/handler/CrashHandlerService.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/handler/CrashHandlerService.kt
@@ -49,10 +49,7 @@ class CrashHandlerService : Service() {
             val channel = CrashNotification.ensureChannelExists(this)
             val notification = NotificationCompat.Builder(this, channel)
                 .setContentTitle(
-                    getString(
-                        R.string.mozac_lib_crash_dialog_title,
-                        crashReporter.promptConfiguration.appName
-                    )
+                    getString(R.string.mozac_lib_gathering_crash_data_in_progress)
                 )
                 .setSmallIcon(R.drawable.mozac_lib_crash_notification)
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT)

--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/notification/CrashNotification.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/notification/CrashNotification.kt
@@ -15,10 +15,8 @@ import mozilla.components.lib.crash.Crash
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.lib.crash.R
 import mozilla.components.lib.crash.prompt.CrashPrompt
-import mozilla.components.lib.crash.service.SendCrashReportService
 import mozilla.components.support.base.ids.SharedIdsHelper
 import mozilla.components.support.utils.PendingIntentUtils
-import mozilla.components.support.utils.asForegroundServicePendingIntent
 
 private const val NOTIFICATION_SDK_LEVEL = 29 // On Android Q+ we show a notification instead of a prompt
 
@@ -37,13 +35,6 @@ internal class CrashNotification(
             context, SharedIdsHelper.getNextIdForTag(context, PENDING_INTENT_TAG),
             CrashPrompt.createIntent(context, crash), getNotificationFlag()
         )
-
-        val reportPendingIntent = SendCrashReportService
-            .createReportIntent(context, crash, NOTIFICATION_TAG, NOTIFICATION_ID)
-            .asForegroundServicePendingIntent(
-                context, SharedIdsHelper.getNextIdForTag(context, PENDING_INTENT_TAG),
-                getNotificationFlag()
-            )
 
         val channel = ensureChannelExists(context)
 
@@ -69,7 +60,7 @@ internal class CrashNotification(
                 context.getString(
                     R.string.mozac_lib_crash_notification_action_report
                 ),
-                reportPendingIntent
+                pendingIntent,
             )
             .setAutoCancel(true)
             .build()

--- a/components/lib/crash/src/main/res/values/strings.xml
+++ b/components/lib/crash/src/main/res/values/strings.xml
@@ -27,6 +27,9 @@
     <!-- Label of notification showing that the crash report service is running. %1$s will be replaced with the name of the organization (e.g. Mozilla). -->
     <string name="mozac_lib_send_crash_report_in_progress">Sending crash report to %1$s</string>
 
+    <!-- Label of notification showing that the crash handling service is gathering the crash data. -->
+    <string name="mozac_lib_gathering_crash_data_in_progress">Gathering crash data</string>
+
     <!-- Label of notification showing that the telemetry service is gathering the crash data. -->
     <string name="mozac_lib_gathering_crash_telemetry_in_progress">Gathering crash telemetry data</string>
 

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/prompt/CrashReporterActivityTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/prompt/CrashReporterActivityTest.kt
@@ -196,6 +196,31 @@ class CrashReporterActivityTest {
             assertEquals(activity.restartButton.visibility, View.GONE)
         }
     }
+
+    @Test
+    fun `WHEN crash is native AND background child THEN is background returns true`() = runTestOnMain {
+        CrashReporter(
+            context = testContext,
+            shouldPrompt = CrashReporter.Prompt.ALWAYS,
+            services = listOf(service),
+            scope = scope
+        ).install(testContext)
+
+        val crash = Crash.NativeCodeCrash(
+            123,
+            "",
+            true,
+            "",
+            Crash.NativeCodeCrash.PROCESS_TYPE_BACKGROUND_CHILD,
+            arrayListOf()
+        )
+
+        val scenario = coroutineContext.launchActivityWithCrash(crash)
+
+        scenario.onActivity { activity ->
+            assert(activity.isRecoverableBackgroundCrash(crash))
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
Fixes #12538