### PR TITLE
Close #12766: Use seconds as unit when checking sync token expiry

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/SyncAuthInfoCache.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/SyncAuthInfoCache.kt
@@ -9,6 +9,7 @@ import mozilla.components.concept.sync.SyncAuthInfo
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.base.utils.SharedPreferencesCache
 import org.json.JSONObject
+import java.util.concurrent.TimeUnit
 
 private const val CACHE_NAME = "SyncAuthInfoCache"
 private const val CACHE_KEY = CACHE_NAME
@@ -44,12 +45,14 @@ class SyncAuthInfoCache(context: Context) : SharedPreferencesCache<SyncAuthInfo>
             fxaAccessToken = obj.getString(KEY_FXA_ACCESS_TOKEN),
             fxaAccessTokenExpiresAt = obj.getLong(KEY_FXA_ACCESS_TOKEN_EXPIRES_AT),
             syncKey = obj.getString(KEY_SYNC_KEY),
-            tokenServerUrl = obj.getString(KEY_TOKEN_SERVER_URL)
+            tokenServerUrl = obj.getString(KEY_TOKEN_SERVER_URL),
         )
     }
 
     fun expired(): Boolean {
         val expiresAt = getCached()?.fxaAccessTokenExpiresAt ?: return true
-        return expiresAt <= System.currentTimeMillis()
+        val now = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())
+
+        return expiresAt <= now
     }
 }

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/SyncAuthInfoCacheTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/SyncAuthInfoCacheTest.kt
@@ -24,8 +24,8 @@ class SyncAuthInfoCacheTest {
         val authInfo = SyncAuthInfo(
             kid = "testKid",
             fxaAccessToken = "fxaAccess",
-            // expires in the future
-            fxaAccessTokenExpiresAt = System.currentTimeMillis() + 60 * 1000L,
+            // expires in the future (in seconds)
+            fxaAccessTokenExpiresAt = (System.currentTimeMillis() / 1000L) + 60,
             syncKey = "long secret key",
             tokenServerUrl = "http://www.token.server/url"
         )
@@ -36,8 +36,8 @@ class SyncAuthInfoCacheTest {
         assertFalse(cache.expired())
 
         val authInfo2 = authInfo.copy(
-            // expires in the past
-            fxaAccessTokenExpiresAt = System.currentTimeMillis() - 60 * 1000L
+            // expires in the past (in seconds)
+            fxaAccessTokenExpiresAt = (System.currentTimeMillis() / 1000L) - 60,
         )
 
         cache.setToCache(authInfo2)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
Fixes #12766