### PR TITLE
For #12676 Allow the search widget to match the resized width

### DIFF
--- a/components/feature/search/src/main/res/layout/mozac_search_widget_extra_small_v2.xml
+++ b/components/feature/search/src/main/res/layout/mozac_search_widget_extra_small_v2.xml
@@ -4,7 +4,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@id/mozac_button_search_widget_new_tab"
-    android:layout_width="64dp"
+    android:layout_width="match_parent"
     android:layout_height="50dp"
     android:layout_gravity="center"
     android:background="@drawable/mozac_rounded_search_widget_background">

--- a/components/feature/search/src/main/res/layout/mozac_search_widget_medium.xml
+++ b/components/feature/search/src/main/res/layout/mozac_search_widget_medium.xml
@@ -4,7 +4,7 @@
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="192dp"
+    android:layout_width="match_parent"
     android:layout_height="50dp"
     android:layout_gravity="center"
     android:background="@drawable/mozac_rounded_search_widget_background">

--- a/components/feature/search/src/main/res/layout/mozac_search_widget_small.xml
+++ b/components/feature/search/src/main/res/layout/mozac_search_widget_small.xml
@@ -2,7 +2,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="100dp"
+    android:layout_width="match_parent"
     android:layout_height="50dp"
     android:background="@drawable/mozac_rounded_search_widget_background"
     android:orientation="horizontal">

--- a/components/feature/search/src/main/res/layout/mozac_search_widget_small_no_mic.xml
+++ b/components/feature/search/src/main/res/layout/mozac_search_widget_small_no_mic.xml
@@ -4,7 +4,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@id/mozac_button_search_widget_new_tab"
-    android:layout_width="100dp"
+    android:layout_width="match_parent"
     android:layout_height="50dp"
     android:layout_gravity="center"
     android:background="@drawable/mozac_rounded_search_widget_background"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,9 @@ permalink: /changelog/
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/v105.0.0/.config.yml)
 
 * **feature-search**:
+  * Allow the search widget to match the resized width [#12676](https://github.com/mozilla-mobile/android-components/issues/12676).
+
+* **feature-search**:
   * Implement the common part of search widget in Android Components [#12565](https://github.com/mozilla-mobile/android-components/issues/12565).
 
 * **feature-prompts**:


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.






### GitHub Automation
Fixes #12676