### PR TITLE
No issue: Update Nimbus plugin to use version 93.6.0

### DIFF
--- a/components/tooling/nimbus-gradle-plugin/src/main/groovy/mozilla/components/tooling/nimbus/NimbusGradlePlugin.groovy
+++ b/components/tooling/nimbus-gradle-plugin/src/main/groovy/mozilla/components/tooling/nimbus/NimbusGradlePlugin.groovy
@@ -171,7 +171,7 @@ class NimbusPlugin implements Plugin<Project> {
         // a) this plugin is going to live in the AS repo (eventually)
         // See https://github.com/mozilla-mobile/android-components/issues/11422 for tying this
         // to a version that is specified in buildSrc/src/main/java/Dependencies.kt
-        return "93.5.0"
+        return "93.6.0"
     }
 
     // Try one or more hosts to download the given file.


### PR DESCRIPTION
As part of mozilla-mobile/fenix#26041, we need to ensure we have at
least version 93.6.0 of the plugin downloaded. The reason we are not
using a newer version, even though they are available, is to reduce the
complexity of things that go into the next AC release in order to get
the Fenix experiment launched.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.


### GitHub Automation
