### PR TITLE
Issue #10377: Increase default maximum desired icon size to 1024px

### DIFF
--- a/components/browser/icons/src/main/res/values/dimens.xml
+++ b/components/browser/icons/src/main/res/values/dimens.xml
@@ -7,7 +7,7 @@
     <dimen name="mozac_browser_icons_size_launcher">48dp</dimen>
     <dimen name="mozac_browser_icons_size_launcher_adaptive">102dp</dimen>
 
-    <dimen name="mozac_browser_icons_maximum_size" tools:ignore="PxUsage">512px</dimen>
+    <dimen name="mozac_browser_icons_maximum_size" tools:ignore="PxUsage">1024px</dimen>
     <dimen name="mozac_browser_icons_minimum_size" tools:ignore="PxUsage">32px</dimen>
     <dimen name="mozac_browser_icons_generator_default_corner_radius">2dp</dimen>
 </resources>


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.



### GitHub Automation
Fixes #10377