### PR TITLE
Update ac-version-for-fenix-beta version to fix sync-strings action

### DIFF
--- a/.github/workflows/sync-strings.yml
+++ b/.github/workflows/sync-strings.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: "Discover A-C Version"
         id: ac-version-for-fenix-beta
-        uses: mozilla-mobile/ac-version-for-fenix-beta@1.1.0
+        uses: mozilla-mobile/ac-version-for-fenix-beta@1.2.0
       - name: "Checkout Main Branch"
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The fenix beta versioning scheme changed in v104, but ac-version-for-fenix-beta was left behind and stopped working.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
