### PR TITLE
For #12683 - Report permission class name in related telemetry

### DIFF
--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/permission/PermissionRequest.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/permission/PermissionRequest.kt
@@ -61,11 +61,17 @@ interface PermissionRequest {
  *
  * @property id an optional native engine-specific ID of this permission.
  * @property desc an optional description of what this permission type is for.
+ * @property name permission name allowing to easily identify and differentiate one from the other.
  */
 @Suppress("UndocumentedPublicClass")
 sealed class Permission {
     abstract val id: String?
     abstract val desc: String?
+    val name: String = with(this::class.java) {
+        // Using the canonicalName is safer - see https://github.com/mozilla-mobile/android-components/pull/10810
+        // simpleName is used as a backup to the avoid not null assertion (!!) operator.
+        canonicalName?.substringAfterLast('.') ?: simpleName
+    }
 
     data class ContentAudioCapture(
         override val id: String? = "ContentAudioCapture",

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/permission/PermissionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/permission/PermissionTest.kt
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.permission
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import kotlin.reflect.full.createInstance
+
+@RunWith(Parameterized::class)
+class PermissionTest<out T : Permission>(private val permission: T) {
+    @Test
+    fun `GIVEN a permission WHEN asking for it's default id THEN return permission's class name`() {
+        assertEquals(permission::class.java.simpleName, permission.id)
+    }
+
+    @Test
+    fun `GIVEN a permission WHEN asking for it's name THEN return permission's class name`() {
+        assertEquals(permission::class.java.simpleName, permission.name)
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun permissions() = Permission::class.sealedSubclasses.map {
+            it.createInstance()
+        }
+    }
+}

--- a/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsFacts.kt
+++ b/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsFacts.kt
@@ -24,32 +24,32 @@ class SitePermissionsFacts {
 
 internal fun emitPermissionDialogDisplayed(permission: Permission) = emitSitePermissionsFact(
     action = Action.DISPLAY,
-    permissions = permission.id!!
+    permissions = permission.name
 )
 
 internal fun emitPermissionsDialogDisplayed(permissions: List<Permission>) = emitSitePermissionsFact(
     action = Action.DISPLAY,
-    permissions = permissions.joinToString { it.id!! }
+    permissions = permissions.distinctBy { it.name }.joinToString { it.name }
 )
 
 internal fun emitPermissionDenied(permission: Permission) = emitSitePermissionsFact(
     action = Action.CANCEL,
-    permissions = permission.id!!
+    permissions = permission.name
 )
 
 internal fun emitPermissionsDenied(permissions: List<Permission>) = emitSitePermissionsFact(
     action = Action.CANCEL,
-    permissions = permissions.joinToString { it.id!! }
+    permissions = permissions.distinctBy { it.name }.joinToString { it.name }
 )
 
 internal fun emitPermissionAllowed(permission: Permission) = emitSitePermissionsFact(
     action = Action.CONFIRM,
-    permissions = permission.id!!
+    permissions = permission.name
 )
 
 internal fun emitPermissionsAllowed(permissions: List<Permission>) = emitSitePermissionsFact(
     action = Action.CONFIRM,
-    permissions = permissions.joinToString { it.id!! }
+    permissions = permissions.distinctBy { it.name }.joinToString { it.name }
 )
 
 private fun emitSitePermissionsFact(

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsFactsTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsFactsTest.kt
@@ -21,78 +21,96 @@ class SitePermissionsFactsTest {
     @Test
     fun `GIVEN a fact for a prompt shown for one permission WHEN it is emitted THEN it is properly configured`() {
         CollectionProcessor.withFactCollection { facts ->
-            emitPermissionDialogDisplayed(Generic())
+            emitPermissionDialogDisplayed(Generic("test", "test"))
 
             assertEquals(1, facts.size)
             assertEquals(FEATURE_SITEPERMISSIONS, facts[0].component)
             assertEquals(Action.DISPLAY, facts[0].action)
             assertEquals(SitePermissionsFacts.Items.PERMISSIONS, facts[0].item)
-            assertEquals(Generic().id, facts[0].value)
+            assertEquals("Generic", facts[0].value)
         }
     }
 
     @Test
     fun `GIVEN a fact for a prompt shown for multiple permissions WHEN it is emitted THEN it is properly configured`() {
         CollectionProcessor.withFactCollection { facts ->
-            emitPermissionsDialogDisplayed(listOf(AppCamera(), ContentCrossOriginStorageAccess()))
+            emitPermissionsDialogDisplayed(
+                listOf(
+                    AppCamera("test", "test"),
+                    ContentCrossOriginStorageAccess("test", "test"),
+                    AppCamera("test2", "test2"),
+                )
+            )
 
             assertEquals(1, facts.size)
             assertEquals(FEATURE_SITEPERMISSIONS, facts[0].component)
             assertEquals(Action.DISPLAY, facts[0].action)
             assertEquals(SitePermissionsFacts.Items.PERMISSIONS, facts[0].item)
-            assertEquals(listOf(AppCamera(), ContentCrossOriginStorageAccess()).joinToString { it.id!! }, facts[0].value)
+            assertEquals("AppCamera, ContentCrossOriginStorageAccess", facts[0].value)
         }
     }
 
     @Test
     fun `GIVEN a fact for a permission prompt being allowed WHEN it is emitted THEN it is properly configured`() {
         CollectionProcessor.withFactCollection { facts ->
-            emitPermissionAllowed(ContentAudioCapture())
+            emitPermissionAllowed(ContentAudioCapture("test", "test"))
 
             assertEquals(1, facts.size)
             assertEquals(FEATURE_SITEPERMISSIONS, facts[0].component)
             assertEquals(Action.CONFIRM, facts[0].action)
             assertEquals(SitePermissionsFacts.Items.PERMISSIONS, facts[0].item)
-            assertEquals(ContentAudioCapture().id, facts[0].value)
+            assertEquals("ContentAudioCapture", facts[0].value)
         }
     }
 
     @Test
     fun `GIVEN a fact for a multiple permission prompt being allowed WHEN it is emitted THEN it is properly configured`() {
         CollectionProcessor.withFactCollection { facts ->
-            emitPermissionsAllowed(listOf(ContentAudioCapture(), ContentVideoCapture()))
+            emitPermissionsAllowed(
+                listOf(
+                    ContentAudioCapture("test", "test"),
+                    ContentVideoCapture("test", "test"),
+                    ContentVideoCapture("test2", "test2"),
+                )
+            )
 
             assertEquals(1, facts.size)
             assertEquals(FEATURE_SITEPERMISSIONS, facts[0].component)
             assertEquals(Action.CONFIRM, facts[0].action)
             assertEquals(SitePermissionsFacts.Items.PERMISSIONS, facts[0].item)
-            assertEquals(listOf(ContentAudioCapture(), ContentVideoCapture()).joinToString { it.id!! }, facts[0].value)
+            assertEquals("ContentAudioCapture, ContentVideoCapture", facts[0].value)
         }
     }
 
     @Test
     fun `GIVEN a fact for a permission prompt being blocked WHEN it is emitted THEN it is properly configured`() {
         CollectionProcessor.withFactCollection { facts ->
-            emitPermissionDenied(AppLocationFine())
+            emitPermissionDenied(AppLocationFine("test", "test"))
 
             assertEquals(1, facts.size)
             assertEquals(FEATURE_SITEPERMISSIONS, facts[0].component)
             assertEquals(Action.CANCEL, facts[0].action)
             assertEquals(SitePermissionsFacts.Items.PERMISSIONS, facts[0].item)
-            assertEquals(AppLocationFine().id, facts[0].value)
+            assertEquals("AppLocationFine", facts[0].value)
         }
     }
 
     @Test
     fun `GIVEN a fact for a multiple permission prompt being blocked WHEN it is emitted THEN it is properly configured`() {
         CollectionProcessor.withFactCollection { facts ->
-            emitPermissionsDenied(listOf(ContentAudioCapture(), ContentVideoCapture()))
+            emitPermissionsDenied(
+                listOf(
+                    ContentAudioCapture("test", "test"),
+                    ContentVideoCapture("test", "test"),
+                    ContentAudioCapture("test2", "test2")
+                )
+            )
 
             assertEquals(1, facts.size)
             assertEquals(FEATURE_SITEPERMISSIONS, facts[0].component)
             assertEquals(Action.CANCEL, facts[0].action)
             assertEquals(SitePermissionsFacts.Items.PERMISSIONS, facts[0].item)
-            assertEquals(listOf(ContentAudioCapture(), ContentVideoCapture()).joinToString { it.id!! }, facts[0].value)
+            assertEquals("ContentAudioCapture, ContentVideoCapture", facts[0].value)
         }
     }
 }

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsFeatureTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsFeatureTest.kt
@@ -1167,7 +1167,7 @@ class SitePermissionsFeatureTest {
             assertEquals(FEATURE_SITEPERMISSIONS, facts[0].component)
             assertEquals(Action.DISPLAY, facts[0].action)
             assertEquals(SitePermissionsFacts.Items.PERMISSIONS, facts[0].item)
-            assertEquals("permission", facts[0].value)
+            assertEquals("ContentGeoLocation", facts[0].value)
         }
     }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **concept-engine**, **feature-sitepermissions**
+  * 🆕 New `name` property for Permission which allows to easily identify and differentiate Permissions.
+  * Use the permission name when reporting telemetry for the permission dialogs. [#12683](https://github.com/mozilla-mobile/android-components/issues/12683).
+
 * **browser-storage-sync**:
   * 🚒 Bug fixed [issue #12689](https://github.com/mozilla-mobile/android-components/issues/12689) Decouple autocomplete suggestions from history search suggestions by using a separate reader which allows for separate management.
 


### PR DESCRIPTION
Previous we were reporting the permission id which can be overwritten
throughout the app.
The class name will allow to easily identify and differentiate permissions.

This patch will also enture that we won't be reporting the same permission
multiple times like it can happen on devices with multiple cameras and the
permission to access all cameras.

---

In my tests instead of 
> Facing front:1, Facing back:0, Default audio input device 

(3 not really explanatory permissions)
we would get only
> ContentVideoCamera, ContentAudioMicrophone

(2 permissions (with duplicated excluded), what should've been from the start)

For devices with many more cameras there would be a bigger difference.

cc @badboy 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.







### GitHub Automation
Fixes #12683