### PR TITLE
Fix #12902: update publish/build gradle files to use the local property in the build version instead of a runtime-generated timestamp

### DIFF
--- a/components/tooling/glean-gradle-plugin/build.gradle
+++ b/components/tooling/glean-gradle-plugin/build.gradle
@@ -48,7 +48,7 @@ publishing {
                 groupId = config.componentsGroupId
                 artifactId = archivesBaseName
                 description = project.ext.description
-                version = config.componentsVersion + (project.hasProperty('local') ? '-local' + getLocalPublicationTimestamp() : '')
+                version = config.componentsVersion + (project.hasProperty('local') ? '-local' + project.property('local') : '')
 
                 licenses {
                     license {

--- a/components/tooling/nimbus-gradle-plugin/build.gradle
+++ b/components/tooling/nimbus-gradle-plugin/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 groupId = config.componentsGroupId
                 artifactId = archivesBaseName
                 description = project.ext.description
-                version = config.componentsVersion + (project.hasProperty('local') ? '-local' + getLocalPublicationTimestamp() : '')
+                version = config.componentsVersion + (project.hasProperty('local') ? '-local' + project.property('local') : '')
 
                 licenses {
                     license {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **all modules**
+  * Updated the locally published artifacts to use a single timestamp rather than many [#12902](https://github.com/mozilla-mobile/android-components/issues/12902)
+
 * **nimbus-gradle-plugin**:
   * Updated the plugin to use the version of application services defined in the buildSrc Dependencies.
 

--- a/publish.gradle
+++ b/publish.gradle
@@ -43,7 +43,7 @@ ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg ->
                     groupId = groupIdArg
                     artifactId = artifactIdArg
                     // 'local' is for streamlining local publication workflow.
-                    version = config.componentsVersion + (project.hasProperty('local') ? '-local' + getLocalPublicationTimestamp() : '')
+                    version = config.componentsVersion + (project.hasProperty('local') ? '-local' + project.property('local') : '')
 
                     pom {
                         description = descriptionArg


### PR DESCRIPTION


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
Fixes #12902