### PR TITLE
Bug 1782194 - Enforce a single Glean major version across all dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,22 @@ subprojects {
     }
 
     project.configurations.all {
+        // Dependencies can't depend on a different major version of Glean than A-C itself.
+        resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == 'org.mozilla.telemetry'
+                    && details.requested.name.contains('glean') ) {
+                def requested = details.requested.version.tokenize(".")
+                def defined = Versions.mozilla_glean.tokenize(".")
+                // Check the major version
+                if (requested[0] != defined[0]) {
+                    throw new AssertionError("Cannot resolve to a single Glean version. Requested: ${details.requested.version}, A-C uses: ${Versions.mozilla_glean}")
+                } else {
+                    // Enforce that all (transitive) dependencies are using the defined Glean version
+                    details.useVersion Versions.mozilla_glean
+                }
+            }
+        }
+
         // Enforce that all (transitive) dependencies are using the same support library version as we do.
         resolutionStrategy.eachDependency { details ->
             if (details.requested.group == 'com.android.support'

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -32,6 +32,7 @@ object Versions {
 
     const val mozilla_appservices = "93.8.0"
 
+    // DO NOT MODIFY MANUALLY. This is auto-updated along with GeckoView.
     const val mozilla_glean = "51.0.1"
 
     const val material = "1.2.1"


### PR DESCRIPTION
Previously we had a check in the Glean Gradle plugin that tried to
enfore a _single_ Glean version across the whole code base.
This is accompanied by a change to the Glean Gradle plugin.

That check wasn't working inside Android Components to begin with,
because it runs on individual components and there's no component which depends on both GeckoView (which provides glean-native)
and an app-services component that also depends on Glean.
It therefore didn't really catch things most of the time.

But when it did catch things (and I have yet to understand exactly when that would be the case)
it really got more in our way than necessary:
To ensure we didn't run into version issues we had to always upgrade Glean in appservices
and get a release before we land upgrades of GeckoView, Glean _and_ appservices in a-c.
That's needlessly restrictive.

What we really want:
The version exported (as a capability) from GeckoView to be used in the final build.
And no other component using a Glean major version lower or higher than that.
Glean itself follows SemVer and so major versions should be compatible.
Enforcing the version exported by GeckoView is therefore enough to get a working build.

Unfortunately in Gradle we can't really ask what version GeckoView provides,
but luckily for use we already have `Versions.mozilla_glean`, which is auto-updated.
We should just not manually modify that value ever.

Note: for major version upgrades we _still_ need to get the Glean update
into appservices first, get that released and then update in A-C.
Hopefully this happens less often now.

---

Glean change: https://github.com/mozilla/glean/pull/2143

I'd like someone with a bit more Gradle knowledge have a look at this and sanity-check my approach.