### PR TITLE
Revert "Update to GeckoView Beta 107.0.20221029133721 on releases/107.0"

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -9,7 +9,7 @@ object Gecko {
     /**
      * GeckoView Version.
      */
-    const val version = "107.0.20221029133721"
+    const val version = "107.0.20221027185833"
 
     /**
      * GeckoView channel


### PR DESCRIPTION
Reverts mozilla-mobile/android-components#13032
13032 should not have merged. Reverting PR.