### PR TITLE
ui-autocomplete: correct InputConnection behavior

### DIFF
--- a/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
+++ b/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
@@ -593,6 +593,7 @@ open class InlineAutocompleteEditText @JvmOverloads constructor(
                     composingEnd - composingStart > text.length &&
                     removeAutocomplete(editable)
                 ) {
+                    finishComposingText()
                     // Make the IME aware that we interrupted the setComposingText call,
                     // by calling restartInput()
                     restartInput()


### PR DESCRIPTION
This PR fix 2 issues in InlineAutocompleteEditText:

1. Backspace erases extra character (related issue: https://github.com/mozilla-mobile/fenix/issues/25249)

Modern input methods tend to use InputConnection APIs rather than sending keycode to simulate keypress. Override method [InputConnection#deleteSurroundingTextInCodePoints(int,int)](https://developer.android.com/reference/android/view/inputmethod/InputConnection#deleteSurroundingTextInCodePoints(int,%20int)) available on API level 24+ to unify the behavior.

2. Composing text state desync between Editor and IME

https://user-images.githubusercontent.com/13914967/197770365-8b3e81a1-9353-4482-9257-7a0ff67e3d8d.mp4

As the video above indicates, input state desyncs between Editor and IME when press <kbd>Backspace</kbd> while there is unfinished composing text. 

To explain the behavior step by step:
1. Type `redd` in address bar, IME presents composing text `redd`, and Inline AutocompleteEditText completes to `redd|it.com`
2. Press <kbd>Backspace</kbd>. IME receives backspace and requests to set composing text to `red`. But AutocompleteEditText ignores the request, finishing composing text `redd` instead
3. Press <kbd>Backspace</kbd> again. IME receives backspace, and requests to set composing text to `re`. But composing range was lost because AutocompleteEditText has finished composing already, causing IME set composing text after finished text `redd`

Looking through `setComposingText` implementation, it always call `removeAutocompleteOnComposing` first.

https://github.com/mozilla-mobile/android-components/blob/bd1adfd687aa496f2bd4805816553241126c32c9/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt#L602-L611

In `removeAutocompleteOnComposing`, when incoming text shorter than existing composing text, it calls `finishingComposingText()` and drops incoming text. Althrough the comment says "having finishComposingText() send change notifications to the IME", but there is **NO** API for IME to know that composing text has been changed, which is the cause of state desync.

https://github.com/mozilla-mobile/android-components/blob/bd1adfd687aa496f2bd4805816553241126c32c9/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt#L575-L592

This PR changes `finishingComposingText()` to `restartInput()`, so IME can know previous InputConnection has been interrupted, allowing IME to reset it's internal state.

After the change, if IME is capable of providing text correction based on surrounding text, it can show candidate words as usual. Otherwise (as the video above), composing range in InlineAutocompleteEditText and IME are both cleared, no desync would occur.

possible related issues:

- https://github.com/mozilla-mobile/fenix/issues/23709

**PS:** it would be nice if there are some documentation mentions that you need `AppCompat` Theme to make `InlineAutocompleteEditText` work correctly.  I spent hours on setting up development environment and test project for this.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
