### PR TITLE
taskcluster: pass --base-ref and --base-rev to taskgraph decision

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -57,6 +57,23 @@ tasks:
                   else:
                       $if: 'tasks_for in ["cron", "action"]'
                       then: '${push.branch}'
+          base_ref:
+              $if: 'tasks_for == "github-pull-request"'
+              then: ${event.pull_request.base.ref}
+              else:
+                  # event.base_ref is barely documented[1]. Testing showed it's only
+                  # defined when creating a new branch. It's null when pushing to an
+                  # existing branch
+                  #
+                  # [1] https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push
+                  $if: 'tasks_for == "github-push" && event.base_ref'
+                  then: ${event.base_ref}
+                  else:
+                      $if: 'tasks_for == "github-push"'
+                      then: ${event.ref}
+                      else:
+                          $if: 'tasks_for in ["cron", "action"]'
+                          then: '${push.branch}'
           base_sha:
               $if: 'tasks_for == "github-push"'
               then: '${event.before}'
@@ -192,6 +209,7 @@ tasks:
                                 # to `mach taskgraph decision` are all on the command line.
                                 $merge:
                                     - MOBILE_BASE_REPOSITORY: '${baseRepoUrl}'
+                                      MOBILE_BASE_REF: '${base_ref}'
                                       MOBILE_BASE_REV: '${base_sha}'
                                       MOBILE_HEAD_REPOSITORY: '${repoUrl}'
                                       MOBILE_HEAD_REF: '${head_branch}'
@@ -247,6 +265,8 @@ tasks:
                                           --owner='${ownerEmail}'
                                           --level='${level}'
                                           --base-repository="$MOBILE_BASE_REPOSITORY"
+                                          --base-ref="$MOBILE_BASE_REF"
+                                          --base-rev="$MOBILE_BASE_REV"
                                           --head-repository="$MOBILE_HEAD_REPOSITORY"
                                           --head-ref="$MOBILE_HEAD_REF"
                                           --head-rev="$MOBILE_HEAD_REV"


### PR DESCRIPTION
When bumping taskgraph I stopped setting the base_rev parameter in ac_taskgraph, but didn't add the necessary plumbing in .taskcluster.yml.

Fixes: 43c65a255c716ad9274eae5384291fd34edf7deb ("taskcluster: bump taskgraph to 3.2.0")



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
