### PR TITLE
Notify nimbus observers on the main thread

### DIFF
--- a/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/Nimbus.kt
+++ b/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/Nimbus.kt
@@ -53,29 +53,29 @@ class Nimbus(
     appInfo: NimbusAppInfo,
     server: NimbusServerSettings?,
     errorReporter: ErrorReporter = loggingErrorReporter,
-    private val observable: Observable<NimbusInterface.Observer> = ObserverRegistry()
+    private val observable: Observable<NimbusInterface.Observer> = ObserverRegistry(),
 ) : ApplicationServicesNimbus(
     context = context,
     appInfo = appInfo,
     server = server,
     deviceInfo = NimbusDeviceInfo(
-        localeTag = Locale.getDefault().getLocaleTag()
+        localeTag = Locale.getDefault().getLocaleTag(),
     ),
     observer = Observer(observable),
     delegate = NimbusDelegate(
         dbScope = CoroutineScope(
             Executors.newSingleThreadExecutor(
-                NamedThreadFactory("NimbusDbScope")
-            ).asCoroutineDispatcher()
+                NamedThreadFactory("NimbusDbScope"),
+            ).asCoroutineDispatcher(),
         ),
         fetchScope = CoroutineScope(
             Executors.newSingleThreadExecutor(
-                NamedThreadFactory("NimbusFetchScope")
-            ).asCoroutineDispatcher()
+                NamedThreadFactory("NimbusFetchScope"),
+            ).asCoroutineDispatcher(),
         ),
         errorReporter = errorReporter,
-        logger = { logger.info(it) }
-    )
+        logger = { logger.info(it) },
+    ),
 ),
     NimbusApi,
     Observable<NimbusInterface.Observer> by observable {
@@ -105,5 +105,5 @@ class Nimbus(
  */
 class NimbusDisabled(
     override val context: Context,
-    private val delegate: Observable<NimbusInterface.Observer> = ObserverRegistry()
+    private val delegate: Observable<NimbusInterface.Observer> = ObserverRegistry(),
 ) : NimbusApi, Observable<NimbusInterface.Observer> by delegate

--- a/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/Nimbus.kt
+++ b/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/Nimbus.kt
@@ -6,7 +6,9 @@ package mozilla.components.service.nimbus
 
 import android.content.Context
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
@@ -79,11 +81,15 @@ class Nimbus(
     Observable<NimbusInterface.Observer> by observable {
     private class Observer(val observable: Observable<NimbusInterface.Observer>) : NimbusInterface.Observer {
         override fun onExperimentsFetched() {
-            observable.notifyObservers { onExperimentsFetched() }
+            MainScope().launch {
+                observable.notifyObservers { onExperimentsFetched() }
+            }
         }
 
         override fun onUpdatesApplied(updated: List<EnrolledExperiment>) {
-            observable.notifyObservers { onUpdatesApplied(updated) }
+            MainScope().launch {
+                observable.notifyObservers { onUpdatesApplied(updated) }
+            }
         }
     }
 }


### PR DESCRIPTION
Relates to [EXP-2697](https://mozilla-hub.atlassian.net/browse/EXP-2697).

This is linked to https://github.com/mozilla/application-services/pull/5131 .

This PR notifies the observers on the Main scope. We're not sure why this needs to be done by Nimbus rather than the observer.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
