### PR TITLE
Bug 1796766 - Add support for silent web notifications

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegate.kt
@@ -32,6 +32,7 @@ internal class GeckoWebNotificationDelegate(
             requireInteraction = requireInteraction,
             triggeredByWebExtension = source == null,
             engineNotification = this@toWebNotification,
+            silent = silent,
         )
     }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webnotifications/WebNotification.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webnotifications/WebNotification.kt
@@ -24,6 +24,7 @@ import mozilla.components.concept.engine.Engine
  * @property timestamp Time when the notification was created.
  * @property triggeredByWebExtension True if this notification was triggered by a
  * web extension, otherwise false.
+ * @property silent Whether or not the notification should be silent.
  */
 data class WebNotification(
     val title: String?,
@@ -37,4 +38,5 @@ data class WebNotification(
     val engineNotification: Parcelable,
     val timestamp: Long = System.currentTimeMillis(),
     val triggeredByWebExtension: Boolean = false,
+    val silent: Boolean = true,
 )

--- a/components/feature/webnotifications/src/main/res/values/strings.xml
+++ b/components/feature/webnotifications/src/main/res/values/strings.xml
@@ -5,4 +5,6 @@
 <resources>
     <!-- Default Web Notification Channel Name. -->
     <string name="mozac_feature_notification_channel_name">Site notifications</string>
+    <!-- Silent Web Notification Channel Name. -->
+    <string name="mozac_feature_notification_silent_channel_name">Silent site notifications</string>
 </resources>

--- a/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/WebNotificationFeatureTest.kt
+++ b/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/WebNotificationFeatureTest.kt
@@ -27,6 +27,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.anyBoolean
+import org.mockito.Mockito.argThat
 import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
@@ -166,5 +167,73 @@ class WebNotificationFeatureTest {
 
         feature.onShowNotification(webExtensionNotification)
         verify(notificationManager).notify(eq(testNotification.tag), eq(NOTIFICATION_ID), any())
+    }
+
+    @Test
+    fun `WHEN a notification is shown THEN it's assigned to the default notification channel`() = runTestOnMain {
+        val webExtensionNotification = WebNotification(
+            "Mozilla",
+            "mozilla.org",
+            "Notification body",
+            "mozilla.org",
+            "https://mozilla.org/image.ico",
+            "rtl",
+            "en",
+            false,
+            mock(),
+            triggeredByWebExtension = true,
+            silent = false,
+        )
+
+        val feature = WebNotificationFeature(
+            context,
+            engine,
+            browserIcons,
+            android.R.drawable.ic_dialog_alert,
+            permissionsStorage,
+            null,
+            coroutineContext,
+        )
+
+        feature.onShowNotification(webExtensionNotification)
+        verify(notificationManager).notify(
+            eq(testNotification.tag),
+            eq(NOTIFICATION_ID),
+            argThat { arg -> arg.channelId == NOTIFICATION_CHANNEL_ID },
+        )
+    }
+
+    @Test
+    fun `WHEN a silent notification is shown THEN it's assigned to the silent notification channel`() = runTestOnMain {
+        val webExtensionNotification = WebNotification(
+            "Mozilla",
+            "mozilla.org",
+            "Notification body",
+            "mozilla.org",
+            "https://mozilla.org/image.ico",
+            "rtl",
+            "en",
+            false,
+            mock(),
+            triggeredByWebExtension = true,
+            silent = true,
+        )
+
+        val feature = WebNotificationFeature(
+            context,
+            engine,
+            browserIcons,
+            android.R.drawable.ic_dialog_alert,
+            permissionsStorage,
+            null,
+            coroutineContext,
+        )
+
+        feature.onShowNotification(webExtensionNotification)
+        verify(notificationManager).notify(
+            eq(testNotification.tag),
+            eq(NOTIFICATION_ID),
+            argThat { arg -> arg.channelId == SILENT_NOTIFICATION_CHANNEL_ID },
+        )
     }
 }


### PR DESCRIPTION
Add support for silent web notifications. The web notifications having the `silent` flag set will be assigned to a new channel.
Since a notification channel's priority can't be changed after it was created, this change will not enable sound on previously allowed notifications after update.

https://user-images.githubusercontent.com/35462038/197219989-13898183-1fc6-4054-bf3d-985eade48bfc.mp4

For the first notification, the default notification sound was played, the second notification was silent.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
