### PR TITLE
Close #12815: Make millisecond separator non-translateable

### DIFF
--- a/components/feature/prompts/src/main/res/values/strings-no-translatable.xml
+++ b/components/feature/prompts/src/main/res/values/strings-no-translatable.xml
@@ -18,4 +18,6 @@
         <item>@string/mozac_feature_prompts_nov</item>
         <item>@string/mozac_feature_prompts_dec</item>
     </string-array>
+    <!-- Text used for the millisecond separator in the time picker. -->
+    <string name="mozac_feature_prompts_millisecond_separator">.</string>
 </resources>

--- a/components/feature/prompts/src/main/res/values/strings.xml
+++ b/components/feature/prompts/src/main/res/values/strings.xml
@@ -86,8 +86,6 @@
     <string name="mozac_feature_prompts_dec">Dec</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Set time</string>
-    <!-- Text used for the millisecond separator in the time picker. -->
-    <string name="mozac_feature_prompts_millisecond_separator">.</string>
     <!-- Text used for the second separator in the time picker. -->
     <string name="mozac_feature_prompts_second_separator">:</string>
     <!-- Option in expanded select login prompt that links to login settings -->


### PR DESCRIPTION
Instead of revert the change or trying something complex, I opted for moving the string to the non-translated file.

See https://github.com/mozilla-l10n/android-l10n/pull/504/files#r971379636 for more context.

Please land ASAP.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
