### PR TITLE
Revert "Use the local server for testing"

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/testing/GleanTestLocalServer.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/testing/GleanTestLocalServer.kt
@@ -14,6 +14,10 @@ package mozilla.components.service.glean.testing
  * initialize Glean more than once but still want to send pings to a local
  * server for validation.
  *
+ * FIXME(bug 1787234): State of the local server can persist across multiple test classes,
+ * leading to hard-to-diagnose intermittent test failures.
+ * It might be necessary to limit use of `GleanTestLocalServer` to a single test class for now.
+ *
  * Example usage:
  *
  * ```

--- a/samples/glean/src/androidTest/java/org/mozilla/samples/glean/MainActivityTest.kt
+++ b/samples/glean/src/androidTest/java/org/mozilla/samples/glean/MainActivityTest.kt
@@ -4,14 +4,11 @@
 
 package org.mozilla.samples.glean
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.service.glean.testing.GleanTestLocalServer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Rule
@@ -23,12 +20,6 @@ import org.mozilla.samples.glean.GleanMetrics.Test as GleanTestMetrics
 class MainActivityTest {
     @get:Rule
     val activityRule: ActivityScenarioRule<MainActivity> = ActivityScenarioRule(MainActivity::class.java)
-
-    @get:Rule
-    val gleanRule = GleanTestLocalServer(context, 0)
-
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun checkGleanClickData() {


### PR DESCRIPTION
This reverts commit 465b85378d32d9f921bab2b7650edcfd3cecc8f7.

In Glean v50 `testGetValue` methods are actually not gated on test
mode (it's still not recommended though and absolutely IS still a
test-only API for all intents and purposes).

Further it turns out that calling `GleanTestLocalServer` in one test
might influence the other test and we're seeing intermittens where
`BaselinePingTest` is trying to upload to `localhost:0`, which of course
is invalid.
I have not yet figured out how we can properly separate out the state.
Alternatively we could merge the 2 tests into a single one.

Fixes #11340

---


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
