### PR TITLE
Bug 1797260 - Remove code that re-enables new supported addons

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/migration/SupportedAddonsChecker.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/migration/SupportedAddonsChecker.kt
@@ -3,15 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package mozilla.components.feature.addons.migration
 
-import android.app.Notification
-import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
-import android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK
-import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import androidx.annotation.VisibleForTesting
-import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationManagerCompat
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -22,19 +15,10 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import mozilla.components.concept.engine.webextension.EnableSource
-import mozilla.components.feature.addons.Addon
-import mozilla.components.feature.addons.R
-import mozilla.components.feature.addons.ui.translateName
 import mozilla.components.feature.addons.update.GlobalAddonDependencyProvider
 import mozilla.components.feature.addons.worker.shouldReport
-import mozilla.components.support.base.ids.SharedIdsHelper
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.base.worker.Frequency
-import mozilla.components.support.ktx.android.content.appName
-import mozilla.components.support.ktx.android.notification.ChannelData
-import mozilla.components.support.ktx.android.notification.ensureNotificationChannelExists
-import mozilla.components.support.utils.PendingIntentUtils
 import java.util.concurrent.TimeUnit
 
 /**
@@ -57,20 +41,13 @@ interface SupportedAddonsChecker {
  * @property applicationContext The application context.
  * @param frequency (Optional) indicates how often checks should be performed, defaults
  * to once per day.
- * @param onNotificationClickIntent (Optional) Indicates which intent should be passed to the notification
- * when new supported add-ons are available.
  */
 @Suppress("LargeClass")
 class DefaultSupportedAddonsChecker(
     private val applicationContext: Context,
     private val frequency: Frequency = Frequency(1, TimeUnit.DAYS),
-    onNotificationClickIntent: Intent = createDefaultNotificationIntent(applicationContext),
 ) : SupportedAddonsChecker {
     private val logger = Logger("DefaultSupportedAddonsChecker")
-
-    init {
-        SupportedAddonsWorker.onNotificationClickIntent = onNotificationClickIntent
-    }
 
     /**
      * See [SupportedAddonsChecker.registerForChecks]
@@ -122,12 +99,6 @@ class DefaultSupportedAddonsChecker(
         @VisibleForTesting
         internal const val WORK_TAG_PERIODIC =
             "$IDENTIFIER_PREFIX.DefaultSupportedAddonsChecker.periodicWork"
-
-        internal fun createDefaultNotificationIntent(content: Context): Intent {
-            return content.packageManager.getLaunchIntentForPackage(content.packageName)?.apply {
-                flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK
-            } ?: throw IllegalStateException("Package has no launcher intent")
-        }
     }
 }
 
@@ -146,120 +117,28 @@ internal class SupportedAddonsWorker(
             logger.info("Trying to check for new supported add-ons")
 
             val addonManager = GlobalAddonDependencyProvider.requireAddonManager()
+            val addonUpdater = GlobalAddonDependencyProvider.requireAddonUpdater()
 
-            val newSupportedAddons = addonManager.getAddons().filter { addon ->
+            addonManager.getAddons().filter { addon ->
                 addon.isSupported() && addon.isDisabledAsUnsupported()
-            }
-
-            withContext(Dispatchers.Main) {
-                newSupportedAddons.forEach {
-                    addonManager.enableAddon(
-                        it,
-                        source = EnableSource.APP_SUPPORT,
-                        onError = { error ->
-                            GlobalAddonDependencyProvider.onCrash?.invoke(error)
-                        },
-                    )
+            }.let { addons ->
+                if (addons.isNotEmpty()) {
+                    addons.forEach { addon ->
+                        addonUpdater.registerForFutureUpdates(addon.id)
+                    }
+                    val extIds = addons.joinToString { addon -> addon.id }
+                    logger.info("New supported add-ons available $extIds")
                 }
             }
-
-            if (newSupportedAddons.isNotEmpty()) {
-                val extIds = newSupportedAddons.joinToString { it.id }
-                logger.info("New supported add-ons available $extIds")
-                createNotification(newSupportedAddons)
-            }
         } catch (exception: Exception) {
-            logger.error("An exception happened trying to check for new supported add-ons, re-schedule ${exception.message}", exception)
+            logger.error(
+                "An exception happened trying to check for new supported add-ons, re-schedule ${exception.message}",
+                exception,
+            )
             if (exception.shouldReport()) {
                 GlobalAddonDependencyProvider.onCrash?.invoke(exception)
             }
         }
         Result.success()
-    }
-
-    @VisibleForTesting
-    internal fun createNotification(newSupportedAddons: List<Addon>): Notification {
-        val notificationId = SharedIdsHelper.getIdForTag(context, NOTIFICATION_TAG)
-
-        val channel = ChannelData(
-            NOTIFICATION_CHANNEL_ID,
-            R.string.mozac_feature_addons_supported_checker_notification_channel,
-            NotificationManagerCompat.IMPORTANCE_LOW,
-        )
-        val channelId = ensureNotificationChannelExists(context, channel)
-        return NotificationCompat.Builder(context, channelId)
-            .setSmallIcon(mozilla.components.ui.icons.R.drawable.mozac_ic_extensions)
-            .setContentTitle(getNotificationTitle(plural = newSupportedAddons.size > 1))
-            .setContentText(getNotificationBody(newSupportedAddons, context))
-            .setPriority(NotificationCompat.PRIORITY_MAX)
-            .setContentIntent(createContentIntent())
-            .setAutoCancel(true)
-            .build().also {
-                NotificationManagerCompat.from(context).notify(notificationId, it)
-            }
-    }
-
-    @VisibleForTesting
-    internal fun getNotificationTitle(plural: Boolean = false): String {
-        val stringId = if (plural) {
-            R.string.mozac_feature_addons_supported_checker_notification_title_plural
-        } else {
-            R.string.mozac_feature_addons_supported_checker_notification_title
-        }
-        return applicationContext.getString(stringId)
-    }
-
-    @VisibleForTesting
-    internal fun getNotificationBody(newSupportedAddons: List<Addon>, context: Context): String? {
-        return when (newSupportedAddons.size) {
-            0 -> null
-            1 -> {
-                val addonName = newSupportedAddons.first().translateName(context)
-                applicationContext.getString(
-                    R.string.mozac_feature_addons_supported_checker_notification_content_one,
-                    addonName,
-                    applicationContext.appName,
-                )
-            }
-            2 -> {
-                val firstAddonName = newSupportedAddons.first().translateName(context)
-                val secondAddonName = newSupportedAddons[1].translateName(context)
-                applicationContext.getString(
-                    R.string.mozac_feature_addons_supported_checker_notification_content_two,
-                    firstAddonName,
-                    secondAddonName,
-                    applicationContext.appName,
-                )
-            }
-            else -> {
-                /* There's a restriction in the amount of characters that,
-                   we can put in notification. To be safe we just use two variations,
-                   as we don't know how long the name of an add-on could be.*/
-                applicationContext.getString(
-                    R.string.mozac_feature_addons_supported_checker_notification_content_more_than_two,
-                    applicationContext.appName,
-                )
-            }
-        }
-    }
-
-    private fun createContentIntent(): PendingIntent {
-        return PendingIntent.getActivity(
-            context,
-            0,
-            onNotificationClickIntent,
-            PendingIntentUtils.defaultFlags or PendingIntent.FLAG_UPDATE_CURRENT,
-        )
-    }
-
-    @Suppress("MaxLineLength")
-    companion object {
-        private const val NOTIFICATION_CHANNEL_ID =
-            "mozilla.components.feature.addons.migration.DefaultSupportedAddonsChecker.generic.channel"
-
-        @VisibleForTesting
-        internal const val NOTIFICATION_TAG = "mozilla.components.feature.addons.migration.DefaultSupportedAddonsChecker"
-
-        internal var onNotificationClickIntent: Intent = Intent()
     }
 }

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/migration/DefaultSupportedAddonCheckerTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/migration/DefaultSupportedAddonCheckerTest.kt
@@ -53,14 +53,12 @@ class DefaultSupportedAddonCheckerTest {
 
         // Initialize WorkManager (early) for instrumentation tests.
         WorkManagerTestInitHelper.initializeTestWorkManager(testContext, configuration)
-        SupportedAddonsWorker.onNotificationClickIntent = Intent()
     }
 
     @Test
     fun `registerForChecks - schedule work for future checks`() = runTestOnMain {
         val frequency = Frequency(1, TimeUnit.DAYS)
-        val intent = Intent()
-        val checker = DefaultSupportedAddonsChecker(context, frequency, intent)
+        val checker = DefaultSupportedAddonsChecker(context, frequency)
 
         val workId = CHECKER_UNIQUE_PERIODIC_WORK_NAME
 
@@ -72,7 +70,6 @@ class DefaultSupportedAddonCheckerTest {
         checker.registerForChecks()
 
         assertExtensionIsRegisteredForChecks()
-        assertEquals(intent, SupportedAddonsWorker.onNotificationClickIntent)
         // Cleaning work manager
         workManger.cancelUniqueWork(workId)
     }

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/migration/SupportedAddonsWorkerTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/migration/SupportedAddonsWorkerTest.kt
@@ -4,25 +4,15 @@
 
 package mozilla.components.feature.addons.migration
 
-import android.app.NotificationManager
-import androidx.core.content.getSystemService
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.ListenableWorker
 import androidx.work.await
 import androidx.work.testing.TestListenableWorkerBuilder
-import mozilla.components.concept.engine.webextension.EnableSource
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.AddonManager
 import mozilla.components.feature.addons.AddonManagerException
-import mozilla.components.feature.addons.R
-import mozilla.components.feature.addons.migration.SupportedAddonsWorker.Companion.NOTIFICATION_TAG
-import mozilla.components.feature.addons.ui.translateName
+import mozilla.components.feature.addons.update.AddonUpdater
 import mozilla.components.feature.addons.update.GlobalAddonDependencyProvider
-import mozilla.components.support.base.ids.SharedIdsHelper
-import mozilla.components.support.ktx.android.content.appName
-import mozilla.components.support.test.any
-import mozilla.components.support.test.argumentCaptor
-import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
@@ -31,7 +21,6 @@ import mozilla.components.support.test.whenever
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -57,35 +46,27 @@ class SupportedAddonsWorkerTest {
     }
 
     @Test
-    fun `doWork - will return Result_success and create a notification when a new supported add-on is found`() = runTestOnMain {
-        val addonManager = mock<AddonManager>()
-        val worker = TestListenableWorkerBuilder<SupportedAddonsWorker>(testContext).build()
-        var throwable: Throwable? = null
-        val onCrash = { caught: Throwable ->
-            throwable = caught
+    fun `doWork - will return Result_success and update new supported add-ons when found`() =
+        runTestOnMain {
+            val addonManager = mock<AddonManager>()
+            val addonUpdater = mock<AddonUpdater>()
+            val worker = TestListenableWorkerBuilder<SupportedAddonsWorker>(testContext).build()
+            val unsupportedAddon = mock<Addon> {
+                whenever(translatableName).thenReturn(mapOf(Addon.DEFAULT_LOCALE to "one"))
+                whenever(isSupported()).thenReturn(true)
+                whenever(isDisabledAsUnsupported()).thenReturn(true)
+                whenever(defaultLocale).thenReturn(Addon.DEFAULT_LOCALE)
+            }
+
+            GlobalAddonDependencyProvider.initialize(addonManager, addonUpdater, mock())
+
+            whenever(addonManager.getAddons()).thenReturn(listOf(unsupportedAddon))
+            val result = worker.startWork().await()
+
+            assertEquals(ListenableWorker.Result.success(), result)
+
+            verify(addonUpdater).registerForFutureUpdates(unsupportedAddon.id)
         }
-        val unsupportedAddon = mock<Addon> {
-            whenever(translatableName).thenReturn(mapOf(Addon.DEFAULT_LOCALE to "one"))
-            whenever(isSupported()).thenReturn(true)
-            whenever(isDisabledAsUnsupported()).thenReturn(true)
-            whenever(defaultLocale).thenReturn(Addon.DEFAULT_LOCALE)
-        }
-
-        GlobalAddonDependencyProvider.initialize(addonManager, mock(), onCrash)
-        val onErrorCaptor = argumentCaptor<((Throwable) -> Unit)>()
-
-        whenever(addonManager.getAddons()).thenReturn(listOf(unsupportedAddon))
-        val result = worker.startWork().await()
-
-        assertEquals(ListenableWorker.Result.success(), result)
-
-        val notificationId = SharedIdsHelper.getIdForTag(testContext, NOTIFICATION_TAG)
-        assertTrue(isNotificationVisible(notificationId))
-        verify(addonManager).enableAddon(eq(unsupportedAddon), source = eq(EnableSource.APP_SUPPORT), onSuccess = any(), onError = onErrorCaptor.capture())
-
-        onErrorCaptor.value.invoke(Exception())
-        assertNotNull(throwable!!)
-    }
 
     @Test
     fun `doWork - will try pass any exceptions to the crashReporter`() = runTestOnMain {
@@ -121,62 +102,5 @@ class SupportedAddonsWorkerTest {
 
         assertEquals(ListenableWorker.Result.success(), result)
         assertFalse(crashWasReported)
-    }
-
-    @Test
-    fun `getNotificationTitle - must return the correct singular or plural version of the string`() {
-        val worker = TestListenableWorkerBuilder<SupportedAddonsWorker>(testContext).build()
-
-        var stringId = worker.getNotificationTitle(plural = true)
-        var expectedString = testContext.getString(R.string.mozac_feature_addons_supported_checker_notification_title_plural)
-
-        assertEquals(expectedString, stringId)
-
-        stringId = worker.getNotificationTitle()
-        expectedString = testContext.getString(R.string.mozac_feature_addons_supported_checker_notification_title)
-
-        assertEquals(expectedString, stringId)
-    }
-
-    @Test
-    fun `getNotificationBody - must return the correct singular or plural version of the string`() {
-        val worker = TestListenableWorkerBuilder<SupportedAddonsWorker>(testContext).build()
-
-        val appName = testContext.appName
-        val firstAddon = Addon("one", translatableName = mapOf(Addon.DEFAULT_LOCALE to "one"))
-        val secondAddon = Addon("two", translatableName = mapOf(Addon.DEFAULT_LOCALE to "two"))
-        val thirdAddon = Addon("three", translatableName = mapOf(Addon.DEFAULT_LOCALE to "three"))
-
-        // One add-on
-        var contentString = worker.getNotificationBody(listOf(firstAddon), testContext)
-        var expectedString: String? = testContext.getString(R.string.mozac_feature_addons_supported_checker_notification_content_one, firstAddon.translateName(testContext), appName)
-
-        assertEquals(expectedString, contentString)
-
-        // Two add-ons
-        contentString = worker.getNotificationBody(listOf(firstAddon, secondAddon), testContext)
-        expectedString = testContext.getString(R.string.mozac_feature_addons_supported_checker_notification_content_two, firstAddon.translateName(testContext), secondAddon.translateName(testContext), appName)
-
-        assertEquals(expectedString, contentString)
-
-        // More than two add-ons
-        contentString = worker.getNotificationBody(listOf(firstAddon, secondAddon, thirdAddon), testContext)
-        expectedString = testContext.getString(R.string.mozac_feature_addons_supported_checker_notification_content_more_than_two, appName)
-
-        assertEquals(expectedString, contentString)
-
-        // Zero add-ons :(
-        contentString = worker.getNotificationBody(emptyList(), testContext)
-        expectedString = null
-
-        assertEquals(expectedString, contentString)
-    }
-
-    private fun isNotificationVisible(notificationId: Int): Boolean {
-        val manager = testContext.getSystemService<NotificationManager>()!!
-
-        val notifications = manager.activeNotifications
-
-        return notifications.any { it.id == notificationId }
     }
 }


### PR DESCRIPTION
For https://github.com/mozilla-mobile/fenix/issues/26911 
Removed code that re-enables and shows a notification for new supported addons migrated from Fennec.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
