### PR TITLE
For #12882: Allow the QR functionality to be queried and resumed

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **feature-qr**
+  * QRFeature now allows querying if scanning is in progress with a new `isScanInProgress` property. This helps deciding on whether to resume scanning by calling `scan` in a new `QRFeature` instance as it can happen if the process is restarted as a followup to the user updating system permissions for the app.
+
 # 107.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v106.0.0..v107.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/154?closed=1)


### PR DESCRIPTION
Clients can query the QRFragment for isScanInProgress and decide on whether to
resume scanning by calling `scan` in a new `QRFeature` instance.
This may be needed if the process is restarted as a followup to the user
updating system permissions for the app which would recreate the component
owning the QRFeature.

Showing https://github.com/mozilla-mobile/fenix/issues/27228 and part of https://github.com/mozilla-mobile/fenix/issues/27177 fixed:


| search resumed with no issues | sync resumed with no issues |
| --- | --- |
| <video src="https://user-images.githubusercontent.com/11428869/193856325-872052b1-ecb7-4842-8f3c-e2da1900231b.mov" /> | <video src="https://user-images.githubusercontent.com/11428869/193846956-c3045da0-b8f5-4597-87f2-cee00e5dcf59.mp4" /> |













### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
Fixes #12882