### PR TITLE
updates application services to 94.2.1 in 106

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -35,7 +35,7 @@ object Versions {
 
     // When upgrading mozilla_appservices, also upgrade the version in the
     // `getApplicationServiceVersion()` method in NimbusGradlePlugin.groovy.
-    const val mozilla_appservices = "94.2.0"
+    const val mozilla_appservices = "94.2.1"
 
     // DO NOT MODIFY MANUALLY. This is auto-updated along with GeckoView.
     const val mozilla_glean = "51.2.0"

--- a/components/tooling/nimbus-gradle-plugin/src/main/groovy/mozilla/components/tooling/nimbus/NimbusGradlePlugin.groovy
+++ b/components/tooling/nimbus-gradle-plugin/src/main/groovy/mozilla/components/tooling/nimbus/NimbusGradlePlugin.groovy
@@ -179,7 +179,7 @@ class NimbusPlugin implements Plugin<Project> {
         // a) this plugin is going to live in the AS repo (eventually)
         // See https://github.com/mozilla-mobile/android-components/issues/11422 for tying this
         // to a version that is specified in buildSrc/src/main/java/Dependencies.kt
-        return "94.2.0"
+        return "94.2.1"
     }
 
     // Try one or more hosts to download the given file.


### PR DESCRIPTION
Uplifting application services upgrade to 94.2.1 to beta

I'm not familiar with the uplifit process here, so tagging @Amejia481 and @jonalmeida 

@jhugman requested this for the MR work, the A-S release was cut, and below is the changelog:


# v94.2.1 (_2022-09-21_)

[Full Changelog](https://github.com/mozilla/application-services/compare/v94.2.0...v94.2.1)

## Nimbus ⛅️🔬🔭

### What's Changed
 - Added `applyLocalExperiments()` method as short hand for `setLocalExperiments` and `applyPendingExperiments`. ([#5131](https://github.com/mozilla/application-services/pull/5131))
   - `applyLocalExperiments` and `applyPendingExperiments` now returns a cancellable job which can be used in a timeout.
   - `initialize` function takes a raw resource file id, and returns a cancellable `Job`.

### What's Fixed

   - A regression affecting Android in calculating `days_since_install` and `days_since_update` ([#5157](https://github.com/mozilla/application-services/pull/5157))