### PR TITLE
For #12569 - Don't report PlacesException$OperationInterrupted exceptions

### DIFF
--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesStorage.kt
@@ -95,12 +95,8 @@ abstract class PlacesStorage(
      * Allows immediately dismissing all write operations and clearing the write queue.
      */
     internal fun interruptCurrentWrites() {
-        try {
+        handlePlacesExceptions("interruptCurrentWrites") {
             writer.interrupt()
-        } catch (e: PlacesException.OperationInterrupted) {
-            logger.debug("Ignoring expected OperationInterrupted exception for explicit writer interrupt call", e)
-        } catch (e: PlacesException) {
-            logger.warn("Ignoring PlacesException while interrupting writes", e)
         }
     }
 
@@ -109,12 +105,8 @@ abstract class PlacesStorage(
      * Allows avoiding having to wait for stale queries responses and clears the queries queue.
      */
     internal fun interruptCurrentReads() {
-        try {
+        handlePlacesExceptions("interruptCurrentReads") {
             reader.interrupt()
-        } catch (e: PlacesException.OperationInterrupted) {
-            logger.debug("Ignoring expected OperationInterrupted exception for explicit reader interrupt call", e)
-        } catch (e: PlacesException) {
-            logger.warn("Ignoring PlacesException while interrupting reads", e)
         }
     }
 
@@ -129,6 +121,8 @@ abstract class PlacesStorage(
             block()
         } catch (e: PlacesException.UnexpectedPlacesException) {
             throw e
+        } catch (e: PlacesException.OperationInterrupted) {
+            logger.debug("Ignoring expected OperationInterrupted exception when running $operation", e)
         } catch (e: PlacesException) {
             crashReporter?.submitCaughtException(e)
             logger.warn("Ignoring PlacesException while running $operation", e)
@@ -153,6 +147,9 @@ abstract class PlacesStorage(
             block()
         } catch (e: PlacesException.UnexpectedPlacesException) {
             throw e
+        } catch (e: PlacesException.OperationInterrupted) {
+            logger.debug("Ignoring expected OperationInterrupted exception when running $operation", e)
+            default
         } catch (e: PlacesException) {
             crashReporter?.submitCaughtException(e)
             logger.warn("Ignoring PlacesException while running $operation", e)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@ permalink: /changelog/
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
 * **browser-storage-sync**:
-  * Stop loading to the crash servers the expected `OperationInterrupted` exceptions for when interrupting in progress reads/writes from Application-Services. [#12557](https://github.com/mozilla-mobile/android-components/issues/12557)
+  * Stop reporting to the crash servers the expected `OperationInterrupted` exceptions for when interrupting in progress reads/writes from Application-Services. [#12557](https://github.com/mozilla-mobile/android-components/issues/12557), [#12569](https://github.com/mozilla-mobile/android-components/issues/12569).
 
 # 104.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v103.0.0...v104.0.0)


### PR DESCRIPTION
This will catch OperationInterrupted exceptions from the interrupted operation.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.


### GitHub Automation
Fixes #12569