### PR TITLE
Bug 1797273 - Bind OverlayAddOnProgressBinding to the included addonProgressOverlay view

### DIFF
--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonsFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonsFragment.kt
@@ -192,7 +192,7 @@ class AddonsFragment : Fragment(), AddonsManagerAdapterDelegate {
     }
 
     private val onConfirmPermissionButtonClicked: ((Addon) -> Unit) = { addon ->
-        val includedBinding = OverlayAddOnProgressBinding.bind(binding.root)
+        val includedBinding = OverlayAddOnProgressBinding.bind(binding.addonProgressOverlay.addonProgressOverlay)
 
         includedBinding.root.visibility = View.VISIBLE
         isInstallationInProgress = true

--- a/samples/browser/src/main/res/layout/fragment_add_ons.xml
+++ b/samples/browser/src/main/res/layout/fragment_add_ons.xml
@@ -18,6 +18,7 @@
 
 
     <include
+        android:id="@+id/addonProgressOverlay"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"


### PR DESCRIPTION
Allow OverlayAddOnProgressBinding to bind to the included addonProgressOverlay view in `AddonsFragment`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
