### PR TITLE
fix(cron): set MOBILE_BASE_REV to an empty string rather than 'UNDEFI…

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -63,7 +63,7 @@ tasks:
               else:
                   $if: 'tasks_for == "github-pull-request"'
                   then: '${event.pull_request.base.sha}'
-                  else: 'UNDEFINED'
+                  else: ''
           head_sha:
               $if: 'tasks_for == "github-push"'
               then: '${event.after}'


### PR DESCRIPTION
…NED'

This causes the value to be truthy which erroneously passes a check in Taskgraph.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
