### PR TITLE
Make sharing images work with Direct Share

### DIFF
--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt
@@ -148,14 +148,13 @@ fun Context.shareMedia(
         if (message != null) {
             putExtra(EXTRA_TEXT, message)
         }
-    }
-
-    val shareIntent = Intent.createChooser(intent, getString(R.string.mozac_support_ktx_menu_share_with)).apply {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             // Android Q allows us to show a thumbnail preview of the file to be shared.
             clipData = ClipData.newRawUri(contentUri.toString(), contentUri)
         }
+    }
 
+    val shareIntent = Intent.createChooser(intent, getString(R.string.mozac_support_ktx_menu_share_with)).apply {
         flags = FLAG_ACTIVITY_NEW_TASK or FLAG_GRANT_READ_URI_PERMISSION
     }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
 
+* **support-ktx**
+  * 🚒 Bug fixed [issue #12689](https://github.com/mozilla-mobile/android-components/issues/12689)  Make `Context.shareMedia` work with Android Direct Share.
+
 # 105.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v104.0.0...v105.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/152?closed=1)


### PR DESCRIPTION
Image sharing currently only works when sharing to an app but not when
using the Android Direct Share feature, where it fails with a
SecurityException.

"Direct Share" is what Android calls the app created shortcuts,
i.e. individual chats from a messaging application.

The code pretty much already does the right thing (i.e. setting
the FLAG_GRANT_READ_URI_PERMISSION on the target intent as well as the
Chooser action, as described in ACTION_CHOOSE Api docs[1]) but there's
some platform internals that seem to go wrong here but we can work
around it with this patch.

https://issuetracker.google.com/issues/151386328 describes a similar
Problem, especially #12 in there offers a similar workaround and an
explanation:

  The underlying problem is that ACTION_SEND is using EXTRA_STREAM for the
  content URI. But the FLAG_GRANT_*_URI_PERMISSION mechanism only works
  with URIs in Intent.data and Intent.clipData. The framework contains
  some code that tries to work around this limitation. But it doesn't
  handle this particular case. Intent.createChooser() migrates the flags
  and data/clipData from the target Intent, but it does so before the
  framework had a chance to fix up the target Intent via Intent.migrateExtraStreamToClipData().

And indeed moving the clipData into the inner intent makes Direct Share
work and preserves the image preview in the Intent.

[1] file:///<SDK-DIR>/docs/reference/android/content/Intent.html#ACTION_CHOOSER
  If you need to grant URI permissions through a chooser, you must specify
  the permissions to be granted on the ACTION_CHOOSER Intent in addition to
  the EXTRA_INTENT inside. This means using setClipData(ClipData) to
  specify the URIs to be granted as well as FLAG_GRANT_READ_URI_PERMISSION
  and/or FLAG_GRANT_WRITE_URI_PERMISSION as appropriate.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
Fixes #12689
Fixes #12