### PR TITLE
Bug 1783561 - Support custom download dialogs

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBehavior.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBehavior.kt
@@ -6,18 +6,14 @@ package mozilla.components.browser.toolbar.behavior
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.Gravity
 import android.view.MotionEvent
 import android.view.View
 import androidx.annotation.VisibleForTesting
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.ViewCompat
-import com.google.android.material.snackbar.Snackbar
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.support.ktx.android.view.findViewInHierarchy
-
-private const val SMALL_ELEVATION_CHANGE = 0.01f
 
 /**
  * Where the toolbar is placed on the screen.
@@ -35,7 +31,6 @@ enum class ToolbarPosition {
  *
  * This implementation will:
  * - Show/Hide the [BrowserToolbar] automatically when scrolling vertically.
- * - On showing a [Snackbar] position it above the [BrowserToolbar].
  * - Snap the [BrowserToolbar] to be hidden or visible when the user stops scrolling.
  */
 class BrowserToolbarBehavior(
@@ -128,14 +123,6 @@ class BrowserToolbarBehavior(
         return false // allow events to be passed to below listeners
     }
 
-    override fun layoutDependsOn(parent: CoordinatorLayout, child: BrowserToolbar, dependency: View): Boolean {
-        if (toolbarPosition == ToolbarPosition.BOTTOM && dependency is Snackbar.SnackbarLayout) {
-            positionSnackbar(child, dependency)
-        }
-
-        return super.layoutDependsOn(parent, child, dependency)
-    }
-
     override fun onLayoutChild(
         parent: CoordinatorLayout,
         child: BrowserToolbar,
@@ -177,23 +164,6 @@ class BrowserToolbarBehavior(
      */
     fun disableScrolling() {
         isScrollEnabled = false
-    }
-
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun positionSnackbar(child: View, snackbarLayout: Snackbar.SnackbarLayout) {
-        val params = snackbarLayout.layoutParams as CoordinatorLayout.LayoutParams
-
-        // Position the snackbar above the toolbar so that it doesn't overlay the toolbar.
-        params.anchorId = child.id
-        params.anchorGravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
-        params.gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
-
-        snackbarLayout.layoutParams = params
-
-        // In order to avoid the snackbar casting a shadow on the toolbar we adjust the elevation of the snackbar here.
-        // We still place it slightly behind the toolbar so that it will not animate over the toolbar but instead pop
-        // out from under the toolbar.
-        snackbarLayout.elevation = child.elevation - SMALL_ELEVATION_CHANGE
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBehaviorTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBehaviorTest.kt
@@ -6,14 +6,12 @@ package mozilla.components.browser.toolbar.behavior
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.view.Gravity
 import android.view.MotionEvent.ACTION_DOWN
 import android.view.MotionEvent.ACTION_MOVE
 import android.widget.FrameLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.ViewCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.google.android.material.snackbar.Snackbar
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
@@ -472,29 +470,6 @@ class BrowserToolbarBehaviorTest {
         behavior.forceCollapse(toolbar)
 
         verify(yTranslator).collapseWithAnimation(toolbar)
-    }
-
-    @Test
-    fun `Behavior will position snackbar above toolbar`() {
-        val behavior = BrowserToolbarBehavior(testContext, null, ToolbarPosition.BOTTOM)
-
-        val toolbar: BrowserToolbar = mock()
-        doReturn(4223).`when`(toolbar).id
-
-        val layoutParams: CoordinatorLayout.LayoutParams = CoordinatorLayout.LayoutParams(0, 0)
-
-        val snackbarLayout: Snackbar.SnackbarLayout = mock()
-        doReturn(layoutParams).`when`(snackbarLayout).layoutParams
-
-        behavior.layoutDependsOn(
-            parent = mock(),
-            child = toolbar,
-            dependency = snackbarLayout,
-        )
-
-        assertEquals(4223, layoutParams.anchorId)
-        assertEquals(Gravity.TOP or Gravity.CENTER_HORIZONTAL, layoutParams.anchorGravity)
-        assertEquals(Gravity.TOP or Gravity.CENTER_HORIZONTAL, layoutParams.gravity)
     }
 
     @Test

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadDialogFragment.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadDialogFragment.kt
@@ -10,7 +10,7 @@ import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.feature.downloads.DownloadDialogFragment.Companion.BYTES_TO_MB_LIMIT
 import mozilla.components.feature.downloads.DownloadDialogFragment.Companion.KILOBYTE
 import mozilla.components.feature.downloads.DownloadDialogFragment.Companion.MEGABYTE
-import mozilla.components.support.utils.DownloadUtils
+import mozilla.components.feature.downloads.ext.realFilenameOrGuessed
 
 /**
  * This is a general representation of a dialog meant to be used in collaboration with [DownloadsFeature]
@@ -34,11 +34,7 @@ abstract class DownloadDialogFragment : AppCompatDialogFragment() {
      */
     fun setDownload(download: DownloadState) {
         val args = arguments ?: Bundle()
-        args.putString(
-            KEY_FILE_NAME,
-            download.fileName
-                ?: DownloadUtils.guessFileName(null, download.destinationDirectory, download.url, download.contentType),
-        )
+        args.putString(KEY_FILE_NAME, download.realFilenameOrGuessed)
         args.putString(KEY_URL, download.url)
         args.putLong(KEY_CONTENT_LENGTH, download.contentLength ?: 0)
         arguments = args

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
@@ -17,7 +17,6 @@ import androidx.core.net.toUri
 import androidx.fragment.app.FragmentManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.mapNotNull
 import mozilla.components.browser.state.selector.findCustomTabOrSelectedTab
 import mozilla.components.browser.state.selector.findTabOrCustomTabOrSelectedTab
@@ -57,13 +56,25 @@ value class Filename(val value: String)
 value class ContentSize(val value: Long)
 
 /**
- * Action for when the positive button of a download dialog was tapped.
+ * The list of all applications that can perform a download, including this application.
+ */
+@JvmInline
+value class ThirdPartyDownloaderApps(val value: List<DownloaderApp>)
+
+/**
+ * Callback for when the user picked a certain application with which to download the current file.
+ */
+@JvmInline
+value class ThirdPartyDownloaderAppChosenCallback(val value: (DownloaderApp) -> Unit)
+
+/**
+ * Callback for when the positive button of a download dialog was tapped.
  */
 @JvmInline
 value class PositiveActionCallback(val value: () -> Unit)
 
 /**
- * Action for when the negative button of a download dialog was tapped.
+ * Callback for when the negative button of a download dialog was tapped.
  */
 @JvmInline
 value class NegativeActionCallback(val value: () -> Unit)
@@ -87,7 +98,10 @@ value class NegativeActionCallback(val value: () -> Unit)
  * @property promptsStyling styling properties for the dialog.
  * @property shouldForwardToThirdParties Indicates if downloads should be forward to third party apps,
  * if there are multiple apps a chooser dialog will shown.
- * @property customDownloadDialog An optional delegate for showing a download dialog.
+ * @property customFirstPartyDownloadDialog An optional delegate for showing a dialog for a download
+ * that will be processed by the current application.
+ * @property customThirdPartyDownloadDialog An optional delegate for showing a dialog for a download
+ * that can be processed by multiple installed applications including the current one.
  */
 @Suppress("LongParameterList", "LargeClass")
 class DownloadsFeature(
@@ -102,7 +116,10 @@ class DownloadsFeature(
     private val fragmentManager: FragmentManager? = null,
     private val promptsStyling: PromptsStyling? = null,
     private val shouldForwardToThirdParties: () -> Boolean = { false },
-    private val customDownloadDialog: ((Filename, ContentSize, PositiveActionCallback, NegativeActionCallback) -> Unit)? = null,
+    private val customFirstPartyDownloadDialog:
+        ((Filename, ContentSize, PositiveActionCallback, NegativeActionCallback) -> Unit)? = null,
+    private val customThirdPartyDownloadDialog:
+        ((ThirdPartyDownloaderApps, ThirdPartyDownloaderAppChosenCallback, NegativeActionCallback) -> Unit)? = null,
 ) : LifecycleAwareFeature, PermissionsFeature {
 
     var onDownloadStopped: onDownloadStopped
@@ -189,13 +206,25 @@ class DownloadsFeature(
         val shouldShowAppDownloaderDialog = shouldForwardToThirdParties() && apps.size > 1
 
         return if (shouldShowAppDownloaderDialog) {
-            showAppDownloaderDialog(tab, download, apps)
+            when (customThirdPartyDownloadDialog) {
+                null -> showAppDownloaderDialog(tab, download, apps)
+                else -> customThirdPartyDownloadDialog.invoke(
+                    ThirdPartyDownloaderApps(apps),
+                    ThirdPartyDownloaderAppChosenCallback {
+                        onDownloaderAppSelected(it, tab, download)
+                    },
+                    NegativeActionCallback {
+                        useCases.cancelDownloadRequest.invoke(tab.id, download.id)
+                    },
+                )
+            }
+
             false
         } else {
             if (applicationContext.isPermissionGranted(downloadManager.permissions.asIterable())) {
                 when {
-                    customDownloadDialog != null && !download.skipConfirmation -> {
-                        customDownloadDialog.invoke(
+                    customFirstPartyDownloadDialog != null && !download.skipConfirmation -> {
+                        customFirstPartyDownloadDialog.invoke(
                             Filename(download.realFilenameOrGuessed),
                             ContentSize(download.contentLength ?: 0),
                             PositiveActionCallback {
@@ -311,25 +340,7 @@ class DownloadsFeature(
     ) {
         appChooserDialog.setApps(apps)
         appChooserDialog.onAppSelected = { app ->
-            if (app.packageName == applicationContext.packageName) {
-                if (applicationContext.isPermissionGranted(downloadManager.permissions.asIterable())) {
-                    startDownload(download)
-                    useCases.consumeDownload(tab.id, download.id)
-                } else {
-                    onNeedToRequestPermissions(downloadManager.permissions)
-                }
-            } else {
-                try {
-                    applicationContext.startActivity(app.toIntent())
-                } catch (error: ActivityNotFoundException) {
-                    val errorMessage = applicationContext.getString(
-                        R.string.mozac_feature_downloads_unable_to_open_third_party_app,
-                        app.name,
-                    )
-                    Toast.makeText(applicationContext, errorMessage, Toast.LENGTH_SHORT).show()
-                }
-                useCases.consumeDownload(tab.id, download.id)
-            }
+            onDownloaderAppSelected(app, tab, download)
         }
 
         appChooserDialog.onDismiss = {
@@ -338,6 +349,29 @@ class DownloadsFeature(
 
         if (!isAlreadyAppDownloaderDialog() && fragmentManager != null && !fragmentManager.isDestroyed) {
             appChooserDialog.showNow(fragmentManager, DownloadAppChooserDialog.FRAGMENT_TAG)
+        }
+    }
+
+    @VisibleForTesting
+    internal fun onDownloaderAppSelected(app: DownloaderApp, tab: SessionState, download: DownloadState) {
+        if (app.packageName == applicationContext.packageName) {
+            if (applicationContext.isPermissionGranted(downloadManager.permissions.asIterable())) {
+                startDownload(download)
+                useCases.consumeDownload(tab.id, download.id)
+            } else {
+                onNeedToRequestPermissions(downloadManager.permissions)
+            }
+        } else {
+            try {
+                applicationContext.startActivity(app.toIntent())
+            } catch (error: ActivityNotFoundException) {
+                val errorMessage = applicationContext.getString(
+                    R.string.mozac_feature_downloads_unable_to_open_third_party_app,
+                    app.name,
+                )
+                Toast.makeText(applicationContext, errorMessage, Toast.LENGTH_SHORT).show()
+            }
+            useCases.consumeDownload(tab.id, download.id)
         }
     }
 
@@ -411,7 +445,8 @@ class DownloadsFeature(
 
     private val ActivityInfo.identifier: String get() = packageName + name
 
-    private fun DownloaderApp.toIntent(): Intent {
+    @VisibleForTesting
+    internal fun DownloaderApp.toIntent(): Intent {
         return Intent(Intent.ACTION_VIEW).apply {
             setDataAndTypeAndNormalize(url.toUri(), contentType)
             flags = Intent.FLAG_ACTIVITY_NEW_TASK

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/ext/DownloadState.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/ext/DownloadState.kt
@@ -47,3 +47,6 @@ internal fun DownloadState.withResponse(headers: Headers, stream: InputStream?):
         contentLength = contentLength ?: headers[CONTENT_LENGTH]?.toLongOrNull(),
     )
 }
+
+internal val DownloadState.realFilenameOrGuessed
+    get() = fileName ?: DownloadUtils.guessFileName(null, destinationDirectory, url, contentType)

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/ui/DownloaderAppAdapter.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/ui/DownloaderAppAdapter.kt
@@ -16,7 +16,7 @@ import mozilla.components.feature.downloads.R
 /**
  * An adapter for displaying the applications that can perform downloads.
  */
-internal class DownloaderAppAdapter(
+class DownloaderAppAdapter(
     context: Context,
     private val apps: List<DownloaderApp>,
     val onAppSelected: ((DownloaderApp) -> Unit),
@@ -49,11 +49,14 @@ internal class DownloaderAppAdapter(
 /**
  * View holder for a [DownloaderApp] item.
  */
-internal class DownloaderAppViewHolder(
+class DownloaderAppViewHolder(
     itemView: View,
     val nameLabel: TextView,
     val iconImage: ImageView,
 ) : RecyclerView.ViewHolder(itemView) {
+    /**
+     * Show a certain downloader application in the current View.
+     */
     fun bind(app: DownloaderApp, onAppSelected: ((DownloaderApp) -> Unit)) {
         itemView.app = app
         itemView.setOnClickListener {

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
@@ -653,6 +653,49 @@ class DownloadsFeatureTest {
     }
 
     @Test
+    fun `GIVEN download should not be forwarded to third party apps but to a custom delegate WHEN processing a download request THEN forward it to the delegate`() {
+        val tab = createTab("https://www.mozilla.org", id = "test-tab")
+        val download = DownloadState(url = "https://www.mozilla.org/file.txt", sessionId = "test-tab", id = "test")
+        val usecases: DownloadsUseCases = mock()
+        val consumeDownloadUseCase: ConsumeDownloadUseCase = mock()
+        val cancelDownloadUseCase: CancelDownloadRequestUseCase = mock()
+        doReturn(consumeDownloadUseCase).`when`(usecases).consumeDownload
+        doReturn(cancelDownloadUseCase).`when`(usecases).cancelDownloadRequest
+        val downloadManager: DownloadManager = mock()
+        var delegateFilename = ""
+        var delegateContentSize: Long = -1
+        var delegatePositiveActionCallback: (() -> Unit)? = null
+        var delegateNegativeActionCallback: (() -> Unit)? = null
+        grantPermissions()
+        doReturn(arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE)).`when`(downloadManager).permissions
+        val feature = spy(
+            DownloadsFeature(
+                applicationContext = testContext,
+                store = mock(),
+                useCases = usecases,
+                downloadManager = downloadManager,
+                customDownloadDialog = { filename, contentSize, positiveActionCallback, negativeActionCallback ->
+                    delegateFilename = filename.value
+                    delegateContentSize = contentSize.value
+                    delegatePositiveActionCallback = positiveActionCallback.value
+                    delegateNegativeActionCallback = negativeActionCallback.value
+                },
+            ),
+        )
+
+        feature.processDownload(tab, download)
+
+        assertEquals("file.txt", delegateFilename)
+        assertEquals(0, delegateContentSize)
+        assertNotNull(delegatePositiveActionCallback)
+        delegatePositiveActionCallback?.invoke()
+        verify(consumeDownloadUseCase).invoke(tab.id, download.id)
+        assertNotNull(delegateNegativeActionCallback)
+        delegateNegativeActionCallback?.invoke()
+        verify(cancelDownloadUseCase).invoke(tab.id, download.id)
+    }
+
+    @Test
     fun `when url is data url return only our app as downloader app`() {
         val context = mock<Context>()
         val download = DownloadState(url = "data:", sessionId = "test-tab")

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
@@ -30,6 +30,7 @@ import mozilla.components.feature.downloads.manager.DownloadManager
 import mozilla.components.feature.downloads.ui.DownloadAppChooserDialog
 import mozilla.components.feature.downloads.ui.DownloaderApp
 import mozilla.components.support.test.any
+import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
@@ -674,7 +675,8 @@ class DownloadsFeatureTest {
                 store = mock(),
                 useCases = usecases,
                 downloadManager = downloadManager,
-                customDownloadDialog = { filename, contentSize, positiveActionCallback, negativeActionCallback ->
+                shouldForwardToThirdParties = { true },
+                customFirstPartyDownloadDialog = { filename, contentSize, positiveActionCallback, negativeActionCallback ->
                     delegateFilename = filename.value
                     delegateContentSize = contentSize.value
                     delegatePositiveActionCallback = positiveActionCallback.value
@@ -690,6 +692,49 @@ class DownloadsFeatureTest {
         assertNotNull(delegatePositiveActionCallback)
         delegatePositiveActionCallback?.invoke()
         verify(consumeDownloadUseCase).invoke(tab.id, download.id)
+        assertNotNull(delegateNegativeActionCallback)
+        delegateNegativeActionCallback?.invoke()
+        verify(cancelDownloadUseCase).invoke(tab.id, download.id)
+    }
+
+    @Test
+    fun `GIVEN download should be forwarded to third party apps and a custom delegate is set WHEN processing a download request THEN forward it to the delegate`() {
+        val tab = createTab("https://www.mozilla.org", id = "test-tab")
+        val download = DownloadState(url = "https://www.mozilla.org/file.txt", sessionId = "test-tab", id = "test")
+        val usecases: DownloadsUseCases = mock()
+        val cancelDownloadUseCase: CancelDownloadRequestUseCase = mock()
+        doReturn(cancelDownloadUseCase).`when`(usecases).cancelDownloadRequest
+        val downloadManager: DownloadManager = mock()
+        var delegateDownloaderApps: List<DownloaderApp> = emptyList()
+        var delegateChosenAppCallback: ((DownloaderApp) -> Unit)? = null
+        var delegateNegativeActionCallback: (() -> Unit)? = null
+        val ourApp = mock<DownloaderApp>()
+        val anotherApp = mock<DownloaderApp>()
+        grantPermissions()
+        doReturn(arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE)).`when`(downloadManager).permissions
+        val feature = spy(
+            DownloadsFeature(
+                applicationContext = testContext,
+                store = mock(),
+                useCases = usecases,
+                downloadManager = downloadManager,
+                shouldForwardToThirdParties = { true },
+                customThirdPartyDownloadDialog = { apps, chosenAppCallback, dismissCallback ->
+                    delegateDownloaderApps = apps.value
+                    delegateChosenAppCallback = chosenAppCallback.value
+                    delegateNegativeActionCallback = dismissCallback.value
+                },
+            ),
+        )
+        doReturn(listOf(ourApp, anotherApp)).`when`(feature).getDownloaderApps(testContext, download)
+        doNothing().`when`(feature).onDownloaderAppSelected(anotherApp, tab, download)
+
+        feature.processDownload(tab, download)
+
+        assertEquals(listOf(ourApp, anotherApp), delegateDownloaderApps)
+        assertNotNull(delegateChosenAppCallback)
+        delegateChosenAppCallback?.invoke(anotherApp)
+        verify(feature).onDownloaderAppSelected(anotherApp, tab, download)
         assertNotNull(delegateNegativeActionCallback)
         delegateNegativeActionCallback?.invoke()
         verify(cancelDownloadUseCase).invoke(tab.id, download.id)
@@ -871,6 +916,137 @@ class DownloadsFeatureTest {
         verify(feature).startDownload(any())
         verify(consumeDownloadUseCase).invoke(anyString(), anyString())
         verify(spyContext, times(0)).startActivity(any())
+    }
+
+    @Test
+    fun `GIVEN permissions are granted WHEN our app is selected for download THEN perform the download`() {
+        val spyContext = spy(testContext)
+        val usecases: DownloadsUseCases = mock()
+        val consumeDownloadUseCase: ConsumeDownloadUseCase = mock()
+        doReturn(consumeDownloadUseCase).`when`(usecases).consumeDownload
+        val tab = createTab("https://www.mozilla.org", id = "test-tab")
+        val download = DownloadState(url = "https://www.mozilla.org/file.txt", sessionId = "test-tab", id = "test")
+        val ourApp = DownloaderApp(name = "app", packageName = testContext.packageName, resolver = mock(), activityName = "", url = "", contentType = null)
+        var wasPermissionsRequested = false
+        val feature = spy(
+            DownloadsFeature(
+                applicationContext = testContext,
+                store = mock(),
+                useCases = usecases,
+                onNeedToRequestPermissions = { wasPermissionsRequested = true },
+            ),
+        )
+        doReturn(false).`when`(feature).startDownload(any())
+
+        grantPermissions()
+        feature.onDownloaderAppSelected(ourApp, tab, download)
+
+        verify(feature).startDownload(download)
+        verify(consumeDownloadUseCase).invoke(tab.id, download.id)
+        assertFalse(wasPermissionsRequested)
+        verify(spyContext, never()).startActivity(any())
+    }
+
+    @Test
+    fun `GIVEN permissions are not granted WHEN our app is selected for download THEN request the needed permissions`() {
+        val spyContext = spy(testContext)
+        val usecases: DownloadsUseCases = mock()
+        val consumeDownloadUseCase: ConsumeDownloadUseCase = mock()
+        doReturn(consumeDownloadUseCase).`when`(usecases).consumeDownload
+        val tab = createTab("https://www.mozilla.org", id = "test-tab")
+        val download = DownloadState(url = "https://www.mozilla.org/file.txt", sessionId = "test-tab", id = "test")
+        val ourApp = DownloaderApp(name = "app", packageName = testContext.packageName, resolver = mock(), activityName = "", url = "", contentType = null)
+        var wasPermissionsRequested = false
+        val feature = spy(
+            DownloadsFeature(
+                applicationContext = testContext,
+                store = mock(),
+                useCases = usecases,
+                onNeedToRequestPermissions = { wasPermissionsRequested = true },
+            ),
+        )
+
+        feature.onDownloaderAppSelected(ourApp, tab, download)
+
+        verify(feature, never()).startDownload(any())
+        verify(consumeDownloadUseCase, never()).invoke(anyString(), anyString())
+        assertTrue(wasPermissionsRequested)
+        verify(spyContext, never()).startActivity(any())
+    }
+
+    @Test
+    fun `GIVEN a download WHEN a 3rd party app is selected THEN delegate download to it`() {
+        val spyContext = spy(testContext)
+        val usecases: DownloadsUseCases = mock()
+        val consumeDownloadUseCase: ConsumeDownloadUseCase = mock()
+        doReturn(consumeDownloadUseCase).`when`(usecases).consumeDownload
+        val tab = createTab("https://www.mozilla.org", id = "test-tab")
+        val download = DownloadState(url = "https://www.mozilla.org/file.txt", sessionId = "test-tab", id = "test")
+        val anotherApp = DownloaderApp(
+            name = "app",
+            packageName = "test",
+            resolver = mock(),
+            activityName = "",
+            url = download.url,
+            contentType = null,
+        )
+        val feature = spy(
+            DownloadsFeature(
+                applicationContext = spyContext,
+                store = mock(),
+                useCases = usecases,
+            ),
+        )
+        val intentArgumentCaptor = argumentCaptor<Intent>()
+        val expectedIntent = with(feature) { anotherApp.toIntent() }
+
+        feature.onDownloaderAppSelected(anotherApp, tab, download)
+
+        verify(spyContext).startActivity(intentArgumentCaptor.capture())
+        assertEquals(expectedIntent.toUri(0), intentArgumentCaptor.value.toUri(0))
+        verify(consumeDownloadUseCase).invoke(tab.id, download.id)
+        verify(feature, never()).startDownload(any())
+        assertNull(ShadowToast.getTextOfLatestToast())
+    }
+
+    @Test
+    fun `GIVEN a download WHEN a 3rd party app is selected and the download fails THEN show a warning toast and consume the download`() {
+        val spyContext = spy(testContext)
+        val usecases: DownloadsUseCases = mock()
+        val consumeDownloadUseCase: ConsumeDownloadUseCase = mock()
+        doReturn(consumeDownloadUseCase).`when`(usecases).consumeDownload
+        val tab = createTab("https://www.mozilla.org", id = "test-tab")
+        val download = DownloadState(url = "https://www.mozilla.org/file.txt", sessionId = "test-tab", id = "test")
+        val anotherApp = DownloaderApp(
+            name = "app",
+            packageName = "test",
+            resolver = mock(),
+            activityName = "",
+            url = download.url,
+            contentType = null,
+        )
+        val feature = spy(
+            DownloadsFeature(
+                applicationContext = spyContext,
+                store = mock(),
+                useCases = usecases,
+            ),
+        )
+        val expectedWarningText = testContext.getString(
+            R.string.mozac_feature_downloads_unable_to_open_third_party_app,
+            anotherApp.name,
+        )
+        val intentArgumentCaptor = argumentCaptor<Intent>()
+        val expectedIntent = with(feature) { anotherApp.toIntent() }
+        doThrow(ActivityNotFoundException()).`when`(spyContext).startActivity(any())
+
+        feature.onDownloaderAppSelected(anotherApp, tab, download)
+
+        verify(spyContext).startActivity(intentArgumentCaptor.capture())
+        assertEquals(expectedIntent.toUri(0), intentArgumentCaptor.value.toUri(0))
+        verify(consumeDownloadUseCase).invoke(tab.id, download.id)
+        verify(feature, never()).startDownload(any())
+        assertEquals(expectedWarningText, ShadowToast.getTextOfLatestToast())
     }
 
     @Test

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/ext/DownloadStateKtTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/ext/DownloadStateKtTest.kt
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.downloads.ext
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.state.state.content.DownloadState
+import mozilla.components.support.utils.DownloadUtils
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DownloadStateKtTest {
+    @Test
+    fun `GIVEN a download filename is unkwnown WHEN requested with a guessing fallback THEN return a guessed canonical filename`() {
+        val download = DownloadState(
+            url = "url",
+            fileName = null,
+        )
+        val expectedName = with(download) {
+            DownloadUtils.guessFileName(null, destinationDirectory, url, contentType)
+        }
+
+        val result = download.realFilenameOrGuessed
+
+        assertEquals(expectedName, result)
+    }
+
+    @Test
+    fun `GIVEN a download filename is available WHEN requested with a guessing fallback THEN return the available filename`() {
+        val download = DownloadState(
+            url = "http://example.com/file.jpg",
+            fileName = "test",
+            contentType = "image/jpeg",
+        )
+        val guessedName = with(download) {
+            DownloadUtils.guessFileName(null, destinationDirectory, url, contentType)
+        }
+
+        val result = download.realFilenameOrGuessed
+
+        assertEquals("test", result)
+        assertNotEquals(guessedName, result)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,7 +11,8 @@ permalink: /changelog/
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
 * **feature-downloads**:
-  * 🆕 `DownloadsFeature` now allows passing a download dialog delegate for 1st party downloads through a new `customDownloadDialog` parameter.
+  * 🆕 `DownloadsFeature` now allows passing a download dialog delegate for 1st party downloads through a new `customFirstPartyDownloadDialog` parameter.
+  * 🆕 `DownloadsFeature` now allows passing a download dialog delegate for 3rd party downloads through a new `customThirdPartyDownloadDialog` parameter.
 
 * **browser-toolbar**
   * ⚠️ **This is a breaking change**: `BrowserToolbarBehavior` will not position the `Snackbar.SnackbarLayout` anymore. The ownership for the positioning behavior should be reversed with the snackbar choosing whether it want to be shown above the toolbar and exactly how.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **feature-downloads**:
+  * 🆕 `DownloadsFeature` now allows passing a download dialog delegate for 1st party downloads through a new `customDownloadDialog` parameter.
+
 * **browser-toolbar**
   * ⚠️ **This is a breaking change**: `BrowserToolbarBehavior` will not position the `Snackbar.SnackbarLayout` anymore. The ownership for the positioning behavior should be reversed with the snackbar choosing whether it want to be shown above the toolbar and exactly how.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **browser-toolbar**
+  * ⚠️ **This is a breaking change**: `BrowserToolbarBehavior` will not position the `Snackbar.SnackbarLayout` anymore. The ownership for the positioning behavior should be reversed with the snackbar choosing whether it want to be shown above the toolbar and exactly how.
+
 * **feature-qr**
   * QRFeature now allows querying if scanning is in progress with a new `isScanInProgress` property. This helps deciding on whether to resume scanning by calling `scan` in a new `QRFeature` instance as it can happen if the process is restarted as a followup to the user updating system permissions for the app.
 


### PR DESCRIPTION
Clients would benefit from having more control over the download dialogs UI.

Result seen in Fenix where the dialogs are replaces with simple Views:


https://user-images.githubusercontent.com/11428869/196494982-95577c16-b788-4e17-a869-76e44d683f5f.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
