### PR TITLE
For #11422: add plugin properties for NimbusGradlePlugin and replace appservices token with version

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -33,8 +33,6 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "2.8.1"
 
-    // When upgrading mozilla_appservices, also upgrade the version in the
-    // `getApplicationServiceVersion()` method in NimbusGradlePlugin.groovy.
     const val mozilla_appservices = "94.2.0"
 
     // DO NOT MODIFY MANUALLY. This is auto-updated along with GeckoView.

--- a/components/tooling/nimbus-gradle-plugin/build.gradle
+++ b/components/tooling/nimbus-gradle-plugin/build.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
@@ -16,6 +18,15 @@ gradlePlugin {
             implementationClass = "mozilla.components.tooling.nimbus.NimbusPlugin"
         }
     }
+}
+
+// This processes the files in the resources folder and moves them into the target folder. This
+// happens automatically, but has been updated to replace tokens in the resource files. It replaces
+// any tokens (values wrapped in `@`s) with the value for that key in the tokens object.
+processResources {
+    filter ReplaceTokens, tokens: [
+            'Versions.mozilla_appservices': Versions.mozilla_appservices
+    ]
 }
 
 dependencies {

--- a/components/tooling/nimbus-gradle-plugin/src/main/groovy/mozilla/components/tooling/nimbus/NimbusGradlePlugin.groovy
+++ b/components/tooling/nimbus-gradle-plugin/src/main/groovy/mozilla/components/tooling/nimbus/NimbusGradlePlugin.groovy
@@ -173,15 +173,6 @@ class NimbusPlugin implements Plugin<Project> {
         }
     }
 
-    static def getApplicationServiceVersion() {
-        // We would get this from the plugin itself but we don't know this vital piece of information
-        // We don't spend much time looking it up now because:
-        // a) this plugin is going to live in the AS repo (eventually)
-        // See https://github.com/mozilla-mobile/android-components/issues/11422 for tying this
-        // to a version that is specified in buildSrc/src/main/java/Dependencies.kt
-        return "94.2.0"
-    }
-
     // Try one or more hosts to download the given file.
     // Return the hostname that successfully downloaded, or null if none succeeded.
     static def tryDownload(File directory, String filename, String[] urlPrefixes) {
@@ -215,9 +206,12 @@ class NimbusPlugin implements Plugin<Project> {
 
         if (!archive.exists()) {
             println("Downloading archive to $archive")
-            // See https://github.com/mozilla-mobile/android-components/issues/11422 for tying this
-            // to a version that is specified in buildSrc/src/main/java/Dependencies.kt
-            def asVersion = getApplicationServiceVersion()
+
+            Properties props = new Properties()
+            props.load(getClass().getResourceAsStream("/plugin.properties"))
+
+            def asVersion = props.get("mozilla_appservices")
+            println("Using application-services v$asVersion")
             def successfulHost = tryDownload(archive.getParentFile(), archive.getName(),
                     // …the latest one from github.
                     "https://github.com/mozilla/application-services/releases/download/v$asVersion",

--- a/components/tooling/nimbus-gradle-plugin/src/main/resources/plugin.properties
+++ b/components/tooling/nimbus-gradle-plugin/src/main/resources/plugin.properties
@@ -1,0 +1,1 @@
+mozilla_appservices=@Versions.mozilla_appservices@

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,9 @@ permalink: /changelog/
   * ⚠️ **This is a breaking change**: `FxaPushSupportFeature` now requires to be explicitly started with `initialize`.
   * The constructor for `FxaPushSupportFeature` has a `coroutineScope` parameter that defaults to a `CoroutineScope(Dispatchers.IO)`.
 
+* **nimbus-gradle-plugin**:
+  * Updated the plugin to use the version of application services defined in the buildSrc Dependencies. 
+
 # 105.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v104.0.0...v105.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/152?closed=1)


### PR DESCRIPTION
The processResources task copies resources to their target directory and allows them to be processed via various methods built into it. We process the resources for the NimbusGradlePlugin, replacing usages of `@Versions.mozilla_appservices@` with the actual value from the buildSrc generated Versions class. The NimbusGradlePlugin then uses that properties file to retrieve the application services version at runtime without having to have a separate declaration of the version.

https://docs.gradle.org/current/javadoc/org/gradle/language/jvm/tasks/ProcessResources.html

I tested this with Focus Android and saw the log where it downloaded the correct version of the nimbus fml cli.

#11422

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
Fixes #11422