### PR TITLE
No issue: Do not save "about:crashparent" tab when saving state

### DIFF
--- a/components/browser/session-storage/src/main/java/mozilla/components/browser/session/storage/SessionStorage.kt
+++ b/components/browser/session-storage/src/main/java/mozilla/components/browser/session/storage/SessionStorage.kt
@@ -70,13 +70,18 @@ class SessionStorage(
             return true
         }
 
-        val stateToPersist = if (state.selectedTabId != null && state.selectedTab == null) {
+        // "about:crashparent" is meant for testing purposes only.  If saved/restored then it will
+        // continue to crash the app until data is cleared.  Therefore, we are filtering it out.
+        val updatedTabList = state.tabs.filterNot { it.content.url == "about:crashparent" }
+        val updatedState = state.copy(tabs = updatedTabList)
+
+        val stateToPersist = if (updatedState.selectedTabId != null && updatedState.selectedTab == null) {
             // Needs investigation to figure out and prevent cause:
             // https://github.com/mozilla-mobile/android-components/issues/8417
             logger.error("Selected tab ID set, but tab with matching ID not found. Clearing selection.")
-            state.copy(selectedTabId = null)
+            updatedState.copy(selectedTabId = null)
         } else {
-            state
+            updatedState
         }
 
         return synchronized(sessionFileLock) {

--- a/components/browser/session-storage/src/test/java/mozilla/components/browser/session/storage/SessionStorageTest.kt
+++ b/components/browser/session-storage/src/test/java/mozilla/components/browser/session/storage/SessionStorageTest.kt
@@ -357,6 +357,34 @@ class SessionStorageTest {
         // the first one if all tabs have the same last access value.
         assertEquals("mozilla", browsingSession.selectedTabId)
     }
+
+    @Test
+    fun `WHEN saving state with crash parent tab THEN don't save tab`() {
+        val state = BrowserState(
+            tabs = listOf(
+                createTab(url = "about:crashparent", id = "crash"),
+                createTab(url = "https://getpocket.com", id = "pocket")
+            ),
+            selectedTabId = "crash"
+        )
+
+        val engine = FakeEngine()
+
+        val storage = SessionStorage(testContext, engine)
+        val persisted = storage.save(state)
+        assertTrue(persisted)
+
+        // Read it back
+        val browsingSession = storage.restore()
+        assertNotNull(browsingSession!!)
+
+        assertEquals(1, browsingSession.tabs.size)
+        assertEquals("https://getpocket.com", browsingSession.tabs[0].state.url)
+
+        // Selected tab doesn't exist so we take to most recently accessed one, or
+        // the first one if all tabs have the same last access value.
+        assertEquals("pocket", browsingSession.selectedTabId)
+    }
 }
 
 internal fun TabSessionState.assertSameAs(tab: RecoverableTab) {


### PR DESCRIPTION
This is to avoid reloading the tab when testing with "about:crashparent"

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
