### PR TITLE
Upgrade version of AppServices from which we download nimbus-fml.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -30,6 +30,8 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "2.8.1"
 
+    // When upgrading mozilla_appservices, also upgrade the version in the
+    // `getApplicationServiceVersion()` method in NimbusGradlePlugin.groovy.
     const val mozilla_appservices = "93.7.1"
 
     const val mozilla_glean = "50.1.3"

--- a/components/tooling/nimbus-gradle-plugin/src/main/groovy/mozilla/components/tooling/nimbus/NimbusGradlePlugin.groovy
+++ b/components/tooling/nimbus-gradle-plugin/src/main/groovy/mozilla/components/tooling/nimbus/NimbusGradlePlugin.groovy
@@ -171,7 +171,7 @@ class NimbusPlugin implements Plugin<Project> {
         // a) this plugin is going to live in the AS repo (eventually)
         // See https://github.com/mozilla-mobile/android-components/issues/11422 for tying this
         // to a version that is specified in buildSrc/src/main/java/Dependencies.kt
-        return "93.5.0"
+        return "93.7.1"
     }
 
     // Try one or more hosts to download the given file.


### PR DESCRIPTION
This changes the version of the Nimbus FML we use to generate code to access Nimbus features.

Routinely, this should be done when `mozilla_appservices` version is bumped in `Depedencies.kt`. This was last done in 2ce16519563. (/cc @rvandermeulen  )

This wouldn't have prevented https://github.com/mozilla-mobile/fenix/issues/26041 , but is needed as part of the fix.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
