### PR TITLE
Bug 1789398 - ensure task["metadata"]["owner"] is not empty on github…

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -16,7 +16,10 @@ tasks:
                   then: 'skaspari+mozlando@mozilla.com'   # It must match what's in bors.toml
                   else:
                       $if: 'tasks_for == "github-push"'
-                      then: '${event.pusher.email}'
+                      then:
+                          $if: 'event.pusher.email'
+                          then: '${event.pusher.email}'
+                          else: '${event.pusher.name}@users.noreply.github.com'
                       else:
                           $if: 'tasks_for == "github-pull-request"'
                           then: '${event.pull_request.user.login}@users.noreply.github.com'


### PR DESCRIPTION
…-push decision tasks

Treeherder requires this in its ingestion pipeline, so if the pusher doesn't have an email then use their name instead.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
