### PR TITLE
Close #9829: Move IO work in FxaPushSupportFeature to a coroutine

### DIFF
--- a/components/feature/accounts-push/README.md
+++ b/components/feature/accounts-push/README.md
@@ -51,7 +51,10 @@ in order to fix the problem. Therefore, if FxA and Push are used together,
 include the support feature as well:
 
 ```kotlin
-FxaPushSupportFeature(context, fxaAccountManager, autoPushFeature)
+val feature = FxaPushSupportFeature(context, fxaAccountManager, autoPushFeature)
+
+// initialize the feature; this can be done immediately if needed.
+feature.initalize()
 ```
 
 ## License

--- a/components/feature/accounts-push/build.gradle
+++ b/components/feature/accounts-push/build.gradle
@@ -27,6 +27,12 @@ android {
     }
 }
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+        freeCompilerArgs += "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
+    }
+}
+
 dependencies {
     implementation project(':service-firefox-accounts')
     implementation project(':support-ktx')

--- a/components/feature/accounts-push/src/main/java/mozilla/components/feature/accounts/push/cache/PushScopeProperty.kt
+++ b/components/feature/accounts-push/src/main/java/mozilla/components/feature/accounts/push/cache/PushScopeProperty.kt
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.accounts.push.cache
+
+import android.content.Context
+import android.content.SharedPreferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.withContext
+import mozilla.components.feature.accounts.push.FxaPushSupportFeature
+import mozilla.components.feature.accounts.push.PREF_FXA_SCOPE
+import mozilla.components.feature.accounts.push.preference
+import mozilla.components.feature.push.PushScope
+import java.util.UUID
+
+/**
+ * An implementation of a [ScopeProperty] that generates and stores a scope in [SharedPreferences].
+ */
+internal class PushScopeProperty(
+    private val context: Context,
+    private val coroutineScope: CoroutineScope,
+) : ScopeProperty {
+
+    override suspend fun value(): PushScope = withContext(coroutineScope.coroutineContext) {
+        val prefs = preference(context)
+
+        // Generate a unique scope if one doesn't exist.
+        val randomUuid = UUID.randomUUID().toString().replace("-", "")
+
+        // Return a scope in the format example: "fxa_push_scope_a62d5f27c9d74af4996d057f0e0e9c38"
+        val scope = FxaPushSupportFeature.PUSH_SCOPE_PREFIX + randomUuid
+
+        if (!prefs.contains(PREF_FXA_SCOPE)) {
+            prefs.edit().putString(PREF_FXA_SCOPE, scope).apply()
+
+            return@withContext scope
+        }
+
+        // The default string is non-null, so we can safely cast.
+        prefs.getString(PREF_FXA_SCOPE, scope) as String
+    }
+}

--- a/components/feature/accounts-push/src/main/java/mozilla/components/feature/accounts/push/cache/ScopeProperty.kt
+++ b/components/feature/accounts-push/src/main/java/mozilla/components/feature/accounts/push/cache/ScopeProperty.kt
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.accounts.push.cache
+
+import mozilla.components.feature.push.PushScope
+
+/**
+ * A [ScopeProperty] implementation generates and holds the [PushScope].
+ */
+interface ScopeProperty {
+
+    /**
+     * Returns the [PushScope] value.
+     */
+    suspend fun value(): PushScope
+}

--- a/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/FxaPushSupportFeatureTest.kt
+++ b/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/FxaPushSupportFeatureTest.kt
@@ -12,9 +12,11 @@ import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyBoolean
@@ -25,18 +27,31 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class FxaPushSupportFeatureTest {
 
+    @get:Rule
+    val coroutineTestRule = MainCoroutineRule()
+
     private val pushFeature: AutoPushFeature = mock()
     private val accountManager: FxaAccountManager = mock()
+
+    private lateinit var feature: FxaPushSupportFeature
 
     @Before
     fun setup() {
         preference(testContext).edit().remove(PREF_FXA_SCOPE).apply()
         `when`(pushFeature.config).thenReturn(mock())
+
+        feature = FxaPushSupportFeature(
+            context = testContext,
+            accountManager = accountManager,
+            pushFeature = pushFeature,
+            crashReporter = null,
+            coroutineScope = coroutineTestRule.scope
+        )
     }
 
     @Test
     fun `account observer registered`() {
-        FxaPushSupportFeature(testContext, accountManager, pushFeature)
+        feature.initialize()
 
         verify(accountManager).register(any())
         verify(pushFeature).register(any(), any(), anyBoolean())
@@ -44,7 +59,7 @@ class FxaPushSupportFeatureTest {
 
     @Test
     fun `feature generates and caches a scope`() {
-        FxaPushSupportFeature(testContext, accountManager, pushFeature)
+        feature.initialize()
 
         assertTrue(preference(testContext).contains(PREF_FXA_SCOPE))
     }
@@ -53,7 +68,7 @@ class FxaPushSupportFeatureTest {
     fun `feature does not generate a scope if one already exists`() {
         preference(testContext).edit().putString(PREF_FXA_SCOPE, "testScope").apply()
 
-        FxaPushSupportFeature(testContext, accountManager, pushFeature)
+        feature.initialize()
 
         val cachedScope = preference(testContext).getString(PREF_FXA_SCOPE, "")
         assertEquals("testScope", cachedScope!!)
@@ -61,7 +76,7 @@ class FxaPushSupportFeatureTest {
 
     @Test
     fun `feature generates a partially predictable push scope`() {
-        FxaPushSupportFeature(testContext, accountManager, pushFeature)
+        feature.initialize()
 
         val cachedScope = preference(testContext).getString(PREF_FXA_SCOPE, "")
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,10 @@ permalink: /changelog/
 * **support-ktx**
   * 🚒 Bug fixed [issue #12689](https://github.com/mozilla-mobile/android-components/issues/12689)  Make `Context.shareMedia` work with Android Direct Share.
 
+* **feature-accounts-push**:
+  * ⚠️ **This is a breaking change**: `FxaPushSupportFeature` now requires to be explicitly started with `initialize`.
+  * The constructor for `FxaPushSupportFeature` has a `coroutineScope` parameter that defaults to a `CoroutineScope(Dispatchers.IO)`.
+
 # 105.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v104.0.0...v105.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/152?closed=1)
@@ -29,7 +33,7 @@ permalink: /changelog/
 
 * **feature-findinpage**:
   * 🚒 Bug fixed [issue #12637](https://github.com/mozilla-mobile/android-components/issues/12637) Disable find in page previous and forward buttons if the query is empty
-  
+
 * **feature-search**:
   * Implement the common part of search widget in Android Components [#12565](https://github.com/mozilla-mobile/android-components/issues/12565).
 


### PR DESCRIPTION
The `FxaPushSupportFeature` needs to generate, read and write a push
scope (identifier) to disk. This work was meant to be done lazily and
not during app startup. However, if a Sync account is setup then the IO
work is done immediately during the initial account manager
initialization at startup.

In this patch, we delegate this IO work to a new `PushScopeProperty`
that retrieves the value from disk using a provided `CoroutineScope`.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.





### GitHub Automation
Fixes #9829