### PR TITLE
Close #12815: Make second separator non-translateable

### DIFF
--- a/components/feature/prompts/src/main/res/values/strings-no-translatable.xml
+++ b/components/feature/prompts/src/main/res/values/strings-no-translatable.xml
@@ -20,4 +20,6 @@
     </string-array>
     <!-- Text used for the millisecond separator in the time picker. -->
     <string name="mozac_feature_prompts_millisecond_separator">.</string>
+    <!-- Text used for the second separator in the time picker. -->
+    <string name="mozac_feature_prompts_second_separator">:</string>
 </resources>

--- a/components/feature/prompts/src/main/res/values/strings.xml
+++ b/components/feature/prompts/src/main/res/values/strings.xml
@@ -86,8 +86,6 @@
     <string name="mozac_feature_prompts_dec">Dec</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Set time</string>
-    <!-- Text used for the second separator in the time picker. -->
-    <string name="mozac_feature_prompts_second_separator">:</string>
     <!-- Option in expanded select login prompt that links to login settings -->
     <string name="mozac_feature_prompts_manage_logins">Manage logins</string>
     <!-- Content description for expanding the saved logins options in the select login prompt -->


### PR DESCRIPTION
Similar to https://github.com/mozilla-mobile/android-components/pull/12816

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.



### GitHub Automation
Fixes #12815