### PR TITLE
Upgrade release/106.0 Application Services to v94.2.2

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -35,7 +35,7 @@ object Versions {
 
     // When upgrading mozilla_appservices, also upgrade the version in the
     // `getApplicationServiceVersion()` method in NimbusGradlePlugin.groovy.
-    const val mozilla_appservices = "94.2.1"
+    const val mozilla_appservices = "94.2.2"
 
     // DO NOT MODIFY MANUALLY. This is auto-updated along with GeckoView.
     const val mozilla_glean = "51.2.0"

--- a/components/tooling/nimbus-gradle-plugin/src/main/groovy/mozilla/components/tooling/nimbus/NimbusGradlePlugin.groovy
+++ b/components/tooling/nimbus-gradle-plugin/src/main/groovy/mozilla/components/tooling/nimbus/NimbusGradlePlugin.groovy
@@ -179,7 +179,7 @@ class NimbusPlugin implements Plugin<Project> {
         // a) this plugin is going to live in the AS repo (eventually)
         // See https://github.com/mozilla-mobile/android-components/issues/11422 for tying this
         // to a version that is specified in buildSrc/src/main/java/Dependencies.kt
-        return "94.2.1"
+        return "94.2.2"
     }
 
     // Try one or more hosts to download the given file.


### PR DESCRIPTION
This upgrade to `v94.2.2` fixes a noisy Glean event with Nimbus. We have learned all we need to from this event, and it if left unchecked, will become expensive for our Glean event ingestion and storage systems.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
