### PR TITLE
For #12557 - Stop logging AS-places reads/writes explicit interrupts

### DIFF
--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesStorage.kt
@@ -100,7 +100,6 @@ abstract class PlacesStorage(
         } catch (e: PlacesException.OperationInterrupted) {
             logger.debug("Ignoring expected OperationInterrupted exception for explicit writer interrupt call", e)
         } catch (e: PlacesException) {
-            crashReporter?.submitCaughtException(e)
             logger.warn("Ignoring PlacesException while interrupting writes", e)
         }
     }
@@ -115,7 +114,6 @@ abstract class PlacesStorage(
         } catch (e: PlacesException.OperationInterrupted) {
             logger.debug("Ignoring expected OperationInterrupted exception for explicit reader interrupt call", e)
         } catch (e: PlacesException) {
-            crashReporter?.submitCaughtException(e)
             logger.warn("Ignoring PlacesException while interrupting reads", e)
         }
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **browser-storage-sync**:
+  * Stop loading to the crash servers the expected `OperationInterrupted` exceptions for when interrupting in progress reads/writes from Application-Services. [#12557](https://github.com/mozilla-mobile/android-components/issues/12557)
+
 # 104.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v103.0.0...v104.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/151?closed=1)


### PR DESCRIPTION
The OperationInterrupted exceptions are expected so logging them to the crash
servers has little use.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.


### GitHub Automation
Fixes #12557