### PR TITLE
For #12711 - Use a separate reader for autocomplete suggestions

### DIFF
--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
@@ -31,6 +31,7 @@ import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -39,6 +40,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import java.io.File
@@ -457,6 +459,20 @@ class PlacesHistoryStorageTest {
     }
 
     @Test
+    fun `store uses a different reader for autocomplete suggestions`() {
+        val connection: RustPlacesConnection = mock()
+        doReturn(mock<PlacesReaderConnection>()).`when`(connection).reader()
+        doReturn(mock<PlacesReaderConnection>()).`when`(connection).newReader()
+        val storage = MockingPlacesHistoryStorage(connection)
+
+        storage.getAutocompleteSuggestion("Test")
+
+        assertNotEquals(storage.reader, storage.autocompleteReader)
+        verify(storage.autocompleteReader).interrupt()
+        verify(storage.autocompleteReader).matchUrl("Test")
+    }
+
+    @Test
     fun `store ignores url parse exceptions during record operations`() = runTestOnMain {
         // These aren't valid URIs, and if we're not explicitly ignoring exceptions from the underlying
         // storage layer, these calls will throw.
@@ -602,6 +618,11 @@ class PlacesHistoryStorageTest {
                 return mock()
             }
 
+            override fun newReader(): PlacesReaderConnection {
+                fail()
+                return mock()
+            }
+
             override fun writer(): PlacesWriterConnection {
                 fail()
                 return mock()
@@ -658,6 +679,11 @@ class PlacesHistoryStorageTest {
                 return mock()
             }
 
+            override fun newReader(): PlacesReaderConnection {
+                fail()
+                return mock()
+            }
+
             override fun writer(): PlacesWriterConnection {
                 fail()
                 return mock()
@@ -702,6 +728,11 @@ class PlacesHistoryStorageTest {
         val exception = PlacesException.UrlParseFailed("test error")
         val conn = object : Connection {
             override fun reader(): PlacesReaderConnection {
+                fail()
+                return mock()
+            }
+
+            override fun newReader(): PlacesReaderConnection {
                 fail()
                 return mock()
             }
@@ -757,6 +788,11 @@ class PlacesHistoryStorageTest {
         val exception = PlacesException.UnexpectedPlacesException("test panic")
         val conn = object : Connection {
             override fun reader(): PlacesReaderConnection {
+                fail()
+                return mock()
+            }
+
+            override fun newReader(): PlacesReaderConnection {
                 fail()
                 return mock()
             }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,8 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **browser-storage-sync**:
+  * 🚒 Bug fixed [issue #12689](https://github.com/mozilla-mobile/android-components/issues/12689) Decouple autocomplete suggestions from history search suggestions by using a separate reader which allows for separate management.
 
 * **support-ktx**
   * 🚒 Bug fixed [issue #12689](https://github.com/mozilla-mobile/android-components/issues/12689)  Make `Context.shareMedia` work with Android Direct Share.


### PR DESCRIPTION
Decouple this functionality from search suggestions allowing for individual
control over the readers used.

Result:

https://user-images.githubusercontent.com/11428869/187237078-c6d468cf-0571-4aec-8977-1439f0fd02a6.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.



### GitHub Automation
Fixes #12711