### PR TITLE
For #12562 - Handle onPromptDismiss in ChoicePromptDelegate

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/ChoicePromptDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/ChoicePromptDelegate.kt
@@ -19,10 +19,16 @@ import org.mozilla.geckoview.GeckoSession.PromptDelegate.PromptInstanceDelegate
  * with the onPromptUpdate callback.
  * @param previousPrompt [PromptRequest] to be updated.
  */
-internal class ChoicePromptUpdateDelegate(
+internal class ChoicePromptDelegate(
     private val geckoSession: GeckoEngineSession,
     private var previousPrompt: PromptRequest,
 ) : PromptInstanceDelegate {
+
+    override fun onPromptDismiss(prompt: BasePrompt) {
+        geckoSession.notifyObservers {
+            onPromptDismissed(previousPrompt)
+        }
+    }
 
     override fun onPromptUpdate(prompt: BasePrompt) {
         if (prompt is ChoicePrompt) {

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -258,7 +258,7 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
             else -> throw InvalidParameterException("${geckoPrompt.type} is not a valid Gecko @Choice.ChoiceType")
         }
 
-        geckoPrompt.delegate = ChoicePromptUpdateDelegate(
+        geckoPrompt.delegate = ChoicePromptDelegate(
             geckoEngineSession,
             promptRequest
         )

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/ChoicePromptDelegateTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/ChoicePromptDelegateTest.kt
@@ -16,7 +16,7 @@ import org.junit.runner.RunWith
 import org.mozilla.geckoview.GeckoSession
 
 @RunWith(AndroidJUnit4::class)
-class ChoicePromptUpdateDelegateTest {
+class ChoicePromptDelegateTest {
 
     @Test
     fun `WHEN onPromptUpdate is called from GeckoView THEN notifyObservers is invoked with onPromptUpdate`() {
@@ -41,7 +41,7 @@ class ChoicePromptUpdateDelegateTest {
             { isOnConfirmCalled = true },
             { isOnDismissCalled = true }
         )
-        val delegate = ChoicePromptUpdateDelegate(mockSession, prompt)
+        val delegate = ChoicePromptDelegate(mockSession, prompt)
         val updatedPrompt = mock<GeckoSession.PromptDelegate.ChoicePrompt>()
         ReflectionUtils.setField(updatedPrompt, "choices", arrayOf<GeckoChoice>())
 
@@ -54,5 +54,24 @@ class ChoicePromptUpdateDelegateTest {
         (observedPrompt as PromptRequest.SingleChoice).onDismiss()
         assertTrue(isOnDismissCalled)
         assertTrue(isOnConfirmCalled)
+    }
+
+    @Test
+    fun `WHEN onPromptDismiss is called from GeckoView THEN notifyObservers is invoked with onPromptDismissed`() {
+        val mockSession = GeckoEngineSession(mock())
+        var isOnDismissCalled = false
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptDismissed(promptRequest: PromptRequest) {
+                super.onPromptDismissed(promptRequest)
+                isOnDismissCalled = true
+            }
+        })
+        val basePrompt: GeckoSession.PromptDelegate.ChoicePrompt = mock()
+        val prompt: PromptRequest = mock()
+        val delegate = ChoicePromptDelegate(mockSession, prompt)
+
+        delegate.onPromptDismiss(basePrompt)
+
+        assertTrue(isOnDismissCalled)
     }
 }

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -319,6 +319,11 @@ class PromptFeature private constructor(
                                         activePromptRequest as SelectAddress
                                     )
                                 }
+                                is SingleChoice,
+                                is MultipleChoice,
+                                is MenuChoice -> {
+                                    (activePrompt?.get() as? ChoiceDialogFragment)?.dismissAllowingStateLoss()
+                                }
                                 else -> {
                                     // no-op
                                 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **feature-prompts**:
+  * Added prompt dismiss listener to `ChoicePromptDelegate`. [#12562](https://github.com/mozilla-mobile/android-components/issues/12562)
+
 * **browser-storage-sync**:
   * Stop reporting to the crash servers the expected `OperationInterrupted` exceptions for when interrupting in progress reads/writes from Application-Services. [#12557](https://github.com/mozilla-mobile/android-components/issues/12557), [#12569](https://github.com/mozilla-mobile/android-components/issues/12569).
 


### PR DESCRIPTION
Added `onPromptDismiss` callback in `ChoicePromptDelegate`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
Fixes #12562