### PR TITLE
Bug 1798026 - part 1: Don't run geckoview bumps automatically until t…

### DIFF
--- a/.github/workflows/update-geckoview.yml
+++ b/.github/workflows/update-geckoview.yml
@@ -23,9 +23,7 @@ permissions:
   contents: write
   pull-requests: write
 
-on:
-  schedule:
-    - cron: '*/15 * * * *'
+on: workflow_dispatch
 
 jobs:
   main:


### PR DESCRIPTION
…he repo migration is done

This needs to be merged on Sunday so that we can trigger a new A-C nightly on Monday, right after the repo migration. 