### PR TITLE
Fix gradle version code generation on Windows

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -71,7 +71,7 @@ def setupProject(name, path, description) {
 
 def yaml = new Yaml()
 def buildconfig = yaml.load(new File(rootDir, '.buildconfig.yml').newInputStream())
-def componentsVersion = new File(rootDir, 'version.txt').text.replaceAll('\\n', '')
+def componentsVersion = new File(rootDir, 'version.txt').text.stripTrailing()
 buildconfig.projects.each { project ->
     setupProject(project.key, project.value.path, project.value.description)
 }


### PR DESCRIPTION
Building on Windows with the git config `core.autocrlf=true` (sorry) results in a line ending of `\r\n` in `version.txt`, so just removing `\n` leaves trailing whitespace in the resulting Java code that ends in a build failure.

Testing for this perhaps could be included in future Windows-specific CI.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### GitHub Automation
<!-- Do not add anything below this line -->
