### PR TITLE
 For #12930 - Unregister FXA observers to prevent memory leaks 

### DIFF
--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/presenter/DefaultPresenter.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/presenter/DefaultPresenter.kt
@@ -81,7 +81,8 @@ internal class DefaultPresenter(
     }
 
     override fun stop() {
-        // no-op
+        accountManager.unregisterForSyncEvents(eventObserver)
+        accountManager.unregister(accountObserver)
     }
 
     companion object {

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/presenter/DefaultPresenter.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/presenter/DefaultPresenter.kt
@@ -96,7 +96,7 @@ internal class DefaultPresenter(
 
     internal class SyncedTabsAccountObserver(
         private val view: SyncedTabsView,
-        private val controller: SyncedTabsController
+        private val controller: SyncedTabsController,
     ) : AccountObserver {
 
         override fun onLoggedOut() {
@@ -119,7 +119,7 @@ internal class DefaultPresenter(
     internal class SyncedTabsSyncObserver(
         private val context: Context,
         private val view: SyncedTabsView,
-        private val controller: SyncedTabsController
+        private val controller: SyncedTabsController,
     ) : SyncStatusObserver {
 
         override fun onIdle() {

--- a/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/presenter/DefaultPresenterTest.kt
+++ b/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/presenter/DefaultPresenterTest.kt
@@ -236,4 +236,20 @@ class DefaultPresenterTest {
 
         verify(view).onError(ErrorType.SYNC_ENGINE_UNAVAILABLE)
     }
+
+    @Test
+    fun `GIVEN the presenter is started WHEN it is stopped THEN unregister the account and sync events observers`() {
+        val presenter = DefaultPresenter(
+            context,
+            controller,
+            accountManager,
+            view,
+            lifecycleOwner,
+        )
+
+        presenter.stop()
+
+        verify(accountManager).unregisterForSyncEvents(presenter.eventObserver)
+        verify(accountManager).unregister(presenter.accountObserver)
+    }
 }

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -240,7 +240,7 @@ open class FxaAccountManager(
      */
     suspend fun migrateFromAccount(
         fromAccount: ShareableAccount,
-        reuseSessionToken: Boolean = false
+        reuseSessionToken: Boolean = false,
     ): MigrationResult = withContext(coroutineContext) {
         processQueue(Event.Account.MigrateFromAccount(fromAccount, reuseSessionToken))
 
@@ -289,7 +289,7 @@ open class FxaAccountManager(
     ) = withContext(coroutineContext) {
         check(
             customEngineSubset.isEmpty() ||
-                syncConfig?.supportedEngines?.containsAll(customEngineSubset) == true
+                syncConfig?.supportedEngines?.containsAll(customEngineSubset) == true,
         ) {
             "Custom engines for sync must be a subset of supported engines."
         }
@@ -310,7 +310,7 @@ open class FxaAccountManager(
                         maybeUpdateSyncAuthInfoCache()
                     } catch (e: AccessTokenUnexpectedlyWithoutKey) {
                         crashReporter?.submitCaughtException(
-                            AccountManagerException.MissingKeyFromSyncScopedAccessToken("syncNow")
+                            AccountManagerException.MissingKeyFromSyncScopedAccessToken("syncNow"),
                         )
                         processQueue(Event.Account.AccessTokenKeyError)
                         // No point in trying to sync now.
@@ -356,7 +356,8 @@ open class FxaAccountManager(
         is State.Idle -> when (s.accountState) {
             AccountState.Authenticated,
             AccountState.IncompleteMigration,
-            AccountState.AuthenticationProblem -> account
+            AccountState.AuthenticationProblem,
+            -> account
             else -> null
         }
         else -> null
@@ -386,7 +387,8 @@ open class FxaAccountManager(
     fun accountProfile(): Profile? = when (val s = state) {
         is State.Idle -> when (s.accountState) {
             AccountState.Authenticated,
-            AccountState.AuthenticationProblem -> profile
+            AccountState.AuthenticationProblem,
+            -> profile
             else -> null
         }
         else -> null
@@ -424,16 +426,18 @@ open class FxaAccountManager(
 
         // 'deferredAuthUrl' will be set as the state machine reacts to the 'event'.
         var deferredAuthUrl: String? = null
-        oauthObservers.register(object : OAuthObserver {
-            override fun onBeginOAuthFlow(authFlowUrl: AuthFlowUrl) {
-                deferredAuthUrl = authFlowUrl.url
-            }
+        oauthObservers.register(
+            object : OAuthObserver {
+                override fun onBeginOAuthFlow(authFlowUrl: AuthFlowUrl) {
+                    deferredAuthUrl = authFlowUrl.url
+                }
 
-            override fun onError() {
-                // No-op for now.
-                logger.warn("Got an error during 'beginAuthentication'")
-            }
-        })
+                override fun onError() {
+                    // No-op for now.
+                    logger.warn("Got an error during 'beginAuthentication'")
+                }
+            },
+        )
         processQueue(event)
         oauthObservers.unregisterObservers()
         deferredAuthUrl
@@ -505,10 +509,10 @@ open class FxaAccountManager(
 
     internal suspend fun encounteredAuthError(
         operation: String,
-        errorCountWithinTheTimeWindow: Int = 1
+        errorCountWithinTheTimeWindow: Int = 1,
     ) = withContext(coroutineContext) {
         processQueue(
-            Event.Account.AuthenticationError(operation, errorCountWithinTheTimeWindow)
+            Event.Account.AuthenticationError(operation, errorCountWithinTheTimeWindow),
         )
     }
 
@@ -589,7 +593,7 @@ open class FxaAccountManager(
     @Suppress("NestedBlockDepth", "LongMethod")
     private suspend fun internalStateSideEffects(
         forState: State.Active,
-        via: Event
+        via: Event,
     ): Event? = when (forState.progressState) {
         ProgressState.Initializing -> {
             when (accountOnDisk) {
@@ -753,7 +757,7 @@ open class FxaAccountManager(
             // frequently, drive the state machine into an unauthorized state.
             if (via.errorCountWithinTheTimeWindow >= AUTH_CHECK_CIRCUIT_BREAKER_COUNT) {
                 crashReporter?.submitCaughtException(
-                    AccountManagerException.AuthRecoveryCircuitBreakerException(via.operation)
+                    AccountManagerException.AuthRecoveryCircuitBreakerException(via.operation),
                 )
                 logger.warn("Unable to recover from an auth problem, triggered a circuit breaker.")
 
@@ -807,7 +811,7 @@ open class FxaAccountManager(
 
     private suspend fun tryToMigrate(
         reuseSessionToken: Boolean,
-        migrationBlock: suspend () -> JSONObject?
+        migrationBlock: suspend () -> JSONObject?,
     ): Event.Progress {
         return if (migrationBlock() != null) {
             Event.Progress.Migrated(reuseSessionToken)
@@ -894,7 +898,8 @@ open class FxaAccountManager(
     }
 
     private suspend fun finalizeDevice(authType: AuthType) = account.deviceConstellation().finalizeDevice(
-        authType, deviceConfig
+        authType,
+        deviceConfig,
     )
 
     /**
@@ -907,7 +912,7 @@ open class FxaAccountManager(
             maybeUpdateSyncAuthInfoCache()
         } catch (e: AccessTokenUnexpectedlyWithoutKey) {
             crashReporter?.submitCaughtException(
-                AccountManagerException.MissingKeyFromSyncScopedAccessToken(operation)
+                AccountManagerException.MissingKeyFromSyncScopedAccessToken(operation),
             )
             // Since we don't know what's causing a missing key for the SCOPE_SYNC access tokens, we
             // do not attempt to recover here. If this is a persistent state for an account, a recovery
@@ -922,8 +927,8 @@ open class FxaAccountManager(
             DeviceSettings(
                 fxaDeviceId = account.getCurrentDeviceId()!!,
                 name = deviceConfig.name,
-                kind = deviceConfig.type.intoSyncType()
-            )
+                kind = deviceConfig.type.intoSyncType(),
+            ),
         )
         return true
     }
@@ -954,7 +959,7 @@ open class FxaAccountManager(
      */
     @VisibleForTesting
     internal class AccountsToSyncIntegration(
-        private val syncManager: SyncManager
+        private val syncManager: SyncManager,
     ) : AccountObserver {
         override fun onLoggedOut() {
             syncManager.stop()
@@ -963,7 +968,8 @@ open class FxaAccountManager(
         override fun onAuthenticated(account: OAuthAccount, authType: AuthType) {
             val reason = when (authType) {
                 is AuthType.OtherExternal, AuthType.Signin, AuthType.Signup, AuthType.MigratedReuse,
-                AuthType.MigratedCopy, AuthType.Pairing -> SyncReason.FirstSync
+                AuthType.MigratedCopy, AuthType.Pairing,
+                -> SyncReason.FirstSync
                 AuthType.Existing, AuthType.Recovered -> SyncReason.Startup
             }
             syncManager.start()
@@ -984,7 +990,7 @@ open class FxaAccountManager(
      * Sync status changes flowing into account manager.
      */
     private class SyncToAccountsIntegration(
-        private val accountManager: FxaAccountManager
+        private val accountManager: FxaAccountManager,
     ) : SyncStatusObserver {
         override fun onStarted() {
             accountManager.syncStatusObserverRegistry.notifyObservers { onStarted() }

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -178,7 +178,9 @@ open class FxaAccountManager(
 
     @VisibleForTesting
     val accountEventObserverRegistry = ObserverRegistry<AccountEventsObserver>()
-    private val syncStatusObserverRegistry = ObserverRegistry<SyncStatusObserver>()
+
+    @VisibleForTesting
+    open val syncStatusObserverRegistry = ObserverRegistry<SyncStatusObserver>()
 
     // We always obtain a "profile" scope, as that's assumed to be needed for any application integration.
     // We obtain a sync scope only if this was requested by the application via SyncConfig.
@@ -485,6 +487,14 @@ open class FxaAccountManager(
      */
     fun registerForSyncEvents(observer: SyncStatusObserver, owner: LifecycleOwner, autoPause: Boolean) {
         syncStatusObserverRegistry.register(observer, owner, autoPause)
+    }
+
+    /**
+     * Unregister a [SyncStatusObserver] from being informed about "sync lifecycle" events.
+     * The method is safe to call even if the provided observer was not registered before.
+     */
+    fun unregisterForSyncEvents(observer: SyncStatusObserver) {
+        syncStatusObserverRegistry.unregister(observer)
     }
 
     override fun close() {

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -76,7 +76,7 @@ internal class TestableStorageWrapper(
         val account: OAuthAccount = mock()
         `when`(account.deviceConstellation()).thenReturn(mock())
         account
-    }
+    },
 ) : StorageWrapper(manager, accountEventObserverRegistry, serverConfig) {
     override fun obtainAccount(): OAuthAccount = block()
 }
@@ -97,7 +97,7 @@ internal open class TestableFxaAccountManager(
         val account: OAuthAccount = mock()
         `when`(account.deviceConstellation()).thenReturn(mock())
         account
-    }
+    },
 ) : FxaAccountManager(context, config, DeviceConfig("test", DeviceType.UNKNOWN, capabilities), syncConfig, emptySet(), crashReporter, coroutineContext) {
     private val testableStorageWrapper = TestableStorageWrapper(this, accountEventObserverRegistry, serverConfig, block)
 
@@ -203,8 +203,12 @@ class FxaAccountManagerTest {
         val accountObserver: AccountObserver = mock()
 
         val manager = TestableFxaAccountManager(
-            testContext, ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"), accountStorage,
-            setOf(DeviceCapability.SEND_TAB), null, this.coroutineContext
+            testContext,
+            ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"),
+            accountStorage,
+            setOf(DeviceCapability.SEND_TAB),
+            null,
+            this.coroutineContext,
         ) {
             account
         }
@@ -218,7 +222,7 @@ class FxaAccountManagerTest {
         var migratableAccount = ShareableAccount(
             email = "test@example.com",
             sourcePackage = "org.mozilla.firefox",
-            authInfo = MigratingAccountInfo("session", "kSync", "kXCS")
+            authInfo = MigratingAccountInfo("session", "kSync", "kXCS"),
         )
 
         // TODO Need to mock inputs into - mock a PackageManager, and have it return PackageInfo with the right signature.
@@ -228,7 +232,7 @@ class FxaAccountManagerTest {
         account.migrationResult = MigrationResult.Failure
         assertEquals(
             MigrationResult.Failure,
-            manager.migrateFromAccount(migratableAccount)
+            manager.migrateFromAccount(migratableAccount),
         )
 
         assertEquals("session", account.latestMigrateAuthInfo!!.sessionToken)
@@ -243,12 +247,12 @@ class FxaAccountManagerTest {
         // Success.
         account.migrationResult = MigrationResult.Success
         migratableAccount = migratableAccount.copy(
-            authInfo = MigratingAccountInfo("session2", "kSync2", "kXCS2")
+            authInfo = MigratingAccountInfo("session2", "kSync2", "kXCS2"),
         )
 
         assertEquals(
             MigrationResult.Success,
-            manager.migrateFromAccount(migratableAccount)
+            manager.migrateFromAccount(migratableAccount),
         )
 
         assertEquals("session2", account.latestMigrateAuthInfo!!.sessionToken)
@@ -275,8 +279,12 @@ class FxaAccountManagerTest {
         val accountObserver: AccountObserver = mock()
 
         val manager = TestableFxaAccountManager(
-            testContext, ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"), accountStorage,
-            setOf(DeviceCapability.SEND_TAB), null, this.coroutineContext
+            testContext,
+            ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"),
+            accountStorage,
+            setOf(DeviceCapability.SEND_TAB),
+            null,
+            this.coroutineContext,
         ) {
             account
         }
@@ -290,7 +298,7 @@ class FxaAccountManagerTest {
         var migratableAccount = ShareableAccount(
             email = "test@example.com",
             sourcePackage = "org.mozilla.firefox",
-            authInfo = MigratingAccountInfo("session", "kSync", "kXCS")
+            authInfo = MigratingAccountInfo("session", "kSync", "kXCS"),
         )
 
         // TODO Need to mock inputs into - mock a PackageManager, and have it return PackageInfo with the right signature.
@@ -300,7 +308,7 @@ class FxaAccountManagerTest {
         account.migrationResult = MigrationResult.Failure
         assertEquals(
             MigrationResult.Failure,
-            manager.migrateFromAccount(migratableAccount, reuseSessionToken = true)
+            manager.migrateFromAccount(migratableAccount, reuseSessionToken = true),
         )
 
         assertEquals("session", account.latestMigrateAuthInfo!!.sessionToken)
@@ -315,12 +323,12 @@ class FxaAccountManagerTest {
         // Success.
         account.migrationResult = MigrationResult.Success
         migratableAccount = migratableAccount.copy(
-            authInfo = MigratingAccountInfo("session2", "kSync2", "kXCS2")
+            authInfo = MigratingAccountInfo("session2", "kSync2", "kXCS2"),
         )
 
         assertEquals(
             MigrationResult.Success,
-            manager.migrateFromAccount(migratableAccount, reuseSessionToken = true)
+            manager.migrateFromAccount(migratableAccount, reuseSessionToken = true),
         )
 
         assertEquals("session2", account.latestMigrateAuthInfo!!.sessionToken)
@@ -343,8 +351,12 @@ class FxaAccountManagerTest {
         val accountObserver: AccountObserver = mock()
 
         val manager = TestableFxaAccountManager(
-            testContext, ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"), accountStorage,
-            setOf(DeviceCapability.SEND_TAB), null, this.coroutineContext
+            testContext,
+            ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"),
+            accountStorage,
+            setOf(DeviceCapability.SEND_TAB),
+            null,
+            this.coroutineContext,
         ) {
             account
         }
@@ -358,7 +370,7 @@ class FxaAccountManagerTest {
         val migratableAccount = ShareableAccount(
             email = "test@example.com",
             sourcePackage = "org.mozilla.firefox",
-            authInfo = MigratingAccountInfo("session", "kSync", "kXCS")
+            authInfo = MigratingAccountInfo("session", "kSync", "kXCS"),
         )
 
         // TODO Need to mock inputs into - mock a PackageManager, and have it return PackageInfo with the right signature.
@@ -368,7 +380,7 @@ class FxaAccountManagerTest {
         account.migrationResult = MigrationResult.WillRetry
         assertEquals(
             MigrationResult.WillRetry,
-            manager.migrateFromAccount(migratableAccount, reuseSessionToken = true)
+            manager.migrateFromAccount(migratableAccount, reuseSessionToken = true),
         )
 
         assertEquals("session", account.latestMigrateAuthInfo!!.sessionToken)
@@ -401,8 +413,12 @@ class FxaAccountManagerTest {
         val account = StatePersistenceTestableAccount(profile, constellation)
 
         val manager = TestableFxaAccountManager(
-            testContext, ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"), accountStorage,
-            setOf(DeviceCapability.SEND_TAB), null, this.coroutineContext
+            testContext,
+            ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"),
+            accountStorage,
+            setOf(DeviceCapability.SEND_TAB),
+            null,
+            this.coroutineContext,
         ) {
             account
         }
@@ -438,8 +454,12 @@ class FxaAccountManagerTest {
         val account = StatePersistenceTestableAccount(profile, constellation)
 
         val manager = TestableFxaAccountManager(
-            testContext, ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"), accountStorage,
-            setOf(DeviceCapability.SEND_TAB), null, this.coroutineContext
+            testContext,
+            ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"),
+            accountStorage,
+            setOf(DeviceCapability.SEND_TAB),
+            null,
+            this.coroutineContext,
         ) {
             account
         }
@@ -472,8 +492,12 @@ class FxaAccountManagerTest {
         val account = StatePersistenceTestableAccount(profile, constellation)
 
         val manager = TestableFxaAccountManager(
-            testContext, ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"), accountStorage,
-            setOf(DeviceCapability.SEND_TAB), null, this.coroutineContext
+            testContext,
+            ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"),
+            accountStorage,
+            setOf(DeviceCapability.SEND_TAB),
+            null,
+            this.coroutineContext,
         ) {
             account
         }
@@ -504,8 +528,12 @@ class FxaAccountManagerTest {
         val account = StatePersistenceTestableAccount(profile, constellation)
 
         val manager = TestableFxaAccountManager(
-            testContext, ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"), accountStorage,
-            setOf(DeviceCapability.SEND_TAB), null, this.coroutineContext
+            testContext,
+            ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"),
+            accountStorage,
+            setOf(DeviceCapability.SEND_TAB),
+            null,
+            this.coroutineContext,
         ) {
             account
         }
@@ -540,8 +568,12 @@ class FxaAccountManagerTest {
 
         val accountObserver: AccountObserver = mock()
         val manager = TestableFxaAccountManager(
-            testContext, ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"), accountStorage,
-            setOf(DeviceCapability.SEND_TAB), null, this.coroutineContext
+            testContext,
+            ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"),
+            accountStorage,
+            setOf(DeviceCapability.SEND_TAB),
+            null,
+            this.coroutineContext,
         ) {
             account
         }
@@ -575,8 +607,12 @@ class FxaAccountManagerTest {
 
         val accountObserver: AccountObserver = mock()
         val manager = TestableFxaAccountManager(
-            testContext, ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"), accountStorage,
-            setOf(DeviceCapability.SEND_TAB), null, this.coroutineContext
+            testContext,
+            ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"),
+            accountStorage,
+            setOf(DeviceCapability.SEND_TAB),
+            null,
+            this.coroutineContext,
         ) {
             account
         }
@@ -612,7 +648,9 @@ class FxaAccountManagerTest {
             testContext,
             ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
             accountStorage,
-            setOf(DeviceCapability.SEND_TAB), null, this.coroutineContext
+            setOf(DeviceCapability.SEND_TAB),
+            null,
+            this.coroutineContext,
         ) {
             account
         }
@@ -654,7 +692,9 @@ class FxaAccountManagerTest {
             testContext,
             ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
             accountStorage,
-            setOf(DeviceCapability.SEND_TAB), null, this.coroutineContext
+            setOf(DeviceCapability.SEND_TAB),
+            null,
+            this.coroutineContext,
         ) {
             account
         }
@@ -690,7 +730,7 @@ class FxaAccountManagerTest {
         val tokenServerEndpointUrl: String? = null,
         var migrationResult: MigrationResult = MigrationResult.Failure,
         var migrationRetrySuccess: Boolean = false,
-        val accessToken: (() -> AccessTokenInfo)? = null
+        val accessToken: (() -> AccessTokenInfo)? = null,
     ) : OAuthAccount {
 
         var persistenceCallback: StatePersistenceCallback? = null
@@ -807,7 +847,8 @@ class FxaAccountManagerTest {
         val manager = TestableFxaAccountManager(
             testContext,
             ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
-            accountStorage, coroutineContext = this.coroutineContext
+            accountStorage,
+            coroutineContext = this.coroutineContext,
         )
 
         val accountObserver = object : AccountObserver {
@@ -841,7 +882,8 @@ class FxaAccountManagerTest {
         val manager = TestableFxaAccountManager(
             testContext,
             ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
-            accountStorage, coroutineContext = this.coroutineContext
+            accountStorage,
+            coroutineContext = this.coroutineContext,
         )
 
         val accountObserver: AccountObserver = mock()
@@ -867,7 +909,10 @@ class FxaAccountManagerTest {
         val mockAccount: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
         val profile = Profile(
-            "testUid", "test@example.com", null, "Test Profile"
+            "testUid",
+            "test@example.com",
+            null,
+            "Test Profile",
         )
         `when`(mockAccount.getProfile(ignoreCache = false)).thenReturn(profile)
         `when`(mockAccount.isInMigrationState()).thenReturn(null)
@@ -881,7 +926,9 @@ class FxaAccountManagerTest {
             testContext,
             ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
             accountStorage,
-            emptySet(), null, this.coroutineContext
+            emptySet(),
+            null,
+            this.coroutineContext,
         )
 
         val accountObserver: AccountObserver = mock()
@@ -1018,7 +1065,8 @@ class FxaAccountManagerTest {
         val manager = TestableFxaAccountManager(
             testContext,
             ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
-            accountStorage, coroutineContext = coroutineContext
+            accountStorage,
+            coroutineContext = coroutineContext,
         ) {
             mockAccount
         }
@@ -1270,7 +1318,7 @@ class FxaAccountManagerTest {
             accountObserver,
             this.coroutineContext,
             setOf(DeviceCapability.SEND_TAB),
-            crashReporter
+            crashReporter,
         )
 
         // We start off as logged-out, but the event won't be called (initial default state is assumed).
@@ -1316,7 +1364,7 @@ class FxaAccountManagerTest {
             accountObserver,
             this.coroutineContext,
             setOf(DeviceCapability.SEND_TAB),
-            crashReporter
+            crashReporter,
         )
         GlobalAccountManager.setInstance(manager)
 
@@ -1364,7 +1412,7 @@ class FxaAccountManagerTest {
         accountObserver: AccountObserver,
         manager: FxaAccountManager,
         mockAccount: OAuthAccount,
-        crashReporter: CrashReporting
+        crashReporter: CrashReporting,
     ) {
         // During recovery, only 'sign-in' finalize device call should have been made.
         verify(constellation, times(1)).finalizeDevice(eq(AuthType.Signin), any())
@@ -1407,7 +1455,8 @@ class FxaAccountManagerTest {
         val manager = TestableFxaAccountManager(
             testContext,
             ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
-            accountStorage, coroutineContext = this.coroutineContext
+            accountStorage,
+            coroutineContext = this.coroutineContext,
         ) {
             mockAccount
         }
@@ -1441,7 +1490,10 @@ class FxaAccountManagerTest {
         // Make sure we can re-try fetching a profile. This time, let's have it succeed.
         reset(accountObserver)
         val profile = Profile(
-            uid = "testUID", avatar = null, email = "test@example.com", displayName = "test profile"
+            uid = "testUID",
+            avatar = null,
+            email = "test@example.com",
+            displayName = "test profile",
         )
 
         `when`(mockAccount.getProfile(ignoreCache = true)).thenReturn(profile)
@@ -1474,7 +1526,8 @@ class FxaAccountManagerTest {
         val manager = TestableFxaAccountManager(
             testContext,
             ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
-            accountStorage, coroutineContext = this.coroutineContext
+            accountStorage,
+            coroutineContext = this.coroutineContext,
         ) {
             mockAccount
         }
@@ -1533,7 +1586,8 @@ class FxaAccountManagerTest {
         val manager = TestableFxaAccountManager(
             testContext,
             ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
-            accountStorage, coroutineContext = this.coroutineContext
+            accountStorage,
+            coroutineContext = this.coroutineContext,
         ) {
             mockAccount
         }
@@ -1583,7 +1637,10 @@ class FxaAccountManagerTest {
         `when`(constellation.finalizeDevice(any(), any())).thenReturn(ServiceResult.Ok)
 
         val profile = Profile(
-            uid = "testUID", avatar = null, email = "test@example.com", displayName = "test profile"
+            uid = "testUID",
+            avatar = null,
+            email = "test@example.com",
+            displayName = "test profile",
         )
 
         // Recovery flow will hit this API, return a success.
@@ -1597,7 +1654,8 @@ class FxaAccountManagerTest {
         val manager = TestableFxaAccountManager(
             testContext,
             ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
-            accountStorage, coroutineContext = this.coroutineContext
+            accountStorage,
+            coroutineContext = this.coroutineContext,
         ) {
             mockAccount
         }
@@ -1670,7 +1728,8 @@ class FxaAccountManagerTest {
         val manager = TestableFxaAccountManager(
             testContext,
             ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
-            accountStorage, coroutineContext = this.coroutineContext
+            accountStorage,
+            coroutineContext = this.coroutineContext,
         ) {
             mockAccount
         }
@@ -1784,11 +1843,13 @@ class FxaAccountManagerTest {
         accountObserver: AccountObserver,
         coroutineContext: CoroutineContext,
         capabilities: Set<DeviceCapability> = emptySet(),
-        crashReporter: CrashReporting? = null
+        crashReporter: CrashReporting? = null,
     ): FxaAccountManager {
-
         val accessTokenInfo = AccessTokenInfo(
-            "testSc0pe", "someToken", OAuthScopedKey("kty", "testSc0pe", "kid", "k"), System.currentTimeMillis() + 1000 * 10
+            "testSc0pe",
+            "someToken",
+            OAuthScopedKey("kty", "testSc0pe", "kid", "k"),
+            System.currentTimeMillis() + 1000 * 10,
         )
 
         `when`(mockAccount.getProfile(ignoreCache = false)).thenReturn(profile)
@@ -1804,9 +1865,11 @@ class FxaAccountManagerTest {
         val manager = TestableFxaAccountManager(
             testContext,
             ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
-            accountStorage, capabilities,
+            accountStorage,
+            capabilities,
             SyncConfig(setOf(SyncEngine.History, SyncEngine.Bookmarks), PeriodicSyncConfig()),
-            coroutineContext = coroutineContext, crashReporter = crashReporter
+            coroutineContext = coroutineContext,
+            crashReporter = crashReporter,
         ) {
             mockAccount
         }
@@ -1822,7 +1885,7 @@ class FxaAccountManagerTest {
         profile: Profile,
         accountStorage: AccountStorage,
         accountObserver: AccountObserver,
-        coroutineContext: CoroutineContext
+        coroutineContext: CoroutineContext,
     ): FxaAccountManager {
         `when`(mockAccount.getProfile(ignoreCache = false)).thenReturn(profile)
         `when`(mockAccount.deviceConstellation()).thenReturn(mock())
@@ -1835,7 +1898,8 @@ class FxaAccountManagerTest {
         val manager = TestableFxaAccountManager(
             testContext,
             ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
-            accountStorage, coroutineContext = coroutineContext
+            accountStorage,
+            coroutineContext = coroutineContext,
         ) {
             mockAccount
         }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **feature-syncedtabs**
+  * 🚒 Bug fixed [issue #12930](https://github.com/mozilla-mobile/android-components/issues/12930) Ensure `DefaultPresenter` will unregister it's `FxaAccountManager` observers when it's `lifecycleOwner` is stopped to prevent memory leaks. 
+
 * **feature-app-links**
   * 🚒 Bug fixed [issue #12804](https://github.com/mozilla-mobile/android-components/issues/12804) Speculative fix for a TransactionTooLargeException or RuntimeException when querying activities.
 


### PR DESCRIPTION
No leaks in the scenario of opening and closing tabs tray on Fenix:



https://user-images.githubusercontent.com/11428869/195330861-e44619d0-3dcf-4941-957c-8d044c85feca.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.



### GitHub Automation
Fixes #12930