### PR TITLE
Bug 1794933 - Remove autocomplete when not applicable anymore

### DIFF
--- a/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
+++ b/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
@@ -575,9 +575,24 @@ open class InlineAutocompleteEditText @JvmOverloads constructor(
                 return super.deleteSurroundingText(beforeLength, afterLength)
             }
 
+            /**
+             * Optionally remove the current autocompletion depending on the new [text].
+             *
+             * Cases in which the autocompletion will be removed:
+             *  - if the user pressed the backspace to remove the autocompletion or
+             *  - if the user modified their input their input such that the autocompletion does not apply anymore.
+             *
+             * @return `true` if this method consumed the user input, `false` otherwise.
+             */
             @Suppress("ComplexCondition")
             private fun removeAutocompleteOnComposing(text: CharSequence): Boolean {
                 val editable = getText()
+
+                // Remove the autocomplete text as soon as possible if not applicable anymore.
+                if (!editableText.startsWith(text) && removeAutocomplete(editable)) {
+                    return false // If the user modified their input then allow the new text to be set.
+                }
+
                 val composingStart = BaseInputConnection.getComposingSpanStart(editable)
                 val composingEnd = BaseInputConnection.getComposingSpanEnd(editable)
                 // We only delete the autocomplete text when the user is backspacing,

--- a/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
+++ b/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
@@ -352,6 +352,26 @@ class InlineAutocompleteEditTextTest {
     }
 
     @Test
+    fun `GIVEN the current text contains an autocompletion WHEN a new character does not match the autocompletion THEN remove the autocompletion`() {
+        val et = InlineAutocompleteEditText(testContext, attributes)
+        val ic = et.onCreateInputConnection(mock(EditorInfo::class.java))
+
+        ic?.setComposingText("mo", 1)
+        assertEquals("mo", et.text.toString())
+
+        et.applyAutocompleteResult(AutocompleteResult("mozilla", "source", 1))
+        assertEquals("mozilla", et.text.toString())
+
+        // Simulating the user entering a new character which makes the current autocomplete invalid
+        ic?.setComposingText("mod", 1)
+        assertEquals("mod", et.text.toString())
+
+        // Verify that autocompletion works for the new text
+        et.applyAutocompleteResult(AutocompleteResult("moderator", "source", 1))
+        assertEquals("moderator", et.text.toString())
+    }
+
+    @Test
     fun `GIVEN empty edit field WHEN text 'g' added THEN autocomplete to google`() {
         val et = InlineAutocompleteEditText(testContext, attributes)
         et.setText("")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **ui-autocomplete**
+  * 🚒 Bug fixed [issue #1794933](https://bugzilla.mozilla.org/show_bug.cgi?id=1794933) Immediately remove autocomplete when not applicable anymore.
+
 * **compose-cfr**
   * 🆕 New composable popup allowing to offer more context about a specific View anchor on the screen. Supports RTL along with many other customizations and anchorings.
 


### PR DESCRIPTION
Immediately after the user modified it's input text to something that doesn't
match the current autocompleted text the autocompletion will be removed.


| Initial problem 25% speed | Fixed version 25% speed | Fixed version 100% speed |
| --- | --- | --- |
| <video src="https://user-images.githubusercontent.com/11428869/198075697-1de8e3f6-ba9e-44ca-9758-aa53dd0a1c52.mov" /> | <video src="https://user-images.githubusercontent.com/11428869/198075869-ca71edb1-70fe-4a35-9fb1-f1d8d9d5cec8.mp4" /> | <video src="https://user-images.githubusercontent.com/11428869/198075982-9f941107-f761-4316-8042-152c2c73c490.mp4" />


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
